### PR TITLE
docs: plan issue #1703 — demo VFD broadcast timing race

### DIFF
--- a/plan/history/2607/learning/CONCERN-1703.md
+++ b/plan/history/2607/learning/CONCERN-1703.md
@@ -1,0 +1,36 @@
+---
+source: CONCERN-1703
+timestamp: '2026-07-27T18:11:06.011921+00:00'
+title: 'Demo Integration: intermittent VFD broadcast timing race condition across
+  all scenario demos'
+type: learning
+---
+
+The `fccv-handoff` demo CI job failed intermittently with:
+
+```text
+M6 reporter: vfd_state is not VFD, found vfd (vendor_unaware)
+```
+
+**Root cause 1 — timing race (all 6 demos):** `verify_fix_ready`,
+`verify_fix_deployed`, and `verify_publicly_disclosed` all call
+`_check_participant_vfd_state_in` / `_assert_participant_vfd_pxa` as
+single-shot, non-retrying assertions on the receiver container. The
+preceding `wait_for_participant_vfd_state` only polls the
+finder/reporter (secondary) container. The receiver container may not
+have received the VFD broadcast yet when the assertion fires.
+
+**Root cause 2 — wrong actor in fccv_handoff_demo.py (line 821):**
+`verify_publicly_disclosed(receiver_actor_id=c1.id_)` passes C1 (a
+Coordinator), but `_assert_participant_vfd_pxa` checks
+`vfd_state == VFD`. A Coordinator's VFD never transitions past `vfd`.
+Should be `vendor.id_`.
+
+The broadcast participant list divergence (1 vs 2 recipients) noted in
+the issue body is a secondary symptom of root cause 1 — the CaseActor
+broadcasts the VFD ledger entry before the finder's CaseParticipant
+registration is complete, so the finder replica arrives late.
+
+**Resolved**: 2026-07-27 — implementation tracked in #1717.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1718>.
+Spec: `specs/multi-actor-demo.yaml` DEMOMA-06-006.

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -289,6 +289,34 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-06-004
+  - id: DEMOMA-06-006
+    priority: MUST
+    kind: project
+    statement: >-
+      Before calling `verify_fix_ready`, `verify_fix_deployed`, or
+      `verify_publicly_disclosed`, demo scripts MUST first call
+      `wait_for_participant_vfd_state` on every container that the helper will
+      assert against — including the receiver container.  Using a polling wait
+      only on the reporter/finder container and then immediately asserting on
+      the receiver container with a single-shot check is not permitted.
+    rationale: >-
+      Each of these helpers calls `_check_participant_vfd_state_in` or
+      `_assert_participant_vfd_pxa` as a single-shot, non-retrying assertion.
+      VFD state updates are broadcast asynchronously via
+      `Announce(CaseLedgerEntry)` fan-out; if the broadcast has not yet
+      reached the receiver container when the assertion fires, the check
+      fails with a spurious "vfd_state is not VFD" error.  Adding a
+      `wait_for_participant_vfd_state` poll on every target container
+      before the single-shot assertion eliminates this race.  Additionally,
+      the `receiver_actor_id` argument MUST be the full URI of an actor that
+      holds `CVDRole.VENDOR` in the case (see DEMOMA-15-001); passing a
+      Coordinator or other non-Vendor actor whose VFD path never advances
+      will always fail the VFD check.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-06-002
+    - rel_type: refines
+      spec_id: DEMOMA-15-001
 - id: DEMOMA-07
   title: ParticipantStatus Trigger Pattern
   specs:


### PR DESCRIPTION
- Closes #1703

## Summary

- Add `DEMOMA-06-006` to `specs/multi-actor-demo.yaml` requiring demo
  scripts to call `wait_for_participant_vfd_state` on **every target
  container** before any single-shot VFD assertion (`verify_fix_ready`,
  `verify_fix_deployed`, `verify_publicly_disclosed`).
- Rationale covers both the async-broadcast timing race (broadcasts
  arrive asynchronously; receiver may lag) and the wrong-actor failure
  mode (passing a non-Vendor `receiver_actor_id` whose VFD never
  advances past `vfd`).

## Changes

- `specs/multi-actor-demo.yaml` — added DEMOMA-06-006 under
  DEMOMA-06 (Milestone Verification Pattern group), with
  `refines` relationships to DEMOMA-06-002 and DEMOMA-15-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)