### PR TITLE
fix: suggest-actor roles read from stored Offer, not blackboard (ISSUE-1745)

### DIFF
--- a/notes/activitystreams-state-update.md
+++ b/notes/activitystreams-state-update.md
@@ -363,6 +363,32 @@ actor_id = getattr(raw_actor, "id_", None) or request.object_id
 The fallback `request.object_id` retains the `#participant` suffix and should
 only be used as a last resort — log a warning if it is reached.
 
+### Trust Boundary: Roles MUST Come from the Stored Offer We Sent
+
+(ISSUE-1745, 2026-07-28)
+
+When `CaseActor` processes an `Accept(Offer(CaseParticipant))` from the Case
+Owner, the roles for the invited actor MUST be read from the stored
+`Offer(CaseParticipant)` in the DataLayer — the Offer that CaseActor itself
+constructed and sent — NOT from the embedded `CaseParticipant` in the received
+`Accept`.
+
+**Why**: the accepting actor (Case Owner) may have modified or omitted roles in
+their response, or may have sent only a bare ID reference. Reading roles from
+the received `Accept` would allow a malicious or minimally-conformant acceptor
+to substitute different roles than those evaluated and forwarded by the CaseActor.
+
+**Implementation**: `AcceptOfferCaseParticipantReceivedUseCase` looks up the
+stored Offer by `request.object_id`, extracts `stored_participant.roles`, and
+serializes them before passing to
+`create_accept_actor_recommendation_received_tree(roles=...)`. The
+`EmitInviteActorToCaseNode` uses the injected roles directly, falling back to
+the blackboard only in the single-execution path where the blackboard is
+populated.
+
+**ADR**: ADR-0026 Consequences section should document this invariant (see
+tracking issue for ADR update).
+
 ---
 
 ## Target-Field Discriminators: Wire Ambiguity Between Offer Semantics

--- a/plan/history/2607/implementation/ISSUE-1745.md
+++ b/plan/history/2607/implementation/ISSUE-1745.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1745
+timestamp: '2026-07-28T14:48:59.687511+00:00'
+title: suggest-actor roles read from stored Offer, not blackboard
+type: implementation
+---
+
+## Issue #1745 — Bug: suggest-actor ADR-0026 path assigns CVDRole.COORDINATOR instead of CVDRole.VENDOR
+
+Root cause: EmitInviteActorToCaseNode._read_suggested_roles() read from the py_trees blackboard, which is empty in BT execution 2 (separate BTBridge call). The suggested_roles key is only written in BT execution 1.
+
+Fix: AcceptOfferCaseParticipantReceivedUseCase.execute() now reads the stored Offer from DataLayer by ID, extracts stored_participant.roles, serializes the roles, and threads them through create_accept_actor_recommendation_received_tree() → EmitInviteActorToCaseNode as a constructor injection. The received Accept is untrusted (acceptor may modify contents or send a bare ID).
+
+Two regression tests in TestRolesFromStoredOffer cover Invite.roles and full round-trip participant.case_roles.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1750>

--- a/plan/incoming/learnings/20260728-offer-trust-boundary-implicit.md
+++ b/plan/incoming/learnings/20260728-offer-trust-boundary-implicit.md
@@ -1,0 +1,19 @@
+---
+title: Offer trust boundary in suggest-actor flow not documented in spec
+type: learning
+timestamp: 2026-07-28
+source: ISSUE-1745
+signal: spec-ambiguity
+---
+
+The ADR-0026/CM-16 suggest-actor spec does not explicitly state that roles must
+be read from the stored outgoing `Offer(CaseParticipant)` rather than from the
+embedded object inside the received `Accept`. The original implementation read
+from the blackboard (a second-order bug: blackboard empties between BT
+executions) but even a direct read from the received `Accept` would be wrong
+because the accepting actor may modify the embedded CaseParticipant or send
+only a bare ID reference.
+
+The correct invariant — **"roles come from the Offer we sent, not the Accept we
+received"** — is a security boundary, not just an implementation detail.
+ADR-0026 should document this as an explicit trust rule.

