### PR TITLE
feat(bt): decompose AutoCloseBranchNode into precondition + routing + emit Sequence

### DIFF
--- a/notes/bt-pitfalls.md
+++ b/notes/bt-pitfalls.md
@@ -515,12 +515,16 @@ Selector(
 **Why this is necessary**: Received-side use cases run the BT with the receiving
 actor's `actor_id`. Every participant that receives a broadcast may run the same
 BT. Without an in-tree role guard, a CASE_MANAGER-only node such as
-`AutoCloseBranchNode` fires for every receiving actor — including participants who
+`EmitCloseCaseNode` fires for every receiving actor — including participants who
 should remain silent. Placing the guard outside the tree (e.g., in `execute()`) is
 insufficient because the same tree factory may be shared across trigger-side and
 received-side paths.
 
-## Module-Level Idempotency Sets Must Be Paired with a Role Guard
+## Use DataLayer Outbox for Idempotency, Not Module-Level Sets
+
+(Resolved pattern — the former `AutoCloseBranchNode` used a module-level
+`_auto_close_triggered: set[str]` that was replaced in PR #1724 by a
+`CloseNotYetEmittedConditionNode` that queries the DataLayer outbox.)
 
 A module-level `set[str]` used to prevent duplicate fires is **per-process**,
 not per-container. In a Docker deployment, vendor-1 and finder-1 each have
@@ -529,11 +533,11 @@ affect vendor-1. However, **within a single process**, two fires can race:
 if a phantom fire (wrong actor) runs first and claims the slot, the legitimate
 fire (correct actor) is silently skipped.
 
-**Fix**: Always pair a module-level idempotency set with a `CheckIsCaseManagerNode`
-role guard at tree-composition time. The role guard ensures only the correct actor
-can claim the slot. Issue #1030 observed this race on `AutoCloseBranchNode`:
-the phantom fire on finder-1 claimed the set and blocked the real fire on the
-case-actor in the same process.
+**Fix**: Use a `DataLayerCondition` node that queries the DataLayer outbox for
+an existing activity, not a module-level set. This survives process restarts and
+is visible to the BT audit trail. Issue #1030 observed the module-set race on
+the former `AutoCloseBranchNode`; `CloseNotYetEmittedConditionNode` (PR #1724)
+is the idiomatic replacement pattern.
 
 ---
 

--- a/notes/peer-broadcast-failure-semantics.md
+++ b/notes/peer-broadcast-failure-semantics.md
@@ -66,11 +66,12 @@ be blocked by notification gaps. The missing-factory case is an operational
 deployment gap (receive-side use cases don't wire factories), not a data
 error that should roll back state.
 
-**Canonical example:** `SendAnnounceEmbargoEventNode` in
+**Canonical examples:** `SendAnnounceEmbargoEventNode` in
 `vultron/core/behaviors/embargo/nodes/teardown.py` — returns SUCCESS with
 WARNING when `trigger_activity_factory` is `None` or no Case Manager is
-found, rather than FAILURE. The `AutoCloseBranchNode` pattern uses the
-same override.
+found, rather than FAILURE. `EmitCloseCaseNode` in
+`vultron/core/behaviors/status/nodes/lifecycle.py` uses the same override
+(PR #1724).
 
 **When the override does NOT apply:** when the node sits directly in a
 Sequence without a fallback-SUCCESS Selector parent, FAIL-FAST per

--- a/plan/history/2607/implementation/ISSUE-1716.md
+++ b/plan/history/2607/implementation/ISSUE-1716.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1716
+timestamp: '2026-07-27T18:40:04.576359+00:00'
+title: Decompose AutoCloseBranchNode into precondition + routing + emit BT Sequence
+type: implementation
+---
+
+## Issue #1716 — Decompose AutoCloseBranchNode into precondition + routing + emit BT Sequence
+
+Replaced `AutoCloseBranchNode` (BT-IDM-03 god node) with a properly decomposed `py_trees.Sequence` of DataLayer-backed leaf nodes per DEMOMA-07-006.
+
+New nodes: `AllParticipantsRMClosedConditionNode`, `CloseNotYetEmittedConditionNode` (in `conditions.py`), `EmitCloseCaseNode` (in `lifecycle.py`).
+
+Module-level `_auto_close_triggered` set and `_auto_close_lock` removed; idempotency now uses the DataLayer outbox (survives restarts, visible to BT audit).
+
+Architecture violation (lifecycle.py importing `_resolve_case_manager_id` from `use_cases`) resolved; `lifecycle.py` removed from `KNOWN_VIOLATIONS`.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1724>

--- a/plan/incoming/learnings/20260727-blackboard-get-raises-keyerror-footgun.md
+++ b/plan/incoming/learnings/20260727-blackboard-get-raises-keyerror-footgun.md
@@ -1,0 +1,19 @@
+---
+title: "py_trees blackboard.get() raises KeyError on unset registered READ key"
+type: learning
+timestamp: "2026-07-27"
+source: ISSUE-1716
+signal: concern
+---
+
+`py_trees.Blackboard.get(key)` raises `KeyError` (not returns `None`) when the
+key has been registered with `READ` access but has not yet been written by any
+node.  `EmitCloseCaseNode` hit this in code review — the `if not case_manager_id:`
+guard was unreachable and the `KeyError` would propagate uncaught.
+
+Fix applied in ISSUE-1716: wrap `blackboard.get()` in `try/except KeyError`.
+
+The same footgun exists anywhere `DataLayerAction.setup()` registers READ keys
+and `update()` calls `blackboard.get()` without guarding.  A systematic audit of
+all `register_key(..., access=Access.READ)` sites would catch latent bugs of this
+form — worth a Concern issue targeting `behaviors/` BT nodes.

--- a/plan/incoming/learnings/20260727-emit-close-case-best-effort-missing-cm-id.md
+++ b/plan/incoming/learnings/20260727-emit-close-case-best-effort-missing-cm-id.md
@@ -1,0 +1,21 @@
+---
+title: "EmitCloseCaseNode: best-effort SUCCESS when case_manager_id absent from blackboard"
+type: learning
+timestamp: "2026-07-27"
+source: ISSUE-1716
+signal: design-question
+---
+
+`EmitCloseCaseNode.update()` returns `SUCCESS` (not `FAILURE`) when
+`case_manager_id` is not present on the py_trees blackboard, consistent with
+the best-effort semantics used by `SendAnnounceEmbargoEventNode` and the
+former `AutoCloseBranchNode._emit_close_case()`.
+
+Rationale: receive-side BT paths intentionally omit `trigger_activity_factory`;
+treating a missing `case_manager_id` as `FAILURE` would propagate up through the
+`AutoCloseSequence` and cause the `CaseManagerAutoClose` subtree to fail, which
+could block subsequent ticks.  Best-effort SUCCESS keeps the tree moving and logs
+a WARNING.
+
+The same pattern should be applied consistently wherever `DataLayerAction` nodes
+read optional blackboard keys.

--- a/test/architecture/test_behaviors_no_use_case_imports.py
+++ b/test/architecture/test_behaviors_no_use_case_imports.py
@@ -108,7 +108,6 @@ KNOWN_VIOLATIONS: frozenset[str] = frozenset(
         "vultron/core/behaviors/report/nodes/rm_transitions.py",
         "vultron/core/behaviors/report/nodes/storage.py",
         "vultron/core/behaviors/sender/nodes/actions.py",
-        "vultron/core/behaviors/status/nodes/lifecycle.py",
         "vultron/core/behaviors/sync/nodes/chain.py",
         "vultron/core/behaviors/sync/nodes/replay.py",
     ]

--- a/test/core/behaviors/status/nodes/test_lifecycle.py
+++ b/test/core/behaviors/status/nodes/test_lifecycle.py
@@ -182,3 +182,19 @@ class TestEmitCloseCaseNode:
             actor=ACTOR_ID,
             to=[CASE_MANAGER_ID],
         )
+        outbox = populated_dl.outbox_list_for_actor(ACTOR_ID)
+        assert activity_id in outbox
+
+    def test_fails_on_factory_exception(self, populated_dl):
+        """factory.close_case raises → FAILURE (unexpected error path)."""
+        factory = MagicMock()
+        factory.close_case.side_effect = RuntimeError("boom")
+
+        py_trees.blackboard.Blackboard.storage["/case_manager_id"] = (
+            CASE_MANAGER_ID
+        )
+        bridge = BTBridge(datalayer=populated_dl, trigger_activity=factory)
+        node = EmitCloseCaseNode(case_id=CASE_ID)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.FAILURE

--- a/test/core/behaviors/status/nodes/test_lifecycle.py
+++ b/test/core/behaviors/status/nodes/test_lifecycle.py
@@ -15,7 +15,7 @@
 
 """Unit tests for case lifecycle trigger nodes.
 
-Tests PublicDisclosureBranchNode and AutoCloseBranchNode
+Tests PublicDisclosureBranchNode and EmitCloseCaseNode
 from nodes.lifecycle.
 
 Per DEMOMA-07-003 steps 4–5.
@@ -24,11 +24,12 @@ Per DEMOMA-07-003 steps 4–5.
 import pytest
 import py_trees
 from py_trees.common import Status
+from unittest.mock import MagicMock
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.status.nodes.lifecycle import (
-    AutoCloseBranchNode,
+    EmitCloseCaseNode,
     PublicDisclosureBranchNode,
 )
 from vultron.enums.roles import CVDRole
@@ -129,21 +130,55 @@ class TestPublicDisclosureBranchNode:
 
 
 # ---------------------------------------------------------------------------
-# AutoCloseBranchNode
+# EmitCloseCaseNode
 # ---------------------------------------------------------------------------
 
 
-class TestAutoCloseBranchNode:
-    def test_always_succeeds(self, populated_bridge):
-        node = AutoCloseBranchNode(case_id=CASE_ID)
+class TestEmitCloseCaseNode:
+    def test_succeeds_when_no_factory(self, populated_bridge):
+        """No trigger_activity_factory → best-effort SUCCESS (receive-side)."""
+        # Seed blackboard with a case_manager_id
+        py_trees.blackboard.Blackboard.storage["/case_manager_id"] = (
+            CASE_MANAGER_ID
+        )
+        node = EmitCloseCaseNode(case_id=CASE_ID)
         result = populated_bridge.execute_with_setup(
             tree=node, actor_id=CASE_MANAGER_ID
         )
         assert result.status == Status.SUCCESS
 
     def test_succeeds_with_none_case_id(self, populated_bridge):
-        node = AutoCloseBranchNode(case_id=None)
+        """None case_id → early SUCCESS (nothing to emit)."""
+        node = EmitCloseCaseNode(case_id=None)
         result = populated_bridge.execute_with_setup(
             tree=node, actor_id=CASE_MANAGER_ID
         )
         assert result.status == Status.SUCCESS
+
+    def test_succeeds_when_case_manager_id_missing(self, populated_bridge):
+        """Missing case_manager_id on blackboard → WARNING + SUCCESS."""
+        node = EmitCloseCaseNode(case_id=CASE_ID)
+        result = populated_bridge.execute_with_setup(
+            tree=node, actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_happy_path_emits_leave_and_records_outbox(self, populated_dl):
+        """With factory + case_manager_id on blackboard → queues Leave, SUCCESS."""
+        activity_id = "https://example.org/activities/leave-01"
+        factory = MagicMock()
+        factory.close_case.return_value = (activity_id, {})
+
+        py_trees.blackboard.Blackboard.storage["/case_manager_id"] = (
+            CASE_MANAGER_ID
+        )
+        bridge = BTBridge(datalayer=populated_dl, trigger_activity=factory)
+        node = EmitCloseCaseNode(case_id=CASE_ID)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        factory.close_case.assert_called_once_with(
+            case_id=CASE_ID,
+            actor=ACTOR_ID,
+            to=[CASE_MANAGER_ID],
+        )

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -17,12 +17,14 @@
 
 Covers all four DEMOMA-07-003 steps (step 3 raw re-broadcast removed
 per DEMOMA-07-005):
-  1. VerifySenderIsParticipantNode — unknown sender is rejected
-  2. AppendParticipantStatusNode  — status appended, RM regression rejected
-  4. PublicDisclosureBranchNode   — always SUCCESS, only triggers teardown on CS.P + CASE_OWNER
-  5. AutoCloseBranchNode          — always SUCCESS, logs when all RM.CLOSED
+  1. VerifySenderIsParticipantNode             — unknown sender is rejected
+  2. AppendParticipantStatusNode               — status appended, RM regression rejected
+  4. PublicDisclosureBranchNode               — always SUCCESS, only triggers teardown on CS.P + CASE_OWNER
+  5. AllParticipantsRMClosedConditionNode     — FAILURE when any participant not RM.CLOSED
+     CloseNotYetEmittedConditionNode          — FAILURE when Leave already in outbox
+     EmitCloseCaseNode                        — queues Leave(VulnerabilityCase)
 
-Per specs/multi-actor-demo.yaml DEMOMA-07-003 and DEMOMA-07-005.
+Per specs/multi-actor-demo.yaml DEMOMA-07-003, DEMOMA-07-005, DEMOMA-07-006.
 """
 
 import py_trees
@@ -38,9 +40,10 @@ from vultron.core.behaviors.status.append_participant_status_tree import (
     append_participant_status_tree,
 )
 from vultron.core.behaviors.status.nodes import (
+    AllParticipantsRMClosedConditionNode,
     AppendStatusAndSaveParticipantNode,
-    AutoCloseBranchNode,
     CheckStatusNotAlreadyAppendedNode,
+    CloseNotYetEmittedConditionNode,
     LoadParticipantNode,
     PublicDisclosureBranchNode,
     ResolveAndPersistStatusObjectNode,
@@ -740,26 +743,25 @@ class TestPublicDisclosureBranchNode:
 
 
 # ---------------------------------------------------------------------------
-# Step 5: AutoCloseBranchNode
+# Step 5: AllParticipantsRMClosedConditionNode (DEMOMA-07-006)
 # ---------------------------------------------------------------------------
 
 
-class TestAutoCloseBranchNode:
-    def test_skips_when_participants_not_closed(self, populated_bridge):
-        node = AutoCloseBranchNode(case_id=CASE_ID)
+class TestAllParticipantsRMClosedConditionNode:
+    def test_fails_when_participants_not_closed(self, populated_bridge):
+        """No closed status on participant → FAILURE (not all closed)."""
+        node = AllParticipantsRMClosedConditionNode(case_id=CASE_ID)
         result = populated_bridge.execute_with_setup(
             tree=node, actor_id=CASE_MANAGER_ID
         )
-        assert result.status == Status.SUCCESS
+        assert result.status == Status.FAILURE
 
-    def test_logs_auto_close_when_all_closed(
+    def test_succeeds_when_all_participants_closed(
         self,
         populated_dl,
-        populated_bridge,
         participant,
-        case_manager_participant,
     ):
-        """When all CVD participants have RM.CLOSED, auto-close branch logs it."""
+        """All CVD participants RM.CLOSED → SUCCESS."""
         closed_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/closed",
             context=CASE_ID,
@@ -769,15 +771,104 @@ class TestAutoCloseBranchNode:
         participant.participant_statuses.append(closed_status)
         populated_dl.save(participant)
 
-        node = AutoCloseBranchNode(case_id=CASE_ID)
+        bridge = BTBridge(datalayer=populated_dl)
+        node = AllParticipantsRMClosedConditionNode(case_id=CASE_ID)
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_skips_case_manager_participant(
+        self,
+        populated_dl,
+        participant,
+        case_manager_participant,
+    ):
+        """CASE_MANAGER participant is excluded from the RM.CLOSED check."""
+        # Only vendor has CLOSED — case_manager_participant has no status
+        closed_status = as_ParticipantStatus(
+            id_=f"{STATUS_ID}/closed",
+            context=CASE_ID,
+            rm_state=RM.CLOSED,
+        )
+        populated_dl.create(closed_status)
+        participant.participant_statuses.append(closed_status)
+        populated_dl.save(participant)
+
+        bridge = BTBridge(datalayer=populated_dl)
+        node = AllParticipantsRMClosedConditionNode(case_id=CASE_ID)
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        # CASE_MANAGER is skipped, so only vendor matters → SUCCESS
+        assert result.status == Status.SUCCESS
+
+    def test_fails_when_no_case_id(self, bridge):
+        """No case_id → FAILURE."""
+        node = AllParticipantsRMClosedConditionNode(case_id=None)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_fails_when_case_not_found(self, bridge):
+        """Case not in DataLayer → FAILURE."""
+        node = AllParticipantsRMClosedConditionNode(
+            case_id="https://example.org/cases/nonexistent"
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# Step 5: CloseNotYetEmittedConditionNode (DEMOMA-07-006 idempotency)
+# ---------------------------------------------------------------------------
+
+
+class TestCloseNotYetEmittedConditionNode:
+    def test_succeeds_when_outbox_empty(self, populated_bridge):
+        """Empty outbox → no prior Leave → SUCCESS."""
+        node = CloseNotYetEmittedConditionNode(case_id=CASE_ID)
         result = populated_bridge.execute_with_setup(
             tree=node, actor_id=CASE_MANAGER_ID
         )
         assert result.status == Status.SUCCESS
 
-    def test_skips_when_no_case_id(self, bridge):
-        node = AutoCloseBranchNode(case_id=None)
+    def test_fails_when_no_case_id(self, bridge):
+        """No case_id → FAILURE."""
+        node = CloseNotYetEmittedConditionNode(case_id=None)
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_fails_when_leave_already_in_outbox(self, populated_dl):
+        """Leave(VulnerabilityCase) already in outbox → FAILURE (idempotency)."""
+        from vultron.core.models.activity import VultronActivity
+
+        leave_activity = VultronActivity(
+            id_=f"{CASE_ID}/activities/leave-01",
+            type_="Leave",
+            actor=CASE_MANAGER_ID,
+            object_=CASE_ID,
+        )
+        populated_dl.create(leave_activity)
+        populated_dl.record_outbox_item(CASE_MANAGER_ID, leave_activity.id_)
+
+        bridge = BTBridge(datalayer=populated_dl)
+        node = CloseNotYetEmittedConditionNode(case_id=CASE_ID)
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.FAILURE
+
+    def test_succeeds_when_leave_for_different_case(self, populated_dl):
+        """Leave in outbox for a different case → SUCCESS (not our case)."""
+        from vultron.core.models.activity import VultronActivity
+
+        other_case_id = "https://example.org/cases/other-case"
+        leave_activity = VultronActivity(
+            id_=f"{other_case_id}/activities/leave-01",
+            type_="Leave",
+            actor=CASE_MANAGER_ID,
+            object_=other_case_id,
+        )
+        populated_dl.create(leave_activity)
+        populated_dl.record_outbox_item(CASE_MANAGER_ID, leave_activity.id_)
+
+        bridge = BTBridge(datalayer=populated_dl)
+        node = CloseNotYetEmittedConditionNode(case_id=CASE_ID)
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
         assert result.status == Status.SUCCESS
 
 

--- a/vultron/core/behaviors/status/add_participant_status_tree.py
+++ b/vultron/core/behaviors/status/add_participant_status_tree.py
@@ -20,21 +20,25 @@ Composes the four-step DEMOMA-07-003 workflow as a Sequence BT
 (step 3 raw peer re-broadcast removed per DEMOMA-07-005):
 
     AddParticipantStatusBT (Sequence)
-    ├─ VerifySenderIsParticipantNode      # Step 1: sender must be known participant
-    ├─ CheckParticipantRMNotClosedNode    # Guard: reject CLOSED→CLOSED rewrites
+    ├─ VerifySenderIsParticipantNode          # Step 1: sender must be known participant
+    ├─ CheckParticipantRMNotClosedNode        # Guard: reject CLOSED→CLOSED rewrites
     ├─ GuardedCommitOrSkip (Selector, only if case_id)  # Record receipt first (CLP-10-006)
     │   ├─ Sequence("SkipIfNotCaseManager")
     │   │   └─ Inverter(CheckIsCaseManagerNode)
     │   └─ CommitCaseLedgerEntryNode
-    ├─ AppendParticipantStatusNode        # Step 2: append status to participant record
-    ├─ PublicDisclosureBranchNode         # Step 4: embargo teardown on CS.P + CASE_OWNER
-    └─ AutoCloseIfCaseManager (Selector)  # Step 5: auto-close only when CASE_MANAGER
+    ├─ AppendParticipantStatusNode            # Step 2: append status to participant record
+    ├─ PublicDisclosureBranchNode             # Step 4: embargo teardown on CS.P + CASE_OWNER
+    └─ AutoCloseIfCaseManager (Selector)      # Step 5: auto-close only when CASE_MANAGER
         ├─ Sequence
         │   ├─ CheckIsCaseManagerNode
-        │   └─ AutoCloseBranchNode
+        │   └─ AutoCloseSequence (Sequence)   # DEMOMA-07-006 decomposed auto-close
+        │       ├─ AllParticipantsRMClosedConditionNode
+        │       ├─ CloseNotYetEmittedConditionNode
+        │       ├─ ResolveCaseManagerNode
+        │       └─ EmitCloseCaseNode
         └─ Success (skip if not CASE_MANAGER)
 
-Per specs/multi-actor-demo.yaml DEMOMA-07-003 and DEMOMA-07-005.
+Per specs/multi-actor-demo.yaml DEMOMA-07-003, DEMOMA-07-005, DEMOMA-07-006.
 """
 
 import logging
@@ -48,12 +52,15 @@ from vultron.core.behaviors.case.nodes.conditions import CheckIsCaseManagerNode
 from vultron.core.behaviors.case.nodes.lifecycle import (
     create_receive_activity_tree,
 )
+from vultron.core.behaviors.sender.nodes.actions import ResolveCaseManagerNode
 from vultron.core.behaviors.status.append_participant_status_tree import (
     append_participant_status_tree,
 )
 from vultron.core.behaviors.status.nodes import (
-    AutoCloseBranchNode,
+    AllParticipantsRMClosedConditionNode,
     CheckParticipantRMNotClosedNode,
+    CloseNotYetEmittedConditionNode,
+    EmitCloseCaseNode,
     PublicDisclosureBranchNode,
     VerifySenderIsParticipantNode,
 )
@@ -112,6 +119,17 @@ def add_participant_status_tree(
         if context_field:
             tree_case_id = str(context_field)
 
+    auto_close_sequence = py_trees.composites.Sequence(
+        name="AutoCloseSequence",
+        memory=False,
+        children=[
+            AllParticipantsRMClosedConditionNode(case_id=tree_case_id),
+            CloseNotYetEmittedConditionNode(case_id=tree_case_id),
+            ResolveCaseManagerNode(case_id=tree_case_id or ""),
+            EmitCloseCaseNode(case_id=tree_case_id),
+        ],
+    )
+
     auto_close_selector = py_trees.composites.Selector(
         name="AutoCloseIfCaseManager",
         memory=False,
@@ -121,7 +139,7 @@ def add_participant_status_tree(
                 memory=False,
                 children=[
                     CheckIsCaseManagerNode(case_id=tree_case_id),
-                    AutoCloseBranchNode(case_id=tree_case_id),
+                    auto_close_sequence,
                 ],
             ),
             py_trees.behaviours.Success(name="AutoCloseSkippedNotCaseManager"),

--- a/vultron/core/behaviors/status/nodes/__init__.py
+++ b/vultron/core/behaviors/status/nodes/__init__.py
@@ -21,16 +21,17 @@ submodules so that existing import paths
 without modification.
 
 Submodules:
-- ``conditions``: Participant verification condition nodes
+- ``conditions``: Participant verification, all-participants-closed precondition,
+  and close-not-yet-emitted idempotency guard nodes
 - ``broadcast``: (removed — case-manager lookup consolidated into
   ``_resolve_case_manager_id`` in ``vultron.core.use_cases._helpers``)
 - ``append``: Load, validate RM transition, and append action nodes
   (SkipIfIdempotentNode, LoadParticipantNode,
   CheckStatusNotAlreadyAppendedNode, ResolveAndPersistStatusObjectNode,
   ValidateRMTransitionNode, AppendStatusAndSaveParticipantNode)
-- ``lifecycle``: Public disclosure and auto-close lifecycle nodes
+- ``lifecycle``: Public disclosure and auto-close emit lifecycle nodes
   (_PublicDisclosureSkipConditionNode, PublicDisclosureBranchNode,
-  AutoCloseBranchNode)
+  EmitCloseCaseNode)
 - ``case_status``: Idempotency guard, EM/PXA transition validation, and
   append nodes for the AddCaseStatusToCase workflow
 """
@@ -42,6 +43,8 @@ from vultron.core.behaviors.status.nodes.case_status import (
     ValidateCaseStatusTransitionNode,
 )
 from vultron.core.behaviors.status.nodes.conditions import (
+    AllParticipantsRMClosedConditionNode,
+    CloseNotYetEmittedConditionNode,
     VerifySenderIsParticipantNode,
 )
 from vultron.core.behaviors.status.nodes.append import (
@@ -54,13 +57,15 @@ from vultron.core.behaviors.status.nodes.append import (
     ValidateRMTransitionNode,
 )
 from vultron.core.behaviors.status.nodes.lifecycle import (
-    AutoCloseBranchNode,
+    EmitCloseCaseNode,
     PublicDisclosureBranchNode,
     _PublicDisclosureSkipConditionNode,
 )
 
 __all__ = [
     # conditions
+    "AllParticipantsRMClosedConditionNode",
+    "CloseNotYetEmittedConditionNode",
     "VerifySenderIsParticipantNode",
     # append
     "LoadParticipantNode",
@@ -73,7 +78,7 @@ __all__ = [
     # lifecycle
     "_PublicDisclosureSkipConditionNode",
     "PublicDisclosureBranchNode",
-    "AutoCloseBranchNode",
+    "EmitCloseCaseNode",
     # case_status
     "CASE_STATUS_ALREADY_PRESENT",
     "CheckCaseStatusIdempotencyNode",

--- a/vultron/core/behaviors/status/nodes/conditions.py
+++ b/vultron/core/behaviors/status/nodes/conditions.py
@@ -16,14 +16,27 @@
 """Participant verification condition nodes for status workflows.
 
 Contains the sender-is-participant guard node used as step 1 of the
-AddParticipantStatusToParticipant workflow (DEMOMA-07-003).
+AddParticipantStatusToParticipant workflow (DEMOMA-07-003), and the
+two precondition nodes extracted from AutoCloseBranchNode per DEMOMA-07-006:
+AllParticipantsRMClosedConditionNode and CloseNotYetEmittedConditionNode.
 """
 
 import logging
+from typing import Any, cast
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import FindParticipantByActorIdNode
+from vultron.core.behaviors.helpers import (
+    DataLayerCondition,
+    FindParticipantByActorIdNode,
+)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models._helpers import _as_id
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.states.rm import RM
+from vultron.enums.roles import CVDRole
 
 logger = logging.getLogger(__name__)
 
@@ -96,5 +109,143 @@ class VerifySenderIsParticipantNode(FindParticipantByActorIdNode):
             " (DEMOMA-07-003 step 1)",
             self.sender_actor_id,
             case_id,
+        )
+        return Status.SUCCESS
+
+
+class AllParticipantsRMClosedConditionNode(DataLayerCondition):
+    """Precondition: all CVD participants in the case have RM.CLOSED.
+
+    Iterates ``case.actor_participant_index``, skips any participant whose
+    ``roles`` include ``CVDRole.CASE_MANAGER`` (the Case Actor), and returns
+    ``FAILURE`` if any remaining participant's latest status ``rm_state`` is
+    not ``RM.CLOSED``.  Returns ``SUCCESS`` when every non-CASE_MANAGER
+    participant is at ``RM.CLOSED``.
+
+    Per DEMOMA-07-006(a)(b)(c).
+    """
+
+    def __init__(
+        self,
+        case_id: str | None,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def _all_participants_closed(self, case: Any) -> bool:
+        assert self.datalayer is not None
+        for p_id in case.actor_participant_index.values():
+            p = self.datalayer.read(p_id)
+            if p is None:
+                return False
+            roles = p.roles if isinstance(p, CaseParticipant) else []
+            if CVDRole.CASE_MANAGER in roles:
+                continue
+            statuses = getattr(p, "participant_statuses", [])
+            if not statuses:
+                return False
+            latest_ref = statuses[-1]
+            if isinstance(latest_ref, str):
+                ref_id = _as_id(latest_ref)
+                if ref_id is None:
+                    return False
+                latest = self.datalayer.read(ref_id)
+            else:
+                latest = latest_ref
+            if not isinstance(latest, ParticipantStatus):
+                return False
+            if latest.rm.state != RM.CLOSED:
+                return False
+        return True
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        if not self.case_id:
+            self.feedback_message = "No case_id — skipping auto-close check"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.feedback_message = (
+                f"Case '{self.case_id}' not found or wrong type"
+            )
+            return Status.FAILURE
+
+        if not self._all_participants_closed(case):
+            self.feedback_message = (
+                "Not all participants are RM.CLOSED — skipping auto-close"
+            )
+            return Status.FAILURE
+
+        self.logger.debug(
+            "AllParticipantsRMClosed: all CVD participants are RM.CLOSED"
+            " for case '%s' (DEMOMA-07-006)",
+            self.case_id,
+        )
+        return Status.SUCCESS
+
+
+class CloseNotYetEmittedConditionNode(DataLayerCondition):
+    """Idempotency guard: no ``Leave(VulnerabilityCase)`` in the outbox yet.
+
+    Queries the actor's outbox for existing activities and checks whether any
+    is a ``Leave`` activity targeting ``self.case_id``.  Returns ``FAILURE``
+    (skip) when a ``Leave(VulnerabilityCase)`` has already been queued, or
+    ``SUCCESS`` when none has been emitted yet.
+
+    Uses the DataLayer outbox — not a process-level in-memory set — so the
+    check survives process restarts and is visible to the BT audit trail.
+
+    Per DEMOMA-07-006 idempotency requirement.
+    """
+
+    def __init__(
+        self,
+        case_id: str | None,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+
+        if not self.case_id:
+            self.feedback_message = "No case_id — cannot check idempotency"
+            return Status.FAILURE
+
+        outbox_port = cast(CaseOutboxPersistence, self.datalayer)
+        activity_ids = outbox_port.outbox_list_for_actor(self.actor_id)
+
+        for activity_id in activity_ids:
+            activity = self.datalayer.read(activity_id)
+            if activity is None:
+                continue
+            activity_type = getattr(activity, "type_", None)
+            if activity_type != "Leave":
+                continue
+            obj = getattr(activity, "object_", None)
+            obj_id = _as_id(obj) if obj is not None else None
+            if obj_id == self.case_id:
+                self.feedback_message = (
+                    f"Leave(VulnerabilityCase) already emitted for case"
+                    f" '{self.case_id}' — skipping duplicate"
+                )
+                self.logger.debug(
+                    "CloseNotYetEmitted: %s", self.feedback_message
+                )
+                return Status.FAILURE
+
+        self.logger.debug(
+            "CloseNotYetEmitted: no prior Leave(VulnerabilityCase) in outbox"
+            " for case '%s' — proceeding",
+            self.case_id,
         )
         return Status.SUCCESS

--- a/vultron/core/behaviors/status/nodes/conditions.py
+++ b/vultron/core/behaviors/status/nodes/conditions.py
@@ -135,6 +135,8 @@ class AllParticipantsRMClosedConditionNode(DataLayerCondition):
 
     def _all_participants_closed(self, case: Any) -> bool:
         assert self.datalayer is not None
+        if not case.actor_participant_index:
+            return False
         for p_id in case.actor_participant_index.values():
             p = self.datalayer.read(p_id)
             if p is None:

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -16,12 +16,13 @@
 """Case lifecycle trigger nodes for DEMOMA-07-003 steps 4–5.
 
 Contains the public-disclosure embargo teardown branch (step 4) and the
-all-participants-closed auto-close branch (step 5).
+auto-close emit node (step 5).  The auto-close precondition and idempotency
+guards are in ``conditions.py``; the routing guard is
+:class:`~vultron.core.behaviors.sender.nodes.actions.ResolveCaseManagerNode`.
 """
 
 import logging
-import threading
-from typing import Any, cast
+from typing import cast
 
 import py_trees
 from py_trees.common import Status
@@ -29,23 +30,13 @@ from py_trees.common import Status
 from vultron.core.behaviors.embargo.trigger_tree import terminate_embargo_bt
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.use_cases._helpers import _resolve_case_manager_id
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.protocols import PersistableModel
-from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.core.models._helpers import _as_id
 
 logger = logging.getLogger(__name__)
-
-# Guard against AutoCloseBranchNode firing more than once per case.
-# Keyed by case_id — the first BT execution to observe all-participants-CLOSED
-# for a given case wins; subsequent ones are no-ops for that case.
-# Protected by a threading.Lock because FastAPI BackgroundTasks run on a
-# thread pool (see AGENTS.md: "BTBridge Thread-Safety (RLock)").
-_auto_close_lock: threading.Lock = threading.Lock()
-_auto_close_triggered: set[str] = set()  # case_ids that have fired AutoClose
 
 
 class _PublicDisclosureSkipConditionNode(DataLayerCondition):
@@ -99,7 +90,7 @@ class _PublicDisclosureSkipConditionNode(DataLayerCondition):
         except Exception:
             return False
 
-    def _sender_is_case_owner(self, case: Any) -> bool:
+    def _sender_is_case_owner(self, case: VulnerabilityCase) -> bool:
         """Return True iff sender is a known CASE_OWNER participant."""
         assert self.datalayer is not None
         sender_participant_id = case.actor_participant_index.get(
@@ -191,19 +182,20 @@ class PublicDisclosureBranchNode(py_trees.composites.Selector):
         )
 
 
-class AutoCloseBranchNode(DataLayerAction):
-    """Step 5: Log case auto-close when all participants are RM.CLOSED.
+class EmitCloseCaseNode(DataLayerAction):
+    """Step 5 emit: Queue a ``Leave(VulnerabilityCase)`` to the Case Manager.
 
-    Checks whether every CVD participant in the case has ``RM.CLOSED``
-    as their most recent status.  The CASE_MANAGER (Case Actor) is a
-    coordinator role and is excluded from this check.
+    Reads ``case_manager_id`` from the blackboard (written by the preceding
+    :class:`~vultron.core.behaviors.sender.nodes.actions.ResolveCaseManagerNode`)
+    and calls ``trigger_activity_factory.close_case(...)`` to create and queue
+    the activity.
 
-    Actual case closure is **not** persisted here — this is log-only
-    behaviour for the prototype demo.
+    Returns SUCCESS when the activity is queued successfully or when
+    ``trigger_activity_factory`` is absent (best-effort: receive-side paths
+    intentionally omit the factory).
+    Returns FAILURE only on an unexpected exception during activity creation.
 
-    Always returns SUCCESS.
-
-    Per DEMOMA-07-003 step 5.
+    Per DEMOMA-07-003 step 5, DEMOMA-07-006.
     """
 
     def __init__(
@@ -214,50 +206,42 @@ class AutoCloseBranchNode(DataLayerAction):
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
 
-    def _all_participants_closed(self, case: Any) -> bool:
-        """Return True iff every CVD participant has RM.CLOSED."""
-        if self.datalayer is None:
-            return False
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_manager_id",
+            access=py_trees.common.Access.READ,
+        )
 
-        for p_id in case.actor_participant_index.values():
-            p = self.datalayer.read(p_id)
-            if p is None:
-                return False
-            roles = p.roles if isinstance(p, CaseParticipant) else []
-            if CVDRole.CASE_MANAGER in roles:
-                continue
-            statuses = getattr(p, "participant_statuses", [])
-            if not statuses:
-                return False
-            latest_ref = statuses[-1]
-            if isinstance(latest_ref, str):
-                ref_id = _as_id(latest_ref)
-                if ref_id is None:
-                    return False
-                latest = self.datalayer.read(ref_id)
-            else:
-                latest = latest_ref
-            if latest is None:
-                return False
-            rm_state = (
-                getattr(latest, "rm").state if hasattr(latest, "rm") else None
-            )
-            if rm_state is None or rm_state != RM.CLOSED:
-                return False
-        return True
+    def update(self) -> Status:
+        if self.datalayer is None or not self.case_id:
+            return Status.SUCCESS
 
-    def _emit_close_case(self, case_manager_id: str) -> None:
-        """Emit close_case activity to the Case Manager's outbox."""
         if self.trigger_activity_factory is None:
             self.logger.warning(
-                "AutoCloseBranch: no TriggerActivityPort — cannot emit"
-                " close_case activity for case '%s'",
+                "EmitCloseCase: no TriggerActivityPort — cannot emit"
+                " Leave(VulnerabilityCase) for case '%s'",
                 self.case_id,
             )
-            return
+            return Status.SUCCESS
+
+        try:
+            case_manager_id: str | None = self.blackboard.get(
+                "case_manager_id"
+            )
+        except KeyError:
+            case_manager_id = None
+        if not case_manager_id:
+            self.feedback_message = (
+                f"EmitCloseCase: case_manager_id not set on blackboard"
+                f" for case '{self.case_id}' — cannot emit"
+            )
+            self.logger.warning(self.feedback_message)
+            return Status.SUCCESS
+
         try:
             activity_id, _ = self.trigger_activity_factory.close_case(
-                case_id=self.case_id,  # type: ignore[arg-type]
+                case_id=self.case_id,
                 actor=self.actor_id or "",
                 to=[case_manager_id],
             )
@@ -265,53 +249,16 @@ class AutoCloseBranchNode(DataLayerAction):
                 self.actor_id or "", activity_id
             )
             self.logger.info(
-                "AutoCloseBranch: emitted close_case activity '%s'"
-                " to CaseActor '%s'",
+                "EmitCloseCase: queued Leave(VulnerabilityCase) '%s'"
+                " to CaseActor '%s' (DEMOMA-07-003 step 5)",
                 activity_id,
                 case_manager_id,
             )
         except Exception as e:
-            self.logger.error(
-                "AutoCloseBranch: failed to emit close_case: %s", e
+            self.feedback_message = (
+                f"EmitCloseCase: failed to emit close_case: {e}"
             )
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
 
-    def _claim_close(self) -> bool:
-        """Thread-safe check-and-set; return True iff this call should fire."""
-        with _auto_close_lock:
-            if self.case_id in _auto_close_triggered:
-                self.logger.debug(
-                    "AutoCloseBranch: close_case already triggered for"
-                    " case '%s' — skipping duplicate fire",
-                    self.case_id,
-                )
-                return False
-            _auto_close_triggered.add(self.case_id)  # type: ignore[arg-type]
-            return True
-
-    def update(self) -> Status:
-        if self.datalayer is None or not self.case_id:
-            return Status.SUCCESS
-        case = self.datalayer.read(self.case_id)
-        if not isinstance(
-            case, VulnerabilityCase
-        ) or not self._all_participants_closed(case):
-            return Status.SUCCESS
-        if not self._claim_close():
-            return Status.SUCCESS
-        case_manager_id = _resolve_case_manager_id(case, self.datalayer)
-        if case_manager_id is None:
-            self.logger.warning(
-                "AutoCloseBranch: no Case Manager found"
-                " — cannot auto-close case '%s'",
-                self.case_id,
-            )
-            return Status.SUCCESS
-        self.logger.info(
-            "AutoCloseBranch: all participants CLOSED for case '%s'"
-            " — emitting Leave(VulnerabilityCase) to CaseActor '%s'"
-            " (DEMOMA-07-003 step 5)",
-            self.case_id,
-            case_manager_id,
-        )
-        self._emit_close_case(case_manager_id)
         return Status.SUCCESS


### PR DESCRIPTION
## Issue

Closes #1716

## Summary

Replaces `AutoCloseBranchNode` (BT-IDM-03 god node — 4 responsibilities in one `update()`) with a properly decomposed `py_trees.Sequence` of DataLayer-backed leaf nodes per DEMOMA-07-006.

**Before:**
```
AutoCloseIfCaseManager (Selector)
├─ Sequence
│   ├─ CheckIsCaseManagerNode
│   └─ AutoCloseBranchNode   ← god node: checks all-closed, idempotency,
│                                resolves CM, emits Leave — all in update()
└─ Success
```

**After:**
```
AutoCloseIfCaseManager (Selector)
├─ CaseManagerAutoClose (Sequence)
│   ├─ CheckIsCaseManagerNode
│   └─ AutoCloseSequence (Sequence)
│       ├─ AllParticipantsRMClosedConditionNode   ← precondition (DEMOMA-07-006a–c)
│       ├─ CloseNotYetEmittedConditionNode        ← idempotency guard (outbox query)
│       ├─ ResolveCaseManagerNode                 ← existing routing guard (reused)
│       └─ EmitCloseCaseNode                      ← action: queue Leave(VulnerabilityCase)
└─ AutoCloseSkippedNotCaseManager (Success)
```

## Changes

- **`conditions.py`** — two new `DataLayerCondition` subclasses:
  - `AllParticipantsRMClosedConditionNode`: iterates `actor_participant_index`, skips `CVDRole.CASE_MANAGER`, returns FAILURE if any non-CM participant's latest `rm.state != RM.CLOSED` (DEMOMA-07-006a–c)
  - `CloseNotYetEmittedConditionNode`: queries `outbox_list_for_actor`, returns FAILURE if `Leave` activity with matching `object_==case_id` already present — replaces process-level `_auto_close_triggered` set
- **`lifecycle.py`** — removes `AutoCloseBranchNode`, `_auto_close_triggered`, `_auto_close_lock`; adds `EmitCloseCaseNode(DataLayerAction)` that reads `case_manager_id` from blackboard and calls `trigger_activity_factory.close_case()`; removes `_resolve_case_manager_id` import from `use_cases` (resolves BTND-04-003 violation)
- **`__init__.py`** — re-exports updated: `AutoCloseBranchNode` removed, three new nodes added
- **`add_participant_status_tree.py`** — wires the new `AutoCloseSequence`; imports `ResolveCaseManagerNode` from `behaviors/sender/`
- **Tests** — `TestEmitCloseCaseNode` replaces `TestAutoCloseBranchNode`; three new test classes for the two condition nodes; happy-path test for `EmitCloseCaseNode` with mock factory + outbox assertion
- **Architecture ratchet** — `lifecycle.py` removed from `KNOWN_VIOLATIONS` (BTND-04-003 violation fixed)

## Code-review findings addressed

- FAIL: `blackboard.get()` wrapped in `try/except KeyError` (py_trees raises on unset key, does not return None)
- FAIL: `from typing import cast` moved to module level (was inline in `update()`)
- FAIL: happy-path `EmitCloseCaseNode` test added with mock factory + `close_case` call assertion
- IMPROVE: `hasattr`/`getattr` TOCTOU replaced with `isinstance(latest, ParticipantStatus)` for type-safe `rm.state` access
- IMPROVE: `ParticipantStatus` import added to `conditions.py`

## Verification

```
5471 passed, 224 skipped, 932 deselected, 2 xfailed in 118s
black: clean, flake8: clean, mypy: 0 issues, pyright: 0 errors
```