### PR TITLE
Route cross-actor test delivery through TestClient (drop hand-rolled ASGITransport)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1779.md
+++ b/plan/history/2607/implementation/ISSUE-1779.md
@@ -1,0 +1,24 @@
+---
+source: ISSUE-1779
+timestamp: '2026-07-29T15:24:34.960882+00:00'
+title: Route cross-actor test delivery through TestClient
+type: implementation
+---
+
+## Issue #1779 — Route cross-actor test delivery through TestClient (drop hand-rolled ASGITransport)
+
+Rewired the isolated multi-actor demo test harness (`test/demo/conftest.py`) to
+route cross-actor delivery through each target actor's FastAPI `TestClient`
+inbox instead of a hand-rolled `httpx.ASGITransport`, per ADR-0042 /
+`outbox.yaml` OX-12-003.
+
+- `_TestASGIRouter` → `_TestClientRouter`; `emit()` POSTs to the target
+  `TestClient` inbox, offloading the blocking call via
+  `anyio.to_thread.run_sync` to avoid a same-portal deadlock on CaseActor
+  `cc:`-to-self loopback delivery.
+- `register()` now takes a `TestClient`; all call sites updated.
+- `serialize_as_any=True` preserved (no SYNC-02-004 / SYNC-13-004 regression).
+- No test module constructs `httpx.ASGITransport` (AC-2 grep-clean).
+- Full suite green: 6576 passed, 265 skipped, 3 xfailed.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1796>

--- a/plan/incoming/learnings/20260729-testclient-router-portal-threading.md
+++ b/plan/incoming/learnings/20260729-testclient-router-portal-threading.md
@@ -1,0 +1,49 @@
+---
+title: Cross-actor TestClient router must offload blocking POST off the portal loop
+type: learning
+timestamp: 2026-07-29
+source: ISSUE-1779
+signal: design-question
+---
+
+## Context
+
+Issue #1779 asked to route cross-actor delivery in the isolated multi-actor
+demo harness (`test/demo/conftest.py`) through each target actor's FastAPI
+`TestClient` inbox instead of a hand-rolled `httpx.ASGITransport`, per ADR-0042
+/ `outbox.yaml` OX-12-003. The issue specified *what* transport to use but not
+*how* to invoke it safely given the harness's threading model.
+
+## Design decision (beyond the issue text)
+
+`_TestClientRouter.emit()` is `async` and runs inside a FastAPI
+`BackgroundTask` on the **sending** app's `TestClient` portal event loop.
+`TestClient.post()` is **blocking** and drives the target app through its own
+portal (an `anyio` blocking portal on a separate thread). Two hazards:
+
+1. Calling the blocking `TestClient.post()` directly on the sending portal's
+   event loop blocks that loop.
+2. For CaseActor `cc:`-to-self loopback delivery (CLP-10-001), the sender and
+   target are the **same** `TestClient` / same portal — a direct blocking call
+   would deadlock (this is the exact reentrancy the retired `ASGIEmitter`
+   papered over with its `_asgi_delivery_depth` contextvar guard).
+
+**Resolution:** dispatch the blocking POST via
+`anyio.to_thread.run_sync(functools.partial(client.post, ...))`. The POST runs
+on a fresh worker thread, freeing the calling event loop; the target portal can
+then service the inbound request without self-deadlock. This is the standard
+pattern for nested/loopback `TestClient` calls.
+
+## How to apply
+
+When any in-process test harness routes a message from one FastAPI
+`TestClient` into another (or back into itself) from within an already-running
+request/BackgroundTask, run the blocking `TestClient.post()` via
+`anyio.to_thread.run_sync`, not directly. Register `TestClient` instances (not
+raw ASGI apps) with the router, and enter every client's context before any
+delivery is routed to it so its portal is live.
+
+Candidate destination if promoted: `test/AGENTS.md` §"SYNC Replication Test
+Patterns" or a short note under `notes/` on the multi-actor test harness
+threading model. Relates to [[sync-ledger-adapter-write-conflict]] (same
+isolated-app harness).

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -116,8 +116,11 @@ CI failures: see [`notes/demo-ci-diagnostics.md`](../notes/demo-ci-diagnostics.m
 
 ### Happy-Path (SYNC-901)
 
-Use two isolated `create_isolated_actor_app` instances + shared `_TestASGIRouter`
-as emitter fallback. Each app has its own actor-scoped `DataLayer`. Use
+Use two isolated `create_isolated_actor_app` instances + shared
+`_TestClientRouter` as emitter fallback. The router POSTs cross-actor
+deliveries to each target app's `TestClient` inbox (the only sanctioned
+in-process transport per ADR-0042 / OX-12-003 — no hand-rolled
+`httpx.ASGITransport`). Each app has its own actor-scoped `DataLayer`. Use
 `post_actor_inbox` for inbound activities.
 
 ### Predecessor-Mismatch (SYNC-902)

