### PR TITLE
docs: plan concern #1674 — wire ambiguity between OFFER_CASE_MANAGER_ROLE and OFFER_CASE_OWNERSHIP_TRANSFER

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,6 +400,15 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   see [notes/bt-pitfalls.md](notes/bt-pitfalls.md).
 - **Semantic Registry Pattern Must Match Inbound Wire Format** —
   see [notes/activitystreams-state-update.md](notes/activitystreams-state-update.md).
+- **`OFFER_CASE_MANAGER_ROLE` and `OFFER_CASE_OWNERSHIP_TRANSFER` Share
+  `Offer(VulnerabilityCase)` — Registry Order and Required `target` Field Are
+  the Current Guards** — `OFFER_CASE_MANAGER_ROLE` MUST appear before
+  `OFFER_CASE_OWNERSHIP_TRANSFER` in `SEMANTIC_REGISTRY` (enforced by
+  `_validate_registry_order()`). `_OfferCaseManagerRoleActivity.target` MUST
+  remain required. Do NOT add a third `Offer(VulnerabilityCase)` pattern without
+  a distinct object type. See SE-07-001, SE-07-002, ADR-0039,
+  [notes/activitystreams-state-update.md](notes/activitystreams-state-update.md)
+  § "Target-Field Discriminators".
 - **`offer_case_participant_activity`: `event.object_id` Has `#participant` Suffix**
   — extract `actor_id` from `event.attributed_to`.
   See [notes/activitystreams-state-update.md](notes/activitystreams-state-update.md).

--- a/docs/adr/0039-offer-case-participant-role-wire-type.md
+++ b/docs/adr/0039-offer-case-participant-role-wire-type.md
@@ -1,0 +1,88 @@
+---
+status: accepted
+date: 2026-07-27
+---
+
+# Resolve Wire Ambiguity Between OFFER\_CASE\_MANAGER\_ROLE and OFFER\_CASE\_OWNERSHIP\_TRANSFER via Dedicated Object Type
+
+## Context and Problem Statement
+
+`OFFER_CASE_MANAGER_ROLE` and `OFFER_CASE_OWNERSHIP_TRANSFER` both serialize as
+`Offer(VulnerabilityCase)` on the wire. They are currently disambiguated only by
+the presence of `target=CaseParticipant` in the case-manager-role offer and its
+absence in the ownership-transfer offer.
+
+A minimally-conformant or buggy sender that omits the `target` field would have
+its case-manager-role offer silently dispatched as an ownership-transfer offer
+(or vice versa) with no error surfaced. The `SEMANTIC_REGISTRY` ordering guard
+(`_validate_registry_order()`) prevents misrouting within a single implementation
+but does not protect against malformed inbound activities from remote peers.
+
+Issue: CONCERN-1674.
+
+## Decision Drivers
+
+- Wire shapes should be self-describing; disambiguation must not depend on
+  registry ordering alone.
+- The `target` field as a discriminator is semantically odd: the conceptual
+  target of a role offer is the Actor receiving the role, not the CaseParticipant
+  wrapper record.
+- A general-purpose role-offer mechanism (offering any `CVDRole` to any Actor
+  in a Case context) is more expressive than a CASE_MANAGER-specific flow.
+- Backward compatibility: the existing `OFFER_CASE_MANAGER_ROLE` wire format
+  must be deprecated in a traceable way.
+
+## Considered Options
+
+1. **New `as_CaseParticipantRole` object type** — introduce a dedicated wire
+   object carrying a `CVDRole` value; wire shape becomes
+   `Offer(CaseParticipantRole, target=Actor, context=VulnerabilityCase)`.
+2. **Keep `Offer(VulnerabilityCase)`; add `strict=True` to the pattern** —
+   enforce the target discriminator at the pattern layer without a type change.
+3. **Spec-and-notes documentation only** — record the ordering requirement and
+   the target-as-discriminator rationale; no wire format change.
+
+## Decision Outcome
+
+Chosen option: **Option 1 — new `as_CaseParticipantRole` object type**, because:
+
+- It eliminates the structural ambiguity; the wire shape is self-describing
+  regardless of registry ordering or sender compliance.
+- A general `Offer(CaseParticipantRole, target=Actor, context=VulnerabilityCase)`
+  is more semantically correct than targeting a CaseParticipant wrapper, and
+  generalises naturally to offering any `CVDRole` (VENDOR, COORDINATOR, etc.)
+  rather than only CASE_MANAGER.
+- Options 2 and 3 leave the latent misrouting risk in place for external senders.
+
+### Consequences
+
+- Good, because wire shapes for role delegation and ownership transfer are
+  structurally distinct and self-describing.
+- Good, because the general role-offer mechanism supports future role delegation
+  flows beyond CASE_MANAGER.
+- Good, because `target=Actor` is semantically correct; the target of a role
+  offer is the Actor receiving the role, not the CaseParticipant wrapper.
+- Bad, because this is a breaking wire format change for `OFFER_CASE_MANAGER_ROLE`;
+  existing devlogs and interop partners must be migrated.
+- Bad, because it requires a new `VultronObjectType` enum value, new vocab class,
+  updated factory, updated pattern, and new use case + BT handler.
+
+## Validation
+
+- Import-time `_validate_registry_order()` guard confirms no less-specific
+  `Offer(VulnerabilityCase)` pattern precedes the new `Offer(CaseParticipantRole)`
+  pattern in `SEMANTIC_REGISTRY`.
+- Unit tests in `test/test_semantic_activity_patterns.py` assert correct dispatch.
+- Demo scenario emits the new wire format and the invariant harness validates it.
+
+## More Information
+
+- Interim protection while the migration is in flight: `SE-07-001` through
+  `SE-07-002` mandate registry ordering and required target field until the
+  wire type migration is complete.
+- `SE-07-003` records the SHOULD preference for dedicated object types over
+  target-field discrimination.
+- Implementation issue: tracked as a GitHub Task issue blocked by CONCERN-1674.
+
+Generated spec requirements: `specs/semantic-extraction.yaml` SE-07-001,
+SE-07-002, SE-07-003.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -105,6 +105,8 @@ General information about architectural decision records is available at <https:
   suggest-actor-to-case Protocol](0029-notification-loop-suggest-actor.md)
 - [ADR-0030 Publish Leaf Expansion: Single Actuator →
   Draft-Review-Submit Pipeline](0030-publish-leaf-draft-review-submit-pipeline.md)
