### PR TITLE
feat(demo-report): replace absolute timestamp with delta-T column (DRPT-04-007)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1762.md
+++ b/plan/history/2607/implementation/ISSUE-1762.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-1762
+timestamp: '2026-07-28T16:25:30.241197+00:00'
+title: Replace absolute timestamp with delta-T column
+type: implementation
+---
+
+## Issue #1762 — Report: implement delta-T Time column (DRPT-04-007)
+
+Replaced the absolute ISO-8601 `Time` column in the demo report case timeline table with a compact `ΔT` column showing elapsed time from the previous row.
+
+Added `_format_delta()` helper, updated both markdown and HTML renderers with `prev_ts` state tracking, and added 13 unit tests plus renderer integration tests.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1764>

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -30,6 +30,7 @@ from vultron.demo.report import (
     CaseTimelineEvent,
     ReportError,
     _case_time_range,
+    _format_delta,
     _parse_timestamp,
     build_timeline,
     collect_actor_names,
@@ -521,6 +522,79 @@ class TestFriendlyNaming:
 
 
 # ---------------------------------------------------------------------------
+# DRPT-05-005 — _format_delta unit tests (AC-6)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDelta:
+    def test_both_none_returns_em_dash(self):
+        assert _format_delta(None, None) == "—"
+
+    def test_received_at_none_returns_em_dash(self):
+        assert _format_delta(None, "2026-07-01T12:00:00Z") == "—"
+
+    def test_first_row_no_prev_returns_plus_zero_s(self):
+        assert _format_delta("2026-07-01T12:00:00Z", None) == "+0s"
+
+    def test_sub_minute_delta(self):
+        assert (
+            _format_delta("2026-07-01T12:00:45Z", "2026-07-01T12:00:00Z")
+            == "+45s"
+        )
+
+    def test_sub_hour_delta(self):
+        assert (
+            _format_delta("2026-07-01T12:03:15Z", "2026-07-01T12:00:00Z")
+            == "+3m 15s"
+        )
+
+    def test_multi_hour_delta(self):
+        assert (
+            _format_delta("2026-07-01T14:03:15Z", "2026-07-01T12:00:00Z")
+            == "+2h 3m 15s"
+        )
+
+    def test_exact_one_minute(self):
+        assert (
+            _format_delta("2026-07-01T12:01:00Z", "2026-07-01T12:00:00Z")
+            == "+1m 0s"
+        )
+
+    def test_exact_one_hour(self):
+        assert (
+            _format_delta("2026-07-01T13:00:00Z", "2026-07-01T12:00:00Z")
+            == "+1h 0m 0s"
+        )
+
+    def test_zero_delta_same_timestamp(self):
+        assert (
+            _format_delta("2026-07-01T12:00:00Z", "2026-07-01T12:00:00Z")
+            == "+0s"
+        )
+
+    def test_unparseable_received_at_returns_em_dash(self):
+        assert _format_delta("not-a-timestamp", "2026-07-01T12:00:00Z") == "—"
+
+    def test_unparseable_prev_returns_em_dash(self):
+        assert _format_delta("2026-07-01T12:00:00Z", "bad") == "—"
+
+    def test_negative_delta_clamped_to_zero(self):
+        """Out-of-order rows clamp to +0s rather than producing a negative string."""
+        assert (
+            _format_delta("2026-07-01T11:00:00Z", "2026-07-01T13:00:00Z")
+            == "+0s"
+        )
+
+    def test_offset_notation_accepted(self):
+        assert (
+            _format_delta(
+                "2026-07-01T12:00:30+00:00", "2026-07-01T12:00:00+00:00"
+            )
+            == "+30s"
+        )
+
+
+# ---------------------------------------------------------------------------
 # DRPT-02-004 / DRPT-02-005 — merge, dedup, presence
 # ---------------------------------------------------------------------------
 
@@ -708,11 +782,6 @@ class TestMarkdownRenderer:
         md = render_markdown(events, actors)
         assert "Vendor validated the report" in md
 
-    def test_pipe_in_value_is_escaped(self):
-        raw = _camel_entry(receivedAt="a|b")
-        md = render_markdown(build_timeline({"vendor": [raw]}), ["vendor"])
-        assert "a\\|b" in md
-
     def test_pipe_in_actor_dir_name_is_escaped(self):
         """Actor column headers must be cell-escaped like data cells."""
         md = render_markdown(
@@ -736,6 +805,77 @@ class TestMarkdownRenderer:
         assert "- Cases: 2" in md
         # Two header rows — one table per case.
         assert sum(1 for ln in md.splitlines() if ln.startswith("| #")) == 2
+
+    def test_time_column_header_is_delta_t(self):
+        """AC-7: ΔT header appears in markdown table (DRPT-04-007)."""
+        events, actors = _sample_events()
+        md = render_markdown(events, actors)
+        header = next(ln for ln in md.splitlines() if ln.startswith("| #"))
+        assert "| ΔT |" in header
+
+    def test_time_cells_contain_delta_strings_not_iso(self):
+        """AC-7: Time cells show +0s / +Ns, not ISO 8601 timestamps (DRPT-04-007)."""
+        replicas = {
+            "vendor": [
+                _camel_entry(
+                    logIndex=0,
+                    entryHash="a" * 64,
+                    receivedAt="2026-07-01T12:00:00Z",
+                ),
+                _camel_entry(
+                    logIndex=1,
+                    entryHash="b" * 64,
+                    receivedAt="2026-07-01T12:00:30Z",
+                ),
+            ],
+        }
+        events = build_timeline(replicas)
+        md = render_markdown(events, ["vendor"])
+        data_rows = [
+            ln
+            for ln in md.splitlines()
+            if ln.startswith("| ") and "---" not in ln and "| #" not in ln
+        ]
+        assert len(data_rows) == 2
+        assert "+0s" in data_rows[0]
+        assert "+30s" in data_rows[1]
+        # ISO timestamps must not appear in the table body cells.
+        for row in data_rows:
+            assert "2026-07-01T" not in row
+
+    def test_prev_ts_carries_through_none_timestamp_row(self):
+        """A None-timestamp row must not reset the prev_ts anchor (DRPT-04-007)."""
+        replicas = {
+            "vendor": [
+                _camel_entry(
+                    logIndex=0,
+                    entryHash="a" * 64,
+                    receivedAt="2026-07-01T12:00:00Z",
+                ),
+                _camel_entry(
+                    logIndex=1,
+                    entryHash="b" * 64,
+                    receivedAt=None,
+                ),
+                _camel_entry(
+                    logIndex=2,
+                    entryHash="c" * 64,
+                    receivedAt="2026-07-01T12:01:30Z",
+                ),
+            ],
+        }
+        events = build_timeline(replicas)
+        md = render_markdown(events, ["vendor"])
+        data_rows = [
+            ln
+            for ln in md.splitlines()
+            if ln.startswith("| ") and "---" not in ln and "| #" not in ln
+        ]
+        assert len(data_rows) == 3
+        assert "+0s" in data_rows[0]
+        assert "—" in data_rows[1]
+        # Third row delta is from row 0 (T+0), not row 1 (which had no ts).
+        assert "+1m 30s" in data_rows[2]
 
 
 class TestHtmlRenderer:
@@ -802,6 +942,64 @@ class TestHtmlRenderer:
         assert "<h2>Case urn:case:B</h2>" in out
         assert out.count("<table>") == 2
         assert "Cases: 2" in out
+
+    def test_time_column_header_is_delta_t(self):
+        """AC-7: ΔT header appears in HTML table (DRPT-04-007)."""
+        events, actors = _sample_events()
+        out = render_html(events, actors)
+        assert "<th>ΔT</th>" in out
+
+    def test_time_cells_contain_delta_strings_not_iso(self):
+        """AC-7: Time cells show +0s / +Ns, not ISO 8601 in cell body (DRPT-04-007)."""
+        replicas = {
+            "vendor": [
+                _camel_entry(
+                    logIndex=0,
+                    entryHash="a" * 64,
+                    receivedAt="2026-07-01T12:00:00Z",
+                ),
+                _camel_entry(
+                    logIndex=1,
+                    entryHash="b" * 64,
+                    receivedAt="2026-07-01T12:00:45Z",
+                ),
+            ],
+        }
+        events = build_timeline(replicas)
+        out = render_html(events, ["vendor"])
+        assert ">+0s<" in out
+        assert ">+45s<" in out
+
+    def test_time_cell_iso_retained_as_tooltip(self):
+        """AC-7: Full ISO timestamp retained as title= tooltip on ΔT <td> (DRPT-04-007)."""
+        replicas = {
+            "vendor": [
+                _camel_entry(
+                    logIndex=0,
+                    entryHash="a" * 64,
+                    receivedAt="2026-07-01T12:00:00Z",
+                ),
+            ],
+        }
+        events = build_timeline(replicas)
+        out = render_html(events, ["vendor"])
+        assert 'title="2026-07-01T12:00:00Z"' in out
+
+    def test_time_cell_no_tooltip_when_no_timestamp(self):
+        """AC-7: No title= attribute when received_at is absent (no ISO to show)."""
+        replicas = {
+            "vendor": [
+                _camel_entry(
+                    logIndex=0,
+                    entryHash="a" * 64,
+                    receivedAt=None,
+                ),
+            ],
+        }
+        events = build_timeline(replicas)
+        out = render_html(events, ["vendor"])
+        # ΔT cell must be <td>—</td> (no title= attribute when no timestamp).
+        assert "<td>—</td>" in out
 
     def test_case_id_in_heading_is_escaped(self):
         """A case_id carrying markup is escaped in the <h2> heading."""

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -785,7 +785,7 @@ def discovered_actors(replicas: dict[str, list[dict[str, Any]]]) -> list[str]:
 
 _TABLE_HEADERS = [
     "#",
-    "Time",
+    "ΔT",
     "Actor",
     "Event",
     "Target",
@@ -809,6 +809,39 @@ def _parse_timestamp(ts: str) -> datetime:
     Python < 3.11) and ``+00:00`` offset forms.
     """
     return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def _format_delta(
+    received_at: str | None,
+    prev_received_at: str | None,
+) -> str:
+    """Return a compact delta string between two ``receivedAt`` timestamps.
+
+    - Returns ``"—"`` when ``received_at`` is ``None`` (no timestamp on this row).
+    - Returns ``"+0s"`` when ``prev_received_at`` is ``None`` and ``received_at``
+      is set (first timestamped row — anchor point).
+    - Returns ``"+Ns"`` / ``"+Nm Ns"`` / ``"+Nh Nm Ns"`` for a positive delta;
+      no day component (spec: DRPT-04-007).
+    """
+    if received_at is None:
+        return "—"
+    if prev_received_at is None:
+        return "+0s"
+    try:
+        dt_curr = _parse_timestamp(received_at)
+        dt_prev = _parse_timestamp(prev_received_at)
+    except ValueError:
+        return "—"
+    total_seconds = int((dt_curr - dt_prev).total_seconds())
+    if total_seconds < 0:
+        total_seconds = 0
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"+{hours}h {minutes}m {seconds}s"
+    if minutes:
+        return f"+{minutes}m {seconds}s"
+    return f"+{seconds}s"
 
 
 def _case_time_range(
@@ -844,10 +877,14 @@ def _render_markdown_case(
     lines.append("| " + " | ".join(headers) + " |")
     lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
 
+    prev_ts: str | None = None
     for event in events:
+        delta = _format_delta(event.received_at, prev_ts)
+        if event.received_at is not None:
+            prev_ts = event.received_at
         row = [
             str(event.log_index),
-            _md_cell(event.received_at or ""),
+            _md_cell(delta),
             _md_cell(event.actor_label),
             _md_cell(event.summary),
             _md_cell(event.target_label or ""),
@@ -948,13 +985,17 @@ def _render_html_case_table(
     )
 
     body_rows: list[str] = []
+    prev_ts: str | None = None
     for event in events:
         row_class = (
             "" if event.disposition == "recorded" else ' class="rejected"'
         )
+        delta = _format_delta(event.received_at, prev_ts)
+        if event.received_at is not None:
+            prev_ts = event.received_at
         cells = [
             _html_cell(str(event.log_index)),
-            _html_cell(event.received_at or ""),
+            _html_cell(delta, title=event.received_at or None),
             _html_cell(event.actor_label, title=event.actor_uri or None),
             _html_cell(event.summary),
             _html_cell(

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -832,7 +832,7 @@ def _format_delta(
         dt_prev = _parse_timestamp(prev_received_at)
     except ValueError:
         return "—"
-    total_seconds = int((dt_curr - dt_prev).total_seconds())
+    total_seconds = round((dt_curr - dt_prev).total_seconds())
     if total_seconds < 0:
         total_seconds = 0
     hours, remainder = divmod(total_seconds, 3600)


### PR DESCRIPTION
- Closes #1762

## Summary

Implements DRPT-04-007: replaces the absolute ISO-8601 `Time` column in the case timeline table with a compact `ΔT` column showing elapsed time from the previous row.

### Changes

**`vultron/demo/report.py`**
- Added `_format_delta(received_at, prev_received_at)` standalone helper returning `+0s` (first timestamped row), `—` (no timestamp), or adaptive `+Ns` / `+Nm Ns` / `+Nh Nm Ns` (DRPT-04-007)
- Updated `_TABLE_HEADERS`: `"Time"` → `"ΔT"` (AC-2)
- Updated `_render_markdown_case`: uses `_format_delta` with `prev_ts` state variable; `None`-timestamp rows do not reset the anchor (AC-3)
- Updated `_render_html_case_table`: same delta logic; full ISO timestamp retained as `title=` tooltip on the ΔT `<td>` (AC-4)

**`test/demo/test_report.py`**
- Removed `test_pipe_in_value_is_escaped` (no longer applicable — raw timestamps no longer appear in table cells) (AC-5)
- Added `TestFormatDelta` class (13 cases): `+0s` first-row, `—` no-timestamp, both-`None`, three format tiers, negative-delta clamping, unparseable inputs, `+00:00` offset (AC-6)
- Added `test_time_column_header_is_delta_t`, `test_time_cells_contain_delta_strings_not_iso`, `test_prev_ts_carries_through_none_timestamp_row` to `TestMarkdownRenderer` (AC-7)
- Added `test_time_column_header_is_delta_t`, `test_time_cells_contain_delta_strings_not_iso`, `test_time_cell_iso_retained_as_tooltip`, `test_time_cell_no_tooltip_when_no_timestamp` to `TestHtmlRenderer` (AC-7)

## Test plan

- [x] `uv run pytest test/demo/test_report.py -m ""` → 131 passed
- [x] Full test suite → exit code 0
- [x] `uv run black` → unchanged
- [x] `uv run flake8` → clean
- [x] `uv run mypy` → no issues
- [x] `uv run pyright` → 0 errors