### PR TITLE
docs: plan issue #1178 — in-process fuzz simulation scenario

### DIFF
--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -303,3 +303,56 @@ the bundle/singleton/Protocol pattern as the resolved design. See
 Mechanism (2026-07-23 amendment)".
 
 Normative requirements: `specs/behavior-tree-integration.yaml` BT-23.
+
+---
+
+## Multi-Actor In-Process Simulation
+
+The three-mode model and STOCHASTIC bundles are the foundation for the
+**fully-fuzzed in-process simulation scenario** tracked in issue #1178 (see
+spec `DEMOMA-18`).
+
+### Design decisions (from #1178 planning)
+
+**In-process delivery via direct DataLayer injection** was chosen over two
+alternatives:
+
+- *ASGIEmitter loopback* — more realistic wire path, but requires spinning up
+  a FastAPI ASGI application per actor and routing inbound AS2 JSON through
+  the full HTTP pipeline; significant setup overhead for a simulation tool.
+- *In-memory message queue* — closest to the conceptual worker model in
+  `notes/event-driven-control-flow.md`, but requires new infrastructure
+  (a queue type + delivery scheduler) with no benefit over direct injection
+  for an in-process simulation.
+
+Direct injection: when actor A's BT emits an activity to actor B, the
+simulation controller intercepts A's outbox and directly calls B's dispatcher
+with the activity object. No network, no serialisation round-trip. The full
+trigger→BT→outbox→peer-inbox cascade is exercised within the single Python
+process.
+
+**Finder + Coordinator + Vendor (3 actors)** was chosen as the minimum
+meaningful configuration. FV (2 actors) omits coordinator role interactions;
+FCV (3) covers the core multi-party CVD pattern exercised by existing
+deterministic scenario demos.
+
+**Fresh in-memory DataLayer per iteration** ensures each iteration is an
+independent probabilistic sample. Persisting state across iterations would
+cause later runs to depend on earlier ones.
+
+**Multi-container variant deferred** — a future Idea under a new "stochastic
+demos" Epic should scope a containerised fuzz scenario once container reset
+and STOCHASTIC bundle configuration via environment variables are designed.
+
+### Termination model
+
+The simulation controller drives each iteration forward by:
+
+1. Calling a trigger on one actor (Finder submits report).
+2. Processing each outbox emission as an inbound activity on the target actor.
+3. Repeating until all actors reach `RM.CLOSED` or no state change occurs
+   over a configurable number of rounds (stall detection).
+
+A tick-count-only limit was rejected because many use-case BTs only activate
+on incoming activities; "ticks" have no direct meaning in the event-driven
+prototype. Progress is measured by RM state advancement across actors.

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -50,6 +50,18 @@ be treated as working implementations.
 | FCCV-handoff | #1216 | C1 transfers to C2; C2 invites V | — | **implemented** (#1216) — `fccv-handoff` CLI command + CI job |
 | FCVCV | #1217 | F+C1+V1+C2+V2 (5 actors) | #1212, #1215 | planned |
 
+### Fuzz simulation scenarios
+
+| Scenario | Issue | Description | Status |
+|----------|-------|-------------|--------|
+| In-process fuzz | #1178 | FCV in-process; STOCHASTIC bundles; N configurable iterations; `vultron demo fuzz` CLI command | planned |
+| Multi-container fuzz | *(future Idea under "stochastic demos" Epic)* | Containerised variant of #1178; each actor in its own container; STOCHASTIC bundles configurable via environment; container state reset between iterations | idea-stage |
+
+The multi-container variant is deferred until container reset and STOCHASTIC
+bundle configuration via environment variables are designed. See
+`notes/call-out-configuration.md` § "Multi-Actor In-Process Simulation" for
+the design decisions reached in the #1178 planning session.
+
 ### Role-expansion scenarios
 
 | Scenario | Issue | Description |

--- a/plan/history/2607/idea/IDEA-1178.md
+++ b/plan/history/2607/idea/IDEA-1178.md
@@ -1,0 +1,18 @@
+---
+source: IDEA-1178
+timestamp: '2026-07-27T19:40:16.511292+00:00'
+title: 'Demo scenario: fully-fuzzed protocol simulation (port vultron/bt simulator
+  to AS2-backed py_trees)'
+type: idea
+---
+
+Build a fully-fuzzed protocol simulation scenario — equivalent to what the old `vultron/bt/` simulator did, but with full AS2 protocol on top.
+
+The old simulator exercised all state machine transitions by running many iterations with randomised fuzzer outcomes per run, producing diverse case paths. Each run was different; the simulation explored the protocol state space probabilistically rather than following a single deterministic script.
+
+This new scenario does the same thing, but the BT execution drives real AS2 protocol activities (via trigger endpoints) rather than just exercising state machines in isolation.
+
+**Processed**: 2026-07-27 — implementation tracked in #1732.
+**Docs PR**: <https://github.com/CERTCC/Vultron/pull/1731>.
+**Spec**: `specs/multi-actor-demo.yaml` DEMOMA-18-001 through DEMOMA-18-008.
+**Notes**: `notes/call-out-configuration.md` § "Multi-Actor In-Process Simulation".

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1894,6 +1894,118 @@ groups:
     - rel_type: refines
       spec_id: DEMOCI-04-004
 