--- a/plan/incoming/learnings/20260728-participant-additional-roles-concern.md
+++ b/plan/incoming/learnings/20260728-participant-additional-roles-concern.md
@@ -1,0 +1,17 @@
+---
+title: No protocol mechanism for participant to request additional roles after joining
+type: learning
+timestamp: 2026-07-28
+source: ISSUE-1745
+signal: concern
+---
+
+Surfaced during ISSUE-1745 bugfix: once a participant joins via the suggest-actor
+flow, there is no protocol path to request additional CVD roles. The fix
+intentionally restricts role assignment to what was offered — the acceptor cannot
+add roles. This is correct security behavior, but it leaves a legitimate use-case
+unaddressed.
+
+Filed as Concern #1752. See that issue for details and a sketch of a possible
+`Request(CaseParticipant)` activity type reusing the ADR-0026 Accept/Reject
+pattern.

--- a/test/core/use_cases/received/actor/test_offer_case_participant.py
+++ b/test/core/use_cases/received/actor/test_offer_case_participant.py
@@ -391,6 +391,158 @@ def _seed_dl_for_ac1() -> SqliteDataLayer:
     return dl
 
 
+class TestRolesFromStoredOffer:
+    """Regression test for ISSUE-1745: roles must come from stored Offer, not blackboard.
+
+    The suggest-actor path (ADR-0026) runs in two separate BT executions:
+    1. CaseActor receives Offer(Actor, Case) → stores Offer(CaseParticipant) with roles
+    2. CaseActor receives Accept(Offer(CaseParticipant)) → emits Invite with those roles
+
+    The blackboard is not shared between executions, so roles must be read from
+    the DataLayer (the stored Offer), not from a blackboard key that is always
+    empty in the second execution.
+    """
+
+    @pytest.fixture(autouse=True)
+    def clear_blackboard(self):
+        py_trees.blackboard.Blackboard.storage.clear()
+        yield
+        py_trees.blackboard.Blackboard.storage.clear()
+
+    def _seed_and_store_offer(
+        self, roles: list
+    ) -> tuple[SqliteDataLayer, "AcceptOfferCaseParticipantReceivedEvent"]:
+        """Seed a DataLayer as the CaseActor would: store the Offer that was sent."""
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+
+        dl = _seed_dl_for_ac1()
+        adapter = TriggerActivityAdapter(dl)
+        # Store the Offer as offer_actor_to_case() does when sending it to Case Owner.
+        offer_id, _ = adapter.offer_actor_to_case(
+            recommender_id="https://example.org/actors/ac1-finder",
+            recommended_id=AC1_INVITEE_ID,
+            case_id=AC1_CASE_ID,
+            actor=AC1_CASE_ACTOR_ID,
+            to=[AC1_CASE_OWNER_ID],
+            origin="https://example.org/activities/orig-offer-001",
+            roles=roles,
+        )
+        # Build Accept(Offer) using the STORED offer (as Case Owner would).
+        stored_offer = dl.read(offer_id)
+        from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+            as_Offer,
+        )
+
+        accept = accept_case_participant_offer_activity(
+            cast(as_Offer, stored_offer),
+            target=AC1_CASE_ID,
+            actor=AC1_CASE_OWNER_ID,
+            to=[AC1_CASE_ACTOR_ID],
+        )
+        event = cast(
+            AcceptOfferCaseParticipantReceivedEvent, extract_event(accept)
+        )
+        return dl, event
+
+    def test_invite_carries_roles_from_stored_offer(self):
+        """Roles from the stored Offer are threaded into the emitted Invite.
+
+        ISSUE-1745: when CaseActor receives Accept(Offer(CaseParticipant[VENDOR])),
+        the Invite it emits to the invitee must carry roles=[VENDOR], read from
+        the stored Offer in the DataLayer (not from the blackboard, which is empty
+        in this separate BT execution).
+        """
+        from vultron.enums.roles import CVDRole
+
+        dl, event = self._seed_and_store_offer(roles=[CVDRole.VENDOR])
+        AcceptOfferCaseParticipantReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        outbox = dl.outbox_list_for_actor(AC1_CASE_ACTOR_ID)
+        invite_obj = None
+        for act_id in outbox:
+            obj = dl.read(act_id)
+            if obj is not None and str(getattr(obj, "type_", "")) == "Invite":
+                invite_obj = obj
+                break
+
+        assert (
+            invite_obj is not None
+        ), "Invite must be stored in CaseActor outbox"
+        invite_roles = getattr(invite_obj, "roles", None)
+        assert invite_roles == [CVDRole.VENDOR.value], (
+            f"ISSUE-1745: Invite must carry roles from stored Offer; "
+            f"expected ['{CVDRole.VENDOR.value}'], got {invite_roles!r}"
+        )
+
+    def test_participant_case_roles_vendor_after_full_round_trip(self):
+        """Full round-trip: Accept(Invite) creates participant with VENDOR role.
+
+        ISSUE-1745: after the fix, participant.case_roles should be [VENDOR]
+        (read from the stored Offer), not [] (missing blackboard key).
+        """
+        from vultron.core.use_cases.received.actor.invite import (
+            AcceptInviteActorToCaseReceivedUseCase,
+        )
+        from vultron.enums.roles import CVDRole
+
+        dl, event = self._seed_and_store_offer(roles=[CVDRole.VENDOR])
+
+        # Step 1: CaseActor receives Accept(Offer(CaseParticipant[VENDOR])) → emits Invite
+        AcceptOfferCaseParticipantReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        # Step 2: find the stored Invite
+        outbox = dl.outbox_list_for_actor(AC1_CASE_ACTOR_ID)
+        invite_obj = None
+        for act_id in outbox:
+            obj = dl.read(act_id)
+            if obj is not None and str(getattr(obj, "type_", "")) == "Invite":
+                invite_obj = obj
+                break
+        assert (
+            invite_obj is not None
+        ), "Invite must be present in CaseActor outbox"
+
+        # Step 3: invitee accepts the Invite
+        py_trees.blackboard.Blackboard.storage.clear()
+        from vultron.core.models.events.actor import (
+            AcceptInviteActorToCaseReceivedEvent,
+        )
+        from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+            as_Invite,
+        )
+
+        accept_invite = rm_accept_invite_to_case_activity(
+            cast(as_Invite, invite_obj), actor=AC1_INVITEE_ID
+        )
+        accept_invite_event = cast(
+            AcceptInviteActorToCaseReceivedEvent, extract_event(accept_invite)
+        )
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl, accept_invite_event, sync_port=MagicMock()
+        ).execute()
+
+        # Step 4: participant must have VENDOR role
+        reloaded_case = cast(Any, dl.read(AC1_CASE_ID))
+        participant_id = reloaded_case.actor_participant_index.get(
+            AC1_INVITEE_ID
+        )
+        assert (
+            participant_id is not None
+        ), "Invitee must be registered as participant"
+        participant = cast(Any, dl.get(id_=participant_id))
+        assert participant is not None
+        assert CVDRole.VENDOR in participant.case_roles, (
+            f"ISSUE-1745: participant.case_roles must contain VENDOR after "
+            f"full round-trip; got {participant.case_roles!r}"
+        )
+
+
 class TestAcceptOfferCaseParticipantRolesThreading:
     """AC-1/AC-2 (ISSUE-1406): roles threading through suggest-actor received path.
 

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -58,9 +58,17 @@ class EmitInviteActorToCaseNode(DataLayerAction):
     ``attributed_to`` carries the original requesting actor when the invite
     is sent from the Case Actor identity (PCR-08-007).
 
-    Reads ``suggested_roles`` from the blackboard (written by
-    ``EvaluateDefaultRolesNode`` or the Case Owner's Accept response) and
-    embeds the roles in the Invite (CM-17-003).
+    Roles are resolved via ``_read_suggested_roles()``, which uses two paths:
+
+    1. **Injected roles** (``roles`` constructor parameter): used when the
+       node is instantiated from a stored ``Offer(CaseParticipant)`` in the
+       DataLayer (ISSUE-1745).  The stored Offer is the trusted source because
+       the received ``Accept`` is untrusted — the accepting actor may have
+       modified or omitted roles.  This path is used in BT execution 2, where
+       the blackboard is empty.
+    2. **Blackboard fallback**: used in the single-execution path where
+       ``EvaluateDefaultRolesNode`` wrote ``suggested_roles`` to the blackboard
+       in the same ``BTBridge.execute_with_setup()`` call (CM-17-003).
 
     Reads the ``VulnerabilityCase`` from the DataLayer and passes it as
     ``target`` to ``TriggerActivityPort.invite_actor_to_case()``.  The adapter
@@ -76,7 +84,7 @@ class EmitInviteActorToCaseNode(DataLayerAction):
         case_actor_id: str | None = None,
         attributed_to: str | None = None,
         captured: dict | None = None,
-        roles: list | None = None,
+        roles: list[str] | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(name=name or self.__class__.__name__)

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -76,6 +76,7 @@ class EmitInviteActorToCaseNode(DataLayerAction):
         case_actor_id: str | None = None,
         attributed_to: str | None = None,
         captured: dict | None = None,
+        roles: list | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(name=name or self.__class__.__name__)
@@ -84,6 +85,7 @@ class EmitInviteActorToCaseNode(DataLayerAction):
         self.case_actor_id = case_actor_id
         self.attributed_to = attributed_to
         self._captured = captured
+        self._injected_roles = roles
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -92,6 +94,10 @@ class EmitInviteActorToCaseNode(DataLayerAction):
         )
 
     def _read_suggested_roles(self) -> list[str] | None:
+        # Use injected roles (from stored Offer via DataLayer) when available
+        # (ISSUE-1745: blackboard is empty in a separate BT execution).
+        if self._injected_roles is not None:
+            return self._injected_roles if self._injected_roles else None
         try:
             roles = self.blackboard.get("suggested_roles")
             if isinstance(roles, list):

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -228,7 +228,7 @@ def create_accept_actor_recommendation_received_tree(
     recommender_id: str,
     invitee_id: str,
     case_id: str,
-    roles: list | None = None,
+    roles: list[str] | None = None,
 ) -> py_trees.composites.Sequence:
     """Received-side BT for Accept(Offer(CaseParticipant)) on the CaseActor inbox.
 

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -228,6 +228,7 @@ def create_accept_actor_recommendation_received_tree(
     recommender_id: str,
     invitee_id: str,
     case_id: str,
+    roles: list | None = None,
 ) -> py_trees.composites.Sequence:
     """Received-side BT for Accept(Offer(CaseParticipant)) on the CaseActor inbox.
 
@@ -236,12 +237,21 @@ def create_accept_actor_recommendation_received_tree(
     (CM-16-006 step 3) and ``Invite(CaseStub+embargo+roles)`` to the
     invitee (CM-16-006 step 4, CM-17).
 
+    ``roles`` must come from the stored ``Offer(CaseParticipant)`` in the
+    DataLayer (ISSUE-1745): the blackboard is empty in this separate BT
+    execution, so the use case is responsible for reading the trusted roles
+    from the stored Offer before calling this factory.
+
     Args:
         recommendation_id: ID of the original ``Offer(Actor, Case)`` from the
             recommender (carried in the ``origin`` field of the transformed Offer).
         recommender_id: Actor ID of the original recommender.
         invitee_id: Actor ID of the suggested new participant.
         case_id: ID of the VulnerabilityCase.
+        roles: Serialized CVD role strings from the stored
+            ``Offer(CaseParticipant)``; passed directly to
+            ``EmitInviteActorToCaseNode`` so the Invite carries the correct
+            roles without relying on the blackboard.
 
     Returns:
         Root ``AcceptActorRecommendationBT`` Sequence node.
@@ -261,6 +271,7 @@ def create_accept_actor_recommendation_received_tree(
                 invitee_id=invitee_id,
                 case_id=case_id,
                 case_actor_id=None,
+                roles=roles,
             ),
         ],
     )

--- a/vultron/core/use_cases/received/actor/offer_case_participant.py
+++ b/vultron/core/use_cases/received/actor/offer_case_participant.py
@@ -40,6 +40,7 @@ from vultron.core.models.events.actor import (
 )
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.use_cases.received.sync import _find_local_actor_id
+from vultron.enums.roles import serialize_roles
 
 if TYPE_CHECKING:
     from vultron.core.ports.trigger_activity import TriggerActivityPort
@@ -135,6 +136,20 @@ class AcceptOfferCaseParticipantReceivedUseCase:
                     recommendation_id
                 )
 
+        # Read the stored Offer (written by offer_actor_to_case()) to get the
+        # trusted roles. Do NOT use the embedded CaseParticipant from the
+        # received Accept — the accepting actor may have modified it or may
+        # have sent only a bare ID reference (ISSUE-1745).
+        offer_roles: list | None = None
+        raw_offer_id = getattr(inner_offer, "id_", None)
+        offer_id = raw_offer_id if isinstance(raw_offer_id, str) else None
+        if offer_id:
+            stored_offer = self._dl.read(offer_id)
+            stored_participant = getattr(stored_offer, "object_", None)
+            raw_roles = getattr(stored_participant, "roles", None)
+            if isinstance(raw_roles, list) and raw_roles:
+                offer_roles = serialize_roles(raw_roles)
+
         if not case_id or not invitee_id:
             logger.warning(
                 "AcceptOfferCaseParticipantReceived: missing case_id or"
@@ -157,6 +172,7 @@ class AcceptOfferCaseParticipantReceivedUseCase:
             recommender_id=recommender_id or "",
             invitee_id=invitee_id,
             case_id=case_id,
+            roles=offer_roles,
         )
         bridge = BTBridge(
             datalayer=self._dl, trigger_activity=self._trigger_activity


### PR DESCRIPTION
## Summary

- Closes #1745

- **Bug**: `AcceptOfferCaseParticipantReceivedUseCase` emitted `Invite(Actor, Case)` with no roles, causing participants to receive the default `CVDRole.COORDINATOR` instead of the roles specified in the original offer.
- **Root cause**: `EmitInviteActorToCaseNode._read_suggested_roles()` read from the py_trees blackboard, which is empty in BT execution 2. The `suggested_roles` key is only written during BT execution 1 (`create_recommend_actor_to_case_received_tree`), which runs in a separate `BTBridge.execute_with_setup()` call; the blackboard does not persist between calls (ADR-0022).
- **Fix**: Read roles from the stored `Offer(CaseParticipant)` in the DataLayer — the offer written by `offer_actor_to_case()` is the trusted source. The received `Accept` is untrusted (the accepting actor may have modified it or sent only a bare ID).

## Changes

- `offer_case_participant.py`: look up stored Offer by ID, extract `stored_participant.roles`, serialize, pass to tree factory. Uses `.roles` property (not `getattr(..., "case_roles", ...)`) to satisfy architecture ratchet PRM-01-003.
- `suggest_actor_tree.py`: `create_accept_actor_recommendation_received_tree()` gains `roles: list | None = None` param; forwards to `EmitInviteActorToCaseNode`.
- `nodes/actor.py`: `EmitInviteActorToCaseNode` gains `roles: list | None = None` constructor param; `_read_suggested_roles()` returns injected roles first, falls back to blackboard for the existing single-execution path.

## Regression Tests

Two new tests in `TestRolesFromStoredOffer`:
- `test_invite_carries_roles_from_stored_offer` — asserts the emitted Invite carries `roles=['vendor']` when a `VENDOR` Offer is stored in DataLayer.
- `test_participant_case_roles_vendor_after_full_round_trip` — full round-trip through `AcceptInviteActorToCaseReceivedUseCase`; asserts `participant.case_roles` contains `CVDRole.VENDOR`.

## Test plan
- [x] Architecture ratchet `test_no_getattr_case_roles_read_in_core` passes
- [x] New regression tests pass
- [x] Full test suite passes (exit code 0)
- [x] mypy + pyright + flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)