### PR TITLE
docs: plan concern #1675 — add event-phrase pitfall to vultron/demo/AGENTS.md

### DIFF
--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -198,3 +198,23 @@ pattern to eliminate; CONCERN-1653's self-delivery pattern is orthogonal and
 remains correct.
 
 <!-- Source: CONCERN-1635 -->
+
+---
+
+### Event-Phrase Lookups MUST Use `lookup_entry()`, Not a Local Phrase Dict
+
+Any display-layer code that maps a `MessageSemantics` value to a human-readable
+phrase MUST use `lookup_entry(semantics).phrase` from
+`vultron.semantic_registry`, not a local `dict[str, str]` parallel table.
+
+**Why:** A local dict keyed by `MessageSemantics` values will silently drift
+as new semantics are added to the enum. `SemanticEntry.phrase` is mandatory
+(SE-07-003), so a missing phrase is a `TypeError` at registry construction
+time — not a silent fallback at render time.
+
+**How to apply:** Import `from vultron.semantic_registry import lookup_entry`
+and render with `lookup_entry(semantics).phrase.format_map(defaultdict(lambda: "—", slots))`.
+Use the fallback humanizer (`event_type.replace("_", " ")`) only for event
+types not in the registry (e.g., data from a future protocol version).
+
+<!-- Source: CONCERN-1675 -->


### PR DESCRIPTION
- Closes #1675

## Summary

The core concern (silent drift between `_EVENT_PHRASES` and `MessageSemantics`)
was already resolved by #1729 (merged via #1751), which added the mandatory
`phrase` field to `SemanticEntry` and migrated `report.py` to use `lookup_entry()`.

This PR adds the agent-facing pitfall entry to `vultron/demo/AGENTS.md`
capturing the rule that display-layer phrase lookups keyed by `MessageSemantics`
MUST use `lookup_entry()` from the semantic registry, not a local parallel dict.

## Changes

- `vultron/demo/AGENTS.md`: add "Event-Phrase Lookups MUST Use `lookup_entry()`"
  pitfall (SE-07-001, DRPT-03-002, CONCERN-1675)

## Test plan

- [x] Markdown lint passes (`markdownlint-cli2`)
- [x] No code changes; no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)