### PR TITLE
docs: plan issue #423 — UseCaseResult envelope and UseCase Protocol contract

### DIFF
--- a/docs/adr/0040-use-case-result-envelope.md
+++ b/docs/adr/0040-use-case-result-envelope.md
@@ -1,0 +1,120 @@
+---
+status: accepted
+date: 2026-07-28
+deciders: Allen D. Householder
+---
+
+# Introduce UseCaseResult Envelope; Do Not Introduce UseCaseRequest
+
+## Context and Problem Statement
+
+All use-case `execute()` methods previously declared bare `None` (received
+path) or `dict` (trigger path) return types. The `UseCase` Protocol declared
+`execute() -> Any`. This meant:
+
+- mypy could not check that a use-case subtype returned a conforming result.
+- Callers that consumed the trigger result used untyped dict-key access
+  (`result["activity"]`), which silently broke when keys changed.
+- The interface contract between core and its driving adapters was invisible
+  to static analysis.
+
+A related question arose: should a `UseCaseRequest` base class be introduced
+to unify the two request paths (`VultronEvent` for received-side and
+`TriggerRequest` for trigger-side)?
+
+## Decision Drivers
+
+- Make the use-case interface contract explicit and machine-checkable.
+- Preserve the semantic distinction between received-side events and
+  trigger-side requests.
+- Avoid conflating inbound remote actor identity with local actor intent.
+- Keep the change mechanical on the result side; avoid regressions from
+  request-side restructuring.
+
+## Considered Options (result side)
+
+1. **`UseCaseResult` base with `HandlerResult` / `TriggerResult` subtypes**
+   — formalises the existing two-path return contract with typed models.
+2. **Generic `UseCaseResult[T]`** — a single generic model with a typed
+   `payload: T` field. Defers subtype decisions to call sites.
+3. **Fixed plain envelope** — `UseCaseResult(ok: bool, payload: dict | None)`.
+   Simple but loses payload type safety.
+
+## Considered Options (request side)
+
+A. **Skip `UseCaseRequest` entirely** — `UseCase` Protocol stays
+   `execute() -> UseCaseResult`; `__init__` request parameter remains `Any`
+   at the Protocol level, concretely typed in each class.
+B. **Marker base `UseCaseRequest(BaseModel)` with no fields** — `VultronEvent`
+   and `TriggerRequest` gain a shared parent; Protocol becomes
+   `UseCase[UseCaseRequest, UseCaseResult]`.
+C. **Shared-field base — push `actor_id` into `UseCaseRequest`** — both
+   hierarchies share a common required field.
+
+## Decision Outcome
+
+**Result side: option 1 — `UseCaseResult` with `HandlerResult` / `TriggerResult`.**
+
+**Request side: option A — skip `UseCaseRequest` entirely.**
+
+### Why HandlerResult / TriggerResult over generic
+
+The two paths have genuinely different payload shapes. `HandlerResult` carries
+no required payload; `TriggerResult` carries `activity` and `emitting_actor_id`.
+A generic would push the type parameter to every call site and complicate the
+Protocol definition. Named subtypes are more readable and allow mypy to infer
+the correct shape from the concrete class.
+
+### Why UseCaseRequest was not introduced
+
+`VultronEvent` and `TriggerRequest` share the field name `actor_id`, but the
+two carry it in semantically opposite roles:
+
+- On `VultronEvent`: `actor_id` is the **remote actor's identity** — extracted
+  from the inbound wire-format activity, representing what a remote party
+  asserted. The event is "what they told us happened."
+- On `TriggerRequest`: `actor_id` is the **local actor's identity** — injected
+  by the driving adapter from the URL path, representing an intent our actor
+  is about to execute. The request is "what we intend to do."
+
+Merging these into a shared base would collapse the distinction between
+inbound remote identity and local outbound intent. A use case accepting
+`UseCaseRequest` could no longer statically distinguish which role `actor_id`
+played. This is a security-boundary concern, not merely a naming coincidence:
+the direction of trust is opposite.
+
+A marker base (option B) avoids the semantic conflation but provides no
+enforcement gain — it carries no fields and the structural `Protocol` typing
+does not require inheritance. A marker adds an inheritance layer for no benefit.
+
+The `UseCase` Protocol is structural (implicit conformance). Concrete classes
+do not need a common base for Protocol compliance. Keeping the `__init__`
+request parameter as `Any` at the Protocol level, with precise types at each
+concrete class, is explicit and honest.
+
+### Consequences
+
+- Good: `execute()` return type is statically checkable at all 82 call sites.
+- Good: Trigger routers use typed attribute access instead of dict-key access.
+- Good: The two request paths remain semantically distinct and auditable.
+- Neutral: `UseCase` Protocol `__init__` parameter stays `Any`; request typing
+  is enforced at the concrete class level, not the Protocol level.
+- Bad: Adding a new use case requires the author to return the correct subtype;
+  the ratchet test (UCORG-05-004) catches omissions at CI time.
+
+## Validation
+
+- Architecture ratchet test: `test/architecture/test_execute_return_types.py`
+  — asserts all concrete use-case classes declare `execute()` → `UseCaseResult`
+  or a registered subtype.
+- mypy: `UseCase` Protocol declares `execute() -> UseCaseResult`; mypy reports
+  non-conforming concrete classes.
+
+## More Information
+
+Generated spec requirements: `specs/use-case-organization.yaml` UCORG-05-001
+through UCORG-05-006.
+
+Design note: `notes/use-case-protocol.md`.
+
+Source idea: #423.