+- [ADR-0039 Resolve Wire Ambiguity Between OFFER\_CASE\_MANAGER\_ROLE and
+  OFFER\_CASE\_OWNERSHIP\_TRANSFER via Dedicated Object Type](0039-offer-case-participant-role-wire-type.md)
 
 ## Proposed ADRs
 

--- a/notes/activitystreams-state-update.md
+++ b/notes/activitystreams-state-update.md
@@ -4,8 +4,10 @@ status: active
 description: >
   Case state update path, CaseActor authoritativeness, DR-series named bugs,
   transitive activity patterns, base-typed serialization, invite response parsing,
-  bootstrap embedded-object contract, semantic registry patterns, and
-  offer_case_participant_activity object-id semantics.
+  bootstrap embedded-object contract, semantic registry patterns,
+  offer_case_participant_activity object-id semantics, and target-field
+  discriminator wire ambiguity between OFFER_CASE_MANAGER_ROLE and
+  OFFER_CASE_OWNERSHIP_TRANSFER.
 related_specs:
   - specs/semantic-extraction.yaml
   - specs/response-format.yaml
@@ -360,3 +362,42 @@ actor_id = getattr(raw_actor, "id_", None) or request.object_id
 
 The fallback `request.object_id` retains the `#participant` suffix and should
 only be used as a last resort — log a warning if it is reached.
