### PR TITLE
Improve issue management: glacier/calving model, board-ID fix, DRY board writes

### DIFF
--- a/.agents/skills/calve-epics/SKILL.md
+++ b/.agents/skills/calve-epics/SKILL.md
@@ -134,8 +134,11 @@ failing because the right home does not exist yet.
 
 Trigger: run periodically, or when routing repeatedly struggles because the
 epics themselves are muddled — redundant umbrellas, epics mixing prod-only and
-buildable-soon work, grab-bag epics with no coherent identity, or an iceberg
-that has grown two design ideas and needs splitting.
+buildable-soon work, grab-bag epics with no coherent identity, an iceberg that
+has grown two design ideas and needs splitting, or a **tier inversion**
+(`check-priority-status` reports an issue blocked by something in a strictly
+later tier — a Now item gated by a Someday item, a Focus item gated by a Next
+item, etc.).
 
 This is an anneal pass over the **not-yet-active** region only. Treat epics at
 Now/Focus as frozen: you may *add* children to them, but do not re-tier or
@@ -151,6 +154,15 @@ Recognized events (each requires human confirmation before any mutation):
 - **Split** an overgrown iceberg that now holds two design ideas into two.
 - **Dissolve a grab-bag**: route each child to a design-coherent home, then
   close the emptied shell with a comment recording where its children went.
+- **Resolve a tier inversion**: an issue blocked by something in a strictly
+  later tier is scheduled ahead of the work it depends on. Diagnose which way
+  the grain actually runs, then pick the fix: re-parent the dependent onto the
+  blocker's epic (Mode 1 routing) if it simply landed on the wrong glacier;
+  re-tier one of the two if the horizons are just mis-set; or, if the dependent
+  and its blocker turn out to be one coherent design idea artificially split,
+  calve them together into a single iceberg (Mode 2). Never fix an inversion by
+  re-tiering a Now/Focus epic — those are frozen; move the *later* item earlier
+  or re-parent instead.
 
 Procedure:
 

