### PR TITLE
fix(vfd-role-guard): gate d→D on DEPLOYER, f→F on VENDOR; fix notify-published VFD bug

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1736.md
+++ b/plan/history/2607/implementation/ISSUE-1736.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1736
+timestamp: '2026-07-28T16:34:24.497798+00:00'
+title: 'fix(vfd-role-guard): VFD role guards and notify-published fix'
+type: implementation
+---
+
+## Issue #1736 — fix(vfd-role-guard): gate d→D on DEPLOYER, f→F on VENDOR; fix notify-published VFD bug
+
+Implemented all four acceptance criteria:
+
+- AC-1: `CheckDeployerRoleNode` gates d→D (vfd_state=VFD); returns FAILURE when actor lacks CVDRole.DEPLOYER
+- AC-2: `CheckVendorRoleNode` gates f→F (vfd_state=VFd); returns FAILURE when actor lacks CVDRole.VENDOR
+- AC-3: `demo_notify_published` no longer passes vfd_state=VFD (only pxa_state=Pxa)
+- AC-4: All six demo scenarios updated to remove actor_notifies_fix_deployed for vendor-only actors; terminal state VFd not VFD
+
+New files: vultron/core/behaviors/case/nodes/vfd_role_guards.py, test/core/behaviors/case/nodes/test_vfd_role_guards.py
+5602 tests pass, 10 new. PR: <https://github.com/CERTCC/Vultron/pull/1765>

--- a/plan/incoming/learnings/20260728-verify-fix-deployed-vendor-confusion.md
+++ b/plan/incoming/learnings/20260728-verify-fix-deployed-vendor-confusion.md
@@ -1,0 +1,21 @@
+---
+title: verify_fix_deployed confusing for vendor-only actors after CSB-15-002 enforcement
+type: learning
+timestamp: 2026-07-28T16:40:00Z
+source: ISSUE-1736
+signal: concern
+---
+
+`verify_fix_deployed` in `vultron/demo/helpers/milestones.py` asserts
+`CVDRole.VENDOR` in participant roles, then checks for `vfd_state == VFD`.
+After enforcing CSB-15-002 (only DEPLOYER actors advance to VFD), calling
+`verify_fix_deployed` with a vendor-only actor will fail at the VENDOR role
+check before reaching the VFD state assertion — giving a confusing error
+("actor does not hold CVDRole.VENDOR") when the real issue is that the actor
+is a vendor-only actor who terminates at VFd, not VFD.
+
+A future concern issue should: rename `verify_fix_deployed` to clarify it
+is for DEPLOYER actors, update its docstring to remove the VENDOR role
+requirement (DEPLOYER actors need not be VENDOR), and add a
+`verify_fix_deployed_for_deployer` that checks for DEPLOYER role instead.
+Tracked as a DEFER from ISSUE-1736 review.

--- a/test/ci/invariants/common.py
+++ b/test/ci/invariants/common.py
@@ -592,10 +592,12 @@ def cs_observations_from_snap(snap: dict) -> tuple[bool, bool, bool]:
 def check_cs_state_transitions_observed(
     replicas: dict[str, list[dict]],
 ) -> list[str]:
-    """All three key CS transitions observed in the authoritative log (Invariant 15).
+    """Key CS transitions observed in the authoritative log (Invariant 15).
 
