### PR TITLE
history: archive learning CONCERN-1700 — CreateCaseActorServiceNode must write to case-actor container DataLayer

### DIFF
--- a/.agents/skills/shared/add-to-project.sh
+++ b/.agents/skills/shared/add-to-project.sh
@@ -12,10 +12,10 @@ PROJECT_ID="PVT_kwDOAjf0s84BZnre"
 SCHEDULE_FIELD_ID="PVTSSF_lADOAjf0s84BZnrezhUlFOM"
 
 case "$SCHEDULE" in
-  Now)     SCHEDULE_OPTION_ID="626ed293" ;;
-  Next)    SCHEDULE_OPTION_ID="5f492ed4" ;;
-  Later)   SCHEDULE_OPTION_ID="1668bcd8" ;;
-  Someday) SCHEDULE_OPTION_ID="43f174f4" ;;
+  Now)     SCHEDULE_OPTION_ID="22e6679d" ;;
+  Next)    SCHEDULE_OPTION_ID="1c1ed63d" ;;
+  Later)   SCHEDULE_OPTION_ID="520032ef" ;;
+  Someday) SCHEDULE_OPTION_ID="a890eacc" ;;
   *) echo "❌ Unknown schedule value: $SCHEDULE (use Now|Next|Later|Someday)" >&2; exit 1 ;;
 esac
 

--- a/plan/history/2607/learning/CONCERN-1700.md
+++ b/plan/history/2607/learning/CONCERN-1700.md
@@ -1,0 +1,40 @@
+---
+source: CONCERN-1700
+timestamp: '2026-07-27T19:44:11.674524+00:00'
+title: CreateCaseActorServiceNode must write to case-actor container DataLayer not
+  local
+type: learning
+---
+
+## Problem
+
+`CreateCaseActorServiceNode` (in `vultron/core/behaviors/case/nodes/case_setup.py`) calls `self.datalayer.create(case_actor)` — writing the `VultronCaseActor` record into the **local** DataLayer of whichever container is running the BT (vendor, coordinator, etc.).
+
+This means that in the multi-container topology (`docker/docker-compose-multi-actor.yml`), with `VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL=http://case-actor:7999/api/v2` pointing at the dedicated case-actor container:
+
+1. `ResolveCaseActorUrlsNode` derives IDs like `http://case-actor:7999/api/v2/actors/case-actor-{slug}` ✅ (correct URL)
+2. `CreateCaseActorServiceNode` writes that record into the **vendor's** DataLayer ❌
+3. Subsequent outbox deliveries addressed to `http://case-actor:7999/api/v2/actors/case-actor-{slug}/inbox/` get **404** because the case-actor container has no record of that actor
+
+The CI Demo Integration jobs (all six scenarios) fail with `Client error '404 Not Found'` for all deliveries to the case-actor container.
+
+### Root cause
+
+`CreateCaseActorServiceNode` violates per-actor DataLayer isolation (ADR-0012): it writes a record that only belongs in the case-actor container's DataLayer. Previously masked because `ResolveCaseActorUrlsNode` derived IDs from `server_base_url` (the container's own URL). PR #1695 introduced the explicit `case_actor_service_url` config field, which made the mismatch visible.
+
+`RegisterCaseActorParticipantNode` has the same issue.
+
+### Resolution (2026-07-27)
+
+Agreed fix: move actor-record creation to `create_case_proposal_received_tree` (case-actor side). The case-actor container creates its own `VultronCaseActor` and `VultronParticipant` records when handling `Create(as_CaseProposal)`. Causal ordering: VultronCaseActor record → VulnerabilityCase → persist both → emit Accept. Remove `CreateCaseActorServiceNode` and `RegisterCaseActorParticipantNode` from the vendor-side `CreateCaseActorNode` tree. This implements the intent of ADR-0023 (CaseProposal protocol) without needing a new ADR.
+
+Key design decisions:
+
+- No outbox queuing approach needed; case-actor handles everything synchronously on receipt of CaseProposal
+- docker-compose: all four containers (finder, vendor, coordinator, actor5) get `VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL=http://case-actor:7999/api/v2`
+- FV demo: remove `verify_case_actor_unused()`, add assertions that case-actor container holds expected records
+- `notes/case-proposal.md` table row for `CreateCaseActorNode` is inaccurate and needs updating (deferred to impl issue AC-5)
+
+Implementation tracked in #1733.
+
+Resolved: 2026-07-27 — implementation tracked in #1733.


### PR DESCRIPTION
## Summary

- Archives planning outcome for Concern #1700 as a learning entry in `plan/history/2607/learning/CONCERN-1700.md`
- Fixes stale Schedule option IDs in `.agents/skills/shared/add-to-project.sh` (all four IDs were stale after a project board update)

## Test plan

- [ ] History file exists at `plan/history/2607/learning/CONCERN-1700.md` with correct frontmatter and body
- [ ] `add-to-project.sh` option IDs match current Project #24 Schedule field values
- [ ] Markdown lint clean (verified in pre-commit)

Closes #1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)