--- a/.agents/skills/calve-epics/SKILL.md
+++ b/.agents/skills/calve-epics/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: calve-epics
+description: >
+  The judgment procedure for shaping the epic roadmap on Project #24 —
+  routing new issues onto the epic that matches them, calving a new epic off
+  an over-accumulated theme, and periodically recrystallizing a muddled epic
+  forest (fusing redundant epics, ejecting cross-grain items, splitting
+  overgrown ones). Owns the glacier/iceberg model and the routing-vs-calving
+  distinction; delegates the mechanics to `create-epic` and
+  `manage-github-issue`. Invoked by `update-plan` (and available to
+  `plan-issue` and `review-priorities`) — not usually run directly.
+---
+
+# Skill: Calve Epics
+
+This skill is the single home for the *judgment* involved in shaping the epic
+roadmap. Other skills call it whenever they need to decide where an issue
+belongs or whether the epic structure itself needs to change. It owns the
+model and the decision rules; it delegates every mechanical mutation to
+`create-epic` (make an epic + wire leaves + schedule) and `manage-github-issue`
+(parent/sub-issue wiring). Keeping the judgment in one place means callers
+never duplicate calving logic.
+
+## How the roadmap actually evolves: the glacier and the icebergs
+
+The project tracks large bodies of related work on Project #24 as **epics**,
+each tagged with a rough horizon — Now, Next, Later, or Someday (with a Focus
+tier for what is actively in flight). Work matures on that board the way ice
+moves through a glacier, and it is worth holding this picture literally rather
+than flattening it into jargon.
+
+Far-out bodies of work behave like **glaciers**. A glacier is a broad,
+still-vague area — "production hardening," "architecture improvements",
+"documentation" — that slowly accumulates related ideas the way a glacier
+accumulates snowfall. New issues drift toward whichever glacier they
+thematically match and pile up there. This accumulation looks like a problem
+— glaciers grow into junk drawers that mix urgent items with things that can
+wait years — but it is the intake mechanism working correctly. The glacier is
+*supposed* to collect loosely-related snowfall; that is its job.
+
+The important, high-skill act is **calving**: recognizing that a region of a
+glacier has accumulated enough coherent mass to break off as an **iceberg** —
+a body of work concrete and self-consistent enough to actually schedule and
+build. The crucial point is that **the line along which a glacier calves is
+drawn by architectural judgment, not by scheduling convenience.** The split
+is not made because a chunk is the right size for a sprint or because a
+deadline looms. It is made because a set of pieces turns out to realize a
+single coherent design idea. Cutting a glacier along a merely convenient line
+— by size, by date, by superficial theme — produces plausible-looking work
+units that are subtly wrong, split across the grain of the actual design.
+
+The metaphor extends, and each extension names a real event: sometimes a new
+idea lands directly on an already-schedulable iceberg rather than on a
+glacier; sometimes two icebergs turn out to belong together and **fuse**;
+sometimes an iceberg accumulates enough new material that it needs to be
+**split** again. All of these are ordinary parts of the process, not signs
+that something has gone wrong.
+
+## Two activities, two levels of judgment
+
+Two distinct activities live inside this picture, and they require very
+different things. **This skill keeps them separate on purpose.**
+
+- **Routing** — when an issue arrives, deciding which glacier or iceberg it
+  belongs to. This is classification against existing categories. It happens
+  frequently and does not require holding the whole design in mind, so an
+  agent may do it (asking a human only when the match is ambiguous).
+
+- **Calving** — deciding *where and when* to break off a schedulable unit, or
+  to fuse, split, or otherwise re-shape epics. This is architectural
+  judgment. It is infrequent, and it cannot be handed to anyone who does not
+  hold the whole design in mind. **The agent may propose a calving line; a
+  human must confirm it before any epic is created, closed, or re-shaped.**
+
+If you remember one rule: **route freely, calve only with a human.**
+
+## Mode 1 — Route an issue onto the forest
+
+Input: one or more leaf issue numbers that currently have no parent (or whose
+parent is wrong). Goal: land each on the epic that matches it.
+
+1. **Load the forest.** List open epics with their Schedule tier (see
+   *Reading the board* below). Read each candidate epic's summary and, when
+   the match is not obvious, its existing children — you are matching against
+   what the epic *is about*, not its title alone.
+
+2. **Match by grain, not by keyword.** Ask which epic's design idea this issue
+   advances. A protocol-correctness bug belongs with protocol correctness even
+   if its title mentions a demo scenario; a prod-only concern belongs with
+   productionization even if it surfaced during demo work.
+
+3. **Decide autonomy by ambiguity:**
+   - **Exactly one clearly-matching epic** → parent it there automatically via
+     `manage-github-issue` (`--sub-issue`). No need to ask.
+   - **Zero plausible epics** → this is a calving signal, not a routing
+     failure. Leave the issue at root and record it as a candidate for Mode 2.
+     Do **not** invent an epic on your own.
+   - **Two or more plausible epics** → ask the user with `AskUserQuestion`,
+     presenting the candidates with a one-line rationale each. Route to their
+     choice.
+
+4. **Inherit the horizon.** A routed issue should adopt its epic's Schedule
+   tier rather than defaulting to Someday, so routing a Next-tier correctness
+   gap onto a Next-tier epic does not silently bury it. Set the issue's
+   Schedule to match its new parent (see *Reading the board*). A true orphan
+   left at root stays Someday.
+
+## Mode 2 — Calve a new iceberg (human-gated)
+
+Trigger: a region of a glacier — or a pile of root-level orphans from Mode 1 —
+has accumulated enough coherent mass to become schedulable, OR routing keeps
+failing because the right home does not exist yet.
+
+1. **Draw the candidate line by design, not size.** Identify the single
+   coherent design idea the pieces realize. Write it as one sentence. If you
+   cannot, you do not have an iceberg yet — say so and stop.
+
+2. **Never cut on convenience.** Do not calve because a set is "about the right
+   size", because a deadline looms, or because several issues share a
+   superficial keyword. Those cuts run across the grain.
+
+3. **Propose, then wait.** Present the proposed iceberg to the user with
+   `AskUserQuestion`: the one-sentence design idea, the leaf issues it would
+   contain, and the Schedule tier you recommend. Ask whether the fracture line
+   is along-grain. **Do not create the epic until the user confirms.**
+
+4. **On confirmation, delegate the mechanics.** Invoke `create-epic` with the
+   agreed title, body (lead with the one-sentence design idea), leaf issue
+   numbers, and Schedule. `create-epic` owns epic-type creation, sub-issue
+   wiring, board placement, and the `needs-decomposition` label — do not
+   reimplement any of that here.
+
+## Mode 3 — Recrystallize a muddled forest (human-gated)
+
+Trigger: run periodically, or when routing repeatedly struggles because the
+epics themselves are muddled — redundant umbrellas, epics mixing prod-only and
+buildable-soon work, grab-bag epics with no coherent identity, or an iceberg
+that has grown two design ideas and needs splitting.
+
+This is an anneal pass over the **not-yet-active** region only. Treat epics at
+Now/Focus as frozen: you may *add* children to them, but do not re-tier or
+re-shape them. Everything at Next/Later/Someday is moldable.
+
+Recognized events (each requires human confirmation before any mutation):
+
+- **Fuse** two epics that are the same glacier split in two: pick one to keep,
+  re-parent the other's children onto it, close the redundant one with a
+  comment pointing to the survivor.
+- **Eject cross-grain material**: move children that flow against an epic's
+  design idea to the epic that matches them (or calve a new one via Mode 2).
+- **Split** an overgrown iceberg that now holds two design ideas into two.
+- **Dissolve a grab-bag**: route each child to a design-coherent home, then
+  close the emptied shell with a comment recording where its children went.
+
+Procedure:
+
+1. Build the current picture: every open epic, its Schedule tier, its parent
+   (sub-epics exist), and its open children. Diagnose where the grain and the
+   current cuts disagree.
+2. Propose the target crystals to the user as a small set of decision forks
+   (`AskUserQuestion`), each naming the design idea of a proposed epic and what
+   moves into it. Confirm tiers explicitly.
+3. On confirmation, execute: create new epics via `create-epic`, re-parent via
+   `manage-github-issue`, close emptied epics with `gh issue close --reason
+   "not planned"` and a comment explaining the consolidation. Verify at the end
+   that no non-epic issue is left orphaned and that the root-epic set reads
+   cleanly.
+
+## Reading the board
+
+Do not hardcode Project #24 field/option IDs — they have drifted from values
+baked into older skills, and a `Focus` tier now exists that older docs omit.
+Query them live.
+
+```bash
+# Project + Schedule field/option IDs (live)
+gh api graphql -f query='
+query($owner:String!){
+  organization(login:$owner){
+    projectV2(number:24){
+      id
+      fields(first:30){ nodes{ ... on ProjectV2SingleSelectField {
+        id name options{ id name } } } }
+    }
+  }
+}' -f owner=CERTCC \
+| jq '{projId: .data.organization.projectV2.id,
+       schedule: (.data.organization.projectV2.fields.nodes[]
+                  | select(.name=="Schedule"))}'
+```
+
+```bash
+# Open epics with their Schedule tier
+gh project item-list 24 --owner CERTCC --format json --limit 300 \
+| jq -r '.items[] | select(.content.type=="Issue")
+         | [( .content.number|tostring), (.schedule // "-"), .content.title]
+         | @tsv'
+# Cross-reference issueType via GraphQL to keep only Epic-type items.
+```
+
+To read an issue's current parent and an epic's open children, use the
+`parent` and `subIssues` fields on the GraphQL `Issue` type.
+
+## Delegation contract
+
+- **This skill decides.** It never contains epic-creation or sub-issue-wiring
+  mechanics of its own.
+- `create-epic` — creates the Epic (correct issue type), wires leaves, places
+  on the board, applies `needs-decomposition`. Call it in Modes 2 and 3.
+- `manage-github-issue` — idempotent parent/sub-issue wiring for existing
+  issues. Call it for all routing and re-parenting.
+- Callers (`update-plan`, `plan-issue`, `review-priorities`) invoke *this*
+  skill for the judgment and let it fan out to the two above.
+
+## Constraints
+
+- Route freely; calve, fuse, split, and dissolve only with human confirmation.
+- Cut by design grain, never by size, date, or superficial theme.
+- Treat Now/Focus epics as frozen: add children only, never re-tier or
+  re-shape them.
+- Do not create an epic when a single coherent design idea cannot be stated in
+  one sentence.
+- Query board field/option IDs live; do not trust hardcoded constants.

--- a/.agents/skills/check-priority-status/REFERENCE.md
+++ b/.agents/skills/check-priority-status/REFERENCE.md
@@ -13,10 +13,11 @@ status check.
 |---|---|
 | Project node ID | `PVT_kwDOAjf0s84BZnre` |
 | Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Schedule: Now | `1e84189c` |
