### PR TITLE
docs: plan concern #1678 — VFD role guards (VENDOR for f→F, DEPLOYER for d→D)

### DIFF
--- a/plan/history/2607/learning/CONCERN-1678.md
+++ b/plan/history/2607/learning/CONCERN-1678.md
@@ -1,0 +1,48 @@
+---
+source: CONCERN-1678
+timestamp: '2026-07-27T20:16:08.399842+00:00'
+title: d→D (fix-deployed) transition not gated on CaseRole.DEPLOYER
+type: learning
+---
+
+## Problem
+
+The `demo_notify_fix_deployed` endpoint and the `add_participant_status_trigger_bt`
+behavior tree applied the d→D VFD state transition without checking the caller's
+CVD role. Any participant — including Finders and Coordinators — could set their
+own participant status to `CS_vfd.VFD`, violating the protocol invariant that only
+DEPLOYER-role actors deploy fixes.
+
+Additionally, `demo_notify_fix_ready` lacked a VENDOR/DEPLOYER guard for the f→F
+transition, and `demo_notify_published` was incorrectly setting `vfd_state=VFD`
+(conflating the P event with the D event — they are independent).
+
+## Root Cause
+
+Role preconditions for VFD state transitions were not specified in any behavioral
+spec (`specs/cs-behavior.yaml`), so there was no authoritative requirement for
+BT implementation to enforce. The demo verification layer had a `_assert_vendor_role`
+check, but this is post-hoc assertion, not a BT-level guard.
+
+## Resolution
+
+- Added CSB-15 group to `specs/cs-behavior.yaml` (v0.1.0 → v0.1.1):
+  - CSB-15-001: VENDOR or DEPLOYER required for f→F (notify-fix-ready)
+  - CSB-15-002: DEPLOYER required for d→D (notify-fix-deployed)
+  - CSB-15-003: `notify-published` MUST_NOT set `vfd_state=VFD`
+
+## Implementation Issues
+
+- #1735: Add CSB-15 spec entries (size:S, blocked-by #1678, child of #1676)
+- #1736: Enforce CSB-15 role guards in BT trigger tree (size:M, blocked-by #1678, child of #1676)
+
+## Key Insight
+
+P (public aware) and D (fix deployed) are semantically independent events. P is
+participant-agnostic (whole-case state); D is participant-specific (vendor-fix path).
+`notify-published` advancing vfd_state to VFD masked the missing DEPLOYER guard and
+caused non-deployer participants to incorrectly reach VFD state.
+
+## PR
+
+<https://github.com/CERTCC/Vultron/pull/1742>

--- a/plan/history/2607/learning/CONCERN-1678.md
+++ b/plan/history/2607/learning/CONCERN-1678.md
@@ -27,7 +27,7 @@ check, but this is post-hoc assertion, not a BT-level guard.
 ## Resolution
 
 - Added CSB-15 group to `specs/cs-behavior.yaml` (v0.1.0 → v0.1.1):
-  - CSB-15-001: VENDOR or DEPLOYER required for f→F (notify-fix-ready)
+  - CSB-15-001: VENDOR required for f→F (notify-fix-ready); Deployers do not produce fixes
   - CSB-15-002: DEPLOYER required for d→D (notify-fix-deployed)
   - CSB-15-003: `notify-published` MUST_NOT set `vfd_state=VFD`
 

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -6,7 +6,7 @@ description: >-
   and specifies typed preconditions, ordered steps, and postconditions that implementations
   must satisfy. CS cascade chains that trigger embargo teardown reference EM behavior
   directly and are developed in concert with the EM behavioral requirements.
-version: 0.1.0
+version: 0.1.1
 tags:
 - behavioral
 - state-machine
@@ -1253,3 +1253,117 @@ groups:
       note: >-
         Once attacks have been observed, fix development SHOULD accelerate and
         embargo teardown process SHOULD begin
