### PR TITLE
docs: plan issue #1782 — demo CI concurrency groups

### DIFF
--- a/plan/history/2607/idea/IDEA-1782.md
+++ b/plan/history/2607/idea/IDEA-1782.md
@@ -1,0 +1,14 @@
+---
+source: IDEA-1782
+timestamp: '2026-07-28T21:13:47.136620+00:00'
+title: Add concurrency + cancel-in-progress to demo CI workflows
+type: idea
+---
+
+Idea: add a concurrency block to the two demo CI workflows so queued/in-progress runs on the same PR branch are cancelled when a newer commit lands, reclaiming wasted CI minutes. Main-branch cache-warm runs are left to always complete.
+
+Resolution: captured as spec requirement DEMOCI-02-011 in specs/demo-ci.yaml — demo-integration.yml uses cancel-in-progress: true (pull_request), demo-image-cache-warm.yml uses cancel-in-progress: false (push to main). Group key ${{ github.workflow }}-${{ github.ref }} on both.
+
+**Processed**: 2026-07-28 — implementation tracked in #1789.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1788>.
+Spec: `specs/demo-ci.yaml` (DEMOCI-02-011).

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -199,6 +199,27 @@ groups:
           GitHub Actions self-hosted runners and persistent environments
           accumulate stale Docker state if teardown is skipped.
 
+      - id: DEMOCI-02-011
+        priority: SHOULD
+        kind: project
+        statement: >-
+          Both demo workflows (demo-integration.yml and
+          demo-image-cache-warm.yml) SHOULD define a `concurrency` group keyed
+          on `${{ github.workflow }}-${{ github.ref }}`. The demo-integration
+          workflow (pull_request-triggered) MUST set `cancel-in-progress: true`
+          so a newer push to a PR branch cancels superseded in-progress and
+          queued runs. The demo-image-cache-warm workflow (push-to-main
+          triggered) MUST set `cancel-in-progress: false` so main-branch cache
+          warms always run to completion.
+        rationale: >-
+          When commits land quickly during iterative work, queued demo runs
+          pile up and waste CI minutes while delaying feedback; a newer commit
+          renders earlier PR-branch runs pointless. Cancelling superseded PR
+          runs reclaims those minutes. Cache-warm runs on main are never
+          cancelled because each successful warm protects the fallback cache
+          scope that new PR branches read from (see the workflow header and
+          DEMOCI-02-007).
+
   - id: DEMOCI-03
     title: Extensibility for Additional Demo Scenarios
     specs:


### PR DESCRIPTION
- Closes #1782

## Summary

Plans #1782 by adding a spec requirement for demo-CI concurrency control.

## Changes

- **`specs/demo-ci.yaml`**: Add `DEMOCI-02-011` to group DEMOCI-02 — both demo workflows define a `concurrency` group keyed on `${{ github.workflow }}-${{ github.ref }}`.
  - `demo-integration.yml` (pull_request) sets `cancel-in-progress: true` so newer PR pushes cancel superseded queued/in-progress runs.
  - `demo-image-cache-warm.yml` (push to main) sets `cancel-in-progress: false` so cache warms always complete.
- **`plan/history/2607/idea/IDEA-1782.md`**: Archive the processed idea; implementation tracked in #1789.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>