--- a/test/demo/conftest.py
+++ b/test/demo/conftest.py
@@ -13,13 +13,14 @@
 
 """Shared fixtures and helpers for demo tests."""
 
+import functools
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
 import logging
 
-import httpx2 as httpx
+import anyio.to_thread
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from fastapi import FastAPI
@@ -76,31 +77,44 @@ class _NullDeliveryAdapter:
         )
 
 
-class _TestASGIRouter:
+class _TestClientRouter:
     """Cross-app delivery adapter for isolated multi-actor test setups.
 
-    Routes outbound activity delivery to the correct ASGI app based on
-    the recipient actor's base URL.  Replace each actor app's
-    ``ASGIEmitter._http_fallback`` with a shared instance of this class so
-    that when Actor A cannot deliver locally (the recipient is on Actor B's
-    app), the delivery is forwarded to Actor B's ASGI app via
-    ``httpx.ASGITransport`` instead of making a real HTTP request.
+    Routes outbound activity delivery to the correct actor app based on the
+    recipient's base URL, POSTing to that app's :class:`TestClient` inbox
+    endpoint.  Replace each actor app's ``ASGIEmitter._http_fallback`` (and,
+    via ``configure_default_emitter``, the module-level default emitter) with a
+    shared instance of this class so that when Actor A delivers to a recipient
+    hosted on Actor B's app, the activity is routed to Actor B's
+    ``TestClient`` — the only sanctioned in-process transport (ADR-0042,
+    ``outbox.yaml`` OX-12-003) — instead of a hand-rolled
+    ``httpx.ASGITransport`` or a real HTTP request.
 
-    Use :meth:`register` to map base URLs to their ASGI apps before
-    entering the TestClient context.
+    Use :meth:`register` to map base URLs to their ``TestClient`` instances
+    after entering each client's context (the ``TestClient`` must be entered so
+    its portal is live before any delivery is routed to it).
+
+    .. note::
+
+       ``emit()`` runs inside a FastAPI ``BackgroundTask`` on the *sending*
+       app's ``TestClient`` portal event loop.  The target ``TestClient.post``
+       call is blocking and drives the target app on its own portal thread, so
+       it is dispatched via :func:`anyio.to_thread.run_sync` to avoid blocking
+       (and, for CaseActor ``cc:``-to-self loopback delivery where sender and
+       target share one portal, deadlocking) the calling event loop.
     """
 
     def __init__(self) -> None:
-        self._apps: dict[str, "FastAPI"] = {}
+        self._clients: dict[str, "TestClient"] = {}
 
-    def register(self, base_url: str, app: "FastAPI") -> None:
-        """Register *app* as the delivery target for *base_url*."""
-        self._apps[base_url.rstrip("/")] = app
+    def register(self, base_url: str, client: "TestClient") -> None:
+        """Register *client* as the delivery target for *base_url*."""
+        self._clients[base_url.rstrip("/")] = client
 
     async def emit(
         self, activity: VultronActivity, recipients: list[str]
     ) -> None:
-        """Deliver *activity* to each recipient via the registered ASGI app."""
+        """Deliver *activity* to each recipient via the registered client."""
         # serialize_as_any=True mirrors the production emitters (ASGIEmitter /
         # DemoHttpDeliveryAdapter) so inline nested-object subtype fields
         # (e.g. a CaseLedgerEntry's case_id/event_type) survive the wire hop
