### PR TITLE
Fix demo VFD timing race: add receiver-container waits and fix fccv/fcv wrong-actor bugs

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1717.md
+++ b/plan/history/2607/implementation/ISSUE-1717.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-1717
+timestamp: '2026-07-27T18:56:03.254384+00:00'
+title: 'Fix demo VFD timing race: receiver-container waits and wrong-actor bug fixes'
+type: implementation
+---
+
+## Issue #1717 — Fix: demo VFD broadcast timing race
+
+Fixed the intermittent CI failures across all 6 demo scenarios caused by a timing race where single-shot VFD assertions fired before the receiver container had received the VFD broadcast.
+
+**Changes:**
+
+- Added `wait_for_participant_vfd_state` on receiver container before every `verify_fix_ready`, `verify_fix_deployed`, and `verify_publicly_disclosed` call in all 6 demo scripts
+- Fixed wrong-actor bug in `fccv_handoff_demo.py` (AC-2): `receiver_actor_id=c1.id_` → `receiver_actor_id=vendor.id_`
+- Fixed same wrong-actor bug in `fcv_demo.py`: `receiver_actor_id=coordinator.id_` → `receiver_actor_id=vendor_in_vendor.id_`
+- Patched `wait_for_participant_vfd_state` in `TestPhasePublicationEmWaitOrdering` to prevent ValidationError
+
+PR: <https://github.com/CERTCC/Vultron/pull/1725>

--- a/test/demo/test_fvcv_extension_demo.py
+++ b/test/demo/test_fvcv_extension_demo.py
@@ -326,6 +326,7 @@ class TestPhasePublicationEmWaitOrdering:
                 side_effect=track_notify_published,
             ),
             patch.object(demo, "verify_publicly_disclosed"),