-| Schedule: Next | `9fca00b2` |
-| Schedule: Later | `e2149d3e` |
-| Schedule: Someday | `fcffa79d` |
+| Schedule: Focus | `6bca50d7` |
+| Schedule: Now | `22e6679d` |
+| Schedule: Next | `1c1ed63d` |
+| Schedule: Later | `520032ef` |
+| Schedule: Someday | `a890eacc` |
 
 ## Data Model
 

--- a/.agents/skills/check-priority-status/REFERENCE.md
+++ b/.agents/skills/check-priority-status/REFERENCE.md
@@ -60,6 +60,33 @@ For each issue with a "blocked by" relationship:
 2. If the blocker is **closed**, do not report it as blocking.
 3. If the blocker is **open**, report the dependent issue as blocked.
 
+### Tier-Inversion Detection
+
+Tiers are totally ordered by how soon the work is scheduled:
+
+```text
+Focus (0) < Now (1) < Next (2) < Later (3) < Someday (4)   # unset = 5 (latest)
+```
+
+A `blocked-by` edge means the blocker must be built first, so a healthy edge
+points to the **same tier or an earlier one** (lower or equal rank). A **tier
+inversion** is an open issue `A` with an open blocker `B` where
+`rank(tier(B)) > rank(tier(A))` — the blocker is scheduled strictly later than
+the thing it gates.
+
+For each open board issue with a formal open blocked-by target:
+
+1. Resolve the Schedule tier of both `A` (dependent) and `B` (blocker) from the
+   Project #24 items query (an item off the board, or with tier unset, ranks as
+   the latest = 5).
+2. Compare ranks. If `rank(B) > rank(A)`, record a tier inversion.
+3. Report the delta (e.g., `Now ⟵ Someday` is a 3-tier inversion) so the worst
+   ones sort to the top.
+
+Report-only: the skill surfaces inversions and stops. Resolution (reparent the
+dependent onto the blocker's epic, re-tier one of them, or calve the pair into
+one iceberg) is `calve-epics`' judgment, not this skill's.
+
 ### Coverage Analysis
 
 **Issues not on board**:

--- a/.agents/skills/check-priority-status/SKILL.md
+++ b/.agents/skills/check-priority-status/SKILL.md
@@ -157,6 +157,25 @@ Open PRs awaiting merge for 7+ days.
 
 Issues with explicit "blocked by" relationships that are still open.
 
+#### Tier-Inversion Dependencies
+
+An open issue whose formal **blocked-by** target sits in a *strictly later*
+Schedule tier than the issue itself. Tier order is
+Focus → Now → Next → Later → Someday; a blocker must be built before the thing
+it blocks, so it must sit at the **same tier or earlier**. A Now item blocked by
+a Someday item, or a Focus item blocked by a Next item, runs backwards against
+the schedule. Report each as:
+
+```text
+#<blocked> (<tier>) ⟵ blocked by #<blocker> (<later tier>)
+```
+
+A tier inversion is a **reparenting / calving signal**, not just a scheduling
+nit — it usually means the dependent is parented on the wrong epic, or that the
+dependent and its blocker are one coherent chunk that should calve into a single
+schedulable iceberg. This skill only surfaces the inversion (see the hard stop);
+`calve-epics` decides how to resolve it.
+
 ### Triage Summary
 
 Count of Someday items on board — these need to be scheduled or assigned

--- a/.agents/skills/create-epic/SKILL.md
+++ b/.agents/skills/create-epic/SKILL.md
@@ -47,11 +47,14 @@ If a matching Epic already exists, skip Step 2 and proceed to Step 3.
 
 ### Step 2 — Create the Epic issue via GraphQL
 
-Use the bash helper script in this skill's directory:
+Use the bash helper script in this skill's directory. It creates the Epic
+(with the correct Epic issue type), then adds it to Project #24 and sets its
+Schedule via the shared `add-to-project.sh` helper — so board IDs live in
+exactly one place:
 
 ```bash
 EPIC_NUMBER=$(.agents/skills/create-epic/create_epic.sh \
-  "${EPIC_TITLE}" "${EPIC_BODY}")
+  "${EPIC_TITLE}" "${EPIC_BODY}" "${SCHEDULE:-Someday}")
 echo "Created Epic #${EPIC_NUMBER}"
 ```
 
@@ -68,38 +71,7 @@ of the Epic. All wiring is idempotent — already-linked issues are skipped.
   --sub-issue <LEAF_3>
 ```
 
-### Step 4 — Add Epic to Project #24 with Schedule
-
-```bash
-# Get Epic node ID
-EPIC_NODE_ID=$(gh api graphql -f query='{
-  repository(owner:"CERTCC", name:"Vultron") {
-    issue(number: '"${EPIC_NUMBER}"') { id }
-  }
-}' --jq '.data.repository.issue.id')
-
-# Add to project
-ITEM_ID=$(gh api graphql -f query="mutation {
-  addProjectV2ItemById(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
-    contentId: \"${EPIC_NODE_ID}\"
-  }) { item { id } }
-}" --jq '.data.addProjectV2ItemById.item.id')
-
-# Set Schedule field (Now=22e6679d Next=1c1ed63d Later=520032ef Someday=a890eacc)
-SCHEDULE_ID="a890eacc"  # default: Someday
-gh api graphql -f query="mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
-    itemId: \"${ITEM_ID}\"
-    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
-    value: { singleSelectOptionId: \"${SCHEDULE_ID}\" }
-  }) { projectV2Item { id } }
-}" >/dev/null
-echo "  Added to Project #24 with Schedule=${SCHEDULE}"
-```
-
-### Step 5 — Apply `needs-decomposition` label
+### Step 4 — Apply `needs-decomposition` label
 
 Every newly created Epic starts without sub-issues. Apply the label
 immediately so the project board and `build` can identify it:
@@ -112,7 +84,7 @@ gh issue edit "${EPIC_NUMBER}" --repo CERTCC/Vultron \
 Skip this step if `LEAF_ISSUES` is non-empty (sub-issues were linked in
 Step 3, so the Epic is not empty).
 
-### Step 6 — Return Epic number
+### Step 5 — Return Epic number
 
 ```bash
 echo "${EPIC_NUMBER}"