-    Checks vfd_state == "VFd" (fix ready), "VFD" (fix deployed), and
-    pxa_state starting with "P" (public aware).
+    Checks vfd_state == "VFd" (fix ready) and pxa_state starting with "P"
+    (public aware).  VFD (fix deployed) is NOT checked here because demo
+    scenarios use vendor-only actors (CVDRole.VENDOR, no CVDRole.DEPLOYER);
+    per CSB-15-002 those actors stop at VFd and never reach VFD.
     """
     auth = auth_entries(replicas)
     status_entries = [
@@ -609,20 +611,15 @@ def check_cs_state_transitions_observed(
             "cannot check CS-transition invariant"
         ]
 
-    saw_fix_ready = saw_fix_deployed = saw_published = False
+    saw_fix_ready = saw_published = False
     for e in status_entries:
-        fix_ready, fix_deployed, published = cs_observations_from_snap(
-            payload(e)
-        )
+        fix_ready, _, published = cs_observations_from_snap(payload(e))
         saw_fix_ready |= fix_ready
-        saw_fix_deployed |= fix_deployed
         saw_published |= published
 
     missing: list[str] = []
     if not saw_fix_ready:
         missing.append("vfd_state == 'VFd' (fix_ready) never observed")
-    if not saw_fix_deployed:
-        missing.append("vfd_state == 'VFD' (fix_deployed) never observed")
     if not saw_published:
         missing.append(
             "pxa_state starting with 'P' (published/public-aware) never observed"

--- a/test/ci/invariants/test_fcv_invariants.py
+++ b/test/ci/invariants/test_fcv_invariants.py
@@ -322,17 +322,18 @@ def test_fcv_vendor_late_joiner_has_full_history(
 
 
 @pytest.mark.case_ledger_invariants
-def test_fcv_vendor_vfd_and_vfd_transitions_observed(
+def test_fcv_vendor_vfd_transition_observed(
     fcv_replicas: dict[str, list[dict]],
 ) -> None:
-    """CS transitions VFd and VFD observed in Vendor's add_participant_status entries.
+    """VFd transition observed in Vendor's add_participant_status entries.
 
-    Spec: DEMOMA-12-009(4) — Vendor fix path; only Vendor has VFD role.
+    Vendor holds CVDRole.VENDOR (not CVDRole.DEPLOYER), so the fix lifecycle
+    stops at VFd per CSB-15-002.  Spec: DEMOMA-12-009(4).
     """
     vendor_entries = fcv_replicas.get("vendor")
     if not vendor_entries:
         pytest.skip(
-            "vendor replica absent; cannot check Vendor VFd/VFD transitions"
+            "vendor replica absent; cannot check Vendor VFd transition"
         )
 
     status_entries = [
@@ -345,20 +346,14 @@ def test_fcv_vendor_vfd_and_vfd_transitions_observed(
             "No add_participant_status_to_participant entries in vendor log"
         )
 
-    saw_fix_ready = saw_fix_deployed = False
+    saw_fix_ready = False
     for e in status_entries:
-        fix_ready, fix_deployed, _ = cs_observations_from_snap(payload(e))
+        fix_ready, _, _ = cs_observations_from_snap(payload(e))
         saw_fix_ready |= fix_ready
-        saw_fix_deployed |= fix_deployed
 
-    missing: list[str] = []
-    if not saw_fix_ready:
-        missing.append("Vendor: vfd_state == 'VFd' (fix_ready) never observed")
-    if not saw_fix_deployed:
-        missing.append(
-            "Vendor: vfd_state == 'VFD' (fix_deployed) never observed"
-        )
-    assert not missing, "Missing Vendor CS transitions:\n" + "\n".join(missing)
+    assert (
+        saw_fix_ready
+    ), "Vendor: vfd_state == 'VFd' (fix_ready) never observed"
 
 
 @pytest.mark.case_ledger_invariants

--- a/test/core/behaviors/case/nodes/test_vfd_role_guards.py
+++ b/test/core/behaviors/case/nodes/test_vfd_role_guards.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for ``CheckVendorRoleNode`` and ``CheckDeployerRoleNode``.
+
+Both nodes gate VFD state transitions per CSB-15-001 and CSB-15-002:
+- CheckVendorRoleNode: gates f→F (vfd_state=VFd); actor must hold CVDRole.VENDOR
+- CheckDeployerRoleNode: gates d→D (vfd_state=VFD); actor must hold CVDRole.DEPLOYER
+"""
+
+import pytest
+from py_trees.common import Status
+
+from test.core.behaviors.bt_harness import BTTestScenario
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckDeployerRoleNode,
+    CheckVendorRoleNode,
+)
+from vultron.core.models.vultron_types import VultronCase, VultronParticipant
+from vultron.enums.roles import CVDRole
+
+CASE_ID = "https://example.org/cases/case-001"
+VENDOR_ACTOR_ID = "https://example.org/actors/vendor"
+DEPLOYER_ACTOR_ID = "https://example.org/actors/deployer"
+COORDINATOR_ACTOR_ID = "https://example.org/actors/coordinator"
+
+
+@pytest.fixture
+def vendor_participant() -> VultronParticipant:
+    return VultronParticipant(
+        id_="https://example.org/participants/vendor-cp-001",
+        attributed_to=VENDOR_ACTOR_ID,
+        context=CASE_ID,
+        case_roles=[CVDRole.VENDOR],
+    )
+
+
+@pytest.fixture
+def deployer_participant() -> VultronParticipant:
+    return VultronParticipant(
+        id_="https://example.org/participants/deployer-cp-001",
+        attributed_to=DEPLOYER_ACTOR_ID,
+        context=CASE_ID,
+        case_roles=[CVDRole.DEPLOYER],
+    )
+
+
+@pytest.fixture
+def coordinator_participant() -> VultronParticipant:
+    return VultronParticipant(
+        id_="https://example.org/participants/coordinator-cp-001",
+        attributed_to=COORDINATOR_ACTOR_ID,
+        context=CASE_ID,
+        case_roles=[CVDRole.COORDINATOR],
+    )
+
+
+@pytest.fixture
+def case_with_vendor_and_deployer(
+    bt_scenario: BTTestScenario,
+    vendor_participant: VultronParticipant,
+    deployer_participant: VultronParticipant,
+    coordinator_participant: VultronParticipant,
+) -> VultronCase:
+    case = VultronCase(
+        id_=CASE_ID,
+        name="Test Case",
+        case_participants=[
+            vendor_participant.id_,
+            deployer_participant.id_,
+            coordinator_participant.id_,
+        ],
+        actor_participant_index={
+            VENDOR_ACTOR_ID: vendor_participant.id_,
+            DEPLOYER_ACTOR_ID: deployer_participant.id_,
+            COORDINATOR_ACTOR_ID: coordinator_participant.id_,
+        },
+    )
+    bt_scenario.seed(
+        vendor_participant, deployer_participant, coordinator_participant, case
+    )
+    return case
+
+
+# ---------------------------------------------------------------------------
+# CheckVendorRoleNode (CSB-15-001: gates f→F)
+# ---------------------------------------------------------------------------
+
+
+def test_vendor_guard_success_for_vendor_actor(
+    bt_scenario: BTTestScenario,
+    case_with_vendor_and_deployer: VultronCase,
+) -> None:
+    """SUCCESS when actor holds CVDRole.VENDOR (f→F allowed)."""
+    result = bt_scenario.run(
+        CheckVendorRoleNode(
+            case_id=case_with_vendor_and_deployer.id_,
+            actor_id=VENDOR_ACTOR_ID,
+        ),
+        actor_id=VENDOR_ACTOR_ID,
+    )
+    assert result.status == Status.SUCCESS
+
+
+def test_vendor_guard_failure_for_deployer_only_actor(
+    bt_scenario: BTTestScenario,
+    case_with_vendor_and_deployer: VultronCase,
+) -> None:
+    """FAILURE when actor holds CVDRole.DEPLOYER but not CVDRole.VENDOR."""
+    result = bt_scenario.run(
+        CheckVendorRoleNode(
+            case_id=case_with_vendor_and_deployer.id_,
+            actor_id=DEPLOYER_ACTOR_ID,
+        ),
+        actor_id=DEPLOYER_ACTOR_ID,
+    )
+    assert result.status == Status.FAILURE
+
+
+def test_vendor_guard_failure_for_coordinator_actor(
+    bt_scenario: BTTestScenario,
+    case_with_vendor_and_deployer: VultronCase,
+) -> None:
+    """FAILURE when actor holds CVDRole.COORDINATOR (no VENDOR)."""
+    result = bt_scenario.run(
+        CheckVendorRoleNode(
+            case_id=case_with_vendor_and_deployer.id_,
+            actor_id=COORDINATOR_ACTOR_ID,
+        ),
+        actor_id=COORDINATOR_ACTOR_ID,
+    )
+    assert result.status == Status.FAILURE
+
+
+def test_vendor_guard_failure_when_case_missing(
+    bt_scenario: BTTestScenario,
+) -> None:
+    """FAILURE when the case record is absent from the DataLayer."""
+    result = bt_scenario.run(
+        CheckVendorRoleNode(case_id=CASE_ID, actor_id=VENDOR_ACTOR_ID),
+        actor_id=VENDOR_ACTOR_ID,
+    )
+    assert result.status == Status.FAILURE
+
+
+def test_vendor_guard_failure_when_actor_not_in_case(
+    bt_scenario: BTTestScenario,
+    vendor_participant: VultronParticipant,
+) -> None:
+    """FAILURE when actor_id is not present in actor_participant_index."""
+    case = VultronCase(
+        id_=CASE_ID,
+        name="Test Case",
+        case_participants=[vendor_participant.id_],
+        actor_participant_index={VENDOR_ACTOR_ID: vendor_participant.id_},
+    )
+    bt_scenario.seed(vendor_participant, case)
+
+    unknown_actor = "https://example.org/actors/unknown"
+    result = bt_scenario.run(
+        CheckVendorRoleNode(case_id=CASE_ID, actor_id=unknown_actor),
+        actor_id=unknown_actor,
+    )
+    assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# CheckDeployerRoleNode (CSB-15-002: gates d→D)
+# ---------------------------------------------------------------------------
+
+
+def test_deployer_guard_success_for_deployer_actor(
+    bt_scenario: BTTestScenario,
+    case_with_vendor_and_deployer: VultronCase,
+) -> None:
+    """SUCCESS when actor holds CVDRole.DEPLOYER (d→D allowed)."""
+    result = bt_scenario.run(
+        CheckDeployerRoleNode(
+            case_id=case_with_vendor_and_deployer.id_,
+            actor_id=DEPLOYER_ACTOR_ID,
+        ),
+        actor_id=DEPLOYER_ACTOR_ID,
+    )
+    assert result.status == Status.SUCCESS
+
+
+def test_deployer_guard_failure_for_vendor_only_actor(
+    bt_scenario: BTTestScenario,
+    case_with_vendor_and_deployer: VultronCase,
+) -> None:
+    """FAILURE when actor holds CVDRole.VENDOR but not CVDRole.DEPLOYER (CSB-15-002)."""
+    result = bt_scenario.run(
+        CheckDeployerRoleNode(
+            case_id=case_with_vendor_and_deployer.id_,
+            actor_id=VENDOR_ACTOR_ID,
+        ),
+        actor_id=VENDOR_ACTOR_ID,
+    )
+    assert result.status == Status.FAILURE
+
+
+def test_deployer_guard_failure_for_coordinator_actor(
+    bt_scenario: BTTestScenario,
+    case_with_vendor_and_deployer: VultronCase,
+) -> None:
+    """FAILURE when actor holds CVDRole.COORDINATOR (no DEPLOYER)."""
+    result = bt_scenario.run(
+        CheckDeployerRoleNode(
+            case_id=case_with_vendor_and_deployer.id_,
+            actor_id=COORDINATOR_ACTOR_ID,
+        ),
+        actor_id=COORDINATOR_ACTOR_ID,
+    )
+    assert result.status == Status.FAILURE
+
+
+def test_deployer_guard_failure_when_case_missing(
+    bt_scenario: BTTestScenario,
+) -> None:
+    """FAILURE when the case record is absent from the DataLayer."""
+    result = bt_scenario.run(
+        CheckDeployerRoleNode(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID),
+        actor_id=DEPLOYER_ACTOR_ID,
+    )
+    assert result.status == Status.FAILURE
+
+
+def test_deployer_guard_failure_when_actor_not_in_case(
+    bt_scenario: BTTestScenario,
+    deployer_participant: VultronParticipant,
+) -> None:
+    """FAILURE when actor_id is not present in actor_participant_index."""
+    case = VultronCase(
+        id_=CASE_ID,
+        name="Test Case",
+        case_participants=[deployer_participant.id_],
+        actor_participant_index={DEPLOYER_ACTOR_ID: deployer_participant.id_},
+    )
+    bt_scenario.seed(deployer_participant, case)
+
+    unknown_actor = "https://example.org/actors/unknown"
+    result = bt_scenario.run(
+        CheckDeployerRoleNode(case_id=CASE_ID, actor_id=unknown_actor),
+        actor_id=unknown_actor,
+    )
+    assert result.status == Status.FAILURE

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -51,6 +51,27 @@ def base(client: TestClient) -> str:
 
 
 @pytest.fixture(scope="module", autouse=True)
+def configure_vendor_default_roles():
+    """Set VULTRON_ACTOR__DEFAULT_CASE_ROLES=["vendor"] for this module.
+
+    In Docker the vendor container is started with this env var so the case
+    owner participant gets CVDRole.VENDOR alongside CVDRole.CASE_OWNER.
+    TestClient doesn't inherit Docker env vars, so we replicate the setting
+    here (mirrors docker/docker-compose-multi-actor.yml vendor service config).
+    """
+    from vultron.config.app import reload_config
+
+    mp = MonkeyPatch()
+    try:
+        mp.setenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", '["vendor"]')
+        reload_config()
+        yield
+    finally:
+        mp.undo()
+        reload_config()
+
+
+@pytest.fixture(scope="module", autouse=True)
 def patch_datalayer_call(client: TestClient, base: str):
     """Patch DataLayerClient.call at the class level for all tests in this module.
 
@@ -731,9 +752,7 @@ class TestActorNotifiesFixDeployed:
 
     def test_vendor_blocked_from_vfd(self, client: TestClient, base: str):
         """Vendor-only actor is blocked from VFD (d→D) by CheckDeployerRoleNode."""
-        import httpx2 as httpx
-
-        from vultron.demo.helpers.actions import actor_notifies_fix_deployed
+        from vultron.demo.utils import post_to_trigger
 
         finder_client, vendor_client, finder, vendor, case = (
             _setup_case_with_3_participants(base)
@@ -743,14 +762,18 @@ class TestActorNotifiesFixDeployed:
             actor=vendor,
             case_id=case.id_,
         )
-        with pytest.raises(httpx.HTTPStatusError) as exc_info:
-            actor_notifies_fix_deployed(
+        # Call post_to_trigger directly so make_testclient_call's AssertionError
+        # for 4xx responses propagates (demo_step would swallow it).
+        with pytest.raises(AssertionError) as exc_info:
+            post_to_trigger(
                 client=vendor_client,
-                actor=vendor,
-                case_id=case.id_,
+                actor_id=vendor.id_,
+                behavior="notify-fix-deployed",
+                body={"case_id": case.id_},
+                path_prefix="demo",
             )
-        assert (
-            exc_info.value.response.status_code == 422
+        assert "422" in str(
+            exc_info.value
         ), "Expected HTTP 422 when vendor-only actor attempts VFD transition"
 
 

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -722,25 +722,36 @@ class TestActorNotifiesFixReady:
 
 
 class TestActorNotifiesFixDeployed:
-    """Tests for actor_notifies_fix_deployed."""
+    """Tests for actor_notifies_fix_deployed guard (CheckDeployerRoleNode).
 
-    def test_returns_response(self, client: TestClient, base: str):
-        """Returns a response dict from the trigger endpoint."""
+    Vendor-only actors (CVDRole.VENDOR, no CVDRole.DEPLOYER) MUST be blocked
+    from the VFD transition per CSB-15-002.  The notify-fix-deployed endpoint
+    returns HTTP 422 when the DEPLOYER guard fires.
+    """
+
+    def test_vendor_blocked_from_vfd(self, client: TestClient, base: str):
+        """Vendor-only actor is blocked from VFD (d→D) by CheckDeployerRoleNode."""
+        import httpx2 as httpx
+
+        from vultron.demo.helpers.actions import actor_notifies_fix_deployed
+
         finder_client, vendor_client, finder, vendor, case = (
             _setup_case_with_3_participants(base)
         )
-        # notify-fix-ready first so VFd state is set before deploying
         demo.actor_notifies_fix_ready(
             client=vendor_client,
             actor=vendor,
             case_id=case.id_,
         )
-        result = demo.actor_notifies_fix_deployed(
-            client=vendor_client,
-            actor=vendor,
-            case_id=case.id_,
-        )
-        assert result is not None
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            actor_notifies_fix_deployed(
+                client=vendor_client,
+                actor=vendor,
+                case_id=case.id_,
+            )
+        assert (
+            exc_info.value.response.status_code == 422
+        ), "Expected HTTP 422 when vendor-only actor attempts VFD transition"
 
 
 class TestActorNotifiesPublished:
@@ -1508,11 +1519,8 @@ def completed_workflow(
     case_data = vendor_client.get(f"/datalayer/{case.id_}")
     case = as_VulnerabilityCase(**case_data)
 
-    # Fix lifecycle.
+    # Fix lifecycle: vendor-only actor stops at VFd (CSB-15-002).
     demo.actor_notifies_fix_ready(
-        client=vendor_client, actor=vendor_in_vendor, case_id=case.id_
-    )
-    demo.actor_notifies_fix_deployed(
         client=vendor_client, actor=vendor_in_vendor, case_id=case.id_
     )
     demo.actor_notifies_published(

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -223,13 +223,12 @@ def demo_notify_published(
 
     Implements: DEMOMA-07-001, TRIG-09-001, TB-01-001, TB-06-001.
     """
-    from vultron.core.states.cs import CS_pxa, CS_vfd
+    from vultron.core.states.cs import CS_pxa
 
     with domain_error_translation():
         result = svc.add_participant_status(
             actor_id=actor_id,
             case_id=body.case_id,
-            vfd_state=CS_vfd.VFD,
             pxa_state=CS_pxa.Pxa,
         )
     background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)

--- a/vultron/core/behaviors/case/add_participant_status_trigger_tree.py
+++ b/vultron/core/behaviors/case/add_participant_status_trigger_tree.py
@@ -38,6 +38,10 @@ import py_trees
 from vultron.core.behaviors.case.nodes.participant import (
     CreateParticipantStatusNode,
 )
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckDeployerRoleNode,
+    CheckVendorRoleNode,
+)
 from vultron.core.behaviors.sender.send_tree import sender_side_bt
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.rm import RM
@@ -53,6 +57,13 @@ def add_participant_status_trigger_bt(
     activity_builder: Callable[[str], list[str]],
 ) -> py_trees.behaviour.Behaviour:
     """Return the trigger-side BT for the add-participant-status workflow.
+
+    When ``vfd_state`` is ``CS_vfd.VFd`` the tree is preceded by
+    :class:`~vultron.core.behaviors.case.nodes.vfd_role_guards.CheckVendorRoleNode`
+    (CSB-15-001).  When ``vfd_state`` is ``CS_vfd.VFD`` the tree is preceded by
+    :class:`~vultron.core.behaviors.case.nodes.vfd_role_guards.CheckDeployerRoleNode`
+    (CSB-15-002).  Both guards return ``FAILURE`` when the actor lacks the
+    required role, blocking the ``CreateParticipantStatusNode`` downstream.
 
     Args:
         case_id: ID of the VulnerabilityCase.
@@ -75,13 +86,23 @@ def add_participant_status_trigger_bt(
     Returns:
         A ``py_trees.composites.Sequence`` that:
 
+        - (optional) Role-guard node when ``vfd_state`` is ``VFd`` or ``VFD``.
         - Creates the ParticipantStatus snapshot (BT-15-001).
         - Resolves the Case Manager, builds the activity, and queues it.
     """
-    return py_trees.composites.Sequence(
-        name="AddParticipantStatusTriggerBT",
-        memory=False,
-        children=[
+    children: list[py_trees.behaviour.Behaviour] = []
+
+    if vfd_state == CS_vfd.VFd:
+        children.append(
+            CheckVendorRoleNode(case_id=case_id, actor_id=actor_id)
+        )
+    elif vfd_state == CS_vfd.VFD:
+        children.append(
+            CheckDeployerRoleNode(case_id=case_id, actor_id=actor_id)
+        )
+
+    children.extend(
+        [
             CreateParticipantStatusNode(
                 case_id=case_id,
                 actor_id=actor_id,
@@ -91,5 +112,11 @@ def add_participant_status_trigger_bt(
                 result_out=result_out,
             ),
             sender_side_bt(case_id=case_id, activity_builder=activity_builder),
-        ],
+        ]
+    )
+
+    return py_trees.composites.Sequence(
+        name="AddParticipantStatusTriggerBT",
+        memory=False,
+        children=children,
     )

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -111,6 +111,10 @@ from vultron.core.behaviors.case.nodes.ownership_transfer import (
     EmitAcceptCaseOwnershipTransferNode,
     EmitOfferCaseOwnershipTransferNode,
 )
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckDeployerRoleNode,
+    CheckVendorRoleNode,
+)
 from vultron.core.behaviors.case.nodes.update import (
     ApplyCaseUpdateNode,
     BroadcastCaseUpdateNode,
@@ -178,6 +182,9 @@ __all__ = [
     # ownership_transfer (leaf nodes)
     "EmitOfferCaseOwnershipTransferNode",
     "EmitAcceptCaseOwnershipTransferNode",
+    # vfd_role_guards (condition nodes)
+    "CheckVendorRoleNode",
+    "CheckDeployerRoleNode",
     # suggest_actor (leaf nodes)
     "ActorAlreadyParticipantNode",
     "EmitAcceptActorRecommendationNode",

--- a/vultron/core/behaviors/case/nodes/vfd_role_guards.py
+++ b/vultron/core/behaviors/case/nodes/vfd_role_guards.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERTⓇ and CERT Coordination CenterⓇ are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""VFD role-guard condition nodes for the add-participant-status trigger.
+
+Two nodes enforce CVD protocol correctness for self-reported VFD transitions
+(CSB-15-001, CSB-15-002):
+
+- :class:`CheckVendorRoleNode` — gates f→F (vfd_state=VFd): actor MUST hold
+  ``CVDRole.VENDOR``
+- :class:`CheckDeployerRoleNode` — gates d→D (vfd_state=VFD): actor MUST hold
+  ``CVDRole.DEPLOYER``
+"""
+
+import logging
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerCondition
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.ports.case_persistence import CasePersistence
+from vultron.enums.roles import CVDRole
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_actor_roles(
+    datalayer: CasePersistence,
+    case_id: str,
+    actor_id: str,
+    node_name: str,
+) -> list[CVDRole] | None:
+    """Return the CVDRole list for *actor_id* in *case_id*, or None on error.
+
+    Returns ``None`` when the case or participant record cannot be resolved;
+    the calling node should return ``Status.FAILURE`` in that case.
+    """
+    case = datalayer.read(case_id)
+    if not isinstance(case, VulnerabilityCase):
+        logger.warning(
+            "%s: case '%s' not found or wrong type", node_name, case_id
+        )
+        return None
+
+    participant_id = case.actor_participant_index.get(actor_id)
+    if participant_id is None:
+        logger.warning(
+            "%s: actor '%s' not in case '%s'", node_name, actor_id, case_id
+        )
+        return None
+
+    participant = datalayer.read(participant_id)
+    if not isinstance(participant, CaseParticipant):
+        logger.warning(
+            "%s: participant '%s' not found or wrong type",
+            node_name,
+            participant_id,
+        )
+        return None
+
+    return list(participant.roles) if participant.roles else []
+
+
+class CheckVendorRoleNode(DataLayerCondition):
+    """Gate f→F (vfd_state=VFd): actor MUST hold CVDRole.VENDOR.
+
+    Returns ``SUCCESS`` when the executing actor holds ``CVDRole.VENDOR`` in
+    their ``CaseParticipant.roles`` for the given case.  Returns ``FAILURE``
+    otherwise, blocking the ``CreateParticipantStatusNode`` downstream from
+    writing a ``VFd`` snapshot.
+
+    Per CSB-15-001 (specs/cs-behavior.yaml).
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._actor_id = actor_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        roles = _resolve_actor_roles(
+            self.datalayer, self._case_id, self._actor_id, self.name
+        )
+        if roles is None:
+            self.feedback_message = (
+                f"Could not resolve roles for actor '{self._actor_id}'"
+                f" in case '{self._case_id}'"
+            )
+            return Status.FAILURE
+
+        if CVDRole.VENDOR not in roles:
+            self.feedback_message = (
+                f"Actor '{self._actor_id}' does not hold CVDRole.VENDOR"
+                f" — f→F (VFd) transition blocked (CSB-15-001)"
+                f" (roles={roles!r})"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        self.logger.debug(
+            "%s: actor '%s' holds CVDRole.VENDOR — f→F guard passed",
+            self.name,
+            self._actor_id,
+        )
+        return Status.SUCCESS
+
+
+class CheckDeployerRoleNode(DataLayerCondition):
+    """Gate d→D (vfd_state=VFD): actor MUST hold CVDRole.DEPLOYER.
+
+    Returns ``SUCCESS`` when the executing actor holds ``CVDRole.DEPLOYER`` in
+    their ``CaseParticipant.roles`` for the given case.  A vendor-only actor
+    (``CVDRole.VENDOR`` without ``CVDRole.DEPLOYER``) MUST stop at VFd; only
+    actors explicitly responsible for deploying fixes may advance to VFD.
+
+    Returns ``FAILURE`` for any actor lacking ``CVDRole.DEPLOYER``, blocking
+    the ``CreateParticipantStatusNode`` downstream from writing a ``VFD``
+    snapshot.
+
+    Per CSB-15-002 (specs/cs-behavior.yaml).
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._actor_id = actor_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        roles = _resolve_actor_roles(
+            self.datalayer, self._case_id, self._actor_id, self.name
+        )
+        if roles is None:
+            self.feedback_message = (
+                f"Could not resolve roles for actor '{self._actor_id}'"
+                f" in case '{self._case_id}'"
+            )
+            return Status.FAILURE
+
+        if CVDRole.DEPLOYER not in roles:
+            self.feedback_message = (
+                f"Actor '{self._actor_id}' does not hold CVDRole.DEPLOYER"
+                f" — d→D (VFD) transition blocked (CSB-15-002)"
+                f" (roles={roles!r})"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        self.logger.debug(
+            "%s: actor '%s' holds CVDRole.DEPLOYER — d→D guard passed",
+            self.name,
+            self._actor_id,
+        )
+        return Status.SUCCESS

--- a/vultron/demo/helpers/milestones.py
+++ b/vultron/demo/helpers/milestones.py
@@ -29,6 +29,7 @@ from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.demo.helpers.sync import _extract_ref_id
 from vultron.demo.helpers.verification import (
+    _assert_participant_pxa_only,
     _assert_participant_vfd_pxa,
     _check_participant_vfd_state_in,
     _fetch_participant,
@@ -294,8 +295,9 @@ def verify_publicly_disclosed(
             )
         logger.info("✓ publicly disclosed %s: EM.EXITED", label)
 
-    # Verify receiver participant's latest status is VFD + public-aware pxa
+    # Verify receiver participant's pxa state (and VFD only for vendor/deployer)
     # on both the coordinator's and reporter's DataLayer replicas.
+    vfd_roles = {CVDRole.VENDOR, CVDRole.DEPLOYER}
     for label, c in [
         ("receiver", receiver_client),
         ("reporter", reporter_client),
@@ -306,7 +308,11 @@ def verify_publicly_disclosed(
                 f"verify_publicly_disclosed {label}: receiver participant"
                 f" {receiver_actor_id!r} not found"
             )
-        _assert_participant_vfd_pxa(p, label, receiver_actor_id)
+        receiver_roles = set(p.case_roles or [])
+        if receiver_roles & vfd_roles:
+            _assert_participant_vfd_pxa(p, label, receiver_actor_id)
+        else:
+            _assert_participant_pxa_only(p, label, receiver_actor_id)
     logger.info("✓ publicly disclosed: both replicas CS.VFDPxa and EM.EXITED")
 
 

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -240,7 +240,11 @@ def _assert_participant_vfd_pxa(
     label: str,
     vendor_actor_id: str,
 ) -> None:
-    """Assert *participant* has VFD and a public-aware pxa_state.
+    """Assert *participant* has fix-ready (VFd or VFD) and a public-aware pxa_state.
+
+    Vendor-only actors stop at VFd per CSB-15-002 (d→D requires DEPLOYER role).
+    Both VFd and VFD are accepted here since the caller may be a vendor or a
+    deployer.
 
     Args:
         participant: The ``as_CaseParticipant`` to check.
@@ -248,18 +252,19 @@ def _assert_participant_vfd_pxa(
         vendor_actor_id: Full URI of the vendor actor (used in error messages).
 
     Raises:
-        AssertionError: If the participant's vfd_state is not VFD or its
-            pxa_state is not public-aware.
+        AssertionError: If the participant's vfd_state is not in {VFd, VFD} or
+            its pxa_state is not public-aware.
     """
     public_aware = {CS_pxa.Pxa, CS_pxa.PxA, CS_pxa.PXa, CS_pxa.PXA}
+    fix_ready_or_deployed = {CS_vfd.VFd, CS_vfd.VFD}
     latest = participant.participant_status
     if latest is None:
         raise AssertionError(
             f"M6 {label}: participant {vendor_actor_id!r} has no statuses"
         )
-    if latest.vfd_state != CS_vfd.VFD:
+    if latest.vfd_state not in fix_ready_or_deployed:
         raise AssertionError(
-            f"M6 {label}: vfd_state is not VFD, found {latest.vfd_state!r}"
+            f"M6 {label}: vfd_state is not VFd or VFD, found {latest.vfd_state!r}"
         )
     cs = getattr(latest, "case_status", None)
     pxa = getattr(cs, "pxa_state", None) if cs is not None else None

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -235,6 +235,34 @@ def _check_participant_vfd_state_in(
         )
 
 
+def _assert_participant_pxa_only(
+    participant: as_CaseParticipant,
+    label: str,
+    actor_id: str,
+) -> None:
+    """Assert *participant* has a public-aware pxa_state (no VFD check).
+
+    Used for non-vendor/non-deployer receivers (e.g. coordinators) whose
+    vfd_state never advances beyond ``vfd`` — only pxa is meaningful for them
+    after a public-disclosure event (CSB-15-003).
+
+    Raises:
+        AssertionError: If pxa_state is not public-aware.
+    """
+    public_aware = {CS_pxa.Pxa, CS_pxa.PxA, CS_pxa.PXa, CS_pxa.PXA}
+    latest = participant.participant_status
+    if latest is None:
+        raise AssertionError(
+            f"M6 {label}: participant {actor_id!r} has no statuses"
+        )
+    cs = getattr(latest, "case_status", None)
+    pxa = getattr(cs, "pxa_state", None) if cs is not None else None
+    if pxa not in public_aware:
+        raise AssertionError(
+            f"M6 {label}: pxa_state is not public-aware, found {pxa!r}"
+        )
+
+
 def _assert_participant_vfd_pxa(
     participant: as_CaseParticipant,
     label: str,

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -69,7 +69,6 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
 )
 from vultron.demo.helpers.actions import (
     actor_closes_case,
-    actor_notifies_fix_deployed,
     actor_notifies_fix_ready,
     actor_notifies_published,
 )
@@ -640,7 +639,7 @@ def _phase_fix_lifecycle(
     """Advance Vendor through the fix-ready and fix-deployed path (VFD only)."""
     logger.info("─" * 80)
     logger.info(
-        "Phase 5: Fix lifecycle — Vendor: VFd (fix ready) → VFD (fix deployed)"
+        "Phase 5: Fix lifecycle — Vendor: VFd (fix ready); vendor stops at VFd (CSB-15-002)"
     )
     logger.info("─" * 80)
 
@@ -680,34 +679,28 @@ def _phase_fix_lifecycle(
             "M5: Vendor replica fix ready",
         )
 
-    actor_notifies_fix_deployed(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
     with demo_check(
-        "M6: C1 replica shows Vendor CS includes D (fix deployed)"
+        "M6: C1 replica shows Vendor CS includes F (fix ready) — vendor stops at VFd"
     ):
         wait_for_participant_vfd_state(
             client=c1_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         _check_participant_vfd_state_in(
             c1_client,
             case.id_,
             vendor.id_,
-            {CS_vfd.VFD},
-            "M6: C1 replica fix deployed",
+            {CS_vfd.VFd},
+            "M6: C1 replica fix ready",
         )
         _check_participant_vfd_state_in(
             vendor_client,
             case.id_,
             vendor.id_,
-            {CS_vfd.VFD},
-            "M6: Vendor replica fix deployed",
+            {CS_vfd.VFd},
+            "M6: Vendor replica fix ready",
         )
 
 
@@ -772,7 +765,7 @@ def _phase_publication(
     )
 
     with demo_check(
-        "M7: all replicas CS.VFDPxa, EM.EXITED, all participants public-aware"
+        "M7: all replicas CS.VFdPxa, EM.EXITED, all participants public-aware"
     ):
         wait_for_case_em_terminated(
             client=finder_client,
@@ -782,7 +775,7 @@ def _phase_publication(
             client=c1_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         verify_publicly_disclosed(
             receiver_client=c1_client,

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -68,14 +68,12 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
 # post_to_inbox_and_wait is retained for self-delivery (CONCERN-1653 exception).
 from vultron.demo.helpers.actions import (
     actor_closes_case,
-    actor_notifies_fix_deployed,
     actor_notifies_fix_ready,
     actor_notifies_published,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
     verify_case_closed,
-    verify_fix_deployed,
     verify_fix_ready,
     verify_publicly_disclosed,
 )
@@ -699,7 +697,7 @@ def _phase_fix_lifecycle(
     """Advance Vendor through the fix-ready and fix-deployed paths."""
     logger.info("─" * 80)
     logger.info(
-        "Phase 5: Fix lifecycle — Vendor: VFd (fix ready) → VFD (fix deployed)"
+        "Phase 5: Fix lifecycle — Vendor: VFd (fix ready); vendor stops at VFd (CSB-15-002)"
     )
     logger.info("─" * 80)
 
@@ -737,28 +735,22 @@ def _phase_fix_lifecycle(
             receiver_actor_id=vendor.id_,
         )
 
-    actor_notifies_fix_deployed(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
     with demo_check(
-        "Finder replica shows Vendor CS includes D (fix deployed)"
+        "Finder replica shows Vendor CS includes F (fix ready) — vendor stops at VFd"
     ):
         wait_for_participant_vfd_state(
             client=c1_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
-        verify_fix_deployed(
+        verify_fix_ready(
             receiver_client=c1_client,
             reporter_client=finder_client,
             case_id=case.id_,
@@ -819,7 +811,7 @@ def _phase_publication(
     )
 
     with demo_check(
-        "All replicas CS.VFDPxa, EM.EXITED, all participants public-aware"
+        "All replicas CS.VFdPxa, EM.EXITED, all participants public-aware"
     ):
         wait_for_case_em_terminated(
             client=finder_client,
@@ -829,13 +821,13 @@ def _phase_publication(
             client=c1_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         verify_publicly_disclosed(
             receiver_client=c1_client,

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -64,14 +64,12 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
 )
 from vultron.demo.helpers.actions import (
     actor_closes_case,
-    actor_notifies_fix_deployed,
     actor_notifies_fix_ready,
     actor_notifies_published,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
     verify_case_closed,
-    verify_fix_deployed,
     verify_fix_ready,
     verify_publicly_disclosed,
 )
@@ -457,7 +455,7 @@ def _phase_fix_lifecycle(
     """Advance Vendor through fix-ready and fix-deployed paths."""
     logger.info("─" * 80)
     logger.info(
-        "Phase 5: Fix lifecycle — Vendor: VFd (fix ready) → VFD (fix deployed)"
+        "Phase 5: Fix lifecycle — Vendor: VFd (fix ready); vendor stops at VFd (CSB-15-002)"
     )
     logger.info("─" * 80)
 
@@ -491,22 +489,16 @@ def _phase_fix_lifecycle(
             receiver_actor_id=vendor.id_,
         )
 
-    actor_notifies_fix_deployed(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
     with demo_check(
-        "M5: Coordinator replica shows Vendor CS includes D (fix deployed)"
+        "M5: Coordinator replica shows Vendor CS includes F (fix ready) — vendor stops at VFd"
     ):
         wait_for_participant_vfd_state(
             client=coordinator_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
-        verify_fix_deployed(
+        verify_fix_ready(
             receiver_client=coordinator_client,
             reporter_client=vendor_client,
             case_id=case.id_,
@@ -561,7 +553,7 @@ def _phase_publication(
     )
 
     with demo_check(
-        "M6: all replicas CS.VFDPxa, EM.EXITED, all participants public-aware"
+        "M6: all replicas CS.VFdPxa, EM.EXITED, all participants public-aware"
     ):
         wait_for_case_em_terminated(
             client=vendor_client,
@@ -571,13 +563,13 @@ def _phase_publication(
             client=coordinator_client,
             case_id=case.id_,
             actor_id=vendor_in_vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor_in_vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         verify_publicly_disclosed(
             receiver_client=coordinator_client,

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -64,7 +64,6 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
 # remains unchanged.
 from vultron.demo.helpers.actions import (  # noqa: F401
     actor_closes_case,
-    actor_notifies_fix_deployed,
     actor_notifies_fix_ready,
     actor_notifies_published,
     actor_notifies_state_change,
@@ -72,7 +71,6 @@ from vultron.demo.helpers.actions import (  # noqa: F401
 from vultron.demo.helpers.milestones import (
     verify_case_active,
     verify_case_closed,
-    verify_fix_deployed,
     verify_fix_ready,
     verify_publicly_disclosed,
 )
@@ -348,8 +346,12 @@ def verify_m5_state(
     case_id: str,
     vendor_actor_id: str,
 ) -> None:
-    """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_fix_deployed`."""
-    return verify_fix_deployed(
+    """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_fix_ready`.
+
+    M5 in the FV scenario is fix-ready (VFd); vendor-only actors stop at VFd
+    per CSB-15-002.
+    """
+    return verify_fix_ready(
         receiver_client=vendor_client,
         reporter_client=finder_client,
         case_id=case_id,
@@ -608,7 +610,7 @@ def _phase_fix_lifecycle(
     """Advance the case through fix-ready and fix-deployed milestones."""
     logger.info("─" * 80)
     logger.info(
-        "Phase 4: Fix lifecycle — VFd (fix ready) → VFD (fix deployed)"
+        "Phase 4: Fix lifecycle — VFd (fix ready); vendor stops at VFd (CSB-15-002)"
     )
     logger.info("─" * 80)
 
@@ -646,26 +648,22 @@ def _phase_fix_lifecycle(
             receiver_actor_id=vendor.id_,
         )
 
-    actor_notifies_fix_deployed(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
-    with demo_check("M5: both replicas show CS includes D (fix deployed)"):
+    with demo_check(
+        "M5: both replicas show CS includes F (fix ready) — vendor stops at VFd"
+    ):
         wait_for_participant_vfd_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
-        verify_fix_deployed(
+        verify_fix_ready(
             receiver_client=vendor_client,
             reporter_client=finder_client,
             case_id=case.id_,
@@ -710,7 +708,7 @@ def _phase_publication(
     )
 
     with demo_check(
-        "M6: both replicas CS.VFDPxa, EM.EXITED, vendor participant is "
+        "M6: both replicas CS.VFdPxa, EM.EXITED, vendor participant is "
         "public-aware"
     ):
         wait_for_case_em_terminated(
@@ -721,13 +719,13 @@ def _phase_publication(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         verify_publicly_disclosed(
             receiver_client=vendor_client,

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -62,14 +62,12 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
 )
 from vultron.demo.helpers.actions import (
     actor_closes_case,
-    actor_notifies_fix_deployed,
     actor_notifies_fix_ready,
     actor_notifies_published,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
     verify_case_closed,
-    verify_fix_deployed,
     verify_fix_ready,
     verify_publicly_disclosed,
 )
@@ -653,7 +651,7 @@ def _phase_fix_lifecycle(
     """Advance both vendors through independent fix-ready and fix-deployed paths."""
     logger.info("─" * 80)
     logger.info(
-        "Phase 5: Fix lifecycle — both vendors: VFd (fix ready) → VFD (fix deployed)"
+        "Phase 5: Fix lifecycle — both vendors: VFd (fix ready); vendors stop at VFd (CSB-15-002)"
     )
     logger.info("─" * 80)
 
@@ -707,33 +705,22 @@ def _phase_fix_lifecycle(
             receiver_actor_id=vendor.id_,
         )
 
-    actor_notifies_fix_deployed(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-    actor_notifies_fix_deployed(
-        client=vendor2_client,
-        actor=vendor2_in_vendor2,
-        case_id=case.id_,
-    )
-
     with demo_check(
-        "M6: Finder replica shows both vendors CS include D (fix deployed)"
+        "M6: Finder replica shows both vendors CS include F (fix ready) — vendors stop at VFd"
     ):
         wait_for_participant_vfd_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
-        verify_fix_deployed(
+        verify_fix_ready(
             receiver_client=vendor_client,
             reporter_client=finder_client,
             case_id=case.id_,
@@ -803,7 +790,7 @@ def _phase_publication(
     )
 
     with demo_check(
-        "M7: all replicas CS.VFDPxa, EM.EXITED, all participants public-aware"
+        "M7: all replicas CS.VFdPxa, EM.EXITED, all participants public-aware"
     ):
         wait_for_case_em_terminated(
             client=finder_client,
@@ -813,13 +800,13 @@ def _phase_publication(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         verify_publicly_disclosed(
             receiver_client=vendor_client,

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -63,7 +63,6 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
 # post_to_inbox_and_wait is retained for self-delivery (CONCERN-1653 exception).
 from vultron.demo.helpers.actions import (
     actor_closes_case,
-    actor_notifies_fix_deployed,
     actor_notifies_fix_ready,
     actor_notifies_published,
 )
@@ -73,7 +72,6 @@ from vultron.demo.helpers.notes import (
 from vultron.demo.helpers.milestones import (
     verify_case_active,
     verify_case_closed,
-    verify_fix_deployed,
     verify_fix_ready,
     verify_publicly_disclosed,
 )
@@ -712,7 +710,7 @@ def _phase_fix_lifecycle(
     """Advance both vendors through fix-ready and fix-deployed paths."""
     logger.info("─" * 80)
     logger.info(
-        "Phase 5: Fix lifecycle — both vendors: VFd (fix ready) → VFD (fix deployed)"
+        "Phase 5: Fix lifecycle — both vendors: VFd (fix ready); vendors stop at VFd (CSB-15-002)"
     )
     logger.info("─" * 80)
 
@@ -766,33 +764,22 @@ def _phase_fix_lifecycle(
             receiver_actor_id=vendor.id_,
         )
 
-    actor_notifies_fix_deployed(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-    actor_notifies_fix_deployed(
-        client=vendor2_client,
-        actor=vendor2_in_vendor2,
-        case_id=case.id_,
-    )
-
     with demo_check(
-        "Finder replica shows both vendors CS include D (fix deployed)"
+        "Finder replica shows both vendors CS include F (fix ready) — vendors stop at VFd"
     ):
         wait_for_participant_vfd_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
-        verify_fix_deployed(
+        verify_fix_ready(
             receiver_client=vendor_client,
             reporter_client=finder_client,
             case_id=case.id_,
@@ -855,9 +842,9 @@ def _phase_publication(
     )
 
     with demo_check(
-        "All replicas CS.VFDPxa, EM.EXITED, all participants public-aware"
+        "All replicas CS.VFdPxa, EM.EXITED, all participants public-aware"
     ):
-        for label, client in [
+        for _label, client in [
             ("coordinator", coordinator_client),
             ("vendor", vendor_client),
             ("vendor2", vendor2_client),
@@ -871,13 +858,13 @@ def _phase_publication(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         verify_publicly_disclosed(
             receiver_client=vendor_client,

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -509,6 +509,7 @@ def _phase_coordinator_invites_vendor2(
             body={
                 "case_id": case.id_,
                 "invitee_id": vendor2.id_,
+                "roles": ["vendor"],
             },
         )
     invite = as_TransitiveActivity.model_validate(invite_result["activity"])

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -62,14 +62,12 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
 )
 from vultron.demo.helpers.actions import (
     actor_closes_case,
-    actor_notifies_fix_deployed,
     actor_notifies_fix_ready,
     actor_notifies_published,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
     verify_case_closed,
-    verify_fix_deployed,
     verify_fix_ready,
     verify_publicly_disclosed,
 )
@@ -432,7 +430,7 @@ def _phase_fix_lifecycle(
     """Advance both vendors through independent fix-ready and fix-deployed paths."""
     logger.info("─" * 80)
     logger.info(
-        "Phase 4: Fix lifecycle — both vendors: VFd (fix ready) → VFD (fix deployed)"
+        "Phase 4: Fix lifecycle — both vendors: VFd (fix ready); vendors stop at VFd (CSB-15-002)"
     )
     logger.info("─" * 80)
 
@@ -486,33 +484,22 @@ def _phase_fix_lifecycle(
             receiver_actor_id=vendor.id_,
         )
 
-    actor_notifies_fix_deployed(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-    actor_notifies_fix_deployed(
-        client=vendor2_client,
-        actor=vendor2_in_vendor2,
-        case_id=case.id_,
-    )
-
     with demo_check(
-        "M5: Finder replica shows both vendors CS include D (fix deployed)"
+        "M5: Finder replica shows both vendors CS include F (fix ready) — vendors stop at VFd"
     ):
         wait_for_participant_vfd_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
-        verify_fix_deployed(
+        verify_fix_ready(
             receiver_client=vendor_client,
             reporter_client=finder_client,
             case_id=case.id_,
@@ -566,7 +553,7 @@ def _phase_publication(
     )
 
     with demo_check(
-        "M6: all replicas CS.VFDPxa, EM.EXITED, all participants public-aware"
+        "M6: all replicas CS.VFdPxa, EM.EXITED, all participants public-aware"
     ):
         wait_for_case_em_terminated(
             client=finder_client,
@@ -576,13 +563,13 @@ def _phase_publication(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         wait_for_participant_vfd_state(
             client=finder_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFD},
+            expected_states={CS_vfd.VFd},
         )
         verify_publicly_disclosed(
             receiver_client=vendor_client,


### PR DESCRIPTION
- Closes #1736

## Summary

Adds `CheckVendorRoleNode` and `CheckDeployerRoleNode` BT condition nodes that gate the f→F and d→D VFD transitions on CVDRole membership (CSB-15-001, CSB-15-002), wires them into `add_participant_status_trigger_bt`, and fixes the `demo_notify_published` endpoint which incorrectly set `vfd_state=VFD` alongside `pxa_state=Pxa` (CSB-15-003).

## Changes

- **`vultron/core/behaviors/case/nodes/vfd_role_guards.py`** (new): `CheckVendorRoleNode` (gates f→F, CSB-15-001) and `CheckDeployerRoleNode` (gates d→D, CSB-15-002), both extending `DataLayerCondition`; shared `_resolve_actor_roles()` helper reads `CaseParticipant.roles` via `CasePersistence`
- **`vultron/core/behaviors/case/nodes/__init__.py`**: registers both new nodes in `__all__` and eager imports
- **`vultron/core/behaviors/case/add_participant_status_trigger_tree.py`**: prepends `CheckVendorRoleNode` when `vfd_state==VFd`, `CheckDeployerRoleNode` when `vfd_state==VFD`
- **`vultron/adapters/driving/fastapi/routers/demo_triggers.py`**: removes `vfd_state=CS_vfd.VFD` from `demo_notify_published` (CSB-15-003)
- **`vultron/demo/helpers/verification.py`**: `_assert_participant_vfd_pxa` accepts `{VFd, VFD}` instead of requiring VFD; vendor-only actors terminate at VFd per CSB-15-002
- **`vultron/demo/scenario/fv_demo.py`** and five other demo scenario files: remove `actor_notifies_fix_deployed` calls for vendor-only actors; update terminal state expectations from VFD → VFd; update phase descriptions
- **`test/core/behaviors/case/nodes/test_vfd_role_guards.py`** (new): 10 unit tests covering SUCCESS/FAILURE paths for both guard nodes, including missing-case and actor-not-in-case edge cases
- **`test/demo/test_fv_demo.py`**: `TestActorNotifiesFixDeployed` now verifies that a vendor-only actor receives HTTP 422 when attempting VFD; `completed_workflow` fixture removes the invalid `actor_notifies_fix_deployed` call

## Verification

- 5602 tests pass (10 new in `test_vfd_role_guards.py`, 1 updated in `test_fv_demo.py`)
- Black, flake8, mypy, pyright all clean
- [x] AC-1: `CheckDeployerRoleNode` returns FAILURE when actor lacks `CVDRole.DEPLOYER`; 5 unit tests
- [x] AC-2: `CheckVendorRoleNode` returns FAILURE when actor lacks `CVDRole.VENDOR`; 5 unit tests
- [x] AC-3: `demo_notify_published` no longer passes `vfd_state`; only `pxa_state=Pxa`
- [x] AC-4: All six demo scenarios remove `actor_notifies_fix_deployed` calls; terminal VFD state updated to `VFd·Pxa`