### PR TITLE
docs: plan issue #1679 — add SemanticEntry phrase field

### DIFF
--- a/plan/history/2607/idea/IDEA-1679.md
+++ b/plan/history/2607/idea/IDEA-1679.md
@@ -1,0 +1,45 @@
+---
+source: IDEA-1679
+timestamp: '2026-07-27T19:15:15.254122+00:00'
+title: Add mandatory phrase format-string template to SemanticEntry
+type: idea
+---
+
+## Summary
+
+Add a mandatory `phrase: str` field to `SemanticEntry`
+(`vultron/semantic_registry/_entry.py`) containing a format-string template
+such as `"{actor} submitted report {object}"`. Slots use AS2 field names from
+`VultronEvent` (`actor`, `object`, `target`, `context`, `origin`,
+`inner_object`). Values at display time use object `name` if present, falling
+back to a short ID. Making the field mandatory ensures every `SemanticEntry`
+is self-documenting and prevents the silent drift described in Concern #1675.
+Replaces `_EVENT_PHRASES` in `vultron/demo/report.py`.
+
+## Motivation
+
+- `_EVENT_PHRASES` (`vultron/demo/report.py:194`) is a parallel dict that can
+  silently drift from `MessageSemantics` — currently 8 of 48 active semantics
+  have no entry.
+- The current phrase format omits object identifiers, making sentences
+  ambiguous in multi-case/multi-report runs.
+- Humanization logic in `demo/report.py` should live in core so API responses,
+  notifications, and audit logs can reuse it without importing demo code.
+
+## Rough Approach
+
+1. Add `phrase: str` to `SemanticEntry` dataclass as a mandatory field (no
+   default).
+2. Populate all 50 registry entries with active-voice templates using
+   `{actor}`, `{object}`, `{target}`, `{context}`, `{origin}`,
+   `{inner_object}` slots.
+3. Add `friendly_name(obj: VultronObject | str | None) -> str` to
+   `vultron/core/display.py`.
+4. Update `CaseLedgerEventRecord.summary` to use
+   `entry.phrase.format_map(slots)` via `defaultdict(lambda: "—")`.
+5. Delete `_EVENT_PHRASES` and `event_phrase()` from `vultron/demo/report.py`.
+
+**Processed**: 2026-07-27 — implementation tracked in #1729.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1728>.
+Spec: `specs/semantic-extraction.yaml`.
+Spec: `specs/demo-report.yaml`.

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -6,7 +6,7 @@ description: >-
   report of who did what, with what activity, and in what order. Covers input discovery,
   the distilled intermediate data model, markdown and HTML rendering, the per-actor
   replica-presence matrix, friendly naming, and test requirements.
-version: 1.5.0
+version: 1.6.0
 scope:
 - prototype
 tags:
@@ -221,14 +221,41 @@ groups:
     - rel_type: extends
       spec_id: DRPT-03-001
   - id: DRPT-03-002
-    priority: SHOULD
+    priority: MUST
     kind: project
     statement: >-
