### PR TITLE
refactor(call-out): move DETERMINISTIC seam into core; fix ADR-0025 core→demo inversion

### DIFF
--- a/docs/adr/0025-call-out-point-abstraction-layer.md
+++ b/docs/adr/0025-call-out-point-abstraction-layer.md
@@ -189,11 +189,26 @@ The concrete form:
 - `specs/behavior-tree-integration.yaml` BT-18 captures the blackboard
   contract requirements that every call-out point implementation must satisfy.
 
-## Bundle Selection Mechanism (2026-07-23 amendment)
+## Bundle Selection Mechanism (2026-07-23 amendment, corrected 2026-07-29)
 
 The original ADR left open the question of **how running code chooses which
 factory to inject**. Issue #1631 (planning session 2026-07-23) resolved this
 design gap. The resulting mechanism is implemented by #1152 (FUZZ-08c).
+
+> **Correction (2026-07-29, issue #1793)**: The 2026-07-23 amendment as first
+> written located the bundle **dataclasses** and the `<DOMAIN>_DETERMINISTIC`
+> **singletons** in `vultron/demo/fuzzer/bundles/`, then had ~11 core tree
+> builders import them as their no-arg defaults. That **inverted the core→demo
+> dependency** and directly violated this ADR's own decision driver "keep
+> simulation artifacts (`vultron/demo/fuzzer/`) out of
+> `vultron/core/behaviors/` (BT-16-001)". The corrected design below moves the
+> dataclasses, the `CallOutBackendFactory` Protocol, the deterministic
+> `AlwaysSucceed`/`AlwaysFail` nodes, and the `<DOMAIN>_DETERMINISTIC`
+> singletons into `vultron/core/behaviors/call_out/`. Only the probabilistic
+> `WeightedBehavior` node family and the `<DOMAIN>_STOCHASTIC` singletons remain
+> in `vultron/demo/fuzzer/`. A ratchet
+> (`test/architecture/test_core_no_demo_imports.py`) now enforces the boundary.
+> The strikethrough/updated text below reflects the corrected locations.
 
 ### Three-mode model
 
@@ -216,18 +231,40 @@ a `frozen @dataclass` that holds all `CallOutBackendFactory` fields for a
 domain area. Two pre-built module-level singletons exist per domain:
 `<DOMAIN>_DETERMINISTIC` and `<DOMAIN>_STOCHASTIC`.
 
+**Layer split (corrected 2026-07-29):** the dataclass and the
+`<DOMAIN>_DETERMINISTIC` singleton live in
+`vultron/core/behaviors/call_out/bundles/<domain>.py` — they are core concerns
+(the DETERMINISTIC bundle is the production-usable happy-path default). The
+`<DOMAIN>_STOCHASTIC` singleton lives in
+`vultron/demo/fuzzer/bundles/<domain>.py` and wires in the probabilistic
+`WeightedBehavior` fuzzer nodes; that module re-exports the core dataclass and
+DETERMINISTIC singleton for backward-compatible import paths. Core tree builders
+default `call_out` to the core DETERMINISTIC singleton and never import from
+`vultron/demo/`.
+
 ```python
+# vultron/core/behaviors/call_out/bundles/validation.py  (core)
+from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
 @dataclass(frozen=True)
 class ValidationCallOutBundle:
-    credibility_factory: CallOutBackendFactory = AlwaysSucceed
-    validity_factory: CallOutBackendFactory = AlwaysSucceed
-    gather_info_factory: CallOutBackendFactory = AlwaysSucceed
+    credibility_factory: CallOutBackendFactory = lambda n: AlwaysSucceed(n)
+    validity_factory: CallOutBackendFactory = lambda n: AlwaysSucceed(n)
+    gather_info_factory: CallOutBackendFactory = lambda n: AlwaysSucceed(n)
 
 VALIDATION_DETERMINISTIC = ValidationCallOutBundle()
+
+# vultron/demo/fuzzer/bundles/validation.py  (simulation)
+from vultron.core.behaviors.call_out.bundles.validation import (
+    VALIDATION_DETERMINISTIC,   # re-exported for back-compat
+    ValidationCallOutBundle,
+)
+
 VALIDATION_STOCHASTIC = ValidationCallOutBundle(
-    credibility_factory=EvaluateReportCredibility,
-    validity_factory=EvaluateReportValidity,
-    gather_info_factory=GatherValidationInfo,
+    credibility_factory=lambda n: EvaluateReportCredibility(n),
+    validity_factory=lambda n: EvaluateReportValidity(n),
+    gather_info_factory=lambda n: GatherValidationInfo(n),
 )
 ```
 

--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -183,13 +183,24 @@ mode it resolves `AlwaysSucceed` so all cases are engaged. In STOCHASTIC mode it
 `EvaluateCasePriority` fuzzer node. A real SSVC evaluator would implement
 `CallOutBackendFactory` and be passed here — no other code change required.
 
-### Module layout
+### Module layout (corrected 2026-07-29, issue #1793)
+
+The bundle **dataclasses**, the `CallOutBackendFactory` Protocol, the
+deterministic `AlwaysSucceed`/`AlwaysFail` nodes, and the
+`<DOMAIN>_DETERMINISTIC` singletons are **core-owned**. Only the probabilistic
+`WeightedBehavior` fuzzer nodes and the `<DOMAIN>_STOCHASTIC` singletons are
+simulation artifacts. Core tree builders default to the core DETERMINISTIC
+singleton and never import from `vultron/demo/` (enforced by
+`test/architecture/test_core_no_demo_imports.py`).
 
 ```text
-vultron/demo/fuzzer/
+vultron/core/behaviors/call_out/     ← core-owned seam
+  __init__.py       ← re-exports CallOutBackendFactory, AlwaysSucceed, AlwaysFail
+  protocol.py       ← CallOutBackendFactory Protocol (canonical home)
+  nodes.py          ← deterministic AlwaysSucceed / AlwaysFail
   bundles/
-    __init__.py     ← re-exports all bundle classes and singletons
-    validation.py   ← ValidationCallOutBundle + singletons
+    __init__.py     ← re-exports all bundle classes + <DOMAIN>_DETERMINISTIC
+    validation.py   ← ValidationCallOutBundle + VALIDATION_DETERMINISTIC
     prioritization.py
     embargo.py
     publication.py
@@ -198,7 +209,21 @@ vultron/demo/fuzzer/
     acquire_exploit.py
     assign_vul_id.py
     close_report.py
+
+vultron/demo/fuzzer/                  ← simulation-only
+  base.py           ← WeightedBehavior family (incl. its own AlwaysSucceed/Fail)
+  bundles/
+    __init__.py     ← re-exports bundle classes + both DETERMINISTIC/STOCHASTIC
+    validation.py   ← VALIDATION_STOCHASTIC (+ re-exports core dataclass/default)
+    ...             ← one per domain, STOCHASTIC singletons only
 ```
+
+> **History**: the original 2026-07-23 design placed the dataclasses and
+> `<DOMAIN>_DETERMINISTIC` singletons under `vultron/demo/fuzzer/bundles/` and
+> had core tree builders import them — a core→demo inversion that violated
+> BT-16-001. Issue #1793 moved the core-owned pieces into
+> `vultron/core/behaviors/call_out/` and added the boundary ratchet. `vultron.core.behaviors.call_out_point` remains as a
+> backward-compatible re-export shim of the Protocol.
 
 ---
 

--- a/plan/history/2607/implementation/ISSUE-1793.md
+++ b/plan/history/2607/implementation/ISSUE-1793.md
@@ -1,0 +1,30 @@
+---
+source: ISSUE-1793
+timestamp: '2026-07-29T15:16:31.328404+00:00'
+title: Fix ADR-0025 core→demo call-out inversion; move DETERMINISTIC seam into core
+type: implementation
+---
+
+## Issue #1793 — Fix ADR-0025 core→demo import inversion
+
+PR: <https://github.com/CERTCC/Vultron/pull/1795>
+
+ADR-0025's 2026-07-23 amendment placed the call-out bundle dataclasses and
+`<DOMAIN>_DETERMINISTIC` singletons in `vultron/demo/fuzzer/bundles/` and had
+~11 core tree builders import them as defaults — a core→demo dependency
+inversion violating ADR-0025's own BT-16-001 driver. Discovered while scoping
+# 1732 (in-process fuzz scenario).
+
+**Outcome:** Introduced `vultron/core/behaviors/call_out/` (Protocol,
+deterministic `AlwaysSucceed`/`AlwaysFail` nodes, 9 bundle dataclasses +
+`<DOMAIN>_DETERMINISTIC` singletons). Core builders now default to the core
+DETERMINISTIC bundle with zero `vultron.demo` imports. Demo bundles keep only
+`<DOMAIN>_STOCHASTIC` and re-export core symbols for back-compat.
+`call_out_point.py` became a re-export shim. `publish_artifact_tree.py`'s
+anomalous STOCHASTIC no-arg default was corrected to DETERMINISTIC. Added
+`test/architecture/test_core_no_demo_imports.py` ratchet. Rewrote the ADR-0025
+amendment, specs BT-23-003/005, and `notes/call-out-configuration.md`.
+
+Deterministic ceiling/floor defaults and STOCHASTIC wiring verified identical
+to pre-refactor across all 9 domains (no behavior change). Full suite: 6577
+passed, 3 pre-existing xfail. Unblocks #1732.

--- a/plan/history/2607/implementation/ISSUE-1793.md
+++ b/plan/history/2607/implementation/ISSUE-1793.md
@@ -13,7 +13,7 @@ ADR-0025's 2026-07-23 amendment placed the call-out bundle dataclasses and
 `<DOMAIN>_DETERMINISTIC` singletons in `vultron/demo/fuzzer/bundles/` and had
 ~11 core tree builders import them as defaults — a core→demo dependency
 inversion violating ADR-0025's own BT-16-001 driver. Discovered while scoping
-# 1732 (in-process fuzz scenario).
+issue #1732 (in-process fuzz scenario).
 
 **Outcome:** Introduced `vultron/core/behaviors/call_out/` (Protocol,
 deterministic `AlwaysSucceed`/`AlwaysFail` nodes, 9 bundle dataclasses +

--- a/plan/incoming/learnings/20260729-adr-0025-core-demo-inversion.md
+++ b/plan/incoming/learnings/20260729-adr-0025-core-demo-inversion.md
@@ -18,9 +18,9 @@ had ~11 core tree builders import them as no-arg defaults (~26
 demo. No architecture ratchet guarded it — `test/architecture/` had
 core-no-wire and core-no-adapter but no core-no-demo test.
 
-#1732 needs STOCHASTIC bundles injected through the trigger→use-case→BT cascade
-(the `Svc*UseCase` classes call tree builders with no `call_out` arg, so the
-whole cascade is DETERMINISTIC and there is no injection seam reaching it).
+Issue #1732 needs STOCHASTIC bundles injected through the trigger→use-case→BT
+cascade (the `Svc*UseCase` classes call tree builders with no `call_out` arg, so
+the whole cascade is DETERMINISTIC and there is no injection seam reaching it).
 Building the scenario as specified would deepen the inversion.
 
 Decision (maintainer adh): fix the layering first, as its own PR, before

--- a/plan/incoming/learnings/20260729-adr-0025-core-demo-inversion.md
+++ b/plan/incoming/learnings/20260729-adr-0025-core-demo-inversion.md
@@ -1,0 +1,36 @@
+---
+title: "ADR-0025 amendment created a core→demo import inversion (blocks #1732)"
+type: learning
+timestamp: "2026-07-29"
+source: ISSUE-1732
+signal: architecture-violation
+---
+
+While scoping #1732 (in-process fuzz simulation scenario), found that ADR-0025's
+2026-07-23 "Bundle Selection Mechanism" amendment contradicts one of ADR-0025's
+own decision drivers: "keep simulation artifacts (`vultron/demo/fuzzer/`) out of
+`vultron/core/behaviors/` (BT-16-001)".
+
+The amendment placed the call-out **bundle dataclasses** and the
+`<DOMAIN>_DETERMINISTIC` **singletons** in `vultron/demo/fuzzer/bundles/`, then
+had ~11 core tree builders import them as no-arg defaults (~26
+`from vultron.demo...` imports under `vultron/core/behaviors/`). Core depends on
+demo. No architecture ratchet guarded it — `test/architecture/` had
+core-no-wire and core-no-adapter but no core-no-demo test.
+
+#1732 needs STOCHASTIC bundles injected through the trigger→use-case→BT cascade
+(the `Svc*UseCase` classes call tree builders with no `call_out` arg, so the
+whole cascade is DETERMINISTIC and there is no injection seam reaching it).
+Building the scenario as specified would deepen the inversion.
+
+Decision (maintainer adh): fix the layering first, as its own PR, before
+building #1732. Corrected design — bundle dataclasses, `<DOMAIN>_DETERMINISTIC`
+singletons, `CallOutBackendFactory` Protocol, and constant `AlwaysSucceed`/
+`AlwaysFail` nodes move into a new `vultron/core/behaviors/call_out/` package;
+only the probabilistic `WeightedBehavior` nodes and `<DOMAIN>_STOCHASTIC` bundles
+stay in demo. Add `test_core_no_demo_imports.py` ratchet. Rewrite the ADR-0025
+amendment to record the correction.
+
+Tracked as #1793, wired to block #1732. The seam-injection mechanism for #1732
+(threading `call_out` explicitly through `TriggerService` → `Svc*UseCase` →
+`_build_tree`) is chosen but implemented after #1793 lands.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -828,12 +828,15 @@ groups:
     statement: >
       Call-out point factories for a domain area MUST be collected into a
       domain bundle — a frozen @dataclass (one per domain area) whose fields are
-      typed CallOutBackendFactory values. Each bundle class MUST provide
-      module-level singleton instances for the DETERMINISTIC and STOCHASTIC
-      modes (e.g. VALIDATION_DETERMINISTIC, VALIDATION_STOCHASTIC). Tree
-      builders that accept call-out factories MUST accept the bundle as a single
-      typed parameter (e.g. call_out: ValidationCallOutBundle) rather than
-      individual per-node factory kwargs.
+      typed CallOutBackendFactory values. The bundle dataclass and its
+      DETERMINISTIC singleton (e.g. VALIDATION_DETERMINISTIC) MUST be defined in
+      the core layer (vultron/core/behaviors/call_out/bundles/<domain>.py); the
+      STOCHASTIC singleton (e.g. VALIDATION_STOCHASTIC) MUST be defined in the
+      simulation layer (vultron/demo/fuzzer/bundles/<domain>.py). Tree builders
+      that accept call-out factories MUST accept the bundle as a single typed
+      parameter (e.g. call_out: ValidationCallOutBundle) rather than individual
+      per-node factory kwargs, and MUST default it to the core DETERMINISTIC
+      singleton without importing from vultron/demo/ (BT-16-001, ARCH-01-001).
     rationale: >
       Individual per-node factory kwargs accumulate quickly (a tree builder may
       have 5–10 call-out points); a bundle dataclass keeps the tree builder
@@ -841,6 +844,14 @@ groups:
       Pre-built singletons avoid non-DRY construction in every demo script and
       test fixture that wants the standard deterministic or stochastic behaviour.
       The frozen constraint prevents accidental mutation after construction.
+      The bundle dataclass and its DETERMINISTIC default are core concerns: the
+      DETERMINISTIC bundle is the production-usable happy-path backend a real
+      actor uses before a coordination agent is wired in, so a core tree builder
+      must resolve its default without reaching into the simulation layer. Only
+      the probabilistic STOCHASTIC wiring is a simulation artefact and stays in
+      vultron/demo/ (corrects the original 2026-07-23 amendment, which located
+      the dataclass and DETERMINISTIC singleton in vultron/demo/ and thereby
+      inverted the core→demo dependency).
     relationships:
     - rel_type: refines
       spec_id: BT-23-001
@@ -874,15 +885,22 @@ groups:
     statement: >
       Domain bundle classes SHOULD follow the naming convention
       <Domain>CallOutBundle (e.g. ValidationCallOutBundle,
-      EmbargoCallOutBundle) and SHOULD be defined in
-      vultron/demo/fuzzer/bundles/<domain>.py. The pre-built singletons SHOULD
-      be named <DOMAIN>_DETERMINISTIC and <DOMAIN>_STOCHASTIC (e.g.
-      VALIDATION_DETERMINISTIC, EMBARGO_STOCHASTIC).
+      EmbargoCallOutBundle) and the pre-built singletons SHOULD be named
+      <DOMAIN>_DETERMINISTIC and <DOMAIN>_STOCHASTIC (e.g.
+      VALIDATION_DETERMINISTIC, EMBARGO_STOCHASTIC). The dataclass and the
+      DETERMINISTIC singleton SHOULD live in
+      vultron/core/behaviors/call_out/bundles/<domain>.py; the STOCHASTIC
+      singleton SHOULD live in vultron/demo/fuzzer/bundles/<domain>.py, which
+      MAY re-export the core dataclass and DETERMINISTIC singleton for
+      backward-compatible import paths.
     rationale: >
       Consistent naming makes the available bundles discoverable without reading
-      the implementation. The bundles/ sub-package is co-located with the fuzzer
-      nodes they reference, respecting the BT-16-001 rule that simulation
-      artefacts stay in vultron/demo/ and do not appear in vultron/core/.
+      the implementation. Splitting the seam by layer keeps the deterministic,
+      production-usable default in core while co-locating the STOCHASTIC wiring
+      with the probabilistic fuzzer nodes it references, respecting the
+      BT-16-001 rule that simulation artefacts stay in vultron/demo/ and do not
+      appear in vultron/core/. The core→demo boundary is enforced by
+      test/architecture/test_core_no_demo_imports.py.
     relationships:
     - rel_type: refines
       spec_id: BT-23-003

--- a/test/architecture/test_core_no_demo_imports.py
+++ b/test/architecture/test_core_no_demo_imports.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Architecture boundary test: core layer must not import from the demo layer.
+
+``vultron/core/`` is the innermost layer in the hexagonal architecture.  It
+MUST NOT import from ``vultron/demo/`` — neither at module level nor via
+deferred (local) imports.  ``vultron/demo/`` (including the ``fuzzer``
+simulation package) is a driving/simulation layer that depends on core, not
+the other way around (BT-16-001: simulation artifacts stay out of core).
+
+This guards the ADR-0025 corrected layering: the call-out point seam
+(``CallOutBackendFactory`` Protocol), the deterministic ``AlwaysSucceed`` /
+``AlwaysFail`` nodes, and the ``<DOMAIN>_DETERMINISTIC`` bundles all live in
+``vultron/core/behaviors/call_out/``; only the probabilistic ``WeightedBehavior``
+nodes and ``<DOMAIN>_STOCHASTIC`` bundles remain in ``vultron/demo/fuzzer/`` and
+are injected explicitly via ``call_out=``.
+
+Spec: ARCH-01-001, BT-16-001
+
+Ratchet pattern
+---------------
+``KNOWN_VIOLATIONS`` documents every pre-existing violation awaiting
+migration.  The test asserts::
+
+    actual_violations == KNOWN_VIOLATIONS
+
+This means:
+
+* **Adding a new violation** causes the test to **fail** immediately.
+* **Fixing a violation** also causes the test to **fail** until the resolved
+  entry is removed from ``KNOWN_VIOLATIONS``.
+
+The set is empty: the core→demo boundary is completely clean.  Keep it that way.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+
+_DEMO_MODULE = "vultron.demo"
+
+_CORE_ROOT = REPO_ROOT / "vultron" / "core"
+
+
+def _imports_from_demo(source_path: Path) -> bool:
+    """Return True if *source_path* contains any import from vultron.demo.
+
+    Detects both top-level and deferred (local) imports, catching violations
+    like ``from vultron.demo.fuzzer.bundles.validation import ...`` placed
+    inside a function body.
+    """
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == _DEMO_MODULE or module.startswith(_DEMO_MODULE + "."):
+                return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == _DEMO_MODULE or alias.name.startswith(
+                    _DEMO_MODULE + "."
+                ):
+                    return True
+    return False
+
+
+def _collect_violations() -> frozenset[str]:
+    """Return repo-relative paths of core files that import from demo."""
+    violations: set[str] = set()
+    for py_file in _CORE_ROOT.rglob("*.py"):
+        if "__pycache__" in py_file.parts:
+            continue
+        if _imports_from_demo(py_file):
+            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    return frozenset(violations)
+
+
+# ---------------------------------------------------------------------------
+# Known pre-existing violations awaiting migration.
+# The core→demo boundary is clean, so this set is empty.  Do not add entries:
+# core code needing a call-out backend default must use the core-owned
+# ``vultron.core.behaviors.call_out`` package, never ``vultron.demo``.
+# ---------------------------------------------------------------------------
+KNOWN_VIOLATIONS: frozenset[str] = frozenset()
+
+
+def test_core_does_not_import_demo():
+    """vultron/core/ must not import from vultron/demo/ at any code path.
+
+    Spec: ARCH-01-001, BT-16-001
+
+    See module docstring for the ratchet strategy.
+    """
+    actual = _collect_violations()
+    new_violations = actual - KNOWN_VIOLATIONS
+    resolved = KNOWN_VIOLATIONS - actual
+
+    diff_lines: list[str] = []
+    if new_violations:
+        diff_lines.append("NEW violations (core must not import from demo):")
+        diff_lines.extend(f"  + {v}" for v in sorted(new_violations))
+    if resolved:
+        diff_lines.append(
+            "RESOLVED violations (remove these entries from KNOWN_VIOLATIONS):"
+        )
+        diff_lines.extend(f"  - {v}" for v in sorted(resolved))
+
+    assert actual == KNOWN_VIOLATIONS, "\n\n" + "\n".join(diff_lines)

--- a/test/core/behaviors/call_out/__init__.py
+++ b/test/core/behaviors/call_out/__init__.py
@@ -1,0 +1,12 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University

--- a/test/core/behaviors/call_out/test_nodes.py
+++ b/test/core/behaviors/call_out/test_nodes.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for the core-owned call-out seam (ADR-0025, BT-23).
+
+Covers the pieces that moved into ``vultron/core/behaviors/call_out/`` when the
+ADR-0025 core→demo inversion was fixed (issue #1793):
+
+- The deterministic ``AlwaysSucceed`` / ``AlwaysFail`` nodes: SUCCESS/FAILURE
+  contract, ``success_rate`` parity attributes, py_trees ``Behaviour`` identity,
+  and default/custom naming.
+- The ``CallOutBackendFactory`` Protocol: the core nodes and the demo
+  ``WeightedBehavior`` nodes both satisfy it (the sole substitutability contract
+  between the two intentionally-duplicated node families).
+- Every ``<DOMAIN>_DETERMINISTIC`` bundle singleton: each factory field builds a
+  core deterministic node honouring the Protocol, and no field reaches into the
+  ``vultron.demo`` layer.
+
+These lock the contract that core tree builders rely on when they default
+``call_out`` to a core DETERMINISTIC bundle.
+"""
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.core.behaviors.call_out import (
+    AlwaysFail,
+    AlwaysSucceed,
+    CallOutBackendFactory,
+)
+from vultron.core.behaviors.call_out.bundles import (
+    ACQUIRE_EXPLOIT_DETERMINISTIC,
+    ASSIGN_VUL_ID_DETERMINISTIC,
+    CLOSE_REPORT_DETERMINISTIC,
+    DEPLOY_FIX_DETERMINISTIC,
+    EMBARGO_DETERMINISTIC,
+    PRIORITIZATION_DETERMINISTIC,
+    PUBLICATION_DETERMINISTIC,
+    REPORT_TO_OTHERS_DETERMINISTIC,
+    VALIDATION_DETERMINISTIC,
+)
+
+# All nine pre-built core DETERMINISTIC bundle singletons.
+_DETERMINISTIC_BUNDLES = [
+    ACQUIRE_EXPLOIT_DETERMINISTIC,
+    ASSIGN_VUL_ID_DETERMINISTIC,
+    CLOSE_REPORT_DETERMINISTIC,
+    DEPLOY_FIX_DETERMINISTIC,
+    EMBARGO_DETERMINISTIC,
+    PRIORITIZATION_DETERMINISTIC,
+    PUBLICATION_DETERMINISTIC,
+    REPORT_TO_OTHERS_DETERMINISTIC,
+    VALIDATION_DETERMINISTIC,
+]
+
+
+def _factory_fields(bundle) -> list:
+    """Return every CallOutBackendFactory field value on a frozen bundle."""
+    return [getattr(bundle, f) for f in vars(bundle)]
+
+
+# ---------------------------------------------------------------------------
+# AlwaysSucceed / AlwaysFail contract
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysSucceed:
+    def test_update_returns_success(self):
+        node = AlwaysSucceed("EvaluateReportCredibility")
+        assert all(node.update() == Status.SUCCESS for _ in range(50))
+
+    def test_tick_sets_success_status(self):
+        node = AlwaysSucceed("n")
+        node.tick_once()
+        assert node.status == Status.SUCCESS
+
+    def test_success_rate_attribute(self):
+        assert AlwaysSucceed.success_rate == 1.0
+
+    def test_is_py_trees_behaviour(self):
+        assert isinstance(AlwaysSucceed("n"), py_trees.behaviour.Behaviour)
+
+    def test_name_passthrough(self):
+        assert AlwaysSucceed("MyNode").name == "MyNode"
+
+    def test_default_name_is_class_name(self):
+        assert AlwaysSucceed().name == "AlwaysSucceed"
+
+
+class TestAlwaysFail:
+    def test_update_returns_failure(self):
+        node = AlwaysFail("DeployFix")
+        assert all(node.update() == Status.FAILURE for _ in range(50))
+
+    def test_tick_sets_failure_status(self):
+        node = AlwaysFail("n")
+        node.tick_once()
+        assert node.status == Status.FAILURE
+
+    def test_success_rate_attribute(self):
+        assert AlwaysFail.success_rate == 0.0
+
+    def test_is_py_trees_behaviour(self):
+        assert isinstance(AlwaysFail("n"), py_trees.behaviour.Behaviour)
+
+    def test_name_passthrough(self):
+        assert AlwaysFail("MyNode").name == "MyNode"
+
+    def test_default_name_is_class_name(self):
+        assert AlwaysFail().name == "AlwaysFail"
+
+
+def test_core_nodes_do_not_subclass_weighted_behavior():
+    """Core nodes are deterministic — not the demo WeightedBehavior family.
+
+    They are intentionally duplicated from (not cross-imported with) the demo
+    ``AlwaysSucceed``/``AlwaysFail`` so that core never imports ``vultron.demo``.
+    """
+    assert AlwaysSucceed.__module__ == "vultron.core.behaviors.call_out.nodes"
+    assert AlwaysFail.__module__ == "vultron.core.behaviors.call_out.nodes"
+
+
+# ---------------------------------------------------------------------------
+# CallOutBackendFactory Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_core_nodes_satisfy_backend_factory_protocol():
+    """Both core node classes are valid CallOutBackendFactory callables."""
+    assert isinstance(AlwaysSucceed, CallOutBackendFactory)
+    assert isinstance(AlwaysFail, CallOutBackendFactory)
+
+
+def test_demo_and_core_nodes_share_the_factory_contract():
+    """The demo WeightedBehavior node also satisfies the same Protocol.
+
+    This is the sole substitutability contract between the two duplicated
+    families — verifying it here guards the design decision from #1793.
+    """
+    from vultron.demo.fuzzer.base import AlwaysSucceed as DemoAlwaysSucceed
+
+    assert isinstance(DemoAlwaysSucceed, CallOutBackendFactory)
+    # Distinct classes, same contract.
+    assert DemoAlwaysSucceed is not AlwaysSucceed
+
+
+# ---------------------------------------------------------------------------
+# DETERMINISTIC bundle singletons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bundle", _DETERMINISTIC_BUNDLES)
+def test_bundle_factories_build_core_deterministic_nodes(bundle):
+    """Every field of each DETERMINISTIC bundle builds a core AlwaysSucceed/Fail
+    node that honours the CallOutBackendFactory contract."""
+    fields = _factory_fields(bundle)
+    assert fields, f"{type(bundle).__name__} has no factory fields"
+    for factory in fields:
+        assert isinstance(factory, CallOutBackendFactory)
+        node = factory("probe")
+        assert isinstance(node, (AlwaysSucceed, AlwaysFail))
+        assert node.name == "probe"
+
+
+@pytest.mark.parametrize("bundle", _DETERMINISTIC_BUNDLES)
+def test_bundle_nodes_are_deterministic_on_tick(bundle):
+    """Each bundle node ticks to a fixed SUCCESS or FAILURE (never RUNNING)."""
+    for factory in _factory_fields(bundle):
+        node = factory("probe")
+        node.tick_once()
+        assert node.status in (Status.SUCCESS, Status.FAILURE)
+
+
+def test_bundles_are_frozen():
+    """Bundles are frozen dataclasses — fields cannot be reassigned."""
+    from dataclasses import FrozenInstanceError
+
+    with pytest.raises(FrozenInstanceError):
+        VALIDATION_DETERMINISTIC.credibility_factory = (  # type: ignore[misc]
+            lambda n: AlwaysFail(n)
+        )

--- a/test/core/behaviors/embargo/test_manage_embargo_tree.py
+++ b/test/core/behaviors/embargo/test_manage_embargo_tree.py
@@ -24,7 +24,7 @@ import py_trees
 from vultron.core.behaviors.embargo.manage_embargo_tree import (
     create_manage_embargo_tree,
 )
-from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
 from vultron.demo.fuzzer.bundles.embargo import (
     EMBARGO_DETERMINISTIC,
     EMBARGO_STOCHASTIC,

--- a/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
+++ b/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
@@ -28,7 +28,7 @@ from vultron.core.behaviors.report.acquire_exploit_strategy_tree import (
     ExploitStrategyDecision,
     create_acquire_exploit_strategy_tree,
 )
-from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
 from vultron.demo.fuzzer.bundles.acquire_exploit import (
     ACQUIRE_EXPLOIT_DETERMINISTIC,
     ACQUIRE_EXPLOIT_STOCHASTIC,

--- a/test/core/behaviors/report/test_acquire_exploit_tree.py
+++ b/test/core/behaviors/report/test_acquire_exploit_tree.py
@@ -23,7 +23,7 @@ import py_trees
 from vultron.core.behaviors.report.acquire_exploit_tree import (
     create_acquire_exploit_tree,
 )
-from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
 from vultron.demo.fuzzer.bundles.acquire_exploit import (
     ACQUIRE_EXPLOIT_DETERMINISTIC,
     ACQUIRE_EXPLOIT_STOCHASTIC,

--- a/test/core/behaviors/report/test_assign_vul_id_tree.py
+++ b/test/core/behaviors/report/test_assign_vul_id_tree.py
@@ -23,7 +23,7 @@ import py_trees
 from vultron.core.behaviors.report.assign_vul_id_tree import (
     create_assign_vul_id_tree,
 )
-from vultron.demo.fuzzer.base import AlwaysSucceed
+from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 from vultron.demo.fuzzer.bundles.assign_vul_id import (
     ASSIGN_VUL_ID_DETERMINISTIC,
     ASSIGN_VUL_ID_STOCHASTIC,

--- a/test/core/behaviors/report/test_close_report_tree.py
+++ b/test/core/behaviors/report/test_close_report_tree.py
@@ -23,7 +23,7 @@ import py_trees
 from vultron.core.behaviors.report.close_report_tree import (
     create_close_report_tree,
 )
-from vultron.demo.fuzzer.base import AlwaysFail
+from vultron.core.behaviors.call_out.nodes import AlwaysFail
 from vultron.demo.fuzzer.bundles.close_report import (
     CLOSE_REPORT_DETERMINISTIC,
     CLOSE_REPORT_STOCHASTIC,

--- a/test/core/behaviors/report/test_deploy_fix_tree.py
+++ b/test/core/behaviors/report/test_deploy_fix_tree.py
@@ -24,7 +24,7 @@ import py_trees
 from vultron.core.behaviors.report.deploy_fix_tree import (
     create_deploy_fix_tree,
 )
-from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
 from vultron.demo.fuzzer.bundles.deploy_fix import (
     DEPLOY_FIX_DETERMINISTIC,
     DEPLOY_FIX_STOCHASTIC,

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -714,7 +714,7 @@ def test_prioritize_subtree_defers_when_engage_path_fails(
     )
 
     def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
-        from vultron.demo.fuzzer.base import AlwaysFail
+        from vultron.core.behaviors.call_out.nodes import AlwaysFail
 
         return AlwaysFail(name)
 

--- a/test/core/behaviors/report/test_prioritize_tree_factory_injection.py
+++ b/test/core/behaviors/report/test_prioritize_tree_factory_injection.py
@@ -61,7 +61,7 @@ def test_evaluate_priority_factory_replaces_default_node():
 
 def test_evaluate_priority_factory_default_is_always_succeed():
     """Default evaluate_priority_factory produces an AlwaysSucceed node named EvaluateCasePriority."""
-    from vultron.demo.fuzzer.base import AlwaysSucceed
+    from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 
     tree = create_prioritize_subtree(
         case_id=CASE_ID,

--- a/test/core/behaviors/report/test_publication_tree.py
+++ b/test/core/behaviors/report/test_publication_tree.py
@@ -173,7 +173,7 @@ def test_each_arm_is_selector(arm_name):
 
 def test_default_prepare_nodes_are_deterministic():
     """DETERMINISTIC default: prepare nodes use AlwaysSucceed (BT-23-002)."""
-    from vultron.demo.fuzzer.base import AlwaysSucceed
+    from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 
     tree = create_publication_tree(case_id=CASE_ID)
     exploit_seq = tree.children[1].children[0]
@@ -208,7 +208,7 @@ def test_stochastic_prepare_nodes_are_fuzzers():
 
 def test_default_publish_pipeline_nodes_are_deterministic():
     """DETERMINISTIC default: pipeline factories produce AlwaysSucceed per arm."""
-    from vultron.demo.fuzzer.base import AlwaysSucceed
+    from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 
     tree = create_publication_tree(case_id=CASE_ID)
     for arm, label in zip(tree.children[1:], ["Exploit", "Fix", "Report"]):

--- a/test/core/behaviors/report/test_publish_artifact_tree.py
+++ b/test/core/behaviors/report/test_publish_artifact_tree.py
@@ -31,6 +31,7 @@ from vultron.core.behaviors.report.publish_artifact_tree import (
     _NeedsRevisionGate,
     create_publish_artifact_tree,
 )
+from vultron.demo.fuzzer.bundles.publication import PUBLICATION_STOCHASTIC
 from vultron.demo.fuzzer.report_management.publication import (
     DraftAdvisoryArtifact,
     ReviewAdvisoryDraft,
@@ -168,18 +169,26 @@ def test_root_has_four_children():
 
 
 def test_draft_is_first_child():
-    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    # STOCHASTIC bundle wires the demo Composer node; the no-arg default is the
+    # core DETERMINISTIC AlwaysSucceed backend (ADR-0025 corrected layering).
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID, call_out=PUBLICATION_STOCHASTIC
+    )
     assert isinstance(tree.children[0], DraftAdvisoryArtifact)
 
 
 def test_review_is_second_child():
-    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID, call_out=PUBLICATION_STOCHASTIC
+    )
     assert isinstance(tree.children[1], ReviewAdvisoryDraft)
 
 
 def test_revision_arm_is_third_child():
     """AC-1: optional revision arm is a Selector (positive gate with Inverter skip)."""
-    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID, call_out=PUBLICATION_STOCHASTIC
+    )
     revision_arm = tree.children[2]
     assert isinstance(revision_arm, py_trees.composites.Selector)
     assert revision_arm.name.startswith("RevisionArm")
@@ -197,7 +206,9 @@ def test_revision_arm_is_third_child():
 
 
 def test_submit_is_fourth_child():
-    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID, call_out=PUBLICATION_STOCHASTIC
+    )
     assert isinstance(tree.children[3], SubmitAdvisoryArtifact)
 
 

--- a/test/core/behaviors/report/test_report_to_others_tree.py
+++ b/test/core/behaviors/report/test_report_to_others_tree.py
@@ -32,7 +32,7 @@ from vultron.core.behaviors.report.report_to_others_tree import (
     _WriteRolesNode,
     create_report_to_others_tree,
 )
-from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
 from vultron.demo.fuzzer.bundles.report_to_others import (
     REPORT_TO_OTHERS_DETERMINISTIC,
     REPORT_TO_OTHERS_STOCHASTIC,

--- a/test/demo/fuzzer/test_stochastic_bundle_scenario.py
+++ b/test/demo/fuzzer/test_stochastic_bundle_scenario.py
@@ -143,10 +143,10 @@ def test_assign_vul_id_stochastic_bundle_end_to_end():
 
 def test_three_mode_comparison():
     """Demonstrate all three modes for the deploy-fix domain side-by-side."""
+    from vultron.core.behaviors.call_out.nodes import AlwaysFail
     from vultron.core.behaviors.report.deploy_fix_tree import (
         create_deploy_fix_tree,
     )
-    from vultron.demo.fuzzer.base import AlwaysFail
     from vultron.demo.fuzzer.bundles.deploy_fix import (
         DEPLOY_FIX_DETERMINISTIC,
         DEPLOY_FIX_STOCHASTIC,

--- a/vultron/core/behaviors/call_out/__init__.py
+++ b/vultron/core/behaviors/call_out/__init__.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Core-owned call-out point seam: Protocol, deterministic nodes, and bundles.
+
+This package holds the parts of the call-out point abstraction (ADR-0025) that
+are **core concerns**, kept out of the simulation layer so that
+``vultron.core.behaviors`` tree builders never import ``vultron.demo``
+(BT-16-001):
+
+- :class:`~vultron.core.behaviors.call_out.protocol.CallOutBackendFactory` —
+  the swappable-backend Protocol (BT-23-004).
+- :class:`~vultron.core.behaviors.call_out.nodes.AlwaysSucceed` /
+  :class:`~vultron.core.behaviors.call_out.nodes.AlwaysFail` — deterministic,
+  production-usable constant backends (BT-23-002).
+- ``bundles`` — per-domain bundle dataclasses and their ``<DOMAIN>_DETERMINISTIC``
+  singletons (BT-23-003), the happy-path defaults every tree builder uses when
+  no explicit ``call_out`` bundle is supplied.
+
+The probabilistic ``WeightedBehavior`` node family and the
+``<DOMAIN>_STOCHASTIC`` bundles remain in ``vultron.demo.fuzzer`` — they are
+simulation artifacts and are injected explicitly via ``call_out=`` by demo /
+test code.
+"""
+
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+__all__ = [
+    "CallOutBackendFactory",
+    "AlwaysSucceed",
+    "AlwaysFail",
+]

--- a/vultron/core/behaviors/call_out/bundles/__init__.py
+++ b/vultron/core/behaviors/call_out/bundles/__init__.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Core-owned call-out backend bundles and DETERMINISTIC singletons (BT-23).
+
+Re-exports the per-domain bundle dataclasses and their pre-built
+``<DOMAIN>_DETERMINISTIC`` singletons.  These are the core, production-usable
+happy-path defaults injected into every BT tree builder when no explicit
+``call_out`` bundle is supplied (ADR-0025).
+
+The matching ``<DOMAIN>_STOCHASTIC`` singletons live in the simulation layer
+(``vultron.demo.fuzzer.bundles``); core never imports them.
+"""
+
+from vultron.core.behaviors.call_out.bundles.acquire_exploit import (
+    ACQUIRE_EXPLOIT_DETERMINISTIC,
+    AcquireExploitCallOutBundle,
+)
+from vultron.core.behaviors.call_out.bundles.assign_vul_id import (
+    ASSIGN_VUL_ID_DETERMINISTIC,
+    AssignVulIdCallOutBundle,
+)
+from vultron.core.behaviors.call_out.bundles.close_report import (
+    CLOSE_REPORT_DETERMINISTIC,
+    CloseReportCallOutBundle,
+)
+from vultron.core.behaviors.call_out.bundles.deploy_fix import (
+    DEPLOY_FIX_DETERMINISTIC,
+    DeployFixCallOutBundle,
+)
+from vultron.core.behaviors.call_out.bundles.embargo import (
+    EMBARGO_DETERMINISTIC,
+    EmbargoCallOutBundle,
+)
+from vultron.core.behaviors.call_out.bundles.prioritization import (
+    PRIORITIZATION_DETERMINISTIC,
+    PrioritizationCallOutBundle,
+)
+from vultron.core.behaviors.call_out.bundles.publication import (
+    PUBLICATION_DETERMINISTIC,
+    PublicationCallOutBundle,
+)
+from vultron.core.behaviors.call_out.bundles.report_to_others import (
+    REPORT_TO_OTHERS_DETERMINISTIC,
+    ReportToOthersCallOutBundle,
+)
+from vultron.core.behaviors.call_out.bundles.validation import (
+    VALIDATION_DETERMINISTIC,
+    ValidationCallOutBundle,
+)
+
+__all__ = [
+    # Bundle classes
+    "AcquireExploitCallOutBundle",
+    "AssignVulIdCallOutBundle",
+    "CloseReportCallOutBundle",
+    "DeployFixCallOutBundle",
+    "EmbargoCallOutBundle",
+    "PrioritizationCallOutBundle",
+    "PublicationCallOutBundle",
+    "ReportToOthersCallOutBundle",
+    "ValidationCallOutBundle",
+    # Deterministic singletons
+    "ACQUIRE_EXPLOIT_DETERMINISTIC",
+    "ASSIGN_VUL_ID_DETERMINISTIC",
+    "CLOSE_REPORT_DETERMINISTIC",
+    "DEPLOY_FIX_DETERMINISTIC",
+    "EMBARGO_DETERMINISTIC",
+    "PRIORITIZATION_DETERMINISTIC",
+    "PUBLICATION_DETERMINISTIC",
+    "REPORT_TO_OTHERS_DETERMINISTIC",
+    "VALIDATION_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/bundles/acquire_exploit.py
+++ b/vultron/core/behaviors/call_out/bundles/acquire_exploit.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the exploit acquisition domain (BT-23-003, BT-23-005).
+
+Provides :class:`AcquireExploitCallOutBundle` and the pre-built core
+DETERMINISTIC singleton :data:`ACQUIRE_EXPLOIT_DETERMINISTIC`.  The matching
+STOCHASTIC singleton lives in the simulation layer
+(:data:`vultron.demo.fuzzer.bundles.acquire_exploit.ACQUIRE_EXPLOIT_STOCHASTIC`).
+
+This bundle covers both
+:func:`~vultron.core.behaviors.report.acquire_exploit_tree.create_acquire_exploit_tree`
+and
+:func:`~vultron.core.behaviors.report.acquire_exploit_strategy_tree.create_acquire_exploit_strategy_tree`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``evaluate_exploit_priority_factory``  — EvaluateExploitPriority   (p=1.0) → AlwaysSucceed
+- ``purchase_exploit_factory``           — PurchaseExploit            (p=0.10) → AlwaysFail
+- ``have_exploit_factory``               — HaveExploit                (p=0.25) → AlwaysFail
+- ``evaluate_exploit_strategy_factory``  — EvaluateExploitStrategy    (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysFail(name)
+
+
+@dataclass(frozen=True)
+class AcquireExploitCallOutBundle:
+    """Call-out backend bundle for the exploit acquisition domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.acquire_exploit_tree.create_acquire_exploit_tree`
+    and
+    :func:`~vultron.core.behaviors.report.acquire_exploit_strategy_tree.create_acquire_exploit_strategy_tree`.
+    """
+
+    evaluate_exploit_priority_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    purchase_exploit_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    have_exploit_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    evaluate_exploit_strategy_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+ACQUIRE_EXPLOIT_DETERMINISTIC = AcquireExploitCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+__all__ = [
+    "AcquireExploitCallOutBundle",
+    "ACQUIRE_EXPLOIT_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/bundles/assign_vul_id.py
+++ b/vultron/core/behaviors/call_out/bundles/assign_vul_id.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the vulnerability ID assignment domain (BT-23-003, BT-23-005).
+
+Provides :class:`AssignVulIdCallOutBundle` and the pre-built core DETERMINISTIC
+singleton :data:`ASSIGN_VUL_ID_DETERMINISTIC`.  The matching STOCHASTIC singleton
+lives in the simulation layer
+(:data:`vultron.demo.fuzzer.bundles.assign_vul_id.ASSIGN_VUL_ID_STOCHASTIC`).
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``id_assignable_factory`` — IdAssignable (p=0.67) → AlwaysSucceed
+- ``in_scope_factory``      — InScope      (p=0.75) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysSucceed(name)
+
+
+@dataclass(frozen=True)
+class AssignVulIdCallOutBundle:
+    """Call-out backend bundle for the vulnerability ID assignment domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.assign_vul_id_tree.create_assign_vul_id_tree`.
+    """
+
+    id_assignable_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    in_scope_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+ASSIGN_VUL_ID_DETERMINISTIC = AssignVulIdCallOutBundle()
+"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
+
+__all__ = [
+    "AssignVulIdCallOutBundle",
+    "ASSIGN_VUL_ID_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/bundles/close_report.py
+++ b/vultron/core/behaviors/call_out/bundles/close_report.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the report closure domain (BT-23-003, BT-23-005).
+
+Provides :class:`CloseReportCallOutBundle` and the pre-built core DETERMINISTIC
+singleton :data:`CLOSE_REPORT_DETERMINISTIC`.  The matching STOCHASTIC singleton
+lives in the simulation layer
+(:data:`vultron.demo.fuzzer.bundles.close_report.CLOSE_REPORT_STOCHASTIC`).
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``other_close_criteria_factory`` — OtherCloseCriteriaMet (p=0.25) → AlwaysFail
+- ``pre_close_action_factory``     — PreCloseAction        (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysFail(name)
+
+
+@dataclass(frozen=True)
+class CloseReportCallOutBundle:
+    """Call-out backend bundle for the report closure domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.close_report_tree.create_close_report_tree`.
+    """
+
+    other_close_criteria_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    pre_close_action_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+CLOSE_REPORT_DETERMINISTIC = CloseReportCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+__all__ = [
+    "CloseReportCallOutBundle",
+    "CLOSE_REPORT_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/bundles/deploy_fix.py
+++ b/vultron/core/behaviors/call_out/bundles/deploy_fix.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the fix deployment domain (BT-23-003, BT-23-005).
+
+Provides :class:`DeployFixCallOutBundle` and the pre-built core DETERMINISTIC
+singleton :data:`DEPLOY_FIX_DETERMINISTIC`.  The matching STOCHASTIC singleton
+lives in the simulation layer
+(:data:`vultron.demo.fuzzer.bundles.deploy_fix.DEPLOY_FIX_STOCHASTIC`).
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``prioritize_deployment_factory``  — PrioritizeDeployment  (p=0.90) → AlwaysSucceed
+- ``deploy_mitigation_factory``      — DeployMitigation      (p=0.75) → AlwaysSucceed
+- ``monitoring_requirement_factory`` — MonitoringRequirement (p=0.70) → AlwaysSucceed
+- ``deploy_fix_factory``             — DeployFix             (p=0.10) → AlwaysFail
+- ``monitor_deployment_factory``     — MonitorDeployment     (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysFail(name)
+
+
+@dataclass(frozen=True)
+class DeployFixCallOutBundle:
+    """Call-out backend bundle for the fix deployment domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`.
+    """
+
+    prioritize_deployment_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    deploy_mitigation_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    monitoring_requirement_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    deploy_fix_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    monitor_deployment_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+DEPLOY_FIX_DETERMINISTIC = DeployFixCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+__all__ = [
+    "DeployFixCallOutBundle",
+    "DEPLOY_FIX_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/bundles/embargo.py
+++ b/vultron/core/behaviors/call_out/bundles/embargo.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the embargo management domain (BT-23-003, BT-23-005).
+
+Provides :class:`EmbargoCallOutBundle` and the pre-built core DETERMINISTIC
+singleton :data:`EMBARGO_DETERMINISTIC`.  The matching STOCHASTIC singleton
+lives in the simulation layer
+(:data:`vultron.demo.fuzzer.bundles.embargo.EMBARGO_STOCHASTIC`).
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``exit_embargo_when_deployed_factory``       — ExitEmbargoWhenDeployed       (p=0.33) → AlwaysFail
+- ``exit_embargo_when_fix_ready_factory``      — ExitEmbargoWhenFixReady       (p=0.25) → AlwaysFail
+- ``exit_embargo_for_other_reason_factory``    — ExitEmbargoForOtherReason     (p=0.005) → AlwaysFail
+- ``stop_proposing_embargo_factory``           — StopProposingEmbargo          (p=0.25) → AlwaysFail
+- ``select_embargo_offer_terms_factory``       — SelectEmbargoOfferTerms       (p=1.0) → AlwaysSucceed
+- ``want_to_propose_embargo_factory``          — WantToProposeEmbargo          (p=0.50) → AlwaysSucceed (tie-break)
+- ``willing_to_counter_factory``               — WillingToCounterEmbargoProposal (p=0.25) → AlwaysFail
+- ``reason_to_propose_when_deployed_factory``  — ReasonToProposeEmbargoWhenDeployed (p=0.07) → AlwaysFail
+- ``evaluate_embargo_proposal_factory``        — EvaluateEmbargoProposal       (p=0.75) → AlwaysSucceed
+- ``current_embargo_acceptable_factory``       — CurrentEmbargoAcceptable      (p=0.90) → AlwaysSucceed
+- ``on_embargo_exit_factory``                  — OnEmbargoExit                 (p=1.0) → AlwaysSucceed
+- ``on_embargo_accept_factory``                — OnEmbargoAccept               (p=1.0) → AlwaysSucceed
+- ``on_embargo_reject_factory``                — OnEmbargoReject               (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysFail(name)
+
+
+@dataclass(frozen=True)
+class EmbargoCallOutBundle:
+    """Call-out backend bundle for the embargo management domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`.
+    """
+
+    exit_embargo_when_deployed_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    exit_embargo_when_fix_ready_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    exit_embargo_for_other_reason_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    stop_proposing_embargo_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    select_embargo_offer_terms_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    want_to_propose_embargo_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    willing_to_counter_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    reason_to_propose_when_deployed_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    evaluate_embargo_proposal_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    current_embargo_acceptable_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    on_embargo_exit_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    on_embargo_accept_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    on_embargo_reject_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+EMBARGO_DETERMINISTIC = EmbargoCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+__all__ = [
+    "EmbargoCallOutBundle",
+    "EMBARGO_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/bundles/prioritization.py
+++ b/vultron/core/behaviors/call_out/bundles/prioritization.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the report prioritization domain (BT-23-003, BT-23-005).
+
+Provides :class:`PrioritizationCallOutBundle` and the pre-built core
+DETERMINISTIC singleton :data:`PRIORITIZATION_DETERMINISTIC`.  The matching
+STOCHASTIC singleton lives in the simulation layer
+(:data:`vultron.demo.fuzzer.bundles.prioritization.PRIORITIZATION_STOCHASTIC`).
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``evaluate_priority_factory`` — EvaluateCasePriority     (p=1.0) → AlwaysSucceed
+- ``on_accept_factory``         — OnAccept                 (p=1.0) → AlwaysSucceed
+- ``on_defer_factory``          — OnDefer                  (p=1.0) → AlwaysSucceed
+- ``enough_info_factory``       — EnoughPrioritizationInfo (p=0.75) → AlwaysSucceed
+- ``gather_info_factory``       — GatherPrioritizationInfo (p=0.90) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysSucceed(name)
+
+
+@dataclass(frozen=True)
+class PrioritizationCallOutBundle:
+    """Call-out backend bundle for the report prioritization domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree`.
+    """
+
+    evaluate_priority_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    on_accept_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    on_defer_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    enough_info_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    gather_info_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+PRIORITIZATION_DETERMINISTIC = PrioritizationCallOutBundle()
+"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
+
+__all__ = [
+    "PrioritizationCallOutBundle",
+    "PRIORITIZATION_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/bundles/publication.py
+++ b/vultron/core/behaviors/call_out/bundles/publication.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the publication pipeline domain (BT-23-003, BT-23-005).
+
+Provides :class:`PublicationCallOutBundle` and the pre-built core DETERMINISTIC
+singleton :data:`PUBLICATION_DETERMINISTIC`.  The matching STOCHASTIC singleton
+lives in the simulation layer
+(:data:`vultron.demo.fuzzer.bundles.publication.PUBLICATION_STOCHASTIC`).
+
+This bundle covers both
+:func:`~vultron.core.behaviors.report.publication_tree.create_publication_tree`
+and
+:func:`~vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``prioritize_publication_intents_factory`` — PrioritizePublicationIntents (p=1.0) → AlwaysSucceed
+- ``prepare_exploit_factory``               — PrepareExploit               (p=0.90) → AlwaysSucceed
+- ``prepare_fix_factory``                   — PrepareFix                   (p=0.90) → AlwaysSucceed
+- ``prepare_report_factory``                — PrepareReport                (p=0.90) → AlwaysSucceed
+- ``draft_advisory_artifact_factory``       — DraftAdvisoryArtifact        (p=0.90) → AlwaysSucceed
+- ``review_advisory_draft_factory``         — ReviewAdvisoryDraft          (p=1.0) → AlwaysSucceed
+- ``revise_advisory_draft_factory``         — ReviseAdvisoryDraft          (p=0.90) → AlwaysSucceed
+- ``submit_advisory_artifact_factory``      — SubmitAdvisoryArtifact       (p=0.90) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysSucceed(name)
+
+
+@dataclass(frozen=True)
+class PublicationCallOutBundle:
+    """Call-out backend bundle for the publication pipeline domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.publication_tree.create_publication_tree`
+    and
+    :func:`~vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`.
+    """
+
+    prioritize_publication_intents_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    prepare_exploit_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    prepare_fix_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    prepare_report_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    draft_advisory_artifact_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    review_advisory_draft_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    revise_advisory_draft_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    submit_advisory_artifact_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+PUBLICATION_DETERMINISTIC = PublicationCallOutBundle()
+"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
+
+__all__ = [
+    "PublicationCallOutBundle",
+    "PUBLICATION_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/bundles/report_to_others.py
+++ b/vultron/core/behaviors/call_out/bundles/report_to_others.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the report-to-others domain (BT-23-003, BT-23-005).
+
+Provides :class:`ReportToOthersCallOutBundle` and the pre-built core
+DETERMINISTIC singleton :data:`REPORT_TO_OTHERS_DETERMINISTIC`.  The matching
+STOCHASTIC singleton lives in the simulation layer
+(:data:`vultron.demo.fuzzer.bundles.report_to_others.REPORT_TO_OTHERS_STOCHASTIC`).
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``all_parties_known_factory``       — AllPartiesKnown       (p=0.50) → AlwaysSucceed (tie-break)
+- ``total_effort_limit_factory``      — TotalEffortLimitMet   (p=0.10) → AlwaysFail
+- ``more_vendors_factory``            — MoreVendors           (p=0.25) → AlwaysFail
+- ``more_coordinators_factory``       — MoreCoordinators      (p=0.10) → AlwaysFail
+- ``more_others_factory``             — MoreOthers            (p=0.10) → AlwaysFail
+- ``suggest_vendor_factory``          — InjectVendor          (p=1.0) → AlwaysSucceed
+- ``suggest_coordinator_factory``     — InjectCoordinator     (p=1.0) → AlwaysSucceed
+- ``suggest_other_factory``           — InjectOther           (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysFail(name)
+
+
+@dataclass(frozen=True)
+class ReportToOthersCallOutBundle:
+    """Call-out backend bundle for the report-to-others domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.report_to_others_tree.create_report_to_others_tree`.
+    """
+
+    all_parties_known_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    total_effort_limit_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    more_vendors_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    more_coordinators_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    more_others_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    suggest_vendor_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    suggest_coordinator_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    suggest_other_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+REPORT_TO_OTHERS_DETERMINISTIC = ReportToOthersCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+__all__ = [
+    "ReportToOthersCallOutBundle",
+    "REPORT_TO_OTHERS_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/bundles/validation.py
+++ b/vultron/core/behaviors/call_out/bundles/validation.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the report validation domain (BT-23-003, BT-23-005).
+
+Provides :class:`ValidationCallOutBundle` and the pre-built core DETERMINISTIC
+singleton :data:`VALIDATION_DETERMINISTIC`.  The matching STOCHASTIC singleton
+lives in the simulation layer
+(:data:`vultron.demo.fuzzer.bundles.validation.VALIDATION_STOCHASTIC`).
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``credibility_factory``   — EvaluateReportCredibility (p=0.90) → AlwaysSucceed
+- ``validity_factory``      — EvaluateReportValidity    (p=0.90) → AlwaysSucceed
+- ``gather_info_factory``   — GatherValidationInfo      (p=0.90) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    return AlwaysSucceed(name)
+
+
+@dataclass(frozen=True)
+class ValidationCallOutBundle:
+    """Call-out backend bundle for the report validation domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.validate_tree.create_validate_report_tree`.
+    """
+
+    credibility_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    validity_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    gather_info_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+VALIDATION_DETERMINISTIC = ValidationCallOutBundle()
+"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
+
+__all__ = [
+    "ValidationCallOutBundle",
+    "VALIDATION_DETERMINISTIC",
+]

--- a/vultron/core/behaviors/call_out/nodes.py
+++ b/vultron/core/behaviors/call_out/nodes.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Deterministic constant call-out point backend nodes (BT-23-001, BT-23-002).
+
+This module provides the two **deterministic** call-out point backends used by
+the ``<DOMAIN>_DETERMINISTIC`` bundles: :class:`AlwaysSucceed` (always returns
+``SUCCESS``) and :class:`AlwaysFail` (always returns ``FAILURE``).
+
+These are core-owned, production-usable backends: the DETERMINISTIC bundle is
+the happy-path default a real actor uses when a call-out point has no wired-in
+coordination agent yet (ADR-0025). They deliberately carry **no** probabilistic
+behaviour — that belongs exclusively to the simulation layer
+(``vultron/demo/fuzzer/base.py``'s ``WeightedBehavior`` family, kept out of core
+per BT-16-001).
+
+Interface contract
+------------------
+Both classes are ``py_trees.behaviour.Behaviour`` subclasses constructed with a
+single ``name: str`` argument, so any
+:class:`~vultron.core.behaviors.call_out.protocol.CallOutBackendFactory` may
+produce them interchangeably with the demo layer's ``WeightedBehavior`` nodes.
+
+A ``success_rate`` class attribute (``1.0`` / ``0.0``) is provided so these
+nodes present the same read-only rate interface as the simulation ``AlwaysSucceed``
+/ ``AlwaysFail`` (which subclass ``WeightedBehavior``). This keeps the two
+same-named-but-distinct node families substitutable for callers that only read
+the rate; the core nodes remain non-probabilistic regardless of the value.
+
+.. note::
+
+    A same-named ``AlwaysSucceed`` / ``AlwaysFail`` pair also exists in
+    ``vultron/demo/fuzzer/base.py`` as ``WeightedBehavior`` subclasses. The two
+    pairs are intentionally **duplicated, not cross-imported**: core must not
+    depend on demo (BT-16-001). They are kept substitutable through the shared
+    :class:`CallOutBackendFactory` contract, not through a shared base class.
+
+References
+----------
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-23-001, BT-23-002
+"""
+
+from __future__ import annotations
+
+import py_trees
+from py_trees.common import Status
+
+
+class AlwaysSucceed(py_trees.behaviour.Behaviour):
+    """Deterministic call-out backend that always returns ``SUCCESS``.
+
+    The ceiling default for any call-out point whose stochastic success
+    probability is ``>= 0.5`` (BT-23-002). Core-owned and production-usable;
+    carries no probabilistic behaviour.
+    """
+
+    #: Read-only rate interface parity with the simulation ``AlwaysSucceed``.
+    success_rate: float = 1.0
+
+    def __init__(self, name: str = "") -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def update(self) -> Status:
+        """Always return ``Status.SUCCESS``."""
+        return Status.SUCCESS
+
+
+class AlwaysFail(py_trees.behaviour.Behaviour):
+    """Deterministic call-out backend that always returns ``FAILURE``.
+
+    The floor default for any call-out point whose stochastic success
+    probability is ``< 0.5`` (BT-23-002). Core-owned and production-usable;
+    carries no probabilistic behaviour.
+    """
+
+    #: Read-only rate interface parity with the simulation ``AlwaysFail``.
+    success_rate: float = 0.0
+
+    def __init__(self, name: str = "") -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def update(self) -> Status:
+        """Always return ``Status.FAILURE``."""
+        return Status.FAILURE
+
+
+__all__ = ["AlwaysSucceed", "AlwaysFail"]

--- a/vultron/core/behaviors/call_out/protocol.py
+++ b/vultron/core/behaviors/call_out/protocol.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out point backend factory Protocol for the Vultron BT port/adapter seam.
+
+This module defines the :class:`CallOutBackendFactory` Protocol used by tree
+builder functions to accept swappable call-out point backends (ADR-0025,
+BT-23-004).
+
+The Protocol lives in ``vultron.core.behaviors.call_out`` so that tree builders
+in ``vultron.core.behaviors`` can reference it — and their DETERMINISTIC bundle
+defaults (also in this package) — without importing from ``vultron.demo``,
+maintaining the hexagonal-architecture layering rule (BT-16-001: simulation
+artifacts stay out of core).
+
+The shape mixin classes and probabilistic (``WeightedBehavior``-based) example
+backends live in ``vultron.demo.fuzzer.call_out_point`` and
+``vultron.demo.fuzzer.base``.
+
+References
+----------
+- ADR-0024: ``docs/adr/0024-coordination-agent-taxonomy.md``
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004, BT-23-004
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import py_trees as _py_trees
+
+
+@runtime_checkable
+class CallOutBackendFactory(Protocol):
+    """Protocol for swappable call-out point backend factories (BT-23-004).
+
+    A factory must accept a single ``name: str`` argument (the BT node's
+    display name) and return a ``py_trees.behaviour.Behaviour`` that honours
+    the call-out point's declared blackboard contract (BT-18-001 through
+    BT-18-004).
+
+    Any callable satisfying this signature is a valid backend — plain lambda
+    functions, module-level functions, and classes with ``__call__`` all
+    qualify.  No central registration, inheritance, or decorator is required.
+    Static type checking via pyright/mypy is the validation mechanism.
+
+    This is the single contract that keeps the core DETERMINISTIC backends
+    (:class:`~vultron.core.behaviors.call_out.nodes.AlwaysSucceed` /
+    :class:`~vultron.core.behaviors.call_out.nodes.AlwaysFail`) and the demo
+    STOCHASTIC backends (``vultron.demo.fuzzer`` ``WeightedBehavior`` nodes)
+    substitutable for one another in a type-safe way, without either layer
+    importing the other's node classes.
+
+    Example::
+
+        from vultron.core.behaviors.call_out import (
+            AlwaysSucceed,
+            CallOutBackendFactory,
+        )
+
+        def create_my_tree(
+            report_id: str,
+            credibility_factory: CallOutBackendFactory = (
+                lambda n: AlwaysSucceed(n)
+            ),
+        ) -> py_trees.behaviour.Behaviour:
+            node = credibility_factory("EvaluateReportCredibility")
+            ...
+    """
+
+    def __call__(self, name: str) -> _py_trees.behaviour.Behaviour: ...
+
+
+__all__ = ["CallOutBackendFactory"]

--- a/vultron/core/behaviors/call_out_point.py
+++ b/vultron/core/behaviors/call_out_point.py
@@ -11,19 +11,16 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out point factory type for the Vultron BT port/adapter seam.
+"""Backward-compatible re-export of :class:`CallOutBackendFactory`.
 
-This module defines the :class:`CallOutBackendFactory` Protocol used by tree
-builder functions to accept swappable call-out point backends (ADR-0025,
-BT-23-004).
+The canonical Protocol definition now lives in
+:mod:`vultron.core.behaviors.call_out.protocol`, co-located with the
+deterministic call-out nodes and the ``<DOMAIN>_DETERMINISTIC`` bundle
+singletons (ADR-0025 corrected layering).  This module re-exports it so that
+existing ``from vultron.core.behaviors.call_out_point import
+CallOutBackendFactory`` imports keep working.
 
-The Protocol lives here (in ``vultron.core.behaviors``) so that tree builders
-in ``vultron.core.behaviors.report`` can reference it without importing from
-``vultron.demo``, maintaining the hexagonal-architecture layering rule
-(BT-16-001: simulation artifacts stay out of core).
-
-The shape mixin classes and illustrative examples live in
-``vultron.demo.fuzzer.call_out_point``.
+New code SHOULD import from ``vultron.core.behaviors.call_out`` instead.
 
 References
 ----------
@@ -33,40 +30,11 @@ References
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+# Backward-compatible re-export shim.  The canonical definition now lives in
+# ``vultron.core.behaviors.call_out.protocol`` alongside the deterministic
+# nodes and DETERMINISTIC bundle singletons (ADR-0025 corrected layering).
+# Existing imports of ``CallOutBackendFactory`` from this module continue to
+# resolve to the same object.
+from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
 
-import py_trees as _py_trees
-
-
-@runtime_checkable
-class CallOutBackendFactory(Protocol):
-    """Protocol for swappable call-out point backend factories (BT-23-004).
-
-    A factory must accept a single ``name: str`` argument (the BT node's
-    display name) and return a ``py_trees.behaviour.Behaviour`` that honours
-    the call-out point's declared blackboard contract (BT-18-001 through
-    BT-18-004).
-
-    Any callable satisfying this signature is a valid backend — plain lambda
-    functions, module-level functions, and classes with ``__call__`` all
-    qualify.  No central registration, inheritance, or decorator is required.
-    Static type checking via pyright/mypy is the validation mechanism.
-
-    Example::
-
-        from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-        from vultron.demo.fuzzer.report_management.validate import (
-            EvaluateReportCredibility as _FuzzerCredibility,
-        )
-
-        def create_my_tree(
-            report_id: str,
-            credibility_factory: CallOutBackendFactory = (
-                lambda n: _FuzzerCredibility(n)
-            ),
-        ) -> py_trees.behaviour.Behaviour:
-            node = credibility_factory("EvaluateReportCredibility")
-            ...
-    """
-
-    def __call__(self, name: str) -> _py_trees.behaviour.Behaviour: ...
+__all__ = ["CallOutBackendFactory"]

--- a/vultron/core/behaviors/embargo/manage_embargo_tree.py
+++ b/vultron/core/behaviors/embargo/manage_embargo_tree.py
@@ -56,7 +56,9 @@ from typing import TYPE_CHECKING
 import py_trees
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.embargo import EmbargoCallOutBundle
+    from vultron.core.behaviors.call_out.bundles.embargo import (
+        EmbargoCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -82,13 +84,15 @@ def create_manage_embargo_tree(
     Args:
         case_id: ID of VulnerabilityCase whose embargo is being managed.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.demo.fuzzer.bundles.embargo.EMBARGO_DETERMINISTIC`
+            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.embargo.EMBARGO_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the manage-embargo behavior tree (Phase 1 stub Sequence).
     """
-    from vultron.demo.fuzzer.bundles.embargo import EMBARGO_DETERMINISTIC
+    from vultron.core.behaviors.call_out.bundles.embargo import (
+        EMBARGO_DETERMINISTIC,
+    )
 
     bundle = call_out if call_out is not None else EMBARGO_DETERMINISTIC
     # Phase 2: bundle.on_embargo_exit_factory, bundle.on_embargo_accept_factory,

--- a/vultron/core/behaviors/report/acquire_exploit_strategy_tree.py
+++ b/vultron/core/behaviors/report/acquire_exploit_strategy_tree.py
@@ -43,7 +43,7 @@ import py_trees
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.acquire_exploit import (
+    from vultron.core.behaviors.call_out.bundles.acquire_exploit import (
         AcquireExploitCallOutBundle,
     )
 
@@ -90,13 +90,13 @@ def create_acquire_exploit_strategy_tree(
     Args:
         case_id: ID of VulnerabilityCase being processed.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.demo.fuzzer.bundles.acquire_exploit.ACQUIRE_EXPLOIT_DETERMINISTIC`
+            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.acquire_exploit.ACQUIRE_EXPLOIT_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
         Root Selector node of the collapsed exploit-strategy subtree.
     """
-    from vultron.demo.fuzzer.bundles.acquire_exploit import (
+    from vultron.core.behaviors.call_out.bundles.acquire_exploit import (
         ACQUIRE_EXPLOIT_DETERMINISTIC,
     )
 

--- a/vultron/core/behaviors/report/acquire_exploit_tree.py
+++ b/vultron/core/behaviors/report/acquire_exploit_tree.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING
 import py_trees
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.acquire_exploit import (
+    from vultron.core.behaviors.call_out.bundles.acquire_exploit import (
         AcquireExploitCallOutBundle,
     )
 
@@ -53,13 +53,13 @@ def create_acquire_exploit_tree(
     Args:
         case_id: ID of VulnerabilityCase being processed.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.demo.fuzzer.bundles.acquire_exploit.ACQUIRE_EXPLOIT_DETERMINISTIC`
+            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.acquire_exploit.ACQUIRE_EXPLOIT_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the acquire-exploit behavior tree (Phase 1 stub Sequence).
     """
-    from vultron.demo.fuzzer.bundles.acquire_exploit import (
+    from vultron.core.behaviors.call_out.bundles.acquire_exploit import (
         ACQUIRE_EXPLOIT_DETERMINISTIC,
     )
 

--- a/vultron/core/behaviors/report/assign_vul_id_tree.py
+++ b/vultron/core/behaviors/report/assign_vul_id_tree.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 import py_trees
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.assign_vul_id import (
+    from vultron.core.behaviors.call_out.bundles.assign_vul_id import (
         AssignVulIdCallOutBundle,
     )
 
@@ -52,13 +52,13 @@ def create_assign_vul_id_tree(
     Args:
         case_id: ID of VulnerabilityCase being processed.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.demo.fuzzer.bundles.assign_vul_id.ASSIGN_VUL_ID_DETERMINISTIC`
+            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.assign_vul_id.ASSIGN_VUL_ID_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the assign-VUL-ID behavior tree (Phase 1 stub Sequence).
     """
-    from vultron.demo.fuzzer.bundles.assign_vul_id import (
+    from vultron.core.behaviors.call_out.bundles.assign_vul_id import (
         ASSIGN_VUL_ID_DETERMINISTIC,
     )
 

--- a/vultron/core/behaviors/report/close_report_tree.py
+++ b/vultron/core/behaviors/report/close_report_tree.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING
 import py_trees
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.close_report import (
+    from vultron.core.behaviors.call_out.bundles.close_report import (
         CloseReportCallOutBundle,
     )
 
@@ -61,13 +61,13 @@ def create_close_report_tree(
     Args:
         case_id: ID of VulnerabilityCase being processed.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.demo.fuzzer.bundles.close_report.CLOSE_REPORT_DETERMINISTIC`
+            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.close_report.CLOSE_REPORT_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the close-report behavior tree (Phase 1 stub).
     """
-    from vultron.demo.fuzzer.bundles.close_report import (
+    from vultron.core.behaviors.call_out.bundles.close_report import (
         CLOSE_REPORT_DETERMINISTIC,
     )
 

--- a/vultron/core/behaviors/report/deploy_fix_tree.py
+++ b/vultron/core/behaviors/report/deploy_fix_tree.py
@@ -41,7 +41,9 @@ from typing import TYPE_CHECKING
 import py_trees
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.deploy_fix import DeployFixCallOutBundle
+    from vultron.core.behaviors.call_out.bundles.deploy_fix import (
+        DeployFixCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -60,13 +62,15 @@ def create_deploy_fix_tree(
     Args:
         case_id: ID of VulnerabilityCase being processed.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.demo.fuzzer.bundles.deploy_fix.DEPLOY_FIX_DETERMINISTIC`
+            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.deploy_fix.DEPLOY_FIX_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the deploy-fix behavior tree (Phase 1 stub Sequence).
     """
-    from vultron.demo.fuzzer.bundles.deploy_fix import DEPLOY_FIX_DETERMINISTIC
+    from vultron.core.behaviors.call_out.bundles.deploy_fix import (
+        DEPLOY_FIX_DETERMINISTIC,
+    )
 
     bundle = call_out if call_out is not None else DEPLOY_FIX_DETERMINISTIC
     root = py_trees.composites.Sequence(

--- a/vultron/core/behaviors/report/prioritize_tree.py
+++ b/vultron/core/behaviors/report/prioritize_tree.py
@@ -70,7 +70,7 @@ from vultron.core.behaviors.report.nodes import (
 
 if TYPE_CHECKING:
     from vultron.core.ports.trigger_activity import TriggerActivityPort
-    from vultron.demo.fuzzer.bundles.prioritization import (
+    from vultron.core.behaviors.call_out.bundles.prioritization import (
         PrioritizationCallOutBundle,
     )
 
@@ -203,13 +203,13 @@ def create_prioritize_subtree(
             time with a descriptive error (consistent with the behaviour
             when the blackboard does not carry a factory).
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.demo.fuzzer.bundles.prioritization.PRIORITIZATION_DETERMINISTIC`
+            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.prioritization.PRIORITIZATION_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the prioritize behavior tree (Selector)
     """
-    from vultron.demo.fuzzer.bundles.prioritization import (
+    from vultron.core.behaviors.call_out.bundles.prioritization import (
         PRIORITIZATION_DETERMINISTIC,
     )
 

--- a/vultron/core/behaviors/report/publication_tree.py
+++ b/vultron/core/behaviors/report/publication_tree.py
@@ -74,7 +74,7 @@ from vultron.core.behaviors.report.publish_artifact_tree import (
 )
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.publication import (
+    from vultron.core.behaviors.call_out.bundles.publication import (
         PublicationCallOutBundle,
     )
 
@@ -296,13 +296,13 @@ def create_publication_tree(
     Args:
         case_id: ID of the VulnerabilityCase to publish for.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.demo.fuzzer.bundles.publication.PUBLICATION_DETERMINISTIC`
+            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.publication.PUBLICATION_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
         Root Sequence node of the collapsed publication behavior tree.
     """
-    from vultron.demo.fuzzer.bundles.publication import (
+    from vultron.core.behaviors.call_out.bundles.publication import (
         PUBLICATION_DETERMINISTIC,
     )
 

--- a/vultron/core/behaviors/report/publish_artifact_tree.py
+++ b/vultron/core/behaviors/report/publish_artifact_tree.py
@@ -72,7 +72,7 @@ from pydantic import BaseModel
 from vultron.core.behaviors.call_out_point import CallOutBackendFactory
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.publication import (
+    from vultron.core.behaviors.call_out.bundles.publication import (
         PublicationCallOutBundle,
     )
 
@@ -190,49 +190,44 @@ class _NeedsRevisionGate(py_trees.behaviour.Behaviour):
 def _default_draft_advisory_artifact_factory(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
-    # Deferred import: demo/publication.py imports AdvisoryReviewDecision from
-    # this module at module level, creating a circular dependency.
-    from vultron.demo.fuzzer.report_management.publication import (
-        DraftAdvisoryArtifact,
-    )
+    # Core DETERMINISTIC default (ADR-0025, BT-23-002): the happy-path backend
+    # a real actor uses before a Composer agent is wired in.  The probabilistic
+    # DraftAdvisoryArtifact fuzzer node lives in the simulation layer and is
+    # injected via ``call_out=PUBLICATION_STOCHASTIC``.
+    from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 
-    return DraftAdvisoryArtifact(name)
+    return AlwaysSucceed(name)
 
 
 def _default_review_advisory_draft_factory(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
-    # Deferred import: avoids circular dependency — demo/publication.py imports
-    # AdvisoryReviewDecision from this module at module level.
-    from vultron.demo.fuzzer.report_management.publication import (
-        ReviewAdvisoryDraft,
-    )
+    # Core DETERMINISTIC default (ADR-0025, BT-23-002); the auto-approve
+    # happy-path backend.  STOCHASTIC ReviewAdvisoryDraft is injected via
+    # ``call_out=PUBLICATION_STOCHASTIC``.
+    from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 
-    return ReviewAdvisoryDraft(name)
+    return AlwaysSucceed(name)
 
 
 def _default_revise_advisory_draft_factory(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
-    # Deferred import: avoids circular dependency — demo/publication.py imports
-    # AdvisoryReviewDecision from this module at module level.
-    from vultron.demo.fuzzer.report_management.publication import (
-        ReviseAdvisoryDraft,
-    )
+    # Core DETERMINISTIC default (ADR-0025, BT-23-002).  STOCHASTIC
+    # ReviseAdvisoryDraft is injected via ``call_out=PUBLICATION_STOCHASTIC``.
+    from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 
-    return ReviseAdvisoryDraft(name)
+    return AlwaysSucceed(name)
 
 
 def _default_submit_advisory_artifact_factory(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
-    # Deferred import: avoids circular dependency — demo/publication.py imports
-    # AdvisoryReviewDecision from this module at module level.
-    from vultron.demo.fuzzer.report_management.publication import (
-        SubmitAdvisoryArtifact,
-    )
+    # Core DETERMINISTIC default (ADR-0025, BT-23-002).  STOCHASTIC
+    # SubmitAdvisoryArtifact is injected via ``call_out=PUBLICATION_STOCHASTIC``.
+    from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 
-    return SubmitAdvisoryArtifact(name)
+    return AlwaysSucceed(name)
 
 
 def create_publish_artifact_tree(
@@ -270,18 +265,21 @@ def create_publish_artifact_tree(
             in the py_trees display tree.  Optional — defaults to empty string.
         draft_advisory_artifact_factory: Factory for the Composer call-out
             point that drafts the advisory artifact from case data.  Defaults
-            to the fuzzer backend (ADR-0025).
+            to the core DETERMINISTIC ``AlwaysSucceed`` backend (ADR-0025,
+            BT-23-002); inject ``call_out=PUBLICATION_STOCHASTIC`` for the
+            probabilistic fuzzer node.
         review_advisory_draft_factory: Factory for the Evaluator call-out
             point that reviews and approves the draft.  The default
-            auto-approve fuzzer implementation allows the pipeline to function
+            auto-approve DETERMINISTIC backend allows the pipeline to function
             before a real review agent is available (AC-3, ADR-0030).
         revise_advisory_draft_factory: Factory for the optional Composer
             call-out point that revises the draft based on review feedback.
             Runs only when the Evaluator sets ``needs_revision=True``.
-            Defaults to the fuzzer backend.
+            Defaults to the core DETERMINISTIC ``AlwaysSucceed`` backend.
         submit_advisory_artifact_factory: Factory for the Actuator call-out
             point that submits the finalized artifact to the external advisory
-            platform.  Defaults to the fuzzer backend.
+            platform.  Defaults to the core DETERMINISTIC ``AlwaysSucceed``
+            backend.
 
     Returns:
         Root Sequence node of the publish-artifact pipeline.

--- a/vultron/core/behaviors/report/report_to_others_tree.py
+++ b/vultron/core/behaviors/report/report_to_others_tree.py
@@ -72,7 +72,7 @@ from vultron.core.behaviors.call_out_point import CallOutBackendFactory
 from vultron.enums.roles import CVDRole
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.report_to_others import (
+    from vultron.core.behaviors.call_out.bundles.report_to_others import (
         ReportToOthersCallOutBundle,
     )
 
@@ -191,13 +191,13 @@ def create_report_to_others_tree(
     Args:
         case_id: ID of the VulnerabilityCase being processed.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.demo.fuzzer.bundles.report_to_others.REPORT_TO_OTHERS_DETERMINISTIC`
+            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.report_to_others.REPORT_TO_OTHERS_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
         Root Sequence node of the notification-loop behavior tree.
     """
-    from vultron.demo.fuzzer.bundles.report_to_others import (
+    from vultron.core.behaviors.call_out.bundles.report_to_others import (
         REPORT_TO_OTHERS_DETERMINISTIC,
     )
 

--- a/vultron/core/behaviors/report/validate_tree.py
+++ b/vultron/core/behaviors/report/validate_tree.py
@@ -70,7 +70,9 @@ from vultron.core.behaviors.report.nodes import (
 from vultron.core.behaviors.report.nodes.emit import EmitValidateReportActivity
 
 if TYPE_CHECKING:
-    from vultron.demo.fuzzer.bundles.validation import ValidationCallOutBundle
+    from vultron.core.behaviors.call_out.bundles.validation import (
+        ValidationCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +132,9 @@ def create_validate_report_tree(
         >>> print(result.status)
         Status.SUCCESS
     """
-    from vultron.demo.fuzzer.bundles.validation import VALIDATION_DETERMINISTIC
+    from vultron.core.behaviors.call_out.bundles.validation import (
+        VALIDATION_DETERMINISTIC,
+    )
 
     bundle = call_out if call_out is not None else VALIDATION_DETERMINISTIC
 

--- a/vultron/demo/fuzzer/bundles/acquire_exploit.py
+++ b/vultron/demo/fuzzer/bundles/acquire_exploit.py
@@ -11,17 +11,14 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out bundle for the exploit acquisition domain (BT-23-003, BT-23-005).
+"""STOCHASTIC call-out bundle for the exploit acquisition domain (BT-23-003, BT-23-005).
 
-Provides :class:`AcquireExploitCallOutBundle` plus the pre-built singletons
-:data:`ACQUIRE_EXPLOIT_DETERMINISTIC` and :data:`ACQUIRE_EXPLOIT_STOCHASTIC`.
+Provides the simulation-layer :data:`ACQUIRE_EXPLOIT_STOCHASTIC` singleton.  The
+bundle dataclass and DETERMINISTIC default are core concerns
+(``vultron.core.behaviors.call_out.bundles.acquire_exploit``) and are re-exported
+here for backward-compatible import paths.
 
-This bundle covers both
-:func:`~vultron.core.behaviors.report.acquire_exploit_tree.create_acquire_exploit_tree`
-and
-:func:`~vultron.core.behaviors.report.acquire_exploit_strategy_tree.create_acquire_exploit_strategy_tree`.
-
-Ceiling/floor mapping (BT-23-002):
+Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
 - ``evaluate_exploit_priority_factory``  — EvaluateExploitPriority   (p=1.0) → AlwaysSucceed
 - ``purchase_exploit_factory``           — PurchaseExploit            (p=0.10) → AlwaysFail
@@ -31,23 +28,12 @@ Ceiling/floor mapping (BT-23-002):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-
-
-def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
-
-
-def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysFail
-
-    return AlwaysFail(name)
+from vultron.core.behaviors.call_out.bundles.acquire_exploit import (  # noqa: F401
+    ACQUIRE_EXPLOIT_DETERMINISTIC,
+    AcquireExploitCallOutBundle,
+)
 
 
 def _stochastic_evaluate_exploit_priority(
@@ -85,33 +71,6 @@ def _stochastic_evaluate_exploit_strategy(
 
     return EvaluateExploitStrategy(name)
 
-
-@dataclass(frozen=True)
-class AcquireExploitCallOutBundle:
-    """Call-out backend bundle for the exploit acquisition domain (BT-23-003).
-
-    Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.report.acquire_exploit_tree.create_acquire_exploit_tree`
-    and
-    :func:`~vultron.core.behaviors.report.acquire_exploit_strategy_tree.create_acquire_exploit_strategy_tree`.
-    """
-
-    evaluate_exploit_priority_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    purchase_exploit_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    have_exploit_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    evaluate_exploit_strategy_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-
-
-ACQUIRE_EXPLOIT_DETERMINISTIC = AcquireExploitCallOutBundle()
-"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
 
 ACQUIRE_EXPLOIT_STOCHASTIC = AcquireExploitCallOutBundle(
     evaluate_exploit_priority_factory=_stochastic_evaluate_exploit_priority,  # type: ignore[arg-type]

--- a/vultron/demo/fuzzer/bundles/assign_vul_id.py
+++ b/vultron/demo/fuzzer/bundles/assign_vul_id.py
@@ -11,12 +11,14 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out bundle for the vulnerability ID assignment domain (BT-23-003, BT-23-005).
+"""STOCHASTIC call-out bundle for the vulnerability ID assignment domain (BT-23).
 
-Provides :class:`AssignVulIdCallOutBundle` plus the pre-built singletons
-:data:`ASSIGN_VUL_ID_DETERMINISTIC` and :data:`ASSIGN_VUL_ID_STOCHASTIC`.
+Provides the simulation-layer :data:`ASSIGN_VUL_ID_STOCHASTIC` singleton.  The
+bundle dataclass and DETERMINISTIC default are core concerns
+(``vultron.core.behaviors.call_out.bundles.assign_vul_id``) and are re-exported
+here for backward-compatible import paths.
 
-Ceiling/floor mapping (BT-23-002):
+Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
 - ``id_assignable_factory`` — IdAssignable (p=0.67) → AlwaysSucceed
 - ``in_scope_factory``      — InScope      (p=0.75) → AlwaysSucceed
@@ -24,17 +26,12 @@ Ceiling/floor mapping (BT-23-002):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-
-
-def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
+from vultron.core.behaviors.call_out.bundles.assign_vul_id import (  # noqa: F401
+    ASSIGN_VUL_ID_DETERMINISTIC,
+    AssignVulIdCallOutBundle,
+)
 
 
 def _stochastic_id_assignable(name: str) -> py_trees.behaviour.Behaviour:
@@ -50,25 +47,6 @@ def _stochastic_in_scope(name: str) -> py_trees.behaviour.Behaviour:
 
     return InScope(name)
 
-
-@dataclass(frozen=True)
-class AssignVulIdCallOutBundle:
-    """Call-out backend bundle for the vulnerability ID assignment domain (BT-23-003).
-
-    Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.report.assign_vul_id_tree.create_assign_vul_id_tree`.
-    """
-
-    id_assignable_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    in_scope_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-
-
-ASSIGN_VUL_ID_DETERMINISTIC = AssignVulIdCallOutBundle()
-"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
 
 ASSIGN_VUL_ID_STOCHASTIC = AssignVulIdCallOutBundle(
     id_assignable_factory=_stochastic_id_assignable,  # type: ignore[arg-type]

--- a/vultron/demo/fuzzer/bundles/close_report.py
+++ b/vultron/demo/fuzzer/bundles/close_report.py
@@ -11,12 +11,14 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out bundle for the report closure domain (BT-23-003, BT-23-005).
+"""STOCHASTIC call-out bundle for the report closure domain (BT-23-003, BT-23-005).
 
-Provides :class:`CloseReportCallOutBundle` plus the pre-built singletons
-:data:`CLOSE_REPORT_DETERMINISTIC` and :data:`CLOSE_REPORT_STOCHASTIC`.
+Provides the simulation-layer :data:`CLOSE_REPORT_STOCHASTIC` singleton.  The
+bundle dataclass and DETERMINISTIC default are core concerns
+(``vultron.core.behaviors.call_out.bundles.close_report``) and are re-exported
+here for backward-compatible import paths.
 
-Ceiling/floor mapping (BT-23-002):
+Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
 - ``other_close_criteria_factory`` — OtherCloseCriteriaMet (p=0.25) → AlwaysFail
 - ``pre_close_action_factory``     — PreCloseAction        (p=1.0) → AlwaysSucceed
@@ -24,23 +26,12 @@ Ceiling/floor mapping (BT-23-002):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-
-
-def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
-
-
-def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysFail
-
-    return AlwaysFail(name)
+from vultron.core.behaviors.call_out.bundles.close_report import (  # noqa: F401
+    CLOSE_REPORT_DETERMINISTIC,
+    CloseReportCallOutBundle,
+)
 
 
 def _stochastic_other_close_criteria(
@@ -60,25 +51,6 @@ def _stochastic_pre_close_action(name: str) -> py_trees.behaviour.Behaviour:
 
     return PreCloseAction(name)
 
-
-@dataclass(frozen=True)
-class CloseReportCallOutBundle:
-    """Call-out backend bundle for the report closure domain (BT-23-003).
-
-    Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.report.close_report_tree.create_close_report_tree`.
-    """
-
-    other_close_criteria_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    pre_close_action_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-
-
-CLOSE_REPORT_DETERMINISTIC = CloseReportCallOutBundle()
-"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
 
 CLOSE_REPORT_STOCHASTIC = CloseReportCallOutBundle(
     other_close_criteria_factory=_stochastic_other_close_criteria,  # type: ignore[arg-type]

--- a/vultron/demo/fuzzer/bundles/deploy_fix.py
+++ b/vultron/demo/fuzzer/bundles/deploy_fix.py
@@ -11,12 +11,14 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out bundle for the fix deployment domain (BT-23-003, BT-23-005).
+"""STOCHASTIC call-out bundle for the fix deployment domain (BT-23-003, BT-23-005).
 
-Provides :class:`DeployFixCallOutBundle` plus the pre-built singletons
-:data:`DEPLOY_FIX_DETERMINISTIC` and :data:`DEPLOY_FIX_STOCHASTIC`.
+Provides the simulation-layer :data:`DEPLOY_FIX_STOCHASTIC` singleton.  The
+bundle dataclass and DETERMINISTIC default are core concerns
+(``vultron.core.behaviors.call_out.bundles.deploy_fix``) and are re-exported
+here for backward-compatible import paths.
 
-Ceiling/floor mapping (BT-23-002):
+Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
 - ``prioritize_deployment_factory``  — PrioritizeDeployment  (p=0.90) → AlwaysSucceed
 - ``deploy_mitigation_factory``      — DeployMitigation      (p=0.75) → AlwaysSucceed
@@ -27,23 +29,12 @@ Ceiling/floor mapping (BT-23-002):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-
-
-def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
-
-
-def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysFail
-
-    return AlwaysFail(name)
+from vultron.core.behaviors.call_out.bundles.deploy_fix import (  # noqa: F401
+    DEPLOY_FIX_DETERMINISTIC,
+    DeployFixCallOutBundle,
+)
 
 
 def _stochastic_prioritize_deployment(
@@ -87,34 +78,6 @@ def _stochastic_monitor_deployment(name: str) -> py_trees.behaviour.Behaviour:
 
     return MonitorDeployment(name)
 
-
-@dataclass(frozen=True)
-class DeployFixCallOutBundle:
-    """Call-out backend bundle for the fix deployment domain (BT-23-003).
-
-    Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`.
-    """
-
-    prioritize_deployment_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    deploy_mitigation_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    monitoring_requirement_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    deploy_fix_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    monitor_deployment_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-
-
-DEPLOY_FIX_DETERMINISTIC = DeployFixCallOutBundle()
-"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
 
 DEPLOY_FIX_STOCHASTIC = DeployFixCallOutBundle(
     prioritize_deployment_factory=_stochastic_prioritize_deployment,  # type: ignore[arg-type]

--- a/vultron/demo/fuzzer/bundles/embargo.py
+++ b/vultron/demo/fuzzer/bundles/embargo.py
@@ -11,12 +11,14 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out bundle for the embargo management domain (BT-23-003, BT-23-005).
+"""STOCHASTIC call-out bundle for the embargo management domain (BT-23-003, BT-23-005).
 
-Provides :class:`EmbargoCallOutBundle` plus the pre-built singletons
-:data:`EMBARGO_DETERMINISTIC` and :data:`EMBARGO_STOCHASTIC`.
+Provides the simulation-layer :data:`EMBARGO_STOCHASTIC` singleton.  The bundle
+dataclass and DETERMINISTIC default are core concerns
+(``vultron.core.behaviors.call_out.bundles.embargo``) and are re-exported here
+for backward-compatible import paths.
 
-Ceiling/floor mapping (BT-23-002):
+Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
 - ``exit_embargo_when_deployed_factory``       — ExitEmbargoWhenDeployed       (p=0.33) → AlwaysFail
 - ``exit_embargo_when_fix_ready_factory``      — ExitEmbargoWhenFixReady       (p=0.25) → AlwaysFail
@@ -35,23 +37,12 @@ Ceiling/floor mapping (BT-23-002):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-
-
-def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
-
-
-def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysFail
-
-    return AlwaysFail(name)
+from vultron.core.behaviors.call_out.bundles.embargo import (  # noqa: F401
+    EMBARGO_DETERMINISTIC,
+    EmbargoCallOutBundle,
+)
 
 
 def _stochastic_exit_when_deployed(name: str) -> py_trees.behaviour.Behaviour:
@@ -135,58 +126,6 @@ def _stochastic_on_reject(name: str) -> py_trees.behaviour.Behaviour:
 
     return OnEmbargoReject(name)
 
-
-@dataclass(frozen=True)
-class EmbargoCallOutBundle:
-    """Call-out backend bundle for the embargo management domain (BT-23-003).
-
-    Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`.
-    """
-
-    exit_embargo_when_deployed_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    exit_embargo_when_fix_ready_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    exit_embargo_for_other_reason_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    stop_proposing_embargo_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    select_embargo_offer_terms_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    want_to_propose_embargo_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    willing_to_counter_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    reason_to_propose_when_deployed_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    evaluate_embargo_proposal_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    current_embargo_acceptable_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    on_embargo_exit_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    on_embargo_accept_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    on_embargo_reject_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-
-
-EMBARGO_DETERMINISTIC = EmbargoCallOutBundle()
-"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
 
 EMBARGO_STOCHASTIC = EmbargoCallOutBundle(
     exit_embargo_when_deployed_factory=_stochastic_exit_when_deployed,  # type: ignore[arg-type]

--- a/vultron/demo/fuzzer/bundles/prioritization.py
+++ b/vultron/demo/fuzzer/bundles/prioritization.py
@@ -11,33 +11,30 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out bundle for the report prioritization domain (BT-23-003, BT-23-005).
+"""STOCHASTIC call-out bundle for the report prioritization domain (BT-23-003, BT-23-005).
 
-Provides :class:`PrioritizationCallOutBundle` plus the pre-built singletons
-:data:`PRIORITIZATION_DETERMINISTIC` and :data:`PRIORITIZATION_STOCHASTIC`.
+Provides the simulation-layer :data:`PRIORITIZATION_STOCHASTIC` singleton.  The
+bundle dataclass and DETERMINISTIC default are core concerns
+(``vultron.core.behaviors.call_out.bundles.prioritization``) and are re-exported
+here for backward-compatible import paths.
 
-Ceiling/floor mapping (BT-23-002):
+Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
-- ``evaluate_priority_factory`` — EvaluateCasePriority  (p=1.0) → AlwaysSucceed
-- ``on_accept_factory``         — OnAccept               (p=1.0) → AlwaysSucceed
-- ``on_defer_factory``          — OnDefer                (p=1.0) → AlwaysSucceed
+- ``evaluate_priority_factory`` — EvaluateCasePriority     (p=1.0) → AlwaysSucceed
+- ``on_accept_factory``         — OnAccept                 (p=1.0) → AlwaysSucceed
+- ``on_defer_factory``          — OnDefer                  (p=1.0) → AlwaysSucceed
 - ``enough_info_factory``       — EnoughPrioritizationInfo (p=0.75) → AlwaysSucceed
 - ``gather_info_factory``       — GatherPrioritizationInfo (p=0.90) → AlwaysSucceed
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-
-
-def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
+from vultron.core.behaviors.call_out.bundles.prioritization import (  # noqa: F401
+    PRIORITIZATION_DETERMINISTIC,
+    PrioritizationCallOutBundle,
+)
 
 
 def _stochastic_evaluate_priority(name: str) -> py_trees.behaviour.Behaviour:
@@ -75,34 +72,6 @@ def _stochastic_gather_info(name: str) -> py_trees.behaviour.Behaviour:
 
     return GatherPrioritizationInfo(name)
 
-
-@dataclass(frozen=True)
-class PrioritizationCallOutBundle:
-    """Call-out backend bundle for the report prioritization domain (BT-23-003).
-
-    Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree`.
-    """
-
-    evaluate_priority_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    on_accept_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    on_defer_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    enough_info_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    gather_info_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-
-
-PRIORITIZATION_DETERMINISTIC = PrioritizationCallOutBundle()
-"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
 
 PRIORITIZATION_STOCHASTIC = PrioritizationCallOutBundle(
     evaluate_priority_factory=_stochastic_evaluate_priority,  # type: ignore[arg-type]

--- a/vultron/demo/fuzzer/bundles/publication.py
+++ b/vultron/demo/fuzzer/bundles/publication.py
@@ -11,17 +11,14 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out bundle for the publication pipeline domain (BT-23-003, BT-23-005).
+"""STOCHASTIC call-out bundle for the publication pipeline domain (BT-23-003, BT-23-005).
 
-Provides :class:`PublicationCallOutBundle` plus the pre-built singletons
-:data:`PUBLICATION_DETERMINISTIC` and :data:`PUBLICATION_STOCHASTIC`.
+Provides the simulation-layer :data:`PUBLICATION_STOCHASTIC` singleton.  The
+bundle dataclass and DETERMINISTIC default are core concerns
+(``vultron.core.behaviors.call_out.bundles.publication``) and are re-exported
+here for backward-compatible import paths.
 
-This bundle covers both
-:func:`~vultron.core.behaviors.report.publication_tree.create_publication_tree`
-and
-:func:`~vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`.
-
-Ceiling/floor mapping (BT-23-002):
+Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
 - ``prioritize_publication_intents_factory`` — PrioritizePublicationIntents (p=1.0) → AlwaysSucceed
 - ``prepare_exploit_factory``               — PrepareExploit               (p=0.90) → AlwaysSucceed
@@ -35,17 +32,12 @@ Ceiling/floor mapping (BT-23-002):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-
-
-def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
+from vultron.core.behaviors.call_out.bundles.publication import (  # noqa: F401
+    PUBLICATION_DETERMINISTIC,
+    PublicationCallOutBundle,
+)
 
 
 def _stochastic_prioritize_intents(name: str) -> py_trees.behaviour.Behaviour:
@@ -107,45 +99,6 @@ def _stochastic_submit_advisory(name: str) -> py_trees.behaviour.Behaviour:
 
     return SubmitAdvisoryArtifact(name)
 
-
-@dataclass(frozen=True)
-class PublicationCallOutBundle:
-    """Call-out backend bundle for the publication pipeline domain (BT-23-003).
-
-    Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.report.publication_tree.create_publication_tree`
-    and
-    :func:`~vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`.
-    """
-
-    prioritize_publication_intents_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    prepare_exploit_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    prepare_fix_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    prepare_report_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    draft_advisory_artifact_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    review_advisory_draft_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    revise_advisory_draft_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    submit_advisory_artifact_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-
-
-PUBLICATION_DETERMINISTIC = PublicationCallOutBundle()
-"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
 
 PUBLICATION_STOCHASTIC = PublicationCallOutBundle(
     prioritize_publication_intents_factory=_stochastic_prioritize_intents,  # type: ignore[arg-type]

--- a/vultron/demo/fuzzer/bundles/report_to_others.py
+++ b/vultron/demo/fuzzer/bundles/report_to_others.py
@@ -11,12 +11,14 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out bundle for the report-to-others domain (BT-23-003, BT-23-005).
+"""STOCHASTIC call-out bundle for the report-to-others domain (BT-23-003, BT-23-005).
 
-Provides :class:`ReportToOthersCallOutBundle` plus the pre-built singletons
-:data:`REPORT_TO_OTHERS_DETERMINISTIC` and :data:`REPORT_TO_OTHERS_STOCHASTIC`.
+Provides the simulation-layer :data:`REPORT_TO_OTHERS_STOCHASTIC` singleton.  The
+bundle dataclass and DETERMINISTIC default are core concerns
+(``vultron.core.behaviors.call_out.bundles.report_to_others``) and are re-exported
+here for backward-compatible import paths.
 
-Ceiling/floor mapping (BT-23-002):
+Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
 - ``all_parties_known_factory``       — AllPartiesKnown       (p=0.50) → AlwaysSucceed (tie-break)
 - ``total_effort_limit_factory``      — TotalEffortLimitMet   (p=0.10) → AlwaysFail
@@ -30,23 +32,12 @@ Ceiling/floor mapping (BT-23-002):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-
-
-def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
-
-
-def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysFail
-
-    return AlwaysFail(name)
+from vultron.core.behaviors.call_out.bundles.report_to_others import (  # noqa: F401
+    REPORT_TO_OTHERS_DETERMINISTIC,
+    ReportToOthersCallOutBundle,
+)
 
 
 def _stochastic_all_parties_known(name: str) -> py_trees.behaviour.Behaviour:
@@ -112,43 +103,6 @@ def _stochastic_suggest_other(name: str) -> py_trees.behaviour.Behaviour:
 
     return InjectOther(name)
 
-
-@dataclass(frozen=True)
-class ReportToOthersCallOutBundle:
-    """Call-out backend bundle for the report-to-others domain (BT-23-003).
-
-    Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.report.report_to_others_tree.create_report_to_others_tree`.
-    """
-
-    all_parties_known_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    total_effort_limit_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    more_vendors_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    more_coordinators_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    more_others_factory: CallOutBackendFactory = field(
-        default=_always_fail  # type: ignore[assignment]
-    )
-    suggest_vendor_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    suggest_coordinator_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    suggest_other_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-
-
-REPORT_TO_OTHERS_DETERMINISTIC = ReportToOthersCallOutBundle()
-"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
 
 REPORT_TO_OTHERS_STOCHASTIC = ReportToOthersCallOutBundle(
     all_parties_known_factory=_stochastic_all_parties_known,  # type: ignore[arg-type]

--- a/vultron/demo/fuzzer/bundles/validation.py
+++ b/vultron/demo/fuzzer/bundles/validation.py
@@ -11,12 +11,17 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Call-out bundle for the report validation domain (BT-23-003, BT-23-005).
+"""STOCHASTIC call-out bundle for the report validation domain (BT-23-003, BT-23-005).
 
-Provides :class:`ValidationCallOutBundle` plus the pre-built singletons
-:data:`VALIDATION_DETERMINISTIC` and :data:`VALIDATION_STOCHASTIC`.
+Provides the simulation-layer :data:`VALIDATION_STOCHASTIC` singleton, which
+wires the probabilistic ``WeightedBehavior`` fuzzer nodes into the core-owned
+:class:`~vultron.core.behaviors.call_out.bundles.validation.ValidationCallOutBundle`.
 
-Ceiling/floor mapping (BT-23-002):
+The bundle dataclass and the DETERMINISTIC default are core concerns and live in
+``vultron.core.behaviors.call_out.bundles.validation``; they are re-exported here
+for backward-compatible import paths.
+
+Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
 - ``credibility_factory``   — EvaluateReportCredibility (p=0.90) → AlwaysSucceed
 - ``validity_factory``      — EvaluateReportValidity    (p=0.90) → AlwaysSucceed
@@ -25,17 +30,14 @@ Ceiling/floor mapping (BT-23-002):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-
-
-def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
+# Core-owned bundle dataclass + DETERMINISTIC default (re-exported for
+# backward-compatible import paths).
+from vultron.core.behaviors.call_out.bundles.validation import (  # noqa: F401
+    VALIDATION_DETERMINISTIC,
+    ValidationCallOutBundle,
+)
 
 
 def _stochastic_credibility(name: str) -> py_trees.behaviour.Behaviour:
@@ -61,28 +63,6 @@ def _stochastic_gather_info(name: str) -> py_trees.behaviour.Behaviour:
 
     return GatherValidationInfo(name)
 
-
-@dataclass(frozen=True)
-class ValidationCallOutBundle:
-    """Call-out backend bundle for the report validation domain (BT-23-003).
-
-    Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.report.validate_tree.create_validate_report_tree`.
-    """
-
-    credibility_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    validity_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    gather_info_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-
-
-VALIDATION_DETERMINISTIC = ValidationCallOutBundle()
-"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
 
 VALIDATION_STOCHASTIC = ValidationCallOutBundle(
     credibility_factory=_stochastic_credibility,  # type: ignore[arg-type]


### PR DESCRIPTION
- Closes #1793

## Summary

ADR-0025's 2026-07-23 "Bundle Selection Mechanism" amendment placed the call-out
bundle **dataclasses** and the `<DOMAIN>_DETERMINISTIC` **singletons** in
`vultron/demo/fuzzer/bundles/`, then had ~11 core tree builders import them as
their no-arg defaults — a **core→demo dependency inversion** that violated
ADR-0025's own decision driver ("keep simulation artifacts out of
`vultron/core/behaviors/`", BT-16-001). No architecture ratchet guarded it.

This PR corrects the layering: the deterministic seam + DETERMINISTIC defaults
become core-owned; only the probabilistic simulation wiring stays in demo.

## Changes

- **New `vultron/core/behaviors/call_out/` package**:
  - `protocol.py` — `CallOutBackendFactory` Protocol (canonical home).
  - `nodes.py` — deterministic `AlwaysSucceed`/`AlwaysFail` (plain py_trees
    `Behaviour`). Intentionally **duplicated** from — not cross-imported with —
    the demo `WeightedBehavior`-based pair; the two families are kept
    substitutable only through the `CallOutBackendFactory` contract.
  - `bundles/` — 9 domain bundle dataclasses + `<DOMAIN>_DETERMINISTIC` singletons.
- **Core tree builders** (~11) now default `call_out` to the core DETERMINISTIC
  bundle; no `vultron.demo` imports remain in `vultron/core/`.
- **Demo bundles** (`vultron/demo/fuzzer/bundles/*.py`) slimmed to hold only
  `<DOMAIN>_STOCHASTIC`, re-exporting the core dataclass + DETERMINISTIC for
  backward-compatible import paths.
- **`call_out_point.py`** is now a re-export shim of the canonical Protocol.
- **`publish_artifact_tree.py`**: its four `_default_*_factory` functions
  previously returned demo probabilistic nodes (the no-arg default was
  anomalously STOCHASTIC); they now return core `AlwaysSucceed`, making the
  default DETERMINISTIC like every sibling builder.
- **New ratchet** `test/architecture/test_core_no_demo_imports.py` — fails if any
  `vultron/core/**` module imports `vultron.demo` (empty `KNOWN_VIOLATIONS`).
- **Docs/spec**: rewrote the ADR-0025 amendment to record the correction; updated
  `specs/behavior-tree-integration.yaml` BT-23-003/005 and
  `notes/call-out-configuration.md` to the corrected split.
- Repointed ~12 test files' `AlwaysSucceed`/`AlwaysFail` imports to the core
  package where they assert on core-built trees.

## Verification

- DETERMINISTIC ceiling/floor defaults and STOCHASTIC field wiring verified
  **identical** to pre-refactor for all 9 domains (mechanical diff vs `HEAD`) —
  no behavior change.
- `black`, `flake8`, `mypy` (Success, no issues), `pyright` (0 errors) all clean.
- Full suite: **6577 passed, 265 skipped, 3 pre-existing xfail**.
- New core→demo ratchet passes; existing `test_core_no_wire_imports` /
  `test_core_no_adapter_imports` unaffected.

Unblocks #1732 (in-process fuzz simulation scenario), which needs STOCHASTIC
bundles injected through the trigger→use-case→BT cascade without deepening the
inversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)