### PR TITLE
docs: capture surface-symptom-vs-underlying-problem in Concern intake

### DIFF
--- a/.agents/skills/new-item/SKILL.md
+++ b/.agents/skills/new-item/SKILL.md
@@ -48,10 +48,20 @@ Cross-type updates are allowed; keep the existing issue type unchanged.
 Use `grill-me` style, but always propose a concrete draft first, then ask the
 user to accept or refine each field.
 
-- **Concern fields**: Summary, Category, Severity, Evidence, Impact if Ignored,
-  Suggested Action.
+- **Concern fields**: Summary, Surface Symptom vs. Underlying Problem, Category,
+  Severity, Evidence, Impact if Ignored, Suggested Action.
 - **Idea fields**: Summary, Motivation, Rough Approach (optional),
   References (optional; auto-seed related issue/spec/ADR links when possible).
+
+For the **Surface Symptom vs. Underlying Problem** field, actively draw out
+both halves: the naive, symptom-level reading someone would stop at, and the
+deeper problem the concern is really about. Infer them from the description
+when context allows; otherwise ask directly. Capture, when relevant, which
+parts of the current design are already correct and should be left untouched.
+Omit only when there is genuinely no gap between the surface reading and the
+underlying problem. This field is Concern-only by design — an Idea's
+Motivation/Rough Approach split already serves the equivalent guardrail, so
+do not add a symptom/root frame to Ideas.
 
 ### Phase 4 — Epic Parent Selection
 

--- a/.github/ISSUE_TEMPLATE/concern.md
+++ b/.github/ISSUE_TEMPLATE/concern.md
@@ -9,6 +9,23 @@ labels: concern
 
 <!-- One or two sentences describing the concern. -->
 
+## Surface Symptom vs. Underlying Problem
+
+<!--
+State two things: (1) the naive, symptom-level reading someone would stop at,
+and (2) the deeper problem underneath it that this concern is really about.
+Naming both turns the concern into a worked example of the judgment involved —
+it shows the jump from the obvious reading to the real one, which is exactly
+what makes concerns useful to learn from later.
+
+If the deeper problem also implies parts of the current design that are
+*already correct and should not be touched*, say so — knowing what to leave
+alone is as valuable as knowing what to change.
+
+Omit only if there genuinely is no gap between the surface reading and the
+underlying problem.
+-->
+
 ## Category
 
 <!-- Check the one that best fits. -->


### PR DESCRIPTION
## Summary

Adds a **Surface Symptom vs. Underlying Problem** section to the Concern
intake path — both the GitHub issue template and the `new-item` skill's
draft-first interview — so the reasoning behind a Concern is captured by
default rather than only when the author happens to write it into the
Summary.

The motivation: Concerns are where the project records "the obvious local
problem is actually a symptom of a deeper design issue." Reviewing recent
closed Concerns showed this symptom-to-root move is exactly what makes them
valuable to learn from later, but nothing in the template asked for it — so
it appeared only by the author's habit. Prompting for both the naive reading
and the real problem turns each Concern into a worked example of that
judgment, with the trap deliberately set.

## Changes

- `.github/ISSUE_TEMPLATE/concern.md`: new "Surface Symptom vs. Underlying
  Problem" section, placed after Summary, with guidance to state (1) the
  symptom-level reading someone would stop at and (2) the deeper problem —
  and, where relevant, which parts of the current design are already correct
  and should be left untouched. Explicitly omittable when there is no gap.
- `.agents/skills/new-item/SKILL.md`: adds the field to the Concern field
  list in the draft-first interview (Phase 3) and instructs the skill to draw
  out both halves from context or by direct question. Documents that Idea
  intake is deliberately left unchanged, since an Idea's Motivation vs. Rough
  Approach split already serves the equivalent guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)