+- id: DEMOMA-18
+  title: In-Process Fuzz Simulation Scenario
+  specs:
+  - id: DEMOMA-18-001
+    priority: MUST
+    kind: project
+    statement: >-
+      The fuzz simulation scenario MUST run entirely in-process with no
+      HTTP servers, containers, or network I/O required; each actor MUST
+      have its own isolated in-memory DataLayer.
+    rationale: >-
+      The scenario is a simulation tool for exploring the protocol state
+      space probabilistically. Container setup would make it unsuitable
+      for local development and CI smoke-testing. Derived from issue #1178
+      planning decisions.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+  - id: DEMOMA-18-002
+    priority: MUST
+    kind: project
+    statement: >-
+      The fuzz simulation scenario MUST support a configurable number of
+      iterations N (default 10); each iteration MUST start with fresh
+      in-memory DataLayers for all actors (no state carried across
+      iterations).
+    rationale: >-
+      Each iteration is an independent probabilistic sample of the
+      protocol state space. Shared state would cause later iterations to
+      depend on earlier ones, undermining the exploration goal.
+  - id: DEMOMA-18-003
+    priority: MUST
+    kind: project
+    statement: >-
+      The fuzz simulation scenario MUST use STOCHASTIC call-out point
+      bundles for all actors so that each call-out decision is drawn
+      from the fuzzer node probability distribution rather than a
+      deterministic default.
+    rationale: >-
+      The scenario's purpose is probabilistic state-space exploration.
+      DETERMINISTIC bundles would produce an identical path on every
+      iteration, defeating the simulation goal.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-18-001
+  - id: DEMOMA-18-004
+    priority: MUST
+    kind: project
+    statement: >-
+      The fuzz simulation scenario MUST simulate in-process message
+      delivery between actors by directly invoking the receiving actor's
+      dispatcher with the emitted activity; no HTTP, ASGIEmitter, or
+      real network transport is permitted.
+    rationale: >-
+      Direct DataLayer injection allows the simulation to run without
+      network infrastructure while still exercising the full
+      trigger-endpoint→BT→outbox→peer-inbox cascade.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-18-001
+  - id: DEMOMA-18-005
+    priority: MUST
+    kind: project
+    statement: >-
+      Each iteration MUST log structured output at INFO level including:
+      the iteration number, each call-out point node name and its
+      SUCCESS/FAILURE outcome, and the final RM/EM/CS state per actor.
+    rationale: >-
+      Per-run logging is the primary diagnostic output of the scenario;
+      it allows users to observe which protocol paths were exercised
+      across iterations.
+  - id: DEMOMA-18-006
+    priority: MUST
+    kind: project
+    statement: >-
+      The fuzz simulation scenario MUST be accessible via the
+      ``vultron demo fuzz`` CLI sub-command, accepting at minimum an
+      ``--iterations N`` option; the default number of iterations MUST
+      be documented in the CLI help text.
+    rationale: >-
+      Consistent with the existing ``vultron demo`` CLI structure
+      (DC-01-001 through DC-01-005); the ``fuzz`` sub-command makes the
+      scenario discoverable alongside other demo commands.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-18-001
+  - id: DEMOMA-18-007
+    priority: MUST
+    kind: project
+    statement: >-
+      Existing deterministic demo scenarios MUST NOT be modified by the
+      fuzz simulation scenario; the fuzz scenario MUST NOT import from
+      or depend on any existing ``vultron/demo/scenario/`` module.
+    rationale: >-
+      The fuzz scenario is a standalone simulation tool; coupling it to
+      deterministic scenario files would break their repeatability and
+      make the fuzz scenario harder to isolate.
+  - id: DEMOMA-18-008
+    priority: MUST
+    kind: project
+    statement: >-
+      A unit test in ``test/demo/`` MUST verify that the fuzz simulation
+      scenario completes a single iteration without raising an exception;
+      the test MUST run with a seeded RNG where possible.
+    rationale: >-
+      The test provides a regression guard confirming the scenario still
+      runs after code changes, independent of the specific protocol path
+      taken.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-18-001
+
 - id: DEMOMA-17
   title: Demo Code Reuse and DRY
   specs:


### PR DESCRIPTION
- Closes #1178

## Summary

Plans and documents the fully-fuzzed in-process CVD simulation scenario
(issue #1178). Adds spec requirements, design-decision notes, and a forward
pointer to the multi-container variant.

## Changes

- **`specs/multi-actor-demo.yaml`**: Adds DEMOMA-18 spec group (8
  requirements) defining the in-process fuzz simulation scenario — actor
  isolation, fresh-DataLayer-per-iteration, STOCHASTIC bundles, in-process
  delivery, structured per-iteration logging, CLI entry point, and smoke test.
- **`notes/call-out-configuration.md`**: Documents multi-actor in-process
  simulation design decisions from the #1178 planning session: why direct
  DataLayer injection was chosen over ASGIEmitter loopback and in-memory
  message queue; FCV actor configuration rationale; termination model
  (progress-based vs. tick-count); multi-container variant deferred.
- **`notes/demo-future-ideas.md`**: Adds "Fuzz simulation scenarios" table
  recording the in-process fuzz (#1178) and the planned multi-container
  variant (future Idea under "stochastic demos" Epic).