+
+- id: CSB-15
+  title: Trigger-Side VFD Role Preconditions
+  description: >-
+    Role-based precondition requirements for self-reported CS VFD state transitions
+    via the trigger path (notify-fix-ready, notify-fix-deployed). These complement the
+    receive-side CSB-02 and CSB-03 groups by specifying which CVD roles may initiate
+    each VFD transition locally.
+  specs:
+  - id: CSB-15-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      An Actor self-reporting a fix-ready transition (f→F, vfd_state=VFd) via the
+      trigger path MUST hold CVDRole.VENDOR or CVDRole.DEPLOYER in the case;
+      the transition MUST be blocked (FAILURE) when neither role is present.
+    rationale: >-
+      Fix readiness (F event) is a Vendor Fix Path state that only makes sense for
+      actors who develop or maintain the affected product. Finders, Reporters, and
+      Coordinators do not develop fixes and MUST NOT self-report fix readiness.
+      Without this guard, non-vendor actors can incorrectly advance their participant
+      VFD state, producing misleading case state records.
+    testable: true
+    preconditions:
+    - description: Actor requests vfd_state=VFd via the trigger path
+    steps:
+    - order: 1
+      actor: trigger
+      action: Check that the requesting actor holds CVDRole.VENDOR or CVDRole.DEPLOYER
+        in the case participant record
+      expected: Role check passes for VENDOR or DEPLOYER; FAILURE returned otherwise
+    - order: 2
+      actor: trigger
+      action: If role check passes, create ParticipantStatus with vfd_state=VFd
+      expected: Status record created; activity emitted to Case Manager
+    postconditions:
+    - description: Only VENDOR/DEPLOYER actors may record vfd_state=VFd; others receive FAILURE
+    relationships:
+    - rel_type: refines
+      spec_id: CSB-02-001
+      note: Trigger-side precondition complementing receive-side CF handling
+
+  - id: CSB-15-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      An Actor self-reporting a fix-deployed transition (d→D, vfd_state=VFD) via the
+      trigger path MUST hold CVDRole.DEPLOYER in the case; the transition MUST be blocked
+      (FAILURE) when CVDRole.DEPLOYER is absent.
+    rationale: >-
+      Fix deployment (D event) represents applying a fix in one's own environment.
+      Only actors who are responsible for operating deployed instances (Deployers) can
+      perform this action. A shipping-product Vendor who does not control downstream
+      deployment holds only CVDRole.VENDOR, not CVDRole.DEPLOYER, and MUST stop at VFd.
+      Without this guard, vendor-only actors reach VFD, misrepresenting the protocol's
+      distinction between fix availability and fix deployment.
+    testable: true
+    preconditions:
+    - description: Actor requests vfd_state=VFD via the trigger path
+    steps:
+    - order: 1
+      actor: trigger
+      action: Check that the requesting actor holds CVDRole.DEPLOYER in the case
+        participant record
+      expected: Role check passes for DEPLOYER; FAILURE returned for VENDOR-only or
+        any other non-DEPLOYER actor
+    - order: 2
+      actor: trigger
+      action: If role check passes, create ParticipantStatus with vfd_state=VFD
+      expected: Status record created; activity emitted to Case Manager
+    postconditions:
+    - description: Only DEPLOYER actors may record vfd_state=VFD; all others receive FAILURE
+    relationships:
+    - rel_type: refines
+      spec_id: CSB-03-001
+      note: Trigger-side precondition complementing receive-side CD handling
+
+  - id: CSB-15-003
+    priority: MUST_NOT
+    kind: protocol
+    statement: >-
+      A self-report trigger for public awareness (P event, pxa_state=Pxa) MUST NOT
+      also set vfd_state=VFD. The D event (fix deployed) is participant-specific and
+      is distinct from the P event (public awareness); they MUST be reported
+      independently.
+    rationale: >-
+      Conflating P and D transitions (as notify-published did by setting both
+      vfd_state=VFD and pxa_state=Pxa) causes non-deployer actors (Finders,
+      Reporters, Coordinators) to incorrectly acquire VFD state when they announce
+      public disclosure. The pxa (P event) is participant-agnostic; the VFD (D event)
+      is only valid for DEPLOYER-role actors who have separately completed deployment.
+    testable: true
+    preconditions:
+    - description: Actor calls the notify-published trigger endpoint
+    steps:
+    - order: 1
+      actor: trigger
+      action: Set pxa_state=Pxa in the ParticipantStatus record
+      expected: Public awareness recorded
+    - order: 2
+      actor: trigger
+      action: Leave vfd_state unchanged (do not set vfd_state=VFD)
+      expected: vfd_state reflects prior state; D event not triggered by P event
+    postconditions:
+    - description: >-
+        ParticipantStatus records pxa_state=Pxa; vfd_state is not modified by
+        this trigger; actors wishing to report VFD must call notify-fix-deployed
+        separately (and must hold CVDRole.DEPLOYER per CSB-15-002)
+    relationships:
+    - rel_type: refines
+      spec_id: CSB-04-001
+      note: >-
+        P event trigger must not imply D event; separates participant-agnostic
+        public awareness from participant-specific fix deployment

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -1257,22 +1257,23 @@ groups:
 - id: CSB-15
   title: Trigger-Side VFD Role Preconditions
   description: >-