--- a/docs/adr/0040-use-case-result-envelope.md
+++ b/docs/adr/0040-use-case-result-envelope.md
@@ -94,7 +94,7 @@ concrete class, is explicit and honest.
 
 ### Consequences
 
-- Good: `execute()` return type is statically checkable at all 82 call sites.
+- Good: `execute()` return type is statically checkable at all concrete use-case definitions.
 - Good: Trigger routers use typed attribute access instead of dict-key access.
 - Good: The two request paths remain semantically distinct and auditable.
 - Neutral: `UseCase` Protocol `__init__` parameter stays `Any`; request typing

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -107,6 +107,8 @@ General information about architectural decision records is available at <https:
   Draft-Review-Submit Pipeline](0030-publish-leaf-draft-review-submit-pipeline.md)
 - [ADR-0039 Resolve Wire Ambiguity Between OFFER\_CASE\_MANAGER\_ROLE and
   OFFER\_CASE\_OWNERSHIP\_TRANSFER via Dedicated Object Type](0039-offer-case-participant-role-wire-type.md)
+- [ADR-0040 Introduce UseCaseResult Envelope; Do Not Introduce
+  UseCaseRequest](0040-use-case-result-envelope.md)
 
 ## Proposed ADRs
 

--- a/notes/README.md
+++ b/notes/README.md
@@ -126,6 +126,16 @@ standardized `UseCase` protocol, and `SEMANTICS_HANDLERS` migration to core.
 **Load when**: adding a new message type end-to-end, restructuring the
 dispatcher or use-case layer, or deciding whether a use case needs a BT.
 
+**`use-case-protocol.md`**
+Design decisions for the `UseCaseResult` type hierarchy (`HandlerResult` /
+`TriggerResult`), the two semantically distinct request paths (`VultronEvent`
+vs `TriggerRequest`), why `UseCaseRequest` was not introduced, how
+`TriggerService` and `TriggerServicePort` were migrated from `dict` to
+`TriggerResult`, and the ratchet test design. ADR: `docs/adr/0040-use-case-result-envelope.md`.
+**Load when**: implementing a new use case, reviewing the `execute()` contract,
+working on `UseCase` Protocol or `TriggerServicePort` signatures, or debugging
+return-type ratchet failures.
+
 **`inbox-orchestration.md`**
 Design decisions for the core BT-backed inbox orchestration module: why
 orchestration belongs in `core/`, two-adapter seam design