+
+---
+
+## Target-Field Discriminators: Wire Ambiguity Between Offer Semantics
+
+(CONCERN-1674, 2026-07-27)
+
+`OFFER_CASE_MANAGER_ROLE` and `OFFER_CASE_OWNERSHIP_TRANSFER` both serialize as
+`Offer(VulnerabilityCase)` on the wire. They are disambiguated solely by the
+presence or absence of `target=CaseParticipant`:
+
+| Semantic | Pattern |
+|---|---|
+| `OFFER_CASE_MANAGER_ROLE` | `Offer(VulnerabilityCase, target=CaseParticipant)` |
+| `OFFER_CASE_OWNERSHIP_TRANSFER` | `Offer(VulnerabilityCase)` (no target) |
+
+**Current protections** (both required while the wire format migration is pending):
+
+1. **Registry ordering** — `OFFER_CASE_MANAGER_ROLE` appears before
+   `OFFER_CASE_OWNERSHIP_TRANSFER` in `SEMANTIC_REGISTRY` (enforced by
+   `_validate_registry_order()` at import time; raises `RegistryOrderError` on
+   violation). See SE-07-001.
+2. **Required target field** — `_OfferCaseManagerRoleActivity.target` is
+   `as_CaseParticipant` (required, not optional). A sender omitting it gets a
+   `ValidationError` at construction time. See SE-07-002.
+
+**Root cause and planned fix** — target-field discrimination is semantically
+odd (the conceptual target is the Actor, not the CaseParticipant wrapper) and
+leaves a latent misrouting risk for buggy or minimally-conformant external
+senders. ADR-0039 records the decision to introduce a dedicated
+`as_CaseParticipantRole` wire object type with
+`Offer(CaseParticipantRole, target=Actor, context=VulnerabilityCase)` as the
+general-purpose role-delegation wire format. The implementation is tracked as
+a GitHub Task issue (blocked by CONCERN-1674). See SE-07-003.
+
+**Rule for new patterns sharing `Offer(VulnerabilityCase)`** — if a new
+semantic requires `Offer(VulnerabilityCase)`, it MUST either (a) use a distinct
+object type, or (b) add a more-specific discriminator field AND be placed before
+the existing less-specific entries in `SEMANTIC_REGISTRY`.

--- a/plan/history/2607/learning/CONCERN-1674.md
+++ b/plan/history/2607/learning/CONCERN-1674.md
@@ -1,0 +1,55 @@
+---
+source: CONCERN-1674
+timestamp: '2026-07-27T19:06:07.129461+00:00'
+title: Wire ambiguity between OFFER_CASE_OWNERSHIP_TRANSFER and OFFER_CASE_MANAGER_ROLE
+type: learning
+---
+
+## Summary
+
+Both `OFFER_CASE_OWNERSHIP_TRANSFER` and `OFFER_CASE_MANAGER_ROLE` serialize as
+`Offer(VulnerabilityCase)` on the wire. They are disambiguated only by the presence
+or absence of `target=CaseParticipant`, plus `SEMANTIC_REGISTRY` dispatch ordering.
+A sender that omits the target field by mistake would cause the wrong handler to fire
+silently.
+
+## Category
+
+Protocol correctness / wire encoding
+
+## Severity
+
+Medium — latent correctness risk currently papered over by registry ordering.
+
+## Evidence
+
+`vultron/wire/as2/extractor/_instances.py` — `OfferCaseOwnershipTransferActivityPattern`
+(`activity_=OFFER, object_=VULNERABILITY_CASE`, no target) vs
+`OfferCaseManagerRolePattern` (`activity_=OFFER, object_=VULNERABILITY_CASE,
+target_=CASE_PARTICIPANT`). `vultron/semantic_registry/actor.py` — ordering dependency
+between the two entries.
+
+## Impact if Ignored
+
+A minimally-conformant or buggy sender omitting the target field would have its
+case-manager-role offer silently dispatched as an ownership-transfer offer (or vice
+versa) with no error surfaced.
+
+## Resolution (2026-07-27)
+
+Two interim protections documented and spec-encoded:
+
+1. Registry ordering guard (`_validate_registry_order()`) — SE-07-001
+2. Required `target` field on `_OfferCaseManagerRoleActivity` — SE-07-002
+
+Structural fix tracked in #1726: introduce `as_CaseParticipantRole` wire object type
+and `OFFER_CASE_PARTICIPANT_ROLE` semantic with
+`Offer(CaseParticipantRole, target=Actor, context=VulnerabilityCase)` wire shape,
+replacing the current `Offer(VulnerabilityCase, target=CaseParticipant)` format.
+
+ADR-0039 records the evaluated alternatives and decision rationale.
+SE-07-003 records the SHOULD preference for dedicated object types.
+
+**Docs PR**: <https://github.com/CERTCC/Vultron/pull/1727>
+**Spec**: `specs/semantic-extraction.yaml` SE-07-001, SE-07-002, SE-07-003.
+**Notes**: `notes/activitystreams-state-update.md` § "Target-Field Discriminators".