@@ -130,6 +102,7 @@ echo "${EPIC_NUMBER}"
   ```
 
 - The repo node ID for `CERTCC/Vultron` is `R_kgDOIn77fA`.
-- Project #24 node ID: `PVT_kwDOAjf0s84BZnre`
-- Schedule field ID: `PVTSSF_lADOAjf0s84BZnrezhUlFOM`
-- Schedule option IDs: `Now=22e6679d`, `Next=1c1ed63d`, `Later=520032ef`, `Someday=a890eacc`
+- Board IDs (project node, Schedule field, Schedule option IDs including
+  `Focus`) are **not** duplicated here — they live in one place,
+  `.agents/skills/shared/README.md`, and are applied by
+  `.agents/skills/shared/add-to-project.sh`, which `create_epic.sh` calls.

--- a/.agents/skills/create-epic/SKILL.md
+++ b/.agents/skills/create-epic/SKILL.md
@@ -86,8 +86,8 @@ ITEM_ID=$(gh api graphql -f query="mutation {
   }) { item { id } }
 }" --jq '.data.addProjectV2ItemById.item.id')
 
-# Set Schedule field (Now=1e84189c Next=9fca00b2 Later=e2149d3e Someday=fcffa79d)
-SCHEDULE_ID="fcffa79d"  # default: Someday
+# Set Schedule field (Now=22e6679d Next=1c1ed63d Later=520032ef Someday=a890eacc)
+SCHEDULE_ID="a890eacc"  # default: Someday
 gh api graphql -f query="mutation {
   updateProjectV2ItemFieldValue(input: {
     projectId: \"PVT_kwDOAjf0s84BZnre\"
@@ -132,4 +132,4 @@ echo "${EPIC_NUMBER}"
 - The repo node ID for `CERTCC/Vultron` is `R_kgDOIn77fA`.
 - Project #24 node ID: `PVT_kwDOAjf0s84BZnre`
 - Schedule field ID: `PVTSSF_lADOAjf0s84BZnrezhUlFOM`
-- Schedule option IDs: `Now=1e84189c`, `Next=9fca00b2`, `Later=e2149d3e`, `Someday=fcffa79d`
+- Schedule option IDs: `Now=22e6679d`, `Next=1c1ed63d`, `Later=520032ef`, `Someday=a890eacc`

--- a/.agents/skills/create-epic/create_epic.sh
+++ b/.agents/skills/create-epic/create_epic.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # create_epic.sh — Create a GitHub Epic issue for CERTCC/Vultron
 #
-# Usage: create_epic.sh <title> <body>
+# Usage: create_epic.sh <title> <body> [schedule]
+#   schedule  Focus | Now | Next | Later | Someday (default: Someday)
 #
 # Prints the new issue number on stdout.
 # All other output goes to stderr.
@@ -9,20 +10,19 @@
 # Example:
 #   EPIC_NUM=$(./create_epic.sh \
 #     "Architecture Hardening (Phase 2): Import violations and BT sync" \
-#     "$(cat body.md)")
+#     "$(cat body.md)" Next)
 
 set -euo pipefail
 
-EPIC_TITLE="${1:?Usage: create_epic.sh <title> <body>}"
-EPIC_BODY="${2:?Usage: create_epic.sh <title> <body>}"
+EPIC_TITLE="${1:?Usage: create_epic.sh <title> <body> [schedule]}"
+EPIC_BODY="${2:?Usage: create_epic.sh <title> <body> [schedule]}"
+SCHEDULE="${3:-Someday}"
 
-REPO_OWNER="CERTCC"
-REPO_NAME="Vultron"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADD_TO_PROJECT="${SCRIPT_DIR}/../shared/add-to-project.sh"
+
 REPO_NODE_ID="R_kgDOIn77fA"
 EPIC_TYPE_ID="IT_kwDOAjf0s84B_E1A"
-PROJECT_ID="PVT_kwDOAjf0s84BZnre"
-SCHEDULE_FIELD_ID="PVTSSF_lADOAjf0s84BZnrezhUlFOM"
-SCHEDULE_SOMEDAY="a890eacc"
 
 # JSON-encode title and body for safe GraphQL embedding
 TITLE_JSON=$(printf '%s' "${EPIC_TITLE}" \
@@ -47,33 +47,14 @@ mutation {
 
 EPIC_NUMBER=$(echo "${RESULT}" | python3 -c \
   "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['number'])")
-EPIC_ID=$(echo "${RESULT}" | python3 -c \
-  "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['id'])")
 EPIC_URL=$(echo "${RESULT}" | python3 -c \
   "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['url'])")
 
 echo "  Created Epic #${EPIC_NUMBER}: ${EPIC_URL}" >&2
 
-# Step 2: Add to Project #24 with Schedule=Someday
-ITEM_ID=$(gh api graphql -f query="
-mutation {
-  addProjectV2ItemById(input: {
-    projectId: \"${PROJECT_ID}\"
-    contentId: \"${EPIC_ID}\"
-  }) { item { id } }
-}" --jq '.data.addProjectV2ItemById.item.id')
-
-gh api graphql -f query="
-mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: \"${PROJECT_ID}\"
-    itemId: \"${ITEM_ID}\"
-    fieldId: \"${SCHEDULE_FIELD_ID}\"
-    value: { singleSelectOptionId: \"${SCHEDULE_SOMEDAY}\" }
-  }) { projectV2Item { id } }
-}" >/dev/null
-
-echo "  Added to Project #24 with Schedule=Someday" >&2
+# Step 2: Add to Project #24 and set Schedule via the shared helper, which is
+# the single source of truth for the project/field/option IDs.
+bash "${ADD_TO_PROJECT}" "${EPIC_NUMBER}" "${SCHEDULE}"
 
 # Output only the Epic issue number on stdout so callers can capture it directly
 echo "${EPIC_NUMBER}"

--- a/.agents/skills/create-epic/create_epic.sh
+++ b/.agents/skills/create-epic/create_epic.sh
@@ -22,7 +22,7 @@ REPO_NODE_ID="R_kgDOIn77fA"
 EPIC_TYPE_ID="IT_kwDOAjf0s84B_E1A"
 PROJECT_ID="PVT_kwDOAjf0s84BZnre"
 SCHEDULE_FIELD_ID="PVTSSF_lADOAjf0s84BZnrezhUlFOM"
-SCHEDULE_SOMEDAY="fcffa79d"
+SCHEDULE_SOMEDAY="a890eacc"
 
 # JSON-encode title and body for safe GraphQL embedding
 TITLE_JSON=$(printf '%s' "${EPIC_TITLE}" \

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -271,6 +271,14 @@ Add each new issue to Project #24:
 bash .agents/skills/shared/add-to-project.sh "${IMPL_NUMBER}"
 ```
 