--- a/notes/use-case-behavior-trees.md
+++ b/notes/use-case-behavior-trees.md
@@ -56,13 +56,14 @@ The `execute()` method of a use case MAY contain infrastructure glue only:
 
 ```python
 class SvcValidateReportUseCase:
-    def execute(self) -> None:
+    def execute(self) -> HandlerResult:  # UCORG-05-001: must return UseCaseResult subtype
         # ... setup ...
         bridge.execute_with_setup(self._dl, bt, bb)   # BT runs
 
         # ❌ ANTI-PATTERN: domain action outside the tree
         if bt.status == Status.SUCCESS:
             SvcEngageCaseUseCase(self._dl, engage_event).execute()
+        return HandlerResult()
 ```
 
 The call to `SvcEngageCaseUseCase` after the BT runs means the
@@ -73,11 +74,12 @@ from the tree structure alone.
 
 ```python
 class SvcValidateReportUseCase:
-    def execute(self) -> None:
+    def execute(self) -> HandlerResult:  # UCORG-05-001: must return UseCaseResult subtype
         # ... setup ...
         bt = ValidateReportBt(...)   # ← includes PrioritizeBt as a child
         bridge.execute_with_setup(self._dl, bt, bb)   # ✅ cascade inside tree
         # check status, extract output only
+        return HandlerResult()
 ```
 
 The validate→engage/defer cascade is a child subtree of `ValidateReportBt`,
@@ -422,32 +424,17 @@ This mirrors the `FooReceivedEvent` / `FooTriggerEvent` convention for domain
 events (CS-10-002) and makes the origin unambiguous at a glance. See
 `specs/code-style.yaml` CS-12-002 and TECHDEBT-21.
 
-### UseCaseRequest Envelope (Future Direction)
+### UseCaseRequest Envelope (Evaluated and Rejected — see ADR-0040)
 
-Design Decision: The `UseCase` protocol and object should be defined to
-include a `UseCaseRequest` parameter in the `__init__()` constructor, so
-that the use case class can validate that it has what it needs before  
-`execute()` is called. Benefits of this approach include:
+`UseCaseRequest` was evaluated during the planning of issue #423 and
+**rejected**. The core finding: `VultronEvent` and `TriggerRequest` share the
+field name `actor_id` but carry it in semantically opposite roles — one
+represents inbound remote actor identity, the other represents local outbound
+intent. Merging them under a shared base collapses a security boundary.
 
-* Validation of required fields occurs at construction time — if a `UseCase`
-  instance exists, it is valid and ready to execute.
-* Fields that are optional in general but required by a specific use case can be
-  enforced by subclassing `UseCaseRequest` with tighter field constraints
-  that are reinforced by the use case constructor validation.
-* The adapter layer needs only to know how to construct a `UseCaseRequest`, not
-  the internals of every use case.
-
-A `UseCaseRequest` base class with optional fields and a set of concrete
-subclasses (one per use case that needs additional fields) would allow most
-handler use cases to share a common base while trigger use cases add their
-domain-specific parameters.
-
-Open Question: Whether to introduce `UseCaseRequest` now or defer until the
-existing naming and Protocol-base work (TECHDEBT-21, TECHDEBT-22) is complete
-to avoid another large rename cycle. Recommendation: Getting the UseCase
-protocol and naming convention in place first will save significant
-refactors later, so it should be given similar priority to TECHDEBT-21 and
-TECHDEBT-22, these items could be batched into a single refactor.
+See `docs/adr/0040-use-case-result-envelope.md` for the full decision
+rationale and `notes/use-case-protocol.md` for implementation guidance on the
+`UseCaseResult` hierarchy that was introduced instead.
 
 ### SEMANTICS_HANDLERS Migration
 