-      Event summaries SHOULD map the event type / message semantics to a concise
-      active-voice phrase (subject verb object). Where a protocol vocabulary of
-      semantics already exists in the codebase, the mapping SHOULD reuse it to
-      stay in sync; otherwise a tool-local mapping table is acceptable with a
-      sensible fallback that renders the raw event type.
+      Event summaries MUST map the event type to a concise active-voice phrase
+      (subject verb object) by looking up the matching `SemanticEntry` in
+      `SEMANTIC_REGISTRY` and rendering `entry.phrase` via `str.format_map()`.
+      The tool MUST NOT maintain a local phrase table parallel to the registry.
+      When no registry entry exists for an event type (e.g. data from a future
+      protocol version), the tool MUST fall back to a humanized form of the raw
+      event-type string.
+    rationale: >-
+      Replaces the tool-local `_EVENT_PHRASES` dict (Concern #1675). Deriving
+      phrases directly from `SemanticEntry.phrase` (SE-07-001) guarantees that
+      new semantics are automatically covered and eliminates the drift risk.
+    relationships:
+    - rel_type: refines
+      spec_id: DRPT-03-001
+  - id: DRPT-03-004
+    priority: MUST
+    kind: project
+    statement: >-
+      When rendering a phrase template, the tool MUST supply slot values for
+      `{actor}`, `{object}`, and `{target}` drawn from the event record's
+      resolved display labels. Missing slots (e.g. `{context}` when no context
+      was recorded) MUST render as an em-dash (`"—"`) rather than raising a
+      `KeyError`.
+    rationale: >-
+      `CaseLedgerEventRecord` is constructed from JSONL data and may not carry
+      all slot values present in a live `VultronEvent`. A `defaultdict` fallback
+      ensures phrases for multi-party semantics (e.g. `{actor} invited {object}
+      to {target}`) degrade gracefully to `"{actor} invited {object} to —"` when
+      the destination is absent rather than surfacing a runtime error.
+    relationships:
+    - rel_type: refines
+      spec_id: DRPT-03-002
 - id: DRPT-04
   title: Rendering
   specs:

--- a/specs/semantic-extraction.yaml
+++ b/specs/semantic-extraction.yaml
@@ -4,7 +4,7 @@ description: >-
   The inbox handler extracts semantic meaning from ActivityStreams activities by matching
   activity type and object type patterns. This semantic type determines which handler function
   processes the activity.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -181,3 +181,48 @@ groups:
     relationships:
     - rel_type: implements
       spec_id: SE-06-001
+- id: SE-07
+  title: Display Metadata
+  specs:
+  - id: SE-07-001
+    priority: MUST
+    kind: project
+    statement: >-
+      Every `SemanticEntry` in `SEMANTIC_REGISTRY` MUST carry a non-empty `phrase: str`
+      field containing an active-voice format-string template suitable for human-readable
+      event summaries (e.g. `"{actor} submitted report {object}"`).
+    rationale: >-
+      A mandatory phrase field ensures every registered semantic is self-documenting and
+      prevents silent drift between the registry and display-layer phrase tables (see
+      CONCERN-1675). Making the field mandatory at the dataclass level means a missing
+      phrase is a construction-time error, not a runtime rendering gap.
+  - id: SE-07-002
+    priority: MUST
+    kind: project
+    statement: >-
+      Phrase templates MUST use named slots drawn from the set `{actor}`, `{object}`,
+      `{target}`, `{context}`, `{origin}`, `{inner_object}`. Slot names MUST be
+      human-facing role identifiers, not Python field names from `VultronEvent`.
+    relationships:
+    - rel_type: refines
+      spec_id: SE-07-001
+  - id: SE-07-003
+    priority: MUST
+    kind: project
+    statement: >-
+      The `SemanticEntry` dataclass `phrase` field MUST have no default value so
+      that omitting it is a construction-time `TypeError`, not a silent empty string.
+    relationships:
+    - rel_type: implements
+      spec_id: SE-07-001
+  - id: SE-07-004
+    priority: MUST
+    kind: project
+    statement: >-
+      A parametrized unit test MUST assert that every entry in `SEMANTIC_REGISTRY`
+      has a non-empty `phrase` and that calling `entry.phrase.format_map(d)` with a
+      `defaultdict(lambda: "X")` returns a non-empty string without raising a
+      `KeyError`.
+    relationships:
+    - rel_type: verifies
+      spec_id: SE-07-001


### PR DESCRIPTION
- Closes #1679

## Summary

Adds SE-07 Display Metadata group to `specs/semantic-extraction.yaml`: mandatory `phrase` field on every `SemanticEntry`, named-slot convention, no-default enforcement requirement, and a round-trip format test requirement. Upgrades DRPT-03-002 from SHOULD to MUST and rewrites it to require registry-driven phrase lookup (no local phrase table). Adds DRPT-03-004: missing slots in phrase templates render as em-dash via `defaultdict` fallback.

## Changes

- `specs/semantic-extraction.yaml` (v1.0.0 → v1.1.0): new SE-07 group with SE-07-001 through SE-07-004
- `specs/demo-report.yaml` (v1.5.0 → v1.6.0): DRPT-03-002 strengthened to MUST; new DRPT-03-004 added

🤖 Generated with [Claude Code](https://claude.com/claude-code)