### PR TITLE
docs: plan concern #1635 — no mail-carrying in demo scripts

### DIFF
--- a/notes/event-driven-control-flow.md
+++ b/notes/event-driven-control-flow.md
@@ -214,12 +214,21 @@ post_to_inbox_and_wait(client, vendor_id, add_participant_activity)  # should be
 ```
 
 ```python
-# ✅ CORRECT — demo injects primary event, verifies outcome
-post_to_inbox_and_wait(client, vendor_id, validate_activity)
-# ... wait for settlement ...
-assert_case_exists_in_datalayer(dl, case_id)  # observe state, not steps
+# ✅ CORRECT — demo triggers primary event, verifies outcome
+post_to_trigger(client, vendor_id, "validate-report", body=report_params)
+# ... poll for settlement ...
+wait_for_case_on_container(dl, case_id)        # observe state, not steps
 assert_participant_added(dl, case_id, finder_id)
 ```
+
+> **Note (CONCERN-1635):** The earlier form of this example used
+> `post_to_inbox_and_wait(client, vendor_id, validate_activity)` and was marked
+> ✅ CORRECT for "demo injects primary event." That pattern is now superseded.
+> CONCERN-1635 prohibits demo scripts from POSTing directly to any actor's inbox
+> — including via `post_to_inbox_and_wait` — even for the primary event. The
+> correct pattern is `post_to_trigger` + a polling assertion
+> (`wait_for_case_on_container`, `find_case_invite_for_actor`, etc.). See the
+> CONCERN-1635 rule in `vultron/demo/AGENTS.md`.
 
 ### Missing External Decision Node
 

--- a/plan/history/2607/learning/CONCERN-1635.md
+++ b/plan/history/2607/learning/CONCERN-1635.md
@@ -1,0 +1,25 @@
+---
+source: CONCERN-1635
+timestamp: '2026-07-27T18:34:09.099027+00:00'
+title: 'Missing rule: demo scripts must never carry one actor''s mail to another''s
+  inbox'
+type: learning
+---
+
+## Summary
+
+`vultron/demo/AGENTS.md` documented "puppeteer via triggers, never spoof via inbox injection" but said nothing about *how to wait for cross-container delivery*. The implicit constraint that `post_to_inbox_and_wait` must be used for explicit cross-container delivery was documented in CONCERN-1635 as the "correct" pattern.
+
+## Root Cause Discovered
+
+During planning, this turned out to be incorrect. `post_to_inbox_and_wait` is itself a form of spoofing — it acts as a surrogate mail carrier, POST-ing one actor's activity directly to another actor's inbox from outside the real delivery path. This violates the puppeteer-not-spoof principle the existing rule was trying to enforce.
+
+The real root cause of the original PR #1623 bug was a `BackgroundTasks` timing gap: the inbox endpoint returns 202 before processing completes, so naive polling timed out. The "fix" replaced a fragile poll with a layering violation.
+
+The correct pattern is: trigger the sending actor via its trigger endpoint, then poll the receiving actor's DataLayer using existing helpers (`wait_for_case_on_container`, `find_case_invite_for_actor`, `verify_object_stored`) with a sufficient timeout. The real HTTP delivery path (`DemoHttpDeliveryAdapter`) with retry/backoff handles cross-container delivery reliably.
+
+## Resolution
+
+**Resolved**: 2026-07-27 — docs rule added in #1722; implementation (remove all mail-carrying calls from scenario files + investigate BackgroundTasks timing) tracked in #1721.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1722>

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -184,4 +184,17 @@ complete; the demo just needs to wait long enough.
    investigation (retry parameters, health checks, container startup order)
    — not a workaround in the demo script.
 
+**Exception — self-delivery (CONCERN-1653):** A demo script MAY call
+`post_to_inbox_and_wait` when an actor needs to deliver an activity to its
+*own* inbox to update its own replica — for example, after triggering
+`accept-case-ownership-transfer`, the accepting actor must self-deliver the
+resulting `Accept` activity so that `AcceptCaseOwnershipTransferReceivedUseCase`
+runs locally. This is not mail-carrying: the actor is posting to its own inbox,
+not acting as a surrogate for the transport layer.
+
+The rule this section prohibits is **cross-actor delivery**: a demo using
+*Actor A's* credentials to POST a message into *Actor B's* inbox. That is the
+pattern to eliminate; CONCERN-1653's self-delivery pattern is orthogonal and
+remains correct.
+
 <!-- Source: CONCERN-1635 -->

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -142,3 +142,46 @@ See `vultron/demo/scenario/fvcv_handoff_demo.py` and
 `vultron/demo/scenario/fccv_handoff_demo.py` for the correct pattern.
 
 <!-- Source: CONCERN-1653 -->
+
+---
+
+### Never Carry One Actor's Mail to Another Actor's Inbox
+
+Demo scripts MUST NOT POST an activity to an actor's inbox on behalf of
+another actor. This includes helper functions such as `post_to_inbox_and_wait`.
+
+**Why:** Delivering an activity to an inbox is the transport layer's job, not
+the demo's. When a demo calls `post_to_inbox_and_wait(vendor_client, vendor_id,
+invite)` it is acting as a surrogate mail carrier — putting a message into
+Vendor's inbox as if it arrived from the network. This is a form of spoofing:
+the real outbox→delivery→inbox path is never exercised, so demo CI proves
+nothing about whether the protocol actually works end-to-end.
+
+The distinction that matters:
+
+- **Triggering** = POST to an actor's *trigger endpoint* to cause it to emit
+  an activity (`POST /actors/{id}/trigger/invite-actor-to-case`). The actor
+  decides and sends. Correct.
+- **Mail-carrying** = POST an activity directly to another actor's *inbox*
+  from outside that actor's own delivery path (`POST /actors/{id}/inbox/`).
+  The demo bypasses the real transport. Wrong.
+
+**Root cause of the pattern:** The inbox endpoint returns 202 immediately
+(`BackgroundTasks`) before the activity is fully processed. Naive polling
+after a trigger timed out, so mail-carrying was added as a workaround. The
+correct fix is to use a polling helper with a sufficient timeout — the real
+HTTP delivery path (`DemoHttpDeliveryAdapter`) with its retry/backoff will
+complete; the demo just needs to wait long enough.
+
+**How to apply:**
+
+1. After triggering an actor to emit an activity, do **not** manually deliver
+   that activity to any inbox. Instead, poll the expected side-effect directly:
+   - Use `wait_for_case_on_container` to verify a case replica arrived.
+   - Use `find_case_invite_for_actor` to verify an invite arrived.
+   - Use `verify_object_stored` after a sufficient `time.sleep` or poll loop.
+2. If a poll times out reliably in CI, the underlying delivery path needs
+   investigation (retry parameters, health checks, container startup order)
+   — not a workaround in the demo script.
+
+<!-- Source: CONCERN-1635 -->


### PR DESCRIPTION
- Closes #1635

## Summary

Adds a pitfall rule to `vultron/demo/AGENTS.md` documenting that demo scripts
must never act as mail carriers — POSTing one actor's activity directly to
another actor's inbox. The correct pattern is: trigger the sending actor via
its trigger endpoint, then poll the receiving actor's DataLayer for the
expected side-effect.

## Changes

- `vultron/demo/AGENTS.md`: new "Never Carry One Actor's Mail to Another
  Actor's Inbox" pitfall entry explaining the spoofing distinction, the
  `BackgroundTasks` timing root cause, and the correct polling replacement
  pattern.

Implementation tracked in #1721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)