--- a/notes/use-case-protocol.md
+++ b/notes/use-case-protocol.md
@@ -1,0 +1,171 @@
+---
+title: Use-Case Protocol — Result Envelope and Request Paths
+status: active
+description: >
+  Design decisions for the UseCaseResult type hierarchy, the two semantically
+  distinct request paths (VultronEvent vs TriggerRequest), and why a shared
+  UseCaseRequest base was not introduced.
+related_specs:
+  - specs/use-case-organization.yaml
+related_notes:
+  - notes/use-case-behavior-trees.md
+  - notes/architecture-hexagonal.md
+relevant_packages:
+  - vultron/core/ports
+  - vultron/core/use_cases
+  - vultron/core/use_cases/received
+  - vultron/core/use_cases/triggers
+---
+
+# Use-Case Protocol — Result Envelope and Request Paths
+
+This note records the design decisions for the `UseCase` Protocol contract:
+the result envelope type hierarchy and the two semantically distinct request
+paths.
+
+See `specs/use-case-organization.yaml` UCORG-05 for the normative requirements.
+See `docs/adr/0040-use-case-result-envelope.md` for the full decision record.
+
+---
+
+## UseCaseResult Hierarchy
+
+```text
+UseCaseResult (base, Pydantic BaseModel)
+  ├── HandlerResult      — returned by received-side use cases
+  └── TriggerResult      — returned by trigger-side use cases
+```
+
+### HandlerResult
+
+Handler use cases (processing inbound `VultronEvent`s) are fire-and-process:
+their primary effect is domain state change, not producing a value for the
+caller. `HandlerResult` makes this explicit with no required payload fields.
+Subclasses MAY add domain-specific fields (e.g. a resolved entity ID) when
+the handler needs to surface something to the dispatcher for logging.
+
+### TriggerResult
+
+Trigger use cases (actor-initiated actions) construct and emit an outbound
+ActivityStreams activity. `TriggerResult` carries:
+
+- `activity` — the constructed outbound AS2 activity (optional; `None` for
+  best-effort paths where no activity was emitted)
+- `emitting_actor_id` — the actor URI that sent the activity
+
+This formalizes what `SvcBTTriggerBase.execute()` previously returned as a
+raw `dict`.
+
+---
+
+## Two Request Paths
+
+Use cases accept one of two semantically distinct request types:
+
+| Path | Type | Meaning | Source |
+|------|------|---------|--------|
+| Received (handler) | `VultronEvent` | "What a remote actor asserted happened" | Wire layer via semantic extractor |
+| Trigger | `TriggerRequest` | "What our local actor intends to do" | Adapter layer from HTTP request body |
+
+These are not the same concept. A `VultronEvent` carries:
+
+- `semantic_type` (what the inbound activity means)
+- `activity_id` (the remote activity's URI)
+- Rich domain objects extracted from wire payload
+
+A `TriggerRequest` carries:
+
+- `actor_id` (the local actor initiating the action)
+- Domain IDs for the operation's targets (e.g. `offer_id`, `case_id`)
+- No wire-layer fields
+
+Both hierarchies are already well-typed at their base classes and add no
+fields that belong to a common ancestor.
+
+---
+
+## Why UseCaseRequest Was Not Introduced
+
+The `UseCase` Protocol is structural (implicit conformance via duck typing).
+Concrete classes do not need to inherit from a base for Protocol compliance —
+mypy checks the shape, not the inheritance.
+
+Two approaches were evaluated:
+
+**Option A: Marker base (empty `UseCaseRequest(BaseModel)`)**
+
+Both `VultronEvent` and `TriggerRequest` would gain `UseCaseRequest` as a
+parent. The Protocol becomes `UseCase[UseCaseRequest, UseCaseResult]`.
+
+Problem: the marker provides no contract. Any `UseCaseRequest` subclass
+satisfies the Protocol. It adds an inheritance layer for no enforcement gain.
+
+**Option B: Shared-field base (push `actor_id` into `UseCaseRequest`)**
+
+`actor_id: NonEmptyString` appears in both `VultronEvent` and `TriggerRequest`.
+A shared base could own this field.
+
+Problem: the two types carry `actor_id` in different semantic roles.
+
+- On `VultronEvent`, `actor_id` is the **identity of the remote actor** who
+  sent the inbound activity — extracted from the wire payload.
+- On `TriggerRequest`, `actor_id` is the **identity of our local actor**
+  initiating the trigger — injected by the driving adapter from the URL path.
+
+These are not the same thing wearing the same name. Merging them into a shared
+base would conflate inbound remote identity with local outbound intent. That
+confusion is a security boundary issue, not just a naming coincidence: a use
+case that accepted either type at the same parameter would lose the distinction
+between "what they told us" and "what we are doing."
+
+**Decision: skip `UseCaseRequest` entirely.**
+
+The `UseCase` Protocol declares `execute() -> UseCaseResult`. The `__init__`
+parameter remains typed as `Any` at the Protocol level; concrete classes
+carry the precise request type. This is explicit, honest, and avoids the
+semantic conflation described above.
+
+See ADR-0040 for the full decision record.
+
+---
+
+## TriggerService and TriggerServicePort Migration
+
+`TriggerService` methods previously returned `dict[str, Any]` because
+`SvcBTTriggerBase.execute()` returned a raw `dict`. After the result-envelope
+migration:
+
+- `SvcBTTriggerBase.execute()` returns `TriggerResult`
+- `TriggerService.*` methods return `TriggerResult`
+- `TriggerServicePort` Protocol method signatures declare `TriggerResult`
+- Routers access typed fields (`result.activity`, `result.emitting_actor_id`)
+  instead of dict keys
+
+This propagation is mechanical: the only semantic change is that callers use
+attribute access instead of dict-key access.
+
+---
+
+## Dispatcher Behavior
+
+The dispatcher calls `use_case_class(dl, event, **extra_kwargs).execute()`.
+After the migration it captures the result in a local variable for logging:
+
+```python
+result = use_case_class(dl, event, **extra_kwargs).execute()
+logger.debug("use case result: %s", result)
+```
+
+The dispatcher's own `dispatch()` return type is **not** changed in this
+issue. Surfacing `UseCaseResult` through the dispatcher boundary is a
+separate architectural decision.
+
+---
+
+## Ratchet Test
+
+`test/architecture/test_execute_return_types.py` inspects all concrete
+use-case classes in `vultron/core/use_cases/` and asserts that their
+`execute()` annotation is `UseCaseResult` or a subtype. This catches drift
+when new use cases are added without the correct return type, independent
+of mypy configuration.

--- a/plan/history/2607/idea/IDEA-423.md
+++ b/plan/history/2607/idea/IDEA-423.md
@@ -1,0 +1,31 @@
+---
+source: IDEA-423
+timestamp: '2026-07-28T18:13:09.192082+00:00'
+title: 'USE-CASE-02: UseCase Protocol generic enforcement with UseCaseResult envelope'
+type: idea
+---
+
+## Summary
+
+Define a consistent UseCaseResult Pydantic return envelope and enforce it via
+mypy across all use-case classes. Currently all execute() methods return None;
+this task decides whether and how to introduce a typed result.
+
+## Context
+
+Deferred pending resolution of technical-debt items TECHDEBT-21/22. The
+decision may be 'keep None' with a rationale note, which would close this issue.
+
+## Acceptance Criteria
+
+- [ ] Design decision recorded (spec entry or notes update) on whether to
+  introduce UseCaseResult or keep execute() -> None
+- [ ] If a result envelope is introduced, all use cases return it and mypy
+  enforces the return type
+- [ ] If the decision is to keep None, this issue is closed with a rationale comment
+
+**Processed**: 2026-07-28 — implementation tracked in #1769.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1768>.
+Spec: `specs/use-case-organization.yaml` (UCORG-05).
+Notes: `notes/use-case-protocol.md`.
+ADR: `docs/adr/0040-use-case-result-envelope.md`.

--- a/specs/use-case-organization.yaml
+++ b/specs/use-case-organization.yaml
@@ -4,8 +4,9 @@ description: >-
   Requirements for the physical package layout of the use_cases package, registry
   synchronization, test mirroring, and documentation of the trigger-to-received-to-sync
   information flow pattern.
-version: 1.0.0
+version: 1.1.0
 scope:
+
 - prototype
 - production
 tags:
@@ -75,3 +76,54 @@ groups:
     statement: >-
       The trigger → received → sync information flow pattern SHOULD be documented in `notes/`
       and summarized in a `README.md` under `vultron/core/use_cases/`
+- id: UCORG-05
+  title: Use-Case Result Protocol
+  specs:
+  - id: UCORG-05-001
+    priority: MUST
+    kind: project
+    statement: >-
+      Every use-case `execute()` method MUST declare a return type that is `UseCaseResult` or a
+      subtype (`HandlerResult`, `TriggerResult`); bare `None` or `dict` return types are
+      not permitted
+    rationale: >-
+      Makes the use-case contract explicit and machine-checkable. See ADR-0040
+      (docs/adr/0040-use-case-result-envelope.md).
+    relationships:
+    - rel_type: implements
+      spec_id: CS-11-001
+  - id: UCORG-05-002
+    priority: MUST
+    kind: project
+    statement: >-
+      Handler (received-side) use cases MUST return `HandlerResult`; trigger use cases MUST
+      return `TriggerResult`; both MUST inherit from `UseCaseResult`
+    rationale: Separate subtypes allow callers to distinguish received-side vs. trigger-side results without isinstance checks on the base.
+  - id: UCORG-05-003
+    priority: MUST
+    kind: project
+    statement: >-
+      The `UseCase` Protocol in `vultron/core/ports/use_case.py` MUST declare
+      `execute() -> UseCaseResult`; the return type MUST NOT be `Any` or `None`
+  - id: UCORG-05-004
+    priority: MUST
+    kind: project
+    statement: >-
+      An architecture ratchet test MUST verify that all concrete use-case classes in
+      `vultron/core/use_cases/` declare an `execute()` return annotation that is
+      `UseCaseResult` or a registered subtype
+    rationale: Belt-and-suspenders companion to mypy enforcement; caught at CI time without mypy strictness flags.
+  - id: UCORG-05-005
+    priority: MUST
+    kind: project
+    statement: >-
+      `TriggerResult` MUST carry `activity` and `emitting_actor_id` fields; `HandlerResult`
+      MAY carry domain-specific result fields but MUST NOT carry raw `dict` payloads
+  - id: UCORG-05-006
+    priority: MUST_NOT
+    kind: project
+    statement: >-
+      `TriggerService` methods and `TriggerServicePort` Protocol method signatures MUST NOT
+      declare `dict` or `dict[str, Any]` as their return type; they MUST declare
+      `TriggerResult`
+    rationale: Propagating dict past the service boundary defeats the typed contract at the router boundary.


### PR DESCRIPTION
- Closes #423

## Summary

Plans the `UseCaseResult` return-envelope for all use-case `execute()` methods,
establishing the typed interface contract between core and its driving adapters.

Key decisions made in this planning session:

- **Introduce `UseCaseResult` hierarchy** with `HandlerResult` (received path)
  and `TriggerResult` (trigger path) subtypes.
- **Do not introduce `UseCaseRequest`** — `VultronEvent` ("what a remote actor
  asserted") and `TriggerRequest` ("what our local actor intends to do") are
  semantically distinct request paths and conflating them would cross a trust
  boundary.
- **`TriggerService` / `TriggerServicePort` in scope** — the full call chain
  (use case → service → port → router) is migrated from `dict[str, Any]` to
  `TriggerResult`.
- **Both mypy enforcement and an architecture ratchet test** are required ACs
  on the implementation issue.
- **ADR-0040** records the full decision rationale for the result envelope and
  the `UseCaseRequest` decision.

Implementation tracked in #1769.

## Changes

- `specs/use-case-organization.yaml` — new group UCORG-05 (Use-Case Result
  Protocol): six requirements covering `execute()` return type, subtype
  hierarchy, Protocol annotation, ratchet test, `TriggerResult` field contract,
  and `TriggerService`/`TriggerServicePort` return type prohibition on `dict`
- `docs/adr/0040-use-case-result-envelope.md` — new ADR: why `UseCaseResult`
  with subtype hierarchy was chosen; why `UseCaseRequest` was not introduced;
  consequences; validation
- `notes/use-case-protocol.md` — new design note: result hierarchy, two request
  paths, `UseCaseRequest` decision rationale, `TriggerService` migration
  guidance, ratchet test design
- `docs/adr/index.md` — ADR-0040 entry added
- `notes/README.md` — `use-case-protocol.md` entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)