@@ -112,10 +126,10 @@ class _TestASGIRouter:
         for recipient_id in recipients:
             parsed = urlparse(recipient_id.rstrip("/") + "/inbox/")
             base = f"{parsed.scheme}://{parsed.netloc}"
-            app = self._apps.get(base)
-            if app is None:
+            client = self._clients.get(base)
+            if client is None:
                 logger.debug(
-                    "_TestASGIRouter: no app registered for %s,"
+                    "_TestClientRouter: no client registered for %s,"
                     " dropping delivery to %s",
                     base,
                     recipient_id,
@@ -123,25 +137,25 @@ class _TestASGIRouter:
                 continue
             inbox_path = parsed.path
             try:
-                transport = httpx.ASGITransport(app=app)  # type: ignore[arg-type]
-                async with httpx.AsyncClient(
-                    transport=transport, base_url=base
-                ) as client:
-                    response = await client.post(
-                        inbox_path,
-                        content=json_body,
-                        headers={"Content-Type": "application/json"},
-                        timeout=10.0,
-                    )
-                    response.raise_for_status()
-                    logger.info(
-                        "_TestASGIRouter: delivered to %s (HTTP %s)",
-                        inbox_path,
-                        response.status_code,
-                    )
+                # TestClient.post is blocking and drives the target app on its
+                # own portal thread; run it off the calling event loop so a
+                # loopback delivery (sender == target) cannot deadlock.
+                post = functools.partial(
+                    client.post,
+                    inbox_path,
+                    content=json_body,
+                    headers={"Content-Type": "application/json"},
+                )
+                response = await anyio.to_thread.run_sync(post)
+                response.raise_for_status()
+                logger.info(
+                    "_TestClientRouter: delivered to %s (HTTP %s)",
+                    inbox_path,
+                    response.status_code,
+                )
             except Exception as exc:
                 logger.warning(
-                    "_TestASGIRouter: delivery to %s failed: %s",
+                    "_TestClientRouter: delivery to %s failed: %s",
                     inbox_path,
                     exc,
                 )
@@ -172,24 +186,29 @@ class IsolatedActorApp:
 
 def create_isolated_actor_app(
     base_url: str,
-    router: "_TestASGIRouter",
+    router: "_TestClientRouter",
 ) -> "IsolatedActorApp":
     """Create an isolated FastAPI app for a single actor in tests.
 
     Creates a fresh :class:`FastAPI` application via :func:`create_app`,
     injects an in-memory :class:`SqliteDataLayer` via ``dependency_overrides``,
-    and wires a :class:`_TestASGIRouter` as the ``ASGIEmitter`` HTTP fallback
-    so that deliveries to other actors are routed to their registered ASGI apps
-    instead of making real HTTP requests.
+    and wires a :class:`_TestClientRouter` as the ``ASGIEmitter`` HTTP fallback
+    so that deliveries to other actors are routed to their registered
+    ``TestClient`` inboxes instead of making real HTTP requests.
 
     The ``ASGIEmitter`` is stored on ``app.state.emitter`` during the lifespan
     startup.  After ``TestClient.__enter__`` fires, the emitter's
-    ``_http_fallback`` is replaced with the shared ``_TestASGIRouter``.
+    ``_http_fallback`` is replaced with the shared ``_TestClientRouter``.
+
+    The actor's ``TestClient`` is registered with *router* under *base_url*.
+    The client reference is stable, but callers MUST enter its context
+    (``with iso.client``) before any delivery is routed to it so its portal is
+    live.
 
     Args:
         base_url: Base URL for this actor (e.g. ``"http://finder.test"``).
             Actor IDs will use this as their URL prefix.
-        router: Shared :class:`_TestASGIRouter` instance that both apps
+        router: Shared :class:`_TestClientRouter` instance that all apps
             register with so cross-app deliveries are routed correctly.
 
     Returns:
@@ -199,9 +218,9 @@ def create_isolated_actor_app(
     isolated_dl = SqliteDataLayer(db_url="sqlite:///:memory:")
     app = create_app(docs_url=None, openapi_url=None)
     app.dependency_overrides[get_shared_dl] = lambda: isolated_dl
-    router.register(base_url, app)
     # TestClient is not yet entered; the caller drives the lifecycle.
     client = TestClient(app, base_url=base_url)
+    router.register(base_url, client)
     return IsolatedActorApp(
         app=app, client=client, dl=isolated_dl, base_url=base_url
     )

--- a/test/demo/test_case_proposal_round_trip.py
+++ b/test/demo/test_case_proposal_round_trip.py
@@ -28,7 +28,7 @@ Coverage
   wrapped by ``test_case_proposal_demo`` below.
 
 These tests use two isolated FastAPI apps (vendor + reporter) wired via a
-shared ``_TestASGIRouter`` so that all outbound deliveries route in-process
+shared ``_TestClientRouter`` so that all outbound deliveries route in-process
 without real HTTP.  They are auto-marked as ``@pytest.mark.integration``
 by the conftest hook in ``test/demo/``.
 
@@ -45,7 +45,7 @@ When the vendor's inbox receives ``SubmitReport`` from the reporter,
 3. Queues the activity to the vendor's outbox via ``record_outbox_item``.
 
 ``UpdateActorOutbox`` then flushes the vendor's outbox.  The
-``_TestASGIRouter`` routes the delivery to the case-actor's inbox on the
+``_TestClientRouter`` routes the delivery to the case-actor's inbox on the
 same app (single-app setup: the case-actor and vendor actor share one
 FastAPI instance backed by the same DataLayer).
 
@@ -75,7 +75,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 from test.demo._helpers import make_testclient_call
-from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
+from test.demo.conftest import _TestClientRouter, create_isolated_actor_app
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
@@ -137,13 +137,13 @@ def two_app_setup(monkeypatch):
     """Vendor app + reporter app wired for end-to-end CaseProposal delivery.
 
     Uses two isolated FastAPI apps each with their own in-memory
-    ``SqliteDataLayer``.  A shared ``_TestASGIRouter`` routes outbound
+    ``SqliteDataLayer``.  A shared ``_TestClientRouter`` routes outbound
     deliveries in-process so the full outbox → inbox → handler chain is
     exercised without real HTTP.
 
     The ``VULTRON_SERVER__BASE_URL`` is patched to ``{_VENDOR_BASE}/api/v2``
     so that ``CreateCaseActorNode`` builds the CaseActor ID using a
-    routable base URL — the ``_TestASGIRouter`` maps this base URL to the
+    routable base URL — the ``_TestClientRouter`` maps this base URL to the
     vendor's ASGI app.
 
     Yields:
@@ -164,7 +164,7 @@ def two_app_setup(monkeypatch):
     )
     reload_config()
 