-    Role-based precondition requirements for self-reported CS VFD state transitions
-    via the trigger path (notify-fix-ready, notify-fix-deployed). These complement the
-    receive-side CSB-02 and CSB-03 groups by specifying which CVD roles may initiate
-    each VFD transition locally.
+    Precondition requirements for self-reported CS trigger endpoints
+    (notify-fix-ready, notify-fix-deployed, notify-published). These complement the
+    receive-side CSB-02, CSB-03, and CSB-04 groups by specifying which CVD roles may
+    initiate each VFD transition locally and what state each trigger endpoint MUST set.
   specs:
   - id: CSB-15-001
     priority: MUST
     kind: protocol
     statement: >-
       An Actor self-reporting a fix-ready transition (f→F, vfd_state=VFd) via the
-      trigger path MUST hold CVDRole.VENDOR or CVDRole.DEPLOYER in the case;
-      the transition MUST be blocked (FAILURE) when neither role is present.
+      trigger path MUST hold CVDRole.VENDOR in the case; the transition MUST be
+      blocked (FAILURE) when CVDRole.VENDOR is absent.
     rationale: >-
-      Fix readiness (F event) is a Vendor Fix Path state that only makes sense for
-      actors who develop or maintain the affected product. Finders, Reporters, and
-      Coordinators do not develop fixes and MUST NOT self-report fix readiness.
+      Fix readiness (F event) represents that the actor has produced a fix. Only
+      actors who develop or maintain the affected product (Vendors) can produce a
+      fix; Deployers operate existing deployments and do not produce fixes. Finders,
+      Reporters, and Coordinators likewise MUST NOT self-report fix readiness.
       Without this guard, non-vendor actors can incorrectly advance their participant
       VFD state, producing misleading case state records.
     testable: true
@@ -1281,17 +1282,17 @@ groups:
     steps:
     - order: 1
       actor: trigger
-      action: Check that the requesting actor holds CVDRole.VENDOR or CVDRole.DEPLOYER
-        in the case participant record
-      expected: Role check passes for VENDOR or DEPLOYER; FAILURE returned otherwise
+      action: Check that the requesting actor holds CVDRole.VENDOR in the case
+        participant record
+      expected: Role check passes for VENDOR; FAILURE returned otherwise
     - order: 2
       actor: trigger
       action: If role check passes, create ParticipantStatus with vfd_state=VFd
       expected: Status record created; activity emitted to Case Manager
     postconditions:
-    - description: Only VENDOR/DEPLOYER actors may record vfd_state=VFd; others receive FAILURE
+    - description: Only VENDOR actors may record vfd_state=VFd; all others receive FAILURE
     relationships:
-    - rel_type: refines
+    - rel_type: constrains
       spec_id: CSB-02-001
       note: Trigger-side precondition complementing receive-side CF handling
 
@@ -1326,18 +1327,18 @@ groups:
     postconditions:
     - description: Only DEPLOYER actors may record vfd_state=VFD; all others receive FAILURE
     relationships:
-    - rel_type: refines
+    - rel_type: constrains
       spec_id: CSB-03-001
       note: Trigger-side precondition complementing receive-side CD handling
 
   - id: CSB-15-003
-    priority: MUST_NOT
+    priority: MUST
     kind: protocol
     statement: >-
-      A self-report trigger for public awareness (P event, pxa_state=Pxa) MUST NOT
-      also set vfd_state=VFD. The D event (fix deployed) is participant-specific and
-      is distinct from the P event (public awareness); they MUST be reported
-      independently.
+      The notify-published trigger endpoint MUST set only pxa_state=Pxa in the
+      ParticipantStatus record. The D event (fix deployed) is participant-specific
+      and distinct from the P event (public awareness); notify-published MUST NOT
+      also modify vfd_state.
     rationale: >-
       Conflating P and D transitions (as notify-published did by setting both
       vfd_state=VFD and pxa_state=Pxa) causes non-deployer actors (Finders,
@@ -1362,7 +1363,7 @@ groups:
         this trigger; actors wishing to report VFD must call notify-fix-deployed
         separately (and must hold CVDRole.DEPLOYER per CSB-15-002)
     relationships:
-    - rel_type: refines
+    - rel_type: constrains
       spec_id: CSB-04-001
       note: >-
         P event trigger must not imply D event; separates participant-agnostic


### PR DESCRIPTION
- Closes #1678
- Closes #1735

## Summary

Adds CSB-15 group to `specs/cs-behavior.yaml` specifying the role preconditions for VFD state transitions: VENDOR only for f→F, and DEPLOYER for d→D. Also prohibits `notify-published` from setting `vfd_state=VFD`.

## Changes

- **`specs/cs-behavior.yaml`**: Bumped version 0.1.0 → 0.1.1; appended new CSB-15 group with three requirements:
  - CSB-15-001: VENDOR required to trigger the f→F (fix-ready) transition
  - CSB-15-002: DEPLOYER required to trigger the d→D (fix-deployed) transition
  - CSB-15-003: `notify-published` MUST NOT set `vfd_state=VFD` (P and D are independent events; P is participant-agnostic, D is participant-specific)