+**Then route it onto the epic forest.** An impl issue wired as a sub-issue of a
+parent Epic (`EPIC_NUMBER` non-empty) is already on the right glacier — leave
+it at its inherited tier. But an impl issue with **no** parent epic should not
+be left flat at Someday: invoke the **`calve-epics`** skill (Mode 1) to route
+it onto the epic it matches, inheriting that epic's Schedule tier. If no epic
+fits, `calve-epics` leaves it at root as a calving candidate — do not mint a
+new epic inline here.
+
 ### Phase 8b — Add Implementation Issue References to Docs PR (Ideas and Concerns only)
 
 After all impl issues are created, edit the PR body to add a forward-tracing
@@ -341,8 +349,10 @@ See the loaded companion file for the type-specific completion step:
 - **Notes file names**: same base name as spec, `.md` in `notes/`
 - **Close behavior**: `Closes #N` in the PR body closes on merge for Ideas
   and Concerns. Epics are never closed by this skill.
-- **Project board**: all new issues added with `Schedule=Someday` via
-  `shared/add-to-project.sh`
+- **Project board**: new issues are added via `shared/add-to-project.sh`, then
+  routed onto the epic forest via `calve-epics` (Mode 1) — inheriting the parent
+  epic's Schedule tier. Only true orphans (no matching epic) stay at
+  `Schedule=Someday` as calving candidates.
 
 ## Relationship to Other Skills
 

--- a/.agents/skills/process-concerns/SKILL.md
+++ b/.agents/skills/process-concerns/SKILL.md
@@ -146,28 +146,14 @@ mutation {
 }")
 ISSUE_NUMBER=$(echo "${RESULT}" | python3 -c \
   "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['number'])")
-ISSUE_NODE_ID=$(echo "${RESULT}" | python3 -c \
-  "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['id'])")
 
 gh issue edit "${ISSUE_NUMBER}" \
   --repo CERTCC/Vultron \
   --add-label "concern"
 
-# Add to Project #24 with Schedule=Someday
-ITEM_ID=$(gh api graphql -f query="mutation {
-  addProjectV2ItemById(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
-    contentId: \"${ISSUE_NODE_ID}\"
-  }) { item { id } }
-}" --jq '.data.addProjectV2ItemById.item.id')
-gh api graphql -f query="mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
-    itemId: \"${ITEM_ID}\"
-    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
-    value: { singleSelectOptionId: \"a890eacc\" }
-  }) { projectV2Item { id } }
-}" >/dev/null
+# Add to Project #24 with Schedule=Someday via the shared helper
+# (single source of truth for board/field/option IDs).
+bash .agents/skills/shared/add-to-project.sh "${ISSUE_NUMBER}" Someday
 
 echo "Created concern issue #${ISSUE_NUMBER}"
 ```

--- a/.agents/skills/process-concerns/SKILL.md
+++ b/.agents/skills/process-concerns/SKILL.md
@@ -165,7 +165,7 @@ gh api graphql -f query="mutation {
     projectId: \"PVT_kwDOAjf0s84BZnre\"
     itemId: \"${ITEM_ID}\"
     fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
-    value: { singleSelectOptionId: \"fcffa79d\" }
+    value: { singleSelectOptionId: \"a890eacc\" }
   }) { projectV2Item { id } }
 }" >/dev/null
 

--- a/.agents/skills/review-priorities/REFERENCE.md
+++ b/.agents/skills/review-priorities/REFERENCE.md
@@ -27,10 +27,11 @@ review-priorities (coordinator)
 |---|---|
 | Project node ID | `PVT_kwDOAjf0s84BZnre` |
 | Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Now option ID | `1e84189c` |
-| Next option ID | `9fca00b2` |
-| Later option ID | `e2149d3e` |
-| Someday option ID | `fcffa79d` |
+| Focus option ID | `6bca50d7` |
+| Now option ID | `22e6679d` |
+| Next option ID | `1c1ed63d` |
+| Later option ID | `520032ef` |
+| Someday option ID | `a890eacc` |
 
 ## Phase 1: Run check-priority-status
 

--- a/.agents/skills/review-priorities/REFERENCE.md
+++ b/.agents/skills/review-priorities/REFERENCE.md
@@ -16,7 +16,7 @@ review-priorities (coordinator)
   ├─ Phase 3: Interactive update loop (ask_user per action)
   │  ├─ Move item between tiers (API mutation)
   │  ├─ Promote triage item (API mutation)
-  │  ├─ Create Epic (invoke create-epic skill)
+  │  ├─ Reshape epic roadmap (invoke calve-epics: route/calve/recrystallize)
   │  └─ Archive Epic (invoke archive-history, close issue)
   └─ Phase 4: Commit if notes/history files changed
 ```
@@ -95,12 +95,14 @@ while True:
 2. Ask which tier to promote to.
 3. Apply the move (same mutation as above).
 
-### Create Epic
+### Reshape the Epic Roadmap
 
-1. Ask for Epic title and description.
-2. Ask which leaf issues to include.
-3. Invoke `create-epic` skill.
-4. Wire sub-issues via `manage-github-issue`.
+1. Invoke the `calve-epics` skill — it owns the route / calve / recrystallize
+   judgment and gates epic creation on human confirmation of the design-grain
+   fracture line.
+2. `calve-epics` delegates the mechanics to `create-epic` (epic creation +
+   sub-issue wiring + board placement) and `manage-github-issue` (re-parenting).
+   Do not invoke `create-epic` directly from this workflow.
 
 ### Archive Completed Epic
 

--- a/.agents/skills/review-priorities/SKILL.md
+++ b/.agents/skills/review-priorities/SKILL.md
@@ -117,10 +117,11 @@ gh api graphql -f query="mutation {
 
 Schedule option IDs:
 
-- Now: `1e84189c`
-- Next: `9fca00b2`
-- Later: `e2149d3e`
-- Someday: `fcffa79d`
+- Focus: `6bca50d7`
+- Now: `22e6679d`
+- Next: `1c1ed63d`
+- Later: `520032ef`
+- Someday: `a890eacc`
 
 ### Create a New Epic
 

--- a/.agents/skills/review-priorities/SKILL.md
+++ b/.agents/skills/review-priorities/SKILL.md
@@ -29,7 +29,7 @@ Run the review-priorities skill. The skill will:
 3. **Offer interactive update options**:
    - Move items between Schedule tiers (Now / Next / Later / Someday)
    - Promote Triage (Someday) items to a schedule tier
