### PR TITLE
docs: plan issue #1771 — CaseActor-authoritative case initialization

### DIFF
--- a/docs/adr/0015-create-case-at-report-receipt.md
+++ b/docs/adr/0015-create-case-at-report-receipt.md
@@ -1,7 +1,8 @@
 ---
-status: accepted
+status: superseded
 date: 2026-04-28
 deciders: Vultron maintainers
+superseded_by: 0041-caseactor-authoritative-case-initialization.md
 ---
 
 # Create VulnerabilityCase at Report Receipt (RM.RECEIVED)

--- a/docs/adr/0041-caseactor-authoritative-case-initialization.md
+++ b/docs/adr/0041-caseactor-authoritative-case-initialization.md
@@ -1,0 +1,179 @@
+---
+status: accepted
+date: 2026-07-28
+deciders: [adh, Claude Sonnet 4.6]
+supersedes: 0015-create-case-at-report-receipt.md
+---
+
+# ADR-0041: CaseActor-Authoritative Case Initialization
+
+## Context and Problem Statement
+
+ADR-0015 established that the receiver (vendor) creates the `VulnerabilityCase`
+object in its own DataLayer at report receipt (`RM.RECEIVED`), then
+retroactively introduces the CaseActor via the `CaseProposal` protocol
+(ADR-0023). This produces an architecture gap: the vendor is not the
+authoritative creator of the canonical case, yet it creates the case object
+before the CaseActor exists.
+
+The concrete problems this gap causes:
+
+1. **AS2 authorship violation**: the vendor creates a `VulnerabilityCase` with
+   itself as `attributed_to`, but per ADR-0023 the CaseActor is the
+   authoritative case creator and the only correct `actor` on
+   `Create(VulnerabilityCase)`.
+
+2. **Prologue back-fill**: `WritePrologueLedgerEntriesNode` (Issue #1688) was
+   introduced as a workaround to stamp vendor-authored initialization entries
+   into the CaseActor's canonical ledger when the CaseActor accepts the
+   `Offer(CaseManagerRole)`. Its own docstring acknowledges "the vendor actor
+   is not the CaseActor and MUST NOT commit canonical case-ledger entries."
+
+3. **Two overlapping init mechanisms**: the `CaseProposal` accept path
+   (ADR-0023) and the prologue back-fill path (#1688) both attempt to establish
+   the initial case at the CaseActor. Their overlap is the direct cause of
+   Issue #1767: `add_case_status_to_case` is rejected by the
+   `_validate_canonical_entry` guard because the CaseActor is stamping a
+   vendor-authored snapshot.
+
+4. **Latent scenario-dependent breakage**: the prologue `add_case_status_to_case`
+   entry is silently skipped in passing runs (the genesis `CaseStatus` is
+   already inlined in the `create_case` entry), so the ledger "works" while
+   quietly dropping an entry. Attempting to commit it (PR #1746, reverted)
+   shifted ledger indices and broke `fvcv-extension` VFD replication timing —
+   evidence that the back-fill is load-bearing scar tissue, not a clean layer.
+
+The question is: **when and by whom should the `VulnerabilityCase` be
+created, and what does the receiver hold locally during the proposal window?**
+
+## Decision Drivers
+
+- Preserve AS2 "I created this" semantics end-to-end (ADR-0023)
+- Single authoritative init path: no back-fill workarounds
+- Receiver needs no local `VulnerabilityCase` before the CaseActor responds
+- Remove `WritePrologueLedgerEntriesNode` and the `Offer(CaseManagerRole)` path
+  as they become unnecessary
+
+## Considered Options
+
+1. **CaseActor-authoritative initialization** (chosen): receiver stores the
+   report and sends `Create(CaseProposal)`, then waits. CaseActor creates the
+   case, adds participants, initializes embargo, and commits canonical ledger
+   entries natively when accepting the proposal. Receiver creates no
+   `VulnerabilityCase` until `Create(VulnerabilityCase)` arrives from the
+   CaseActor.
+
+2. **Keep vendor-created case, fix back-fill signing**: allow the vendor to
+   create the case but have it authored correctly as a vendor-local copy, with
+   the CaseActor superseding it on `Create(VulnerabilityCase)` arrival.
+   Requires complex merge/supersession logic and still violates AS2 `actor`
+   semantics on the vendor-side copy.
+
+3. **Add `("Add", "CaseStatus")` to `_CASE_AUTHORED_SIGNATURES`** (symptom
+   fix only): addresses Issue #1767 but leaves the underlying two-init-path
+   architecture intact. Rejected: treats the symptom without removing the
+   cause.
+
+## Decision Outcome
+
+**Chosen option: CaseActor-authoritative initialization (Option 1).**
+
+### New protocol flow
+
+```text
+Reporter → Offer(VulnerabilityReport) → Receiver inbox
+Receiver: store report + write VultronReportCaseLink(status=PENDING_PROPOSAL)
+Receiver → Create(as_CaseProposal) → CaseActor inbox
+
+CaseActor (on Accept(CaseProposal)):
+  - Create VulnerabilityCase (attributed_to=CaseActor)
+  - Add receiver as CASE_OWNER participant (RM.RECEIVED)
+  - Add reporter as participant (RM.ACCEPTED)
+  - Initialize default embargo
+  - Commit canonical ledger entries natively (no back-fill)
+  - Emit Accept(as_CaseProposal) → Receiver inbox
+  - Emit Create(VulnerabilityCase, actor=CaseActor) → Receiver inbox
+
+Receiver (on Create(VulnerabilityCase)):
+  - Seed local replica via CreateCaseReceivedUseCase (already exists)
+  - Record trust anchors in VultronReportCaseLink
+  - CaseActor is now the comms hub for the case
+```
+
+### What is removed
+
+- `CreateCaseNode`, `CreateCaseOwnerParticipant`, `InitializeDefaultEmbargoNode`,
+  `CreateCaseActivity`/`UpdateActorOutbox` from the vendor's
+  `receive_report_case_tree.py`. The vendor tree becomes: store report →
+  write pending link → `ProposeCaseToActorNode` → done.
+- `WritePrologueLedgerEntriesNode` (Issue #1688) — the back-fill is no longer
+  needed when the CaseActor commits init entries natively.
+- `SendOfferCaseManagerRoleNode` and the `Offer(CaseManagerRole)` / accept
+  path from the vendor tree — the CaseActor adds itself as `CASE_MANAGER` when
+  creating the case natively.
+- `CreateCaseActorNode` from the vendor tree — the CaseActor is a pre-existing
+  service; the vendor does not spawn it.
+
+### What stays
+
+- `ProposeCaseToActorNode` — still needed; the vendor sends
+  `Create(as_CaseProposal)` to initiate the CaseActor-authoritative flow.
+- `CreateCaseReceivedUseCase` — already handles `Create(VulnerabilityCase)`
+  arriving at the vendor inbox; now actually seeds the case rather than hitting
+  the idempotency skip.
+- `VultronReportCaseLink` — vendor's interim record during the proposal window
+  (`status=PENDING_PROPOSAL`). No `VulnerabilityCase` exists vendor-side until
+  the CaseActor's `Create(VulnerabilityCase)` arrives.
+- All of `case_proposal_received_tree.py` structure — enriched with native
+  participant, embargo, and ledger initialization.
+
+### Consequences
+
+- **Good**: AS2 `actor` semantics are correct end-to-end — only the CaseActor
+  bears `actor` on `Create(VulnerabilityCase)`.
+- **Good**: Single initialization path; `WritePrologueLedgerEntriesNode` and
+  the `Offer(CaseManagerRole)` path are removed entirely.
+- **Good**: Issue #1767 is resolved as a consequence — the
+  `add_case_status_to_case` signature conflict disappears because the back-fill
+  is gone.
+- **Good**: `receive_report_case_tree.py` becomes significantly simpler.
+- **Neutral**: `case_proposal_received_tree.py` gains participant creation,
+  embargo initialization, and ledger commit responsibility. This is the correct
+  place for it.
+- **Bad**: The embedded participant payload in `Create(VulnerabilityCase)` must
+  be rich enough for `_store_embedded_participants` and
+  `EnsureReporterParticipantAtAcceptedNode` to seed the vendor's replica
+  correctly. This is an implementation constraint on the CaseActor-side tree.
+
+### Implementation order
+
+Issues must be implemented in this order to keep each step independently
+testable:
+
+1. **Enrich CaseActor tree** (Issue B, blocked by #1771 docs PR): add native
+   participant creation, embargo init, and ledger commits to
+   `case_proposal_received_tree.py`. Additive; vendor tree is untouched.
+   Demo still passes.
+
+2. **Slim vendor tree** (Issue A, blocked by Issue B): remove case-creation
+   nodes from `receive_report_case_tree.py`. Depends on Issue B being merged
+   so the CaseActor's `Create(VulnerabilityCase)` carries full participant
+   data.
+
+3. **Remove prologue and `Offer(CaseManagerRole)` path** (Issue C, blocked by
+   Issue A): delete `WritePrologueLedgerEntriesNode`, gut
+   `offer_case_manager_role_received_tree.py`, remove `SendOfferCaseManagerRoleNode`
+   and `CreateCaseActorNode` from vendor tree. Closes Issue #1767.
+
+4. **Spec and notes updates** (Issue D, parallel with B/C): update CP, CM, CLP
+   specs and `notes/case-proposal.md`, `notes/case-bootstrap-trust.md`.
+
+## More Information
+
+- Supersedes: `docs/adr/0015-create-case-at-report-receipt.md`
+- Refines: `docs/adr/0023-case-proposal-protocol.md`
+- Source concern: Issue #1771
+- Symptom issue resolved: Issue #1767
+- Workaround removed: Issue #1688 (`WritePrologueLedgerEntriesNode`)
+- Generated spec requirements: `specs/case-proposal.yaml` CP-09,
+  `specs/case-management.yaml` CM-16 (CaseActor-authoritative init)

--- a/docs/adr/0041-caseactor-authoritative-case-initialization.md
+++ b/docs/adr/0041-caseactor-authoritative-case-initialization.md
@@ -176,4 +176,5 @@ testable:
 - Symptom issue resolved: Issue #1767
 - Workaround removed: Issue #1688 (`WritePrologueLedgerEntriesNode`)
 - Generated spec requirements: `specs/case-proposal.yaml` CP-09,
-  `specs/case-management.yaml` CM-16 (CaseActor-authoritative init)
+  `specs/case-management.yaml` CM-22 (CaseActor-authoritative init),
+  `specs/case-ledger-processing.yaml` CLP-12

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -64,8 +64,6 @@ General information about architectural decision records is available at <https:
 - [ADR-0013 Unify RM State Tracking](0013-unify-rm-state-tracking.md)
 - [ADR-0014 Pin GitHub Actions to Full Commit SHAs with Version
   Comments](0014-sha-pin-github-actions.md)
-- [ADR-0015 Create VulnerabilityCase at Report Receipt
-  (RM.RECEIVED)](0015-create-case-at-report-receipt.md)
 - [ADR-0016 Replace TinyDB with SQLModel/SQLite DataLayer
   Adapter](0016-sqlmodel-sqlite-datalayer.md)
 - [ADR-0017 Domain/Wire Object Separation: Shared-Base, Two-Branch
@@ -109,6 +107,7 @@ General information about architectural decision records is available at <https:
   OFFER\_CASE\_OWNERSHIP\_TRANSFER via Dedicated Object Type](0039-offer-case-participant-role-wire-type.md)
 - [ADR-0040 Introduce UseCaseResult Envelope; Do Not Introduce
   UseCaseRequest](0040-use-case-result-envelope.md)
+- [ADR-0041 CaseActor-Authoritative Case Initialization](0041-caseactor-authoritative-case-initialization.md)
 
 ## Proposed ADRs
 
@@ -125,4 +124,5 @@ General information about architectural decision records is available at <https:
 
 ## Superseded ADRs
 
-- none
+- [ADR-0015 Create VulnerabilityCase at Report Receipt
+  (RM.RECEIVED)](0015-create-case-at-report-receipt.md) — superseded by ADR-0041

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -436,6 +436,14 @@ reporter at RM.ACCEPTED, receiver at RM.RECEIVED. RM state is tracked
 in `VultronParticipant.participant_status[].rm_state` from the moment
 of case creation.
 
+> **ADR-0015 is superseded by ADR-0041.** In the CaseActor-authoritative model
+> the vendor tree no longer creates the `VulnerabilityCase` directly.  The vendor
+> stores the report, writes a pending `VultronReportCaseLink`, and sends
+> `Create(as_CaseProposal)` to the CaseActor; the CaseActor creates the case,
+> adds participants, and initializes embargo before emitting
+> `Create(VulnerabilityCase)` back to the vendor.  See `notes/case-proposal.md`
+> for the corrected flow (CM-22, CP-09).
+
 `ReportStatus` in the flat status layer is a **transient pre-case
 mechanism** that was previously used for reports not yet associated with
 a case (pre-case RM states: RECEIVED, INVALID). Under ADR-0015, the case

--- a/notes/case-bootstrap-trust.md
+++ b/notes/case-bootstrap-trust.md
@@ -133,26 +133,45 @@ bootstrap `Create(VulnerabilityCase)` for this report/case relationship."
 
 ---
 
+## ADR-0041 Update: Receiver Holds No Interim VulnerabilityCase
+
+Per ADR-0041 (`docs/adr/0041-caseactor-authoritative-case-initialization.md`),
+the receiver (vendor) does **not** create a `VulnerabilityCase` before the
+CaseActor responds. The bootstrap flow for the original report-submission path
+is now:
+
+```text
+Receiver: Offer(VulnerabilityReport) received
+  → store report
+  → write VultronReportCaseLink(status=PENDING_PROPOSAL)
+  → send Create(as_CaseProposal) to CaseActor
+
+CaseActor: Create(VulnerabilityCase, actor=CaseActor, inline participants)
+  → Receiver seeds local replica via CreateCaseReceivedUseCase
+  → trust anchors recorded in VultronReportCaseLink
+```
+
+The `Create(VulnerabilityCase)` from the CaseActor IS the bootstrap. The
+sender is the CaseActor (not the report receiver), so the trust anchor the
+receiver validates is `trusted_case_actor_id` from the `Accept(CaseProposal)`
+recorded earlier in `accept_case_proposal_received_tree.py`.
+
+The `Create(VulnerabilityCase)` payload MUST embed participant objects inline
+so `_store_embedded_participants` can seed them on the receiver's replica.
+
 ## Migration Guidance
 
-This design supersedes the non-owner bootstrap assumptions currently written in
-`notes/participant-case-replica.md` and the corresponding PCR bootstrap rules:
+Per ADR-0041, the following call sites change:
 
-- Original participants do **not** start with `Announce(VulnerabilityCase)`
-  from the CaseActor.
-- `Create(VulnerabilityCase)` is no longer forbidden as a snapshot vehicle in
-  all cases; it is allowed exactly once for creator-signed bootstrap on the
-  original report path.
-- Late joiners still converge on CaseActor-authored `Announce` after their
-  invite-based trust handoff.
-
-When implementation work begins, update these call sites consistently:
-
-1. Case creation at report receipt
-2. Outbound bootstrap activity construction
-3. Participant-side bootstrap validation and trust persistence
-4. Unknown-context / pre-bootstrap queueing and replay request behavior
-5. Invite-to-case handling for late-joiner trust establishment
+1. **Case creation at report receipt** — receiver no longer creates
+   `VulnerabilityCase`; replaced by `VultronReportCaseLink(status=PENDING_PROPOSAL)`
+2. **CaseActor bootstrap payload** — `Create(VulnerabilityCase)` must embed
+   inline participants (not bare IDs)
+3. **Participant-side bootstrap validation and trust persistence** — already
+   implemented in `CreateCaseReceivedUseCase`; no change needed
+4. **Unknown-context / pre-bootstrap queueing** — existing queueing logic
+   applies unchanged
+5. **Invite-to-case handling for late-joiner trust establishment** — unchanged
 
 ---
 

--- a/notes/case-creation-sequence.md
+++ b/notes/case-creation-sequence.md
@@ -1,9 +1,11 @@
 ---
 title: Case Creation Sequence
-status: active
+status: superseded
+superseded_by: notes/case-proposal.md
 description: >
   Design decisions and BT implementation mapping for the canonical case
   initialization sequence at Offer(Report) receipt (CM-14, ADR-0015).
+  Superseded by ADR-0041 — see notes/case-proposal.md for the corrected flow.
 related_specs:
   - specs/case-management.yaml
 related_notes:
@@ -11,11 +13,19 @@ related_notes:
   - notes/embargo-default-semantics.md
   - notes/protocol-event-cascades.md
   - notes/participant-embargo-consent.md
+  - notes/case-proposal.md
 relevant_packages:
   - vultron/core/behaviors/case
   - vultron/core/behaviors/report
   - vultron/core/use_cases/received
 ---
+
+> **SUPERSEDED by ADR-0041.** The vendor-creates-case sequence documented here
+> (`CreateCaseNode`, `CreateCaseOwnerParticipant`, `InitializeDefaultEmbargoNode`)
+> is no longer the correct flow. Per ADR-0041, the vendor stores the report and
+> sends `Create(as_CaseProposal)` to the CaseActor; the CaseActor creates the
+> `VulnerabilityCase` natively. See `notes/case-proposal.md` (ADR-0041 section)
+> for the corrected initialization sequence (CM-22).
 
 # Case Creation Sequence
 

--- a/notes/case-ledger-authority.md
+++ b/notes/case-ledger-authority.md
@@ -397,7 +397,14 @@ itself or from a prior invocation having been authorized.
 
 ---
 
-## Prologue Backfill Pattern (Issue #1688)
+## Prologue Backfill Pattern (Issue #1688) — SUPERSEDED by ADR-0041
+
+> **SUPERSEDED by ADR-0041.** `WritePrologueLedgerEntriesNode` and the
+> `Offer(CaseManagerRole)` accept path are scheduled for removal.  Under
+> ADR-0041 (CaseActor-authoritative initialization) the CaseActor commits all
+> case-initialization ledger entries natively when accepting the `CaseProposal`,
+> so no prologue back-fill is needed.  The section below documents the old
+> pattern for historical context.
 
 When a `CaseActor` accepts the `CASE_MANAGER` role it must back-fill ledger
 entries for protocol events that occurred before it was appointed (report

--- a/notes/case-proposal.md
+++ b/notes/case-proposal.md
@@ -23,8 +23,10 @@ relevant_packages:
 # CaseProposal Protocol
 
 **Source**: 2026-06-22 grill-me planning session, issue #1081.
-Normative requirements: `specs/case-proposal.yaml` (CP-01 through CP-07).
+Normative requirements: `specs/case-proposal.yaml` (CP-01 through CP-09).
 ADR: `docs/adr/0023-case-proposal-protocol.md`.
+Refined by: `docs/adr/0041-caseactor-authoritative-case-initialization.md`
+(supersedes ADR-0015; CaseActor creates case natively on proposal accept).
 
 ---
 
@@ -47,6 +49,11 @@ actual creation.
 
 ## Protocol Flow
 
+**Note**: The flow below reflects the corrected CaseActor-authoritative model
+(ADR-0041). The vendor does NOT create a `VulnerabilityCase` locally before
+the CaseActor responds. The vendor stores the report, writes a pending
+`VultronReportCaseLink`, and waits.
+
 ```text
 Vendor                              CaseActor Service
   |                                       |
@@ -54,15 +61,19 @@ Vendor                              CaseActor Service
   |         actor: vendor URI             |
   |         object_: as_CaseProposal      |
   |                                       |
-  |           [evaluates proposal]        |
+  |   [creates case, adds participants,   |
+  |    initializes embargo, commits       |
+  |    canonical ledger entries natively] |
   |                                       |
   | <-- Accept(CaseProposal) ----------- |  (happy path)
   |         actor: case-actor URI         |
   |         object_: as_CaseProposal      |
+  |         result: case URI              |
   |                                       |
   | <-- Create(VulnerabilityCase) ------- |
   |         actor: case-actor URI         |
   |         context: Accept URI           |
+  |         [inline participants]         |
   |                                       |
   |    -- OR --                           |
   |                                       |
@@ -145,22 +156,62 @@ more-general patterns that share the same outer Activity type (SE-03-002).
 
 ---
 
+## CaseActor Native Initialization (ADR-0041)
+
+When the CaseActor accepts a proposal, `case_proposal_received_tree.py` MUST
+perform the following natively — no back-fill, no prologue:
+
+1. Create `VulnerabilityCase` with `attributed_to=CaseActor` (already implemented)
+2. Add receiver (vendor) as `CASE_OWNER` participant at `RM.RECEIVED`
+3. Add reporter as participant at `RM.ACCEPTED`
+4. Initialize default embargo
+5. Commit canonical ledger entries (`create_case`, `add_report_to_case`,
+   `add_participant_status_to_participant` × N, `add_case_status_to_case`)
+6. Emit `Accept(as_CaseProposal)` with `result=case_id`
+7. Emit `Create(VulnerabilityCase)` with inline participant objects so that
+   `CreateCaseReceivedUseCase._store_embedded_participants` seeds them correctly
+   on the vendor's replica
+
+The `Create(VulnerabilityCase)` payload MUST embed participant objects inline
+(not bare IDs) so the vendor can seed its replica without a DataLayer round-trip
+to the CaseActor.
+
+### Removed nodes (ADR-0041)
+
+The following nodes are **removed** from the vendor's
+`receive_report_case_tree.py` and must not be re-added:
+
+| Removed node | Reason |
+|---|---|
+| `CreateCaseNode` | CaseActor creates the case |
+| `CreateCaseOwnerParticipant` | CaseActor adds receiver as participant |
+| `InitializeDefaultEmbargoNode` | CaseActor initializes embargo |
+| `CreateCaseActivity` / `UpdateActorOutbox` | CaseActor emits `Create(VulnerabilityCase)` |
+| `CreateCaseActorNode` | CaseActor is a pre-existing service, not spawned by vendor |
+| `SendOfferCaseManagerRoleNode` | CaseActor adds itself as `CASE_MANAGER` natively |
+| `WritePrologueLedgerEntriesNode` | Back-fill replaced by native CaseActor init |
+
+### Corrected vendor tree shape (ADR-0041)
+
+`receive_report_case_tree.py` becomes:
+
+```text
+ReceiveReportCaseBT (Sequence)
+├─ CheckAutoCaseCreationEnabledNode
+└─ ReceiveReportCaseSelector (Selector)
+   ├─ CheckPendingProposalExistsForReport    # idempotency
+   └─ ReceiveReportProposalFlow (Sequence)
+      ├─ WritePendingReportCaseLinkNode      # VultronReportCaseLink(status=PENDING_PROPOSAL)
+      └─ ProposeCaseToActorNode              # Create(as_CaseProposal) → CaseActor
+```
+
+No `VulnerabilityCase`, no participants, no embargo created by the vendor.
+
 ## BT Integration: `ProposeCaseToActorNode`
 
-A new BT leaf node `ProposeCaseToActorNode` is responsible for sending
-`Create(as_CaseProposal)` to the case-actor service. It is distinct from
-`CreateCaseActorNode`.
-
-### Node roles — do not conflate
-
-| Node | Responsibility |
-|------|----------------|
-| `CreateCaseActorNode` | Registers the case-actor service as an actor resource in the local DataLayer. Creates the actor identity, not the case. |
-| `ProposeCaseToActorNode` | Sends `Create(as_CaseProposal)` to the already-registered case-actor service. Initiates the case initialization protocol. |
-
-`ProposeCaseToActorNode` is wired into the case-creation BT tree **after**
-`CreateCaseActorNode` succeeds — the actor must exist before the proposal can
-be sent to it.
+`ProposeCaseToActorNode` sends `Create(as_CaseProposal)` to the CaseActor
+service. The CaseActor service URI comes from
+`ActorConfig.case_actor_service_url` (CP-08-001 through CP-08-003).
 
 ---
 

--- a/plan/history/2607/learning/CONCERN-1771.md
+++ b/plan/history/2607/learning/CONCERN-1771.md
@@ -1,0 +1,16 @@
+---
+source: CONCERN-1771
+timestamp: '2026-07-28T19:50:42.701778+00:00'
+title: Case initialization follows obsolete ADR-0015 ordering instead of CaseActor-authoritative
+  model (ADR-0023); prologue back-fill is a workaround
+type: learning
+---
+
+Case initialization does not follow the CaseActor-authoritative model that has been the intent since the CaseActor was introduced. Instead it follows the pre-CaseActor ordering from ADR-0015 (create case at report receipt, in the receiver's DataLayer), then retroactively back-fills the CaseActor's canonical ledger via a workaround node. This is a fundamental architecture gap discovered late in the dev cycle.
+
+The root problem is that `receive_report_case_tree.py` creates `VulnerabilityCase` in the vendor's DataLayer before engaging the CaseActor — violating AS2 authorship semantics (the vendor is not the authoritative case creator). `WritePrologueLedgerEntriesNode` (Issue #1688) was introduced as a back-fill workaround, stamping vendor-authored init entries into the CaseActor's canonical ledger. Issue #1767 is a direct symptom: `add_case_status_to_case` is rejected by `_validate_canonical_entry` because the CaseActor is trying to commit a vendor-authored snapshot.
+
+**Resolved**: 2026-07-28 — design and implementation tracked in #1775, #1776, #1777, #1774.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1773>.
+ADR: `docs/adr/0041-caseactor-authoritative-case-initialization.md` (supersedes ADR-0015).
+Notes: `notes/case-proposal.md`, `notes/case-bootstrap-trust.md`.

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -4,7 +4,7 @@ description: Requirements for participant assertions, CaseActor canonicalization
   projection, and replication-facing CaseLedgerEntry objects. Covers the commit authorization model, per-case genesis hash
   derivation, the canonical entry criteria that separate the case ledger from the process log, and the CaseActor inbox routing
   path that enables ledger entry authorship.
-version: 1.1.0
+version: 1.2.0
 scope:
 - prototype
 - production
@@ -465,3 +465,47 @@ groups:
     statement: When searching for a reply entry in `find_protocol_pair()`, the implementation SHOULD use the `event_type`
       field of `CaseLedgerEntry` (derived from `MessageSemantics.value`) as the primary key, scoped to `case_id`. `in_reply_to`
       chain-following is an internal implementation detail and MUST NOT be exposed as a public port primitive.
+- id: CLP-12
+  title: CaseActor-Authored Signature Completeness
+  description: >-
+    Requirements on the set of canonical-entry signatures the CaseActor is
+    authorized to author (`_CASE_AUTHORED_SIGNATURES` in `chain.py`), ensuring
+    all case-initialization operations are expressible without falling back to
+    vendor authorship or back-fill workarounds.
+  specs:
+  - id: CLP-12-001
+    priority: MUST
+    kind: project
+    statement: >-
+      `_CASE_AUTHORED_SIGNATURES` in `vultron/core/behaviors/sync/nodes/chain.py`
+      MUST include `("Add", "CaseStatus")` so that `add_case_status_to_case`
+      ledger entries authored by the CaseActor are accepted by
+      `_validate_canonical_entry`.
+    rationale: >-
+      Issue #1767: `("Add", "CaseStatus")` appears in `_CANONICAL_PAYLOAD_SIGNATURES`
+      but was absent from `_CASE_AUTHORED_SIGNATURES`, causing
+      `_validate_canonical_entry` to reject CaseActor-authored
+      `add_case_status_to_case` entries.  This is the direct mechanical fix
+      required by ADR-0041's native-initialization model (CM-22-003).
+    relationships:
+    - rel_type: implements
+      spec_id: CM-22-003
+  - id: CLP-12-002
+    priority: MUST
+    kind: project
+    statement: >-
+      `_CASE_AUTHORED_SIGNATURES` MUST be a complete superset of all
+      `("verb", "object-type")` pairs emitted by the CaseActor during native
+      case initialization (create_case, add_report_to_case,
+      add_participant_status_to_participant × N, add_case_status_to_case).
+      Any pair present in `_CANONICAL_PAYLOAD_SIGNATURES` that the CaseActor
+      natively authors MUST also appear in `_CASE_AUTHORED_SIGNATURES`.
+    rationale: >-
+      A CaseActor that cannot author its own initialization entries must resort
+      to vendor-side workarounds (the pattern that ADR-0015 introduced and
+      ADR-0041 supersedes).  Maintaining completeness of the authorized
+      signature set is therefore a prerequisite for the corrected
+      CaseActor-authoritative model.
+    relationships:
+    - rel_type: refines
+      spec_id: CLP-12-001

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -460,6 +460,15 @@ groups:
     priority: MUST
     kind: protocol
     statement: A `VulnerabilityCase` MUST be created when an `Offer(Report)` activity is received by the vendor actor
+    note: >-
+      Superseded by CM-22-001 (ADR-0041): the vendor actor MUST NOT create the
+      `VulnerabilityCase` directly.  The vendor stores the report and waits for
+      `Create(VulnerabilityCase)` from the CaseActor.  CM-12-001 applies only in
+      single-actor deployments where the vendor IS the CaseActor.
+    relationships:
+    - rel_type: supersedes
+      spec_id: CM-22-001
+      note: CM-22-001 (ADR-0041) is the authoritative replacement for multi-actor deployments
   - id: CM-12-002
     priority: MUST
     kind: protocol
@@ -574,6 +583,12 @@ groups:
     rationale: Step 2 precedes step 3 so that the embargo is always created by a participant (the case owner). The Create(Case)
       notification in step 4 is flushed before the reporter is added in step 5 so the reporter's system receives the case
       object before any subsequent Announce(CaseLedgerEntry) fan-out that references it.
+    note: >-
+      Superseded by CM-22 (ADR-0041) for multi-actor deployments: in the
+      CaseActor-authoritative model the `VulnerabilityCase` is created by the
+      CaseActor (not the receiving vendor), so `attributed_to` is the CaseActor's
+      actor ID, not the receiving actor's.  CM-14-001 applies only in single-actor
+      deployments where the vendor IS the CaseActor.
     relationships:
     - rel_type: depends_on
       spec_id: CM-12-001
@@ -581,6 +596,9 @@ groups:
       spec_id: CM-12-002
     - rel_type: refines
       spec_id: CM-12-004
+    - rel_type: supersedes
+      spec_id: CM-22-001
+      note: CM-22-001 (ADR-0041) replaces the attributed_to=receiving_actor semantics for multi-actor deployments
   - id: CM-14-002
     priority: MUST
     kind: protocol
@@ -1120,3 +1138,20 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: CM-22-001
+  - id: CM-22-004
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The CaseActor MUST initialize the default embargo for the new case before
+      emitting `Create(VulnerabilityCase)` to the vendor.
+    rationale: >-
+      Embargo state is protocol-significant.  Deferring initialization to the
+      vendor or to a later message would produce a window in which
+      embargo-gated operations are undefined (ADR-0041, CP-09-003).  The
+      CaseActor holds the default embargo policy and is the only actor that
+      can initialize it authoritatively at case creation.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-22-001
+    - rel_type: implements
+      spec_id: CP-09-003

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -3,7 +3,7 @@ title: Case Management
 description: Requirements for VulnerabilityCase lifecycle management, CaseActor responsibilities, and the RM/EM/CS/VFD state
   model. Covers actor isolation at the protocol level, the distinction between participant-specific and participant-agnostic
   state, case initialization sequencing, embargo acceptance ownership, and the invitation acceptance lifecycle.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -1061,3 +1061,62 @@ groups:
       spec_id: CM-21-002
     - rel_type: refines
       spec_id: CM-21-003
+- id: CM-22
+  title: CaseActor-Authoritative Case Creation
+  description: >-
+    Requirements on the CaseActor's obligations when accepting a CaseProposal,
+    per ADR-0041.  These replace the vendor-authored case-creation described in
+    ADR-0015 and govern how the CaseActor initializes CaseStatus, participants,
+    and embargo in its DataLayer before emitting `Create(VulnerabilityCase)`.
+  specs:
+  - id: CM-22-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The CaseActor MUST create the `VulnerabilityCase` object in its own
+      DataLayer with `attributed_to` equal to the CaseActor's own actor ID when
+      accepting a `Create(as_CaseProposal)`.
+    rationale: >-
+      ADR-0041 supersedes ADR-0015.  `attributed_to` names the authoritative
+      creator of the case; only the CaseActor is the authoritative creator
+      (ADR-0023).  Assigning `attributed_to` to the vendor violates AS2
+      semantics and the chain-of-custody model in `chain.py`.
+    relationships:
+    - rel_type: implements
+      spec_id: CP-09-001
+  - id: CM-22-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      After creating the `VulnerabilityCase`, the CaseActor MUST create
+      `CaseParticipant` records for at minimum: (a) the receiver (vendor) with
+      `CVDRole.CASE_OWNER` and `RM.RECEIVED`, and (b) the reporter with
+      `RM.ACCEPTED`.  These records MUST be written before `Create(VulnerabilityCase)`
+      is emitted to the vendor.
+    rationale: >-
+      The `Create(VulnerabilityCase)` payload embeds participants inline so the
+      vendor's `CreateCaseReceivedUseCase._store_embedded_participants` can seed
+      its local replica.  Absent participant records at emission time produce an
+      empty replica and break role-guard checks (CP-09-002, CP-09-004).
+    relationships:
+    - rel_type: refines
+      spec_id: CM-22-001
+    - rel_type: implements
+      spec_id: CP-09-002
+  - id: CM-22-003
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The CaseActor MUST commit all canonical ledger entries for case
+      initialization (`create_case`, `add_report_to_case`, participant-status
+      entries, `add_case_status_to_case`) natively in its own DataLayer.  These
+      entries MUST NOT be authored by the vendor and back-filled via
+      `WritePrologueLedgerEntriesNode` or any equivalent mechanism.
+    rationale: >-
+      `_validate_canonical_entry` in `chain.py` rejects entries where the
+      `actor_id` does not match `_CASE_AUTHORED_SIGNATURES`.  Vendor-authored
+      entries fail this check (the root cause of Issue #1767).  Native
+      CaseActor authorship is the only compliant path.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-22-001

--- a/specs/case-proposal.yaml
+++ b/specs/case-proposal.yaml
@@ -3,7 +3,7 @@ title: CaseProposal Protocol
 description: Requirements for the CaseProposal protocol flow, which separates the act of requesting case initialization from
   the act of creating the case. Covers the wire vocabulary type, the Create/Accept/Reject message flow, and the corresponding
   MessageSemantics values and received-side use cases.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -247,3 +247,89 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: CP-08-001
+- id: CP-09
+  title: CaseActor-Authoritative Initialization on Accept(CaseProposal)
+  description: >-
+    Requirements for the CaseActor to perform all case initialization natively
+    when accepting a CaseProposal, per ADR-0041.  These replace the
+    vendor-side case-creation and prologue back-fill that ADR-0015 introduced.
+  specs:
+  - id: CP-09-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When the CaseActor accepts a `Create(as_CaseProposal)`, it MUST create
+      the `VulnerabilityCase` object with `attributed_to` set to the CaseActor's
+      own actor ID.  The receiving vendor MUST NOT be the `attributed_to` author
+      of the canonical `VulnerabilityCase`.
+    rationale: >-
+      AS2 `Create(X)` semantics mean "I (the actor) created X."  The CaseActor
+      is the authoritative case creator; attributing the case to the vendor
+      violates AS2 semantics and undermines the trust model (ADR-0023, ADR-0041).
+    relationships:
+    - rel_type: implements
+      spec_id: CP-05-001
+  - id: CP-09-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When the CaseActor creates the `VulnerabilityCase` on proposal acceptance,
+      it MUST add the receiver (vendor) as a `CASE_OWNER` participant at
+      `RM.RECEIVED` and the reporter as a participant at `RM.ACCEPTED` in the
+      CaseActor's DataLayer.  These participant records MUST be created before
+      the CaseActor emits `Create(VulnerabilityCase)` to the vendor.
+    rationale: >-
+      The vendor's replica is seeded from the embedded participant objects in
+      `Create(VulnerabilityCase)`.  If participants are absent at emission time
+      the vendor replica starts with no participant records and downstream
+      operations that require them (e.g. embargo consent, role guards) fail.
+    relationships:
+    - rel_type: refines
+      spec_id: CP-09-001
+  - id: CP-09-003
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The CaseActor MUST initialize the default embargo for the new case before
+      emitting `Create(VulnerabilityCase)`.
+    rationale: >-
+      Embargo state is protocol-significant.  Deferring initialization to the
+      vendor or to a later message would produce a window in which
+      embargo-gated operations are undefined (ADR-0041).
+    relationships:
+    - rel_type: refines
+      spec_id: CP-09-001
+  - id: CP-09-004
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The `Create(VulnerabilityCase)` activity emitted by the CaseActor MUST
+      embed participant objects inline (not as bare ID strings) so that the
+      receiving vendor's `CreateCaseReceivedUseCase` can seed its local
+      participant records without a DataLayer round-trip to the CaseActor.
+    rationale: >-
+      `_store_embedded_participants` and `EnsureReporterParticipantAtAcceptedNode`
+      parse embedded participant objects.  Bare IDs produce empty participant
+      records on the vendor's replica, causing role-guard failures for
+      operations that require `CASE_OWNER` or `CASE_MANAGER` checks.
+    relationships:
+    - rel_type: refines
+      spec_id: CP-09-002
+  - id: CP-09-005
+    priority: MUST_NOT
+    kind: protocol
+    statement: >-
+      The receiving vendor MUST NOT create a `VulnerabilityCase` object in its
+      own DataLayer before receiving `Create(VulnerabilityCase)` from the
+      CaseActor.  The vendor's `receive_report_case_tree` MUST store the
+      inbound report and write a pending `VultronReportCaseLink`, then send
+      `Create(as_CaseProposal)` and wait.
+    rationale: >-
+      Creating a vendor-local `VulnerabilityCase` before the CaseActor responds
+      produces a second, non-authoritative case object and forces a back-fill
+      workaround to reconcile the two copies.  This was the root cause of
+      `WritePrologueLedgerEntriesNode` (Issue #1688) and of Issue #1767
+      (ADR-0041).
+    relationships:
+    - rel_type: refines
+      spec_id: CP-09-001


### PR DESCRIPTION
- Closes #1771

## Summary

Plans Concern #1771: the vendor's `receive_report_case_tree.py` creates a
`VulnerabilityCase` in the vendor's DataLayer before engaging the CaseActor,
violating AS2 authorship semantics and ADR-0023. This PR captures the design
decision and updates notes to guide implementation.

## Changes

- **ADR-0041** (`docs/adr/0041-caseactor-authoritative-case-initialization.md`):
  new ADR superseding ADR-0015. CaseActor creates `VulnerabilityCase` natively
  when accepting `CaseProposal`; receiver holds only a pending
  `VultronReportCaseLink` until `Create(VulnerabilityCase)` arrives. Documents
  the four-issue implementation order (B→A→C, D parallel) and what is removed
  (`WritePrologueLedgerEntriesNode`, `Offer(CaseManagerRole)` path,
  `CreateCaseActorNode` from vendor tree).
- **ADR-0015** (`docs/adr/0015-create-case-at-report-receipt.md`): status
  changed to `superseded`; `superseded_by` pointer added.
- **ADR index** (`docs/adr/index.md`): ADR-0041 added to Accepted; ADR-0015
  moved to Superseded.
- **`notes/case-proposal.md`**: corrected protocol flow diagram (CaseActor
  adds participants + embargo + ledger natively); new "CaseActor Native
  Initialization" section with removed-nodes table and corrected vendor tree
  shape.
- **`notes/case-bootstrap-trust.md`**: new ADR-0041 section describing that
  the receiver holds no interim `VulnerabilityCase`; updated migration guidance
  call-site list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)