-    router = _TestASGIRouter()
+    router = _TestClientRouter()
     vendor_iso = create_isolated_actor_app(
         base_url=_VENDOR_BASE, router=router
     )
@@ -175,7 +175,7 @@ def two_app_setup(monkeypatch):
     # Register the configured base URL so CaseActor deliveries route to
     # the vendor app (CreateCaseActorNode builds IDs from the config URL).
     config_base_url = get_config().server.base_url.rstrip("/")
-    router.register(config_base_url, vendor_iso.app)
+    router.register(config_base_url, vendor_iso.client)
 
     previous_emitter = get_default_emitter()
     configure_default_emitter(router)  # type: ignore[arg-type]

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -1219,9 +1219,9 @@ class TestDeliveryIsolation:
 
     These tests use two isolated FastAPI app instances (created via
     ``create_app()``) each with their own in-memory ``SqliteDataLayer``.
-    A ``_TestASGIRouter`` replaces each app's HTTP fallback emitter so that
-    outbound deliveries are routed to the correct ASGI app in-process rather
-    than making real HTTP requests.
+    A ``_TestClientRouter`` replaces each app's HTTP fallback emitter so that
+    outbound deliveries are routed to the correct actor's TestClient inbox
+    in-process rather than making real HTTP requests.
 
     Passing these tests confirms that:
     - Finder's DataLayer is empty before Vendor delivers via the outbox path.
@@ -1232,13 +1232,13 @@ class TestDeliveryIsolation:
 
     @pytest.fixture
     def delivery_setup(self):
-        """Two isolated actor apps wired with cross-app ASGI delivery."""
+        """Two isolated actor apps wired with cross-app TestClient delivery."""
         from test.demo.conftest import (
-            _TestASGIRouter,
+            _TestClientRouter,
             create_isolated_actor_app,
         )
 