--- a/specs/semantic-extraction.yaml
+++ b/specs/semantic-extraction.yaml
@@ -4,7 +4,7 @@ description: >-
   The inbox handler extracts semantic meaning from ActivityStreams activities by matching
   activity type and object type patterns. This semantic type determines which handler function
   processes the activity.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -181,3 +181,54 @@ groups:
     relationships:
     - rel_type: implements
       spec_id: SE-06-001
+- id: SE-07
+  title: Target-Field Discriminators
+  specs:
+  - id: SE-07-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When two or more `ActivityPattern` entries share the same `activity_` type AND
+      `object_` type, the more-specific pattern MUST include an additional discriminator
+      field (e.g. `target_`, `context_`) that unambiguously distinguishes it from the
+      less-specific pattern. The more-specific pattern MUST appear before the less-specific
+      one in `SEMANTIC_REGISTRY`.
+    rationale: >-
+      `OFFER_CASE_MANAGER_ROLE` and `OFFER_CASE_OWNERSHIP_TRANSFER` both match
+      `Offer(VulnerabilityCase)`. `OFFER_CASE_MANAGER_ROLE` is disambiguated by the
+      presence of `target=CaseParticipant`. If the more-specific entry appeared after the
+      less-specific one, every case-manager delegation offer would be silently misrouted
+      as an ownership transfer. `_validate_registry_order()` enforces this at import time.
+    relationships:
+    - rel_type: refines
+      spec_id: SE-03-002
+  - id: SE-07-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      A wire activity class whose semantic identity depends on a target-field discriminator
+      MUST declare that target field as required (not optional) so that a sender omitting it
+      produces a validation error rather than a silently misrouted activity.
+    rationale: >-
+      `_OfferCaseManagerRoleActivity.target` is `as_CaseParticipant` (required). This ensures
+      that any attempt to construct the activity without the discriminator field fails fast at
+      the sending side rather than reaching the receiver's registry as an ambiguous shape.
+    relationships:
+    - rel_type: refines
+      spec_id: SE-07-001
+  - id: SE-07-003
+    priority: SHOULD
+    kind: protocol
+    statement: >-
+      When two semantics share `Offer(VulnerabilityCase)` and are discriminated only by a
+      target-field value, a dedicated wire object type (e.g. `as_CaseParticipantRole`)
+      SHOULD be preferred over target-field discrimination so that the wire shape is
+      unambiguously self-describing without depending on registry ordering.
+    rationale: >-
+      Target-field discrimination is a latent correctness risk: a minimally-conformant or
+      buggy sender omitting the target will be silently misrouted. A distinct object type
+      eliminates this risk structurally and makes the wire format self-describing.
+      See also `notes/activitystreams-state-update.md` § "Target-Field Discriminators".
+    relationships:
+    - rel_type: refines
+      spec_id: SE-07-001


### PR DESCRIPTION
- Closes #1674

## Summary

Documents the wire ambiguity between `OFFER_CASE_MANAGER_ROLE` and
`OFFER_CASE_OWNERSHIP_TRANSFER` (both serialize as `Offer(VulnerabilityCase)`)
and records the decision to resolve it with a dedicated `as_CaseParticipantRole`
object type.

## Changes

- **`specs/semantic-extraction.yaml`** — New SE-07 group (3 requirements):
  SE-07-001 mandates a discriminator field when patterns share activity+object
  types; SE-07-002 requires that discriminator field to be required (not
  optional) in the wire class; SE-07-003 records the SHOULD preference for
  dedicated object types over target-field discrimination.
- **`docs/adr/0039-offer-case-participant-role-wire-type.md`** — ADR recording
  the decision to introduce `as_CaseParticipantRole` and
  `OFFER_CASE_PARTICIPANT_ROLE`, with evaluated alternatives and consequences.
- **`docs/adr/index.md`** — ADR-0039 added to the Accepted ADRs list.
- **`notes/activitystreams-state-update.md`** — New "Target-Field Discriminators"
  section explaining current protections (registry ordering guard +
  required `target` field), the planned structural fix, and the rule for any
  future `Offer(VulnerabilityCase)` patterns.
- **`AGENTS.md`** — New pitfall entry warning agents never to insert a
  less-specific `Offer(VulnerabilityCase)` pattern above the more-specific one.

## Implementation tracked in

- #1726 — `as_CaseParticipantRole` wire type + `OFFER_CASE_PARTICIPANT_ROLE`
  semantic (blocked by #1674; child of epic #1676)