+            patch.object(demo, "wait_for_participant_vfd_state"),
             patch.object(demo, "demo_check"),
         ):
             demo._phase_publication(

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -720,6 +720,12 @@ def _phase_fix_lifecycle(
 
     with demo_check("Finder replica shows Vendor CS includes F (fix ready)"):
         wait_for_participant_vfd_state(
+            client=c1_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
@@ -741,6 +747,12 @@ def _phase_fix_lifecycle(
     with demo_check(
         "Finder replica shows Vendor CS includes D (fix deployed)"
     ):
+        wait_for_participant_vfd_state(
+            client=c1_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
@@ -814,11 +826,23 @@ def _phase_publication(
             client=finder_client,
             case_id=case.id_,
         )
+        wait_for_participant_vfd_state(
+            client=c1_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
+            client=finder_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
         verify_publicly_disclosed(
             receiver_client=c1_client,
             reporter_client=finder_client,
             case_id=case.id_,
-            receiver_actor_id=c1.id_,
+            receiver_actor_id=vendor.id_,
         )
 
 

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -565,11 +565,23 @@ def _phase_publication(
             client=vendor_client,
             case_id=case.id_,
         )
+        wait_for_participant_vfd_state(
+            client=coordinator_client,
+            case_id=case.id_,
+            actor_id=vendor_in_vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
+            client=finder_client,
+            case_id=case.id_,
+            actor_id=vendor_in_vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
         verify_publicly_disclosed(
             receiver_client=coordinator_client,
             reporter_client=finder_client,
             case_id=case.id_,
-            receiver_actor_id=coordinator.id_,
+            receiver_actor_id=vendor_in_vendor.id_,
         )
 
 

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -629,6 +629,12 @@ def _phase_fix_lifecycle(
 
     with demo_check("M4: both replicas show CS includes F (fix ready)"):
         wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
@@ -648,6 +654,12 @@ def _phase_fix_lifecycle(
     )
 
     with demo_check("M5: both replicas show CS includes D (fix deployed)"):
+        wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
@@ -705,6 +717,18 @@ def _phase_publication(
         wait_for_case_em_terminated(
             client=finder_client,
             case_id=case.id_,
+        )
+        wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
+            client=finder_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
         )
         verify_publicly_disclosed(
             receiver_client=vendor_client,

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -691,6 +691,12 @@ def _phase_fix_lifecycle(
         "M5: Finder replica shows both vendors CS include F (fix ready)"
     ):
         wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
@@ -717,6 +723,12 @@ def _phase_fix_lifecycle(
     with demo_check(
         "M6: Finder replica shows both vendors CS include D (fix deployed)"
     ):
+        wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
@@ -798,6 +810,18 @@ def _phase_publication(
         wait_for_case_em_terminated(
             client=finder_client,
             case_id=case.id_,
+        )
+        wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
+            client=finder_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
         )
         verify_publicly_disclosed(
             receiver_client=vendor_client,

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -756,6 +756,12 @@ def _phase_fix_lifecycle(
         "Finder replica shows both vendors CS include F (fix ready)"
     ):
         wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
@@ -782,6 +788,12 @@ def _phase_fix_lifecycle(
     with demo_check(
         "Finder replica shows both vendors CS include D (fix deployed)"
     ):
+        wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
@@ -863,6 +875,18 @@ def _phase_publication(
                 client=client,
                 case_id=case.id_,
             )
+        wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
+            client=finder_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
         verify_publicly_disclosed(
             receiver_client=vendor_client,
             reporter_client=finder_client,

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -467,6 +467,12 @@ def _phase_fix_lifecycle(
         "M4: Finder replica shows both vendors CS include F (fix ready)"
     ):
         wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
@@ -493,6 +499,12 @@ def _phase_fix_lifecycle(
     with demo_check(
         "M5: Finder replica shows both vendors CS include D (fix deployed)"
     ):
+        wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
@@ -558,6 +570,18 @@ def _phase_publication(
         wait_for_case_em_terminated(
             client=finder_client,
             case_id=case.id_,
+        )
+        wait_for_participant_vfd_state(
+            client=vendor_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
+            client=finder_client,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            expected_states={CS_vfd.VFD},
         )
         verify_publicly_disclosed(
             receiver_client=vendor_client,


### PR DESCRIPTION
Closes #1717

## Summary

- **AC-1**: Added `wait_for_participant_vfd_state` on the **receiver** container inside every `demo_check` block that calls `verify_fix_ready`, `verify_fix_deployed`, or `verify_publicly_disclosed`, across all 6 demo scripts (`fv_demo.py`, `fvv_demo.py`, `fcv_demo.py`, `fvcv_extension_demo.py`, `fvcv_handoff_demo.py`, `fccv_handoff_demo.py`). Each verify call now polls every target container (receiver and reporter) for the expected VFD state before the single-shot assertion fires.
- **AC-2**: Fixed `fccv_handoff_demo.py`: `receiver_actor_id=c1.id_` (a Coordinator whose VFD never reaches VFD) corrected to `receiver_actor_id=vendor.id_` per DEMOMA-15-001.
- **Same wrong-actor bug fixed in `fcv_demo.py`**: `verify_publicly_disclosed` was also using `receiver_actor_id=coordinator.id_`; corrected to `receiver_actor_id=vendor_in_vendor.id_` per DEMOMA-15-001.
- Updated `test/demo/test_fvcv_extension_demo.py::TestPhasePublicationEmWaitOrdering` to also patch `wait_for_participant_vfd_state` (previously unpatched; calling the real function against MagicMock clients now raises a ValidationError).

## Changes

| File | What changed |
|------|-------------|
| `vultron/demo/scenario/fv_demo.py` | Added receiver `wait_for_participant_vfd_state` before M4, M5, M6 verify calls |
| `vultron/demo/scenario/fvv_demo.py` | Same pattern |
| `vultron/demo/scenario/fcv_demo.py` | Same pattern; fixed wrong-actor in `verify_publicly_disclosed` |
| `vultron/demo/scenario/fvcv_extension_demo.py` | Same pattern |
| `vultron/demo/scenario/fvcv_handoff_demo.py` | Same pattern |
| `vultron/demo/scenario/fccv_handoff_demo.py` | Same pattern; fixed wrong-actor (AC-2) |
| `test/demo/test_fvcv_extension_demo.py` | Patched `wait_for_participant_vfd_state` in ordering regression test |

## Verification

- [x] All 926 demo tests pass (`uv run pytest test/demo/ -m ""`)
- [x] Full suite: 5463 passed, 224 skipped, 2 xfailed
- [x] Black, flake8, mypy, pyright: all clean
- [x] DEMOMA-06-006 spec entry verified present in `specs/multi-actor-demo.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)