-   - Create a new Epic for related leaf issues
+   - Reshape the epic roadmap via `calve-epics` (route / calve / recrystallize)
    - Archive a completed Epic (close issue + log history entry)
    - Skip updates and just review
 4. **Commit** any notes or history changes made (board changes happen live
@@ -83,7 +83,7 @@ After reviewing the status report:
 What would you like to do?
   [A] Move item(s) between Schedule tiers
   [B] Promote Triage items to Now/Next/Later
-  [C] Create a new Epic for uncovered issues
+  [C] Reshape the epic roadmap (route / calve / recrystallize)
   [D] Archive a completed Epic
   [E] No changes, exit
 ```
@@ -123,10 +123,21 @@ Schedule option IDs:
 - Later: `520032ef`
 - Someday: `a890eacc`
 
-### Create a New Epic
+### Reshape the Epic Roadmap
 
-Invoke the `create-epic` skill. Provide title, body, and the list of
-leaf issue numbers to wire as sub-issues.
+Do **not** mint an epic on the spot here. Creating, fusing, splitting, or
+dissolving an epic is *calving* — an architectural act that must be gated on a
+human confirming the design-grain fracture line. Invoke the **`calve-epics`**
+skill, which owns that judgment:
+
+- **Route** uncovered leaf issues onto the epic they match (Mode 1).
+- **Calve** a new epic off an over-accumulated theme, after confirming the
+  one-sentence design idea (Mode 2).
+- **Recrystallize** a muddled forest — fuse redundant epics, eject cross-grain
+  children, split overgrown ones (Mode 3).
+
+`calve-epics` delegates the mechanics to `create-epic` and
+`manage-github-issue`; this skill never mints epics inline.
 
 ### Archive a Completed Epic
 

--- a/.agents/skills/shared/README.md
+++ b/.agents/skills/shared/README.md
@@ -26,10 +26,11 @@ Shared scripts and reference documents referenced by multiple skills.
 | Repo node ID | `R_kgDOIn77fA` |
 | Project #24 ID | `PVT_kwDOAjf0s84BZnre` |
 | Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Schedule: Now | `1e84189c` |
-| Schedule: Next | `9fca00b2` |
-| Schedule: Later | `e2149d3e` |
-| Schedule: Someday | `fcffa79d` |
+| Schedule: Focus | `6bca50d7` |
+| Schedule: Now | `22e6679d` |
+| Schedule: Next | `1c1ed63d` |
+| Schedule: Later | `520032ef` |
+| Schedule: Someday | `a890eacc` |
 | Task issue type ID | `IT_kwDOAjf0s84AcFLo` |
 | Bug issue type ID | `IT_kwDOAjf0s84AcFLq` |
 | Epic issue type ID | `IT_kwDOAjf0s84B_E1A` |

--- a/.agents/skills/shared/add-to-project.sh
+++ b/.agents/skills/shared/add-to-project.sh
@@ -2,7 +2,7 @@
 # add-to-project.sh — add a GitHub issue to Project #24 and set its Schedule.
 # Usage: bash .agents/skills/shared/add-to-project.sh <ISSUE_NUMBER> [SCHEDULE]
 #   ISSUE_NUMBER  GitHub issue number to add
-#   SCHEDULE      Schedule value: Now | Next | Later | Someday (default: Someday)
+#   SCHEDULE      Schedule value: Focus | Now | Next | Later | Someday (default: Someday)
 set -euo pipefail
 
 ISSUE_NUMBER="${1:?Usage: add-to-project.sh <ISSUE_NUMBER> [SCHEDULE]}"
@@ -12,11 +12,12 @@ PROJECT_ID="PVT_kwDOAjf0s84BZnre"
 SCHEDULE_FIELD_ID="PVTSSF_lADOAjf0s84BZnrezhUlFOM"
 
 case "$SCHEDULE" in
+  Focus)   SCHEDULE_OPTION_ID="6bca50d7" ;;
   Now)     SCHEDULE_OPTION_ID="22e6679d" ;;
   Next)    SCHEDULE_OPTION_ID="1c1ed63d" ;;
   Later)   SCHEDULE_OPTION_ID="520032ef" ;;
   Someday) SCHEDULE_OPTION_ID="a890eacc" ;;
-  *) echo "❌ Unknown schedule value: $SCHEDULE (use Now|Next|Later|Someday)" >&2; exit 1 ;;
+  *) echo "❌ Unknown schedule value: $SCHEDULE (use Focus|Now|Next|Later|Someday)" >&2; exit 1 ;;
 esac
 
 NODE_ID=$(gh api graphql -f query='{

--- a/.agents/skills/update-plan/SKILL.md
+++ b/.agents/skills/update-plan/SKILL.md
@@ -27,11 +27,25 @@ to keep open Issues aligned with the codebase.
 1. Invoke `orient-agent` then `deepen-context` to load all specs and context.
 2. Run a gap analysis: compare `specs/` + `notes/` against `vultron/` and
    `test/`.
-3. For each gap, create a GitHub Issue (added to Project #24 with
-   Schedule=Someday) rather than a plan entry.
-4. Write any significant observations or open questions directly to the
+3. For each gap, create a GitHub Issue, then **route it onto the epic it
+   belongs to** via the `calve-epics` skill (rather than dropping it flat at
+   Someday).
+4. Surface any accumulated-mass observations as **calving candidates** for the
+   user; do not re-shape epics on your own.
+5. Write any significant observations or open questions directly to the
    appropriate `notes/*.md` file (not to `plan/incoming/learnings/`).
-5. Invoke `commit`.
+6. Invoke `commit`.
+
+## How the roadmap evolves (the glacier model)
+
+This skill generates *snowfall* — new issues precipitated from gap analysis —
+and then **routes** each onto the glacier or iceberg (epic) it matches.
+Routing is frequent, low-judgment classification and is this skill's job.
+**Calving** — deciding where to break off a new schedulable epic, or to fuse,
+split, or dissolve existing ones — is architectural judgment that requires a
+human. The full model and decision rules live in the **`calve-epics`** skill;
+this skill invokes it rather than duplicating that logic. If you only remember
+one rule: **route freely, calve only with a human.**
 
 ## Workflow
 
@@ -67,7 +81,7 @@ Compare the current `specs/` + `notes/` against `vultron/` and `test/`:
 
 > Do not assume missing functionality; confirm via code search first.
 
-### Phase 3 — Create GitHub Issues for gaps
+### Phase 3a — Create GitHub Issues for gaps, then route them
 
 For each confirmed gap, create a GitHub Issue using the `manage-github-issue`
 skill. If the issue has known blockers at creation time, wire them as
@@ -97,62 +111,42 @@ echo "Created gap issue #${ISSUE_NUMBER}"
 Set the `size:` label from AC count: 1–2 → `size:S`; 3–6 → `size:M`;
 7+ → `size:L`.
 
-Then add the issue to Project #24 with `Schedule=Someday`:
-
-```bash
-NODE_ID=$(gh api graphql -f query='{
-  repository(owner:"CERTCC", name:"Vultron") {
-    issue(number: '"${ISSUE_NUMBER}"') { id }
-  }
-}' --jq '.data.repository.issue.id')
-ITEM_ID=$(gh api graphql -f query="mutation {
-  addProjectV2ItemById(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
-    contentId: \"${NODE_ID}\"
-  }) { item { id } }
-}" --jq '.data.addProjectV2ItemById.item.id')
-gh api graphql -f query="mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
-    itemId: \"${ITEM_ID}\"
-    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
-    value: { singleSelectOptionId: \"fcffa79d\" }
-  }) { projectV2Item { id } }
-}" >/dev/null
-```
-
 Do **not** add tasks to GitHub Issues outside the `manage-github-issue`
 workflow documented above.
 
-**Grouping related gaps (PAD-01-002, PAD-01-003):** When the gap analysis
-identifies **2 or more closely related gaps** in the same spec area (e.g.,
-multiple missing implementations of the same protocol feature), consider
-creating a **parent Task Issue** first, then wire the individual gap Issues
-as sub-issues. Use `manage-github-issue` for both the parent and the
-sub-issue wiring:
+**Then route each new issue onto the forest.** Do not drop new gap issues flat
+at `Schedule=Someday`. Instead, invoke the **`calve-epics`** skill in its
+routing mode to land each issue on the epic (glacier or iceberg) it matches:
 
-```bash
-# 1. Create the parent Task issue with the Task issue type
-PARENT_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
-  --title "<Parent task title>" \
-  --body "<Summary of the related gaps>" \
-  --issue-type-id "IT_kwDOAjf0s84AcFLo" \
-  --label "size:<S|M|L>")
+- The clear-match case is auto-parented onto its epic and inherits that epic's
+  Schedule tier.
+- An ambiguous match (two or more plausible epics) is presented to the user to
+  choose.
+- An issue with **no** plausible epic is left at root with `Schedule=Someday`
+  and recorded as a **calving candidate** for Phase 3b — do not invent an epic
+  for it on your own.
 
-# 2. Create each gap issue and wire as sub-issue of the parent
-CHILD_1=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
-  --title "<Gap 1>" --body "..." \
-  --label "size:S" \
-  --parent "${PARENT_NUMBER}")
+`calve-epics` queries the live Project #24 field/option IDs and delegates the
+board mutations, so this skill no longer hardcodes them.
 
-CHILD_2=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
-  --title "<Gap 2>" --body "..." \
-  --label "size:S" \
-  --parent "${PARENT_NUMBER}")
-```
+### Phase 3b — Flag calving candidates (do not calve on your own)
 
-Only create a parent Task if the gaps are genuinely related and benefit from
-grouping. Independent gaps MUST remain flat leaf Issues.
+The old heuristic — "if 2 or more related gaps, create a parent Task" — cut
+epics on convenience (size and superficial theme) rather than on design grain,
+and is retired. Grouping issues into a new epic is **calving**, an
+architectural act reserved for a human decision.
+
+When routing (3a) surfaces a region that has accumulated coherent mass — a set
+of new gaps that realize one design idea with no existing home, or a pile of
+root-level orphans — collect them and hand them to the user as calving
+candidates via the `calve-epics` skill (Mode 2). State the one-sentence design
+idea, list the issues, and let the user confirm the fracture line before any
+epic is created. Never create the epic unprompted.
+
+If the forest itself looks muddled (redundant epics, an epic mixing prod-only
+and buildable-soon work, a grab-bag with no coherent identity), note it and
+recommend a `calve-epics` recrystallization pass (Mode 3) — do not perform it
+inline as part of gap analysis.
 
 ### Phase 4 — Write Observations to notes/
 
@@ -179,6 +173,8 @@ specific message (e.g.,
 
 ## Project Board
 
-All Issues created by this skill are added to Project #24 ("Vultron Planning")
-with `Schedule=Someday`. Use `review-priorities` to move them to Now/Next/Later
-when they are ready to be scheduled.
+Issues created by this skill are added to Project #24 ("Vultron Planning") and
+routed onto an epic via `calve-epics`, inheriting that epic's Schedule tier.
+Only true orphans (no matching epic) stay at `Schedule=Someday` as calving
+candidates. Use `review-priorities` to re-tier items, and invoke `calve-epics`
+(Mode 2/3) when the epic structure itself needs to change.

--- a/.agents/skills/update-priorities/REFERENCE.md
+++ b/.agents/skills/update-priorities/REFERENCE.md
@@ -58,22 +58,16 @@ gh api graphql -f query="mutation {
 
 ## Adding an Issue to the Board
 
+Add the issue and set its Schedule in one call via the shared helper, which is
+the single source of truth for the project / field / option IDs (accepts
+`Focus | Now | Next | Later | Someday`, default `Someday`):
+
 ```bash
-NODE_ID=$(gh api graphql -f query='{
-  repository(owner:"CERTCC", name:"Vultron") {
-    issue(number: '"${ISSUE_NUMBER}"') { id }
-  }
-}' --jq '.data.repository.issue.id')
-
-ITEM_ID=$(gh api graphql -f query="mutation {
-  addProjectV2ItemById(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
-    contentId: \"${NODE_ID}\"
-  }) { item { id } }
-}" --jq '.data.addProjectV2ItemById.item.id')
-
-# Then set Schedule field as above
+bash .agents/skills/shared/add-to-project.sh "${ISSUE_NUMBER}" "${SCHEDULE:-Someday}"
 ```
+
+Do not re-implement the `addProjectV2ItemById` + set-Schedule mutation inline —
+that inline duplication is exactly how the option IDs drifted stale.
 
 ## Archiving a Completed Epic
 

--- a/.agents/skills/update-priorities/REFERENCE.md
+++ b/.agents/skills/update-priorities/REFERENCE.md
@@ -12,10 +12,11 @@ Technical details for the priority update workflow.
 |---|---|
 | Project node ID | `PVT_kwDOAjf0s84BZnre` |
 | Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Now option ID | `1e84189c` |
-| Next option ID | `9fca00b2` |
-| Later option ID | `e2149d3e` |
-| Someday option ID | `fcffa79d` |
+| Focus option ID | `6bca50d7` |
+| Now option ID | `22e6679d` |
+| Next option ID | `1c1ed63d` |
+| Later option ID | `520032ef` |
+| Someday option ID | `a890eacc` |
 
 ## Querying All Board Items
 

--- a/.agents/skills/update-priorities/SKILL.md
+++ b/.agents/skills/update-priorities/SKILL.md
@@ -79,35 +79,17 @@ The skill will:
 
 ### Add Issue to Board
 
-1. Resolve the issue's node ID:
+Add the issue to Project #24 and set its Schedule in one call via the shared
+helper (single source of truth for board/field/option IDs; accepts
+`Focus | Now | Next | Later | Someday`):
 
-   ```bash
-   NODE_ID=$(gh api graphql -f query='{
-     repository(owner:"CERTCC", name:"Vultron") {
-       issue(number: '"${ISSUE_NUMBER}"') { id }
-     }
-   }' --jq '.data.repository.issue.id')
-   ```
+```bash
+bash .agents/skills/shared/add-to-project.sh "${ISSUE_NUMBER}" "${SCHEDULE:-Someday}"
+```
 
-2. Add to project and set Schedule:
-
-   ```bash
-   ITEM_ID=$(gh api graphql -f query="mutation {
-     addProjectV2ItemById(input: {
-       projectId: \"PVT_kwDOAjf0s84BZnre\"
-       contentId: \"${NODE_ID}\"
-     }) { item { id } }
-   }" --jq '.data.addProjectV2ItemById.item.id')
-
-   gh api graphql -f query="mutation {
-     updateProjectV2ItemFieldValue(input: {
-       projectId: \"PVT_kwDOAjf0s84BZnre\"
-       itemId: \"${ITEM_ID}\"
-       fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
-       value: { singleSelectOptionId: \"a890eacc\" }
-     }) { projectV2Item { id } }
-   }" >/dev/null
-   ```
+To **re-tier an item already on the board**, resolve its existing project item
+ID and set the Schedule field directly (the option IDs are listed in the
+Reference table below and in `.agents/skills/shared/README.md`).
 
 ### Archive a Completed Epic
 

--- a/.agents/skills/update-priorities/SKILL.md
+++ b/.agents/skills/update-priorities/SKILL.md
@@ -35,10 +35,11 @@ The skill will:
 |---|---|
 | Project node ID | `PVT_kwDOAjf0s84BZnre` |
 | Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Now option ID | `1e84189c` |
-| Next option ID | `9fca00b2` |
-| Later option ID | `e2149d3e` |
-| Someday option ID | `fcffa79d` |
+| Focus option ID | `6bca50d7` |
+| Now option ID | `22e6679d` |
+| Next option ID | `1c1ed63d` |
+| Later option ID | `520032ef` |
+| Someday option ID | `a890eacc` |
 
 ## Workflows
 
@@ -103,7 +104,7 @@ The skill will:
        projectId: \"PVT_kwDOAjf0s84BZnre\"
        itemId: \"${ITEM_ID}\"
        fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
-       value: { singleSelectOptionId: \"fcffa79d\" }
+       value: { singleSelectOptionId: \"a890eacc\" }
      }) { projectV2Item { id } }
    }" >/dev/null
    ```


### PR DESCRIPTION
Closes #1799.
Closes #1801.

## Summary

Improves the issue-management skill layer: shared vocabulary and a clear
separation of judgment levels for shaping the epic roadmap on Project #24, a
fix for stale board IDs, and de-duplication of how skills write to the board.

### New skill: `calve-epics`

Single, DRY home for roadmap-shaping judgment, built on the **glacier /
iceberg / snowfall / calving** model. Owns the model and decision rules;
delegates every mechanical mutation to `create-epic` and `manage-github-issue`.

- **Mode 1 — Route:** land an issue on the epic it matches. Auto-parent clear
  matches (inheriting the epic's Schedule tier), ask on ambiguity, leave true
  orphans at root as calving signals.
- **Mode 2 — Calve (human-gated):** propose a fracture line stated as one
  sentence of design idea; create the epic only after the user confirms.
- **Mode 3 — Recrystallize (human-gated):** fuse redundant epics, eject
  cross-grain children, split overgrown icebergs, dissolve grab-bags — with
  Now/Focus treated as frozen.

Board field/option IDs are queried **live** rather than hardcoded.

### `update-plan` refresh

- Adds a glacier-model section pointing at `calve-epics`.
- Splits Phase 3 into **3a Route** (route each new gap issue via `calve-epics`
  instead of dropping it flat at Someday) and **3b Flag calving candidates**.
- Retires the "2+ related gaps → create a parent Task" heuristic, which cut
  epics on convenience (size / superficial theme) rather than design grain.

### Board-ID fix

The Schedule single-select option IDs baked into several skills had drifted
from the live Project #24 values:

| Tier | stale | live |
|---|---|---|
| Now | `1e84189c` | `22e6679d` |
| Next | `9fca00b2` | `1c1ed63d` |
| Later | `e2149d3e` | `520032ef` |
| Someday | `fcffa79d` | `a890eacc` |

Replaced across all skill docs and `create_epic.sh`. Also documents the
**Focus** tier (`6bca50d7`), previously absent from every option-ID table, and
adds a Focus case to `add-to-project.sh`.

### DRY board writes (root-cause fix)

Skills duplicated the add-item + set-Schedule mutations and the ID constants
inline — exactly how the IDs drifted. Routed `create_epic.sh`,
`process-concerns`, and `update-priorities` through the shared
`add-to-project.sh` helper, now the single source of truth. (`new-item`, which
adds without a Schedule, and `update-priorities`' re-tier mutation are left
as-is by design.)

## Motivation

Came out of a live recrystallization pass over the not-yet-active epics
(merging two prod umbrellas, calving a new "Reference-Implementation Fidelity
& Correctness" epic #1794, dissolving grab-bag epics, re-parenting 17 orphaned
issues). That session exposed the missing vocabulary, the stale board IDs, and
the duplication that caused the drift.

## Testing

- `markdownlint-cli2`: 0 issues across all changed docs.
- `bash -n` on `add-to-project.sh` and `create_epic.sh`: pass.
- Stale-ID scan across `.agents/`: clean.
- Live values confirmed against the Project #24 GraphQL API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)