-        router = _TestASGIRouter()
+        router = _TestClientRouter()
         finder_isolated = create_isolated_actor_app(
             base_url="http://finder.test",
             router=router,
@@ -1315,7 +1315,7 @@ class TestDeliveryIsolation:
         This is the core delivery-path test for #530.  Without the fix,
         Finder's DataLayer would remain empty because delivery was never
         exercised.  With the fix, the outbox→inbox chain runs in-process
-        via ``_TestASGIRouter`` and Finder's isolated DataLayer receives the
+        via ``_TestClientRouter`` and Finder's isolated DataLayer receives the
         case announcement.
         """
         import types
@@ -1407,7 +1407,7 @@ class TestDeliveryIsolation:
         ), "Expected as_VulnerabilityCase on Vendor after validate-report"
 
         # The case announcement should have been delivered to Finder's inbox
-        # via the outbox→_TestASGIRouter→inbox chain.  Finder's isolated
+        # via the outbox→_TestClientRouter→inbox chain.  Finder's isolated
         # DataLayer must contain the case.
         finder_case = finder_isolated.dl.read(case.id_)
         assert finder_case is not None, (

--- a/test/demo/test_pcr_bootstrap.py
+++ b/test/demo/test_pcr_bootstrap.py
@@ -27,7 +27,7 @@ AC-1 tests (``TestBootstrapSequence.test_announce_creates_case_replica`` and
 separate owner app creates a case by processing a submitted report and then
 validates it.  Validation triggers the CaseActor to emit
 ``Announce(as_VulnerabilityCase)`` via the outbox, which is routed to the
-participant app via ``_TestASGIRouter``.  This exercises the full
+participant app via ``_TestClientRouter``.  This exercises the full
 create-case → emit-Announce path, catching regressions where case creation
 no longer sends the announcement (PCR-07-006).
 
@@ -39,7 +39,7 @@ the handler's side effect (note appended to ``replica.notes``).
 
 import pytest
 
-from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
+from test.demo.conftest import _TestClientRouter, create_isolated_actor_app
 from vultron.core.models.pending_case_inbox import VultronPendingCaseInbox
 from vultron.wire.as2.factories import (
     add_note_to_case_activity,
@@ -83,13 +83,13 @@ def participant_setup():
 
     The case replica is seeded directly via a hand-crafted
     ``Announce(as_VulnerabilityCase)`` (fast, sufficient for routing coverage).
-    The ``_TestASGIRouter`` is wired as the ASGI emitter fallback so that any
+    The ``_TestClientRouter`` is wired as the ASGI emitter fallback so that any
     outbound deliveries from the participant stay in-process.
 
     Yields:
         Tuple of (IsolatedActorApp, TestClient).
     """
-    router = _TestASGIRouter()
+    router = _TestClientRouter()
     participant_isolated = create_isolated_actor_app(
         base_url=_PARTICIPANT_BASE,
         router=router,
@@ -107,19 +107,19 @@ def two_app_setup():
     """Owner app + participant app wired for end-to-end bootstrap delivery.
 
     Uses two isolated FastAPI app instances each with their own in-memory
-    ``SqliteDataLayer``.  A shared ``_TestASGIRouter`` routes outbound
+    ``SqliteDataLayer``.  A shared ``_TestClientRouter`` routes outbound
     deliveries between the apps in-process so the full
     outbox → inbox → inbox-handler chain is exercised.
 
     Lifecycle:
       1. Enters both TestClient contexts (triggers lifespan startup).
       2. Replaces each app's ``ASGIEmitter._http_fallback`` with the shared
-         router so cross-app deliveries use ASGI transport instead of real
-         HTTP.
+         router so cross-app deliveries POST to each target TestClient inbox
+         instead of real HTTP.
       3. Configures the module-level ``_default_emitter`` to the shared
          router so that trigger-endpoint ``outbox_handler`` calls (which
-         don't pass an explicit emitter) route through ASGI instead of
-         making real HTTP requests via ``DemoHttpDeliveryAdapter``.
+         don't pass an explicit emitter) POST to each target TestClient inbox
+         instead of making real HTTP requests via ``DemoHttpDeliveryAdapter``.
       4. Registers the config-default base_url with the router pointing to
          the owner's app so that deliveries to the CaseActor (whose ID uses
          the config base_url) are routed correctly.
@@ -135,7 +135,7 @@ def two_app_setup():
     )
     from vultron.config import get_config
 
-    router = _TestASGIRouter()
+    router = _TestClientRouter()
     owner_iso = create_isolated_actor_app(
         base_url=_OWNER_BASE,
         router=router,
@@ -147,9 +147,9 @@ def two_app_setup():
 
     # Register the config-default base_url (e.g. http://localhost:7999) with
     # the router so that deliveries to CaseActor IDs (which use this URL)
-    # are routed to the owner's app via ASGI.
+    # are routed to the owner's TestClient inbox.
     config_base_url = get_config().server.base_url.rstrip("/")
-    router.register(config_base_url, owner_iso.app)
+    router.register(config_base_url, owner_iso.client)
 
     # Save and replace the module-level default emitter so outbox_handler
     # calls from trigger endpoints use the router instead of
@@ -225,7 +225,7 @@ def _bootstrap_case_for_participant(
     2. Owner validates the report (``trigger/validate-report``), which
        triggers the ``create_validate_report_tree`` BT and causes the
        CaseActor to emit ``Announce(as_VulnerabilityCase)`` to participant.
-    3. The Announce is delivered via the outbox → ``_TestASGIRouter`` →
+    3. The Announce is delivered via the outbox → ``_TestClientRouter`` →
        participant inbox chain.
     4. Participant's inbox handler processes the ``Announce``.
 
@@ -286,7 +286,7 @@ def _bootstrap_case_for_participant(
 
     # Owner validates the report: this triggers the validate-report BT
     # and causes the CaseActor to emit Announce(as_VulnerabilityCase) to
-    # participant via the outbox → _TestASGIRouter → inbox chain.
+    # participant via the outbox → _TestClientRouter → inbox chain.
     resp = owner_tc.post(
         f"/api/v2/actors/{_actor_slug(owner_actor_id)}"
         "/trigger/validate-report",

--- a/test/demo/test_pcr_engage_case.py
+++ b/test/demo/test_pcr_engage_case.py
@@ -40,7 +40,7 @@ import asyncio
 
 import pytest
 
-from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
+from test.demo.conftest import _TestClientRouter, create_isolated_actor_app
 from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
@@ -65,7 +65,7 @@ def two_app_setup(monkeypatch):
     """Owner app + reporter app wired for end-to-end delivery.
 
     Uses two isolated FastAPI app instances each with their own in-memory
-    ``SqliteDataLayer``.  A shared ``_TestASGIRouter`` routes outbound
+    ``SqliteDataLayer``.  A shared ``_TestClientRouter`` routes outbound
     deliveries between the apps in-process so the full
     outbox → inbox → inbox-handler chain is exercised without real HTTP.
 
@@ -77,10 +77,10 @@ def two_app_setup(monkeypatch):
          prefix and therefore gets a 404 from the owner's ASGI app).
       2. Enters both TestClient contexts (triggers lifespan startup).
       3. Replaces each app's ``ASGIEmitter._http_fallback`` with the shared
-         router so cross-app deliveries use ASGI transport.
+         router so cross-app deliveries POST to each target TestClient inbox.
       4. Configures the module-level ``_default_emitter`` to the shared
-         router so trigger-endpoint ``outbox_handler`` calls route through
-         ASGI instead of making real HTTP requests.
+         router so trigger-endpoint ``outbox_handler`` calls POST to each
+         target TestClient inbox instead of making real HTTP requests.
       5. Registers the patched base URL with the router pointing to the
          owner's app so that CaseActor deliveries are routed correctly.
 
@@ -107,14 +107,14 @@ def two_app_setup(monkeypatch):
     )
     reload_config()
 
-    router = _TestASGIRouter()
+    router = _TestClientRouter()
     owner_iso = create_isolated_actor_app(base_url=_OWNER_BASE, router=router)
     reporter_iso = create_isolated_actor_app(
         base_url=_REPORTER_BASE, router=router
     )
 
     config_base_url = get_config().server.base_url.rstrip("/")
-    router.register(config_base_url, owner_iso.app)
+    router.register(config_base_url, owner_iso.client)
 
     previous_emitter = get_default_emitter()
     configure_default_emitter(router)  # type: ignore[arg-type]
@@ -307,7 +307,7 @@ class TestEngageCaseParticipantExpansion:
 
     Exercises the full ``engage-case`` trigger → outbox delivery →
     ``EngageCaseReceivedUseCase`` path using real DataLayer instances and
-    real ASGI transport between apps.  No use-cases, DataLayer methods, or
+    the TestClient router between apps.  No use-cases, DataLayer methods, or
     outbox handler functions are mocked.
 
     AC-1: Reporter's DataLayer contains the owner's CaseParticipant record

--- a/test/demo/test_pcr_late_joiner.py
+++ b/test/demo/test_pcr_late_joiner.py
@@ -58,7 +58,7 @@ import asyncio
 
 import pytest
 
-from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
+from test.demo.conftest import _TestClientRouter, create_isolated_actor_app
 from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
@@ -84,7 +84,7 @@ def three_app_setup(monkeypatch):
     """Owner app + reporter app + late-joiner app wired for end-to-end delivery.
 
     Uses three isolated FastAPI app instances each with their own in-memory
-    ``SqliteDataLayer``.  A shared ``_TestASGIRouter`` routes outbound
+    ``SqliteDataLayer``.  A shared ``_TestClientRouter`` routes outbound
     deliveries between the apps in-process so the full
     outbox → inbox → inbox-handler chain is exercised without real HTTP.
 
@@ -97,10 +97,10 @@ def three_app_setup(monkeypatch):
          app (its routes are at ``/api/v2/actors/…``).
       2. Enters all three TestClient contexts (triggers lifespan startup).
       3. Replaces each app's ``ASGIEmitter._http_fallback`` with the shared
-         router so cross-app deliveries use ASGI transport.
+         router so cross-app deliveries POST to each target TestClient inbox.
       4. Configures the module-level ``_default_emitter`` to the shared
-         router so trigger-endpoint ``outbox_handler`` calls route through
-         ASGI instead of making real HTTP requests.
+         router so trigger-endpoint ``outbox_handler`` calls POST to each
+         target TestClient inbox instead of making real HTTP requests.
       5. Registers the patched ``base_url`` with the router pointing to the
          owner's app so that CaseActor deliveries are routed correctly.
       6. Yields the three ``IsolatedActorApp`` instances and their clients.
@@ -131,7 +131,7 @@ def three_app_setup(monkeypatch):
     )
     reload_config()
 
-    router = _TestASGIRouter()
+    router = _TestClientRouter()
     owner_iso = create_isolated_actor_app(base_url=_OWNER_BASE, router=router)
     reporter_iso = create_isolated_actor_app(
         base_url=_REPORTER_BASE, router=router
@@ -144,7 +144,7 @@ def three_app_setup(monkeypatch):
     # (whose IDs now use http://owner-late-joiner.test/api/v2) route to
     # the owner's ASGI app.
     config_base_url = get_config().server.base_url.rstrip("/")
-    router.register(config_base_url, owner_iso.app)
+    router.register(config_base_url, owner_iso.client)
 
     # Save and replace the module-level default emitter so outbox_handler
     # calls from trigger endpoints use the router instead of
@@ -325,8 +325,8 @@ def _drain_case_actor_outbox(owner_iso, case_actor_id: str) -> None:
     Uses the real ``outbox_handler`` (the same code path as a trigger
     endpoint) so that recipient extraction, ``to:`` field validation
     (OX-08-001), and emitter routing are all exercised end-to-end.  The
-    configured default emitter (the shared ``_TestASGIRouter``) routes the
-    ``Announce`` to the late-joiner's app via ASGI.
+    configured default emitter (the shared ``_TestClientRouter``) routes the
+    ``Announce`` to the late-joiner's app via its TestClient inbox.
 
     Args:
         owner_iso: Owner's ``IsolatedActorApp`` (contains the CaseActor's
@@ -443,7 +443,7 @@ def _run_late_joiner_sequence(
 
     # Step 6: drain CaseActor's outbox via real outbox_handler
     # Announce(VulnerabilityCase) is routed to late-joiner via the
-    # configured default emitter (_TestASGIRouter).
+    # configured default emitter (_TestClientRouter).
     _drain_case_actor_outbox(owner_iso, case_actor_id)
 
     return case_id, lj_actor_id

--- a/test/demo/test_sync_ledger_replication.py
+++ b/test/demo/test_sync_ledger_replication.py
@@ -36,7 +36,7 @@ from vultron.core.use_cases.received.sync import (
     RejectLedgerEntryReceivedUseCase,
 )
 from vultron.semantic_registry import extract_event
-from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
+from test.demo.conftest import _TestClientRouter, create_isolated_actor_app
 from vultron.adapters.driving.fastapi.inbox_handler import (
     handle_inbox_item,
     inbox_handler,
@@ -99,8 +99,8 @@ def _make_log_entry(
 
 @pytest.fixture
 def two_app_setup() -> Iterator[tuple]:
-    """Create two isolated actor apps connected by ``_TestASGIRouter``."""
-    router = _TestASGIRouter()
+    """Create two isolated actor apps connected by ``_TestClientRouter``."""
+    router = _TestClientRouter()
     case_actor_iso = create_isolated_actor_app(
         base_url=_CASE_ACTOR_BASE, router=router
     )


### PR DESCRIPTION
- Closes #1779

## Summary

Prepares the isolated multi-actor demo test harness for HTTP-only inter-actor
delivery (ADR-0042, `outbox.yaml` OX-12) by removing the hand-rolled
`httpx.ASGITransport` usage in cross-actor test delivery. Per OX-12-003,
application/test code MUST NOT construct `ASGITransport` directly — the only
sanctioned in-process transport is FastAPI's `TestClient`. This lands first so
`main` stays green while the production `ASGIEmitter` still exists (its removal
is the blocked follow-up).

## Changes

- Renamed `_TestASGIRouter` → `_TestClientRouter` in `test/demo/conftest.py`.
  Its `emit()` now POSTs each cross-actor delivery to the target actor's
  `TestClient` inbox instead of constructing `httpx.ASGITransport(app=...)`.
- The blocking `TestClient.post` is dispatched via
  `anyio.to_thread.run_sync(functools.partial(...))`. `emit()` runs inside a
  FastAPI `BackgroundTask` on the *sending* app's TestClient portal event
  loop; offloading the blocking POST to a worker thread frees that loop and —
  critically — prevents a same-portal deadlock on CaseActor `cc:`-to-self
  loopback delivery (the reentrancy the old ASGIEmitter guard papered over).
- `_TestClientRouter.register()` now takes a `TestClient` instead of a raw
  ASGI app; `create_isolated_actor_app` registers `client`, and all
  config-base-url `register(..., X.app)` call sites now pass `X.client`.
- `serialize_as_any=True` retained verbatim so inline nested-object subtype
  fields survive the wire hop (no SYNC-02-004 / SYNC-13-004 regression, AC-4).
- Updated `test/AGENTS.md` SYNC-replication guidance and stale in-file
  docstrings/comments to describe the TestClient-inbox mechanism.

## Verification

- **AC-1**: `_TestClientRouter.emit()` delivers by POSTing to the target
  actor's `TestClient`, not a directly-constructed `httpx.ASGITransport`.
- **AC-2**: no test module constructs `httpx.ASGITransport` (grep-clean; the
  only remaining `ASGITransport(` construction is the production `ASGIEmitter`,
  out of scope).
- **AC-3**: isolated multi-actor demo tests pass (`test_pcr_*`,
  `test_case_proposal_round_trip`, `test_sync_ledger_replication`,
  `test_fv_demo`).
- **AC-4**: `serialize_as_any=True` preserved.
- **AC-5**: full suite green — `uv run pytest -m ""` → 6576 passed, 265
  skipped, 3 xfailed.
- Linters clean: black, flake8, mypy, pyright.

## Code review

Pre-PR review found no FAIL. Two IMPROVE items (stale "route through ASGI"
docstring wording and two over-length prose lines) were fixed in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)