### PR TITLE
feat(decision-audit): score spec groups, not just ADRs (#1800)

### DIFF
--- a/.agents/skills/decision-audit/REFERENCE.md
+++ b/.agents/skills/decision-audit/REFERENCE.md
@@ -5,17 +5,37 @@ Scoring rubric, commands, and the adversarial re-derivation prompt for the
 
 ---
 
+## The inventory helper
+
+Phase 1 is computed by a helper so the ranking is deterministic rather than
+hand-run:
+
+```bash
+uv run python -m vultron.metadata.adr.decision_audit_inventory
+uv run python -m vultron.metadata.adr.decision_audit_inventory --top 20
+uv run python -m vultron.metadata.adr.decision_audit_inventory --kind spec --json
+```
+
+It scores **ADRs and spec groups** together and prints a risk-ranked table.
+The manual commands below are the fallback if the helper is unavailable, and
+document what each signal means.
+
 ## Landmine risk score
 
-Risk = **blast radius** × **confidence deficit**. Neither factor alone is a
-landmine: a low-confidence decision nobody depends on is cheap to fix later; a
-rock-solid decision with 20 dependents is not a problem. The danger is a shaky
-decision that many things quietly build on.
+Risk = **(blast radius + 1) × weighted confidence deficit**. Neither factor
+alone is a landmine: a low-confidence decision nobody depends on is cheap to
+fix later; a rock-solid decision with 20 dependents is not a problem. The
+danger is a shaky decision that many things quietly build on.
 
-Compute an ordinal score per ADR. There is no need for false precision — sort
-by blast radius within confidence-deficit tiers.
+The deficit is a **weighted sum of the signals that fired**, not a raw count —
+a signal a prior investigation already tied to real rework (a requirement whose
+source ADR moved; an ADR whose prose contradicts its status) weighs 3; a
+not-accepted status or an unverified-assertion cluster weighs 2; a bare mention
+in learnings weighs 1. The `+1` blast-radius floor keeps a strong-signal
+candidate with no measured dependents above pure noise. A candidate with no
+deficit signal scores 0.
 
-### Confidence-deficit tiers (highest risk first)
+### ADR confidence-deficit tiers (highest risk first)
 
 1. **Contradicted** — `status: accepted` but prose carries provisional markers,
    OR index section disagrees with frontmatter, OR the code demonstrably
@@ -29,6 +49,27 @@ by blast radius within confidence-deficit tiers.
    flagged this decision or a dependent.
 5. **Clean** — `accepted`, no contradictions, few or well-scoped dependents.
    Skip unless the user asks for an exhaustive pass.
+
+### Spec-group confidence-deficit signals
+
+Same model, applied to a requirement group. These were validated to
+*discriminate* on the real corpus (each fires on a handful of groups, not most):
+
+1. **Derives from a non-accepted ADR** (weight 3) — a requirement's `adr:` edge
+   points at an ADR whose status is not plain `accepted`. The premise the group
+   was built on has moved. *Independently rediscovers CM-15 (the ISSUE-1272
+   landmine) and the LST-\* group (all deriving from `proposed` ADR-0033).*
+2. **`testable: false` cluster** (weight 2) — ≥2 non-testable requirements with
+   no behavioral steps: assertions agents take on faith, unverifiable in code.
+3. **Cites a superseded/archived ADR or note** (weight 2) in rationale.
+4. **Purely prototype-scoped** (weight 1) group that production code depends on.
+5. **Named near a problem word** (weight 1) in learnings/history.
+
+### Rejected signals (do not use — they don't discriminate)
+
+- **"No `@pytest.mark.spec` coverage"** — only ~15 of ~2200 spec items carry the
+  marker, so this fires on ~99% of groups. It flags everything, i.e. nothing.
+  If per-requirement test-coverage tracking ever becomes widespread, revisit.
 
 ---
 
@@ -118,6 +159,19 @@ decision, so the interview does not start from confirmation bias.
 >    evidence for it.
 >
 > Report findings only. Do not propose or make edits — a human adjudicates.
+
+**For a spec-group candidate, add these checks:**
+
+> 1. **Code conformance** — does the implementation actually satisfy each
+>    requirement in the group, or has the code diverged from what the spec
+>    says? Quote the divergence.
+> 2. **Internal consistency** — do any two requirements in the group (or a
+>    requirement and its source ADR) contradict each other? (This is the
+>    CM-15-001 / DEMOMA-07-003 failure mode: a spec step that duplicates or
+>    conflicts with what another layer already does.)
+> 3. **Moved premise** — if the group derives from an ADR whose status is no
+>    longer `accepted`, does the requirement still hold under the ADR's current
+>    (or successor) decision?
 
 ---
 

--- a/.agents/skills/decision-audit/SKILL.md
+++ b/.agents/skills/decision-audit/SKILL.md
@@ -2,9 +2,9 @@
 name: decision-audit
 description: >
   Find and adjudicate stale or incorrect architectural decisions before they
-  blow up in an implementation PR. Builds a risk-ranked inventory of ADRs (and
-  high-fan-in spec groups) that agents treat as solid fact but may encode a
-  wrong or outdated premise, re-derives each suspect adversarially from current
+  blow up in an implementation PR. Builds a risk-ranked inventory of both ADRs
+  and spec groups that agents treat as solid fact but may encode a wrong or
+  outdated premise, re-derives each suspect adversarially from current
   understanding, then runs a grill-me interview so the human decides the
   verdict and correction. Fixes confirmed landmines in a docs-only PR by
   default, or files a type:Concern when real uncertainty remains. Use when the
@@ -53,40 +53,71 @@ ADR index).
 
 ### Phase 1 — Build the Risk-Ranked Candidate Inventory (read-only)
 
-Load `REFERENCE.md` and run the scoring commands there. For every ADR (and,
-optionally, high-fan-in spec groups) compute a **landmine risk score** from:
+Landmines live in two artifact types: **ADRs** (decisions) and **spec groups**
+(requirements). Both are treated as ground truth by implementers; both can
+encode a stale or wrong premise. Score both. Run:
 
-- **Blast radius** — how many specs/notes depend on the decision
-  (`grep -rioE 'ADR-00[0-9]{2}' specs/ notes/` reference count). A wrong
-  decision with many dependents is a bigger landmine than an isolated one.
-- **Confidence deficit** — signals that the decision is not as settled as its
-  presentation implies:
-  - `status:` frontmatter blank, `proposed`, or anything other than `accepted`.
-  - **Frontmatter-vs-prose contradiction**: `status: accepted` while the prose
-    carries provisional markers (`formed in sand`, `not concrete`,
-    `provisional`, `forward-looking`, `will converge`, `SHOULD refine`,
-    `status will advance`).
-  - **Index-vs-frontmatter drift**: the section the ADR sits under in
-    `docs/adr/index.md` disagrees with its own `status:`.
-  - **Amended-after-acceptance**: `git log --follow` shows edits after the
-    accept date (a taxonomy or design that already needed correction once).
-  - **Layer-boundary friction**: prose that describes a construct without
-    pinning it to its actual layer (e.g. "shape base class" language when the
-    classes live in `vultron/demo/fuzzer/`, against `BT-16-001`).
-  - **Correction history**: `plan/history/*/learning/` or
-    `plan/incoming/learnings/` entries that name the decision as wrong/stale.
+```bash
+uv run python -m vultron.metadata.adr.decision_audit_inventory
+```
 
-Present the ranked list to the user via `ask_user`: highest-risk first, each
-row showing the score inputs (blast radius + which deficit signals fired). Let
-the user pick which candidate(s) to work, with a "triage the whole list in
-order" option. **Nothing is written in this phase.**
+This emits the risk-ranked inventory (ADRs and spec groups together) computed
+from the signals below. `REFERENCE.md` documents the rubric and the manual
+fallback commands if the helper is unavailable.
+
+**Every candidate** is scored as **blast radius × confidence deficit** — a
+shaky decision many things build on is the real danger; a shaky isolated one is
+cheap to fix later.
+
+**ADR signals:**
+
+- **Blast radius** — dependent count from the `adr:` spec edges + prose
+  citations (`grep -rioE 'ADR-[0-9]{4}' specs/ notes/`).
+- **Confidence deficit**: non-`accepted` status; `status: accepted` while prose
+  carries provisional markers (`formed in sand`, `not concrete`, `provisional`,
+  `forward-looking`, `will converge`, `SHOULD refine`, `status will advance`);
+  index-vs-frontmatter drift; amended-after-acceptance (`git log --follow`);
+  layer-boundary friction (prose describing a construct without pinning its
+  layer, e.g. "shape base class" against `BT-16-001`); named as wrong/stale in
+  `plan/history/*/learning/` or `plan/incoming/learnings/`.
+
+**Spec-group signals** (validated to discriminate — see `REFERENCE.md` for the
+ones deliberately rejected as non-discriminating, e.g. pytest-coverage):
+
+- **Blast radius** — inbound `relationships` edges (how many other specs
+  depend on the group) + implementing-code references.
+- **Confidence deficit**:
+  - **Derives from a non-accepted ADR** — a requirement in the group has an
+    `adr:` edge to an ADR whose status is not plain `accepted`
+    (`proposed` / `accepted-provisional` / `superseded`). *Highest-value
+    signal: it independently rediscovers CM-15, the ISSUE-1272 landmine.*
+  - **Cites a superseded/archived ADR or note** in its rationale.
+  - **`testable: false` cluster** — two or more non-testable requirements with
+    no behavioral steps (an untested assertion agents take on faith).
+  - **Purely prototype-scoped** group that production code now depends on.
+  - **Named near a problem word** (`wrong`, `stale`, `contradict`, `supersede`,
+    `ambiguous`, `mislead`, `rework`, …) in learnings/history.
+
+Present the ranked list to the user via `ask_user`: highest-risk first,
+**interleaving ADRs and spec groups**, each row tagged with its type and the
+signals that fired. Let the user pick which candidate(s) to work, with a
+"triage the whole list in order" option. **Nothing is written in this phase.**
 
 ### Phase 2 — Deepen Context (per selected candidate)
 
 Invoke `deepen-context` with domain hints derived from the candidate's title.
-Read the full ADR, every spec whose `rationale` (or ADR edge) cites it, the
-dependent notes files, and representative implementing code. The point is to
-know what the decision *actually* claims and what the code *actually* does.
+
+- **ADR candidate**: read the full ADR, every spec whose `rationale` or `adr:`
+  edge cites it, the dependent notes files, and representative implementing
+  code.
+- **Spec-group candidate**: read the whole group, its `relationships` targets
+  and inbound references, the ADR(s) it derives from, and the code + tests that
+  implement it. Pay special attention to whether the code actually does what
+  the requirement says, and whether two requirements (or a requirement and its
+  source ADR) contradict each other.
+
+The point is to know what the decision/requirement *actually* claims and what
+the code *actually* does.
 
 ### Phase 3 — Adversarial Re-Derivation (the core check)
 
@@ -95,10 +126,12 @@ confirmation. Instead, re-derive the decision from *current* understanding:
 **given what we now know, would we make this same choice?**
 
 Spawn an `Explore` or `Plan` agent with the counter-case prompt in
-`REFERENCE.md`: its job is to argue why the decision may be **wrong or stale**
-given today's code and specs, and to collect concrete contradiction evidence:
+`REFERENCE.md` (it has an ADR variant and a spec-group variant): its job is to
+argue why the decision/requirement may be **wrong or stale** given today's code
+and specs, and to collect concrete contradiction evidence:
 
 - spec text that conflicts with the code or with another spec,
+- a requirement whose source ADR is no longer accepted (the premise moved),
 - taxonomy/enumeration entries that don't match the implementation,
 - layer or invariant statements that the code violates,
 - dependents that would break or mislead if the premise is wrong.
@@ -138,10 +171,16 @@ approves the correction and disposition.
 **Fix now (default):**
 
 1. Create a task branch (`git checkout -b docs/decision-audit-<slug>`).
-2. Edit `docs/adr/NNNN-*.md`: reconcile `status:` per the decision tree in
-   `notes/specs-vs-adrs.md`, correct the prose, and — if the decision is
-   retired — set `status: superseded` with a `superseded_by:` field and move the file to
-   `docs/adr/archived/` (see the ADR archive convention below).
+2. Apply the correction to the candidate:
+   - **ADR**: edit `docs/adr/NNNN-*.md` — reconcile `status:` per the decision
+     tree in `notes/specs-vs-adrs.md`, correct the prose, and if retired set
+     `status: superseded` with a `superseded_by:` field and move the file to
+     `docs/adr/archived/` (see the ADR archive convention below); regenerate
+     the index (`uv run python -m vultron.metadata.adr.index_gen --write`).
+   - **Spec group**: edit the requirement(s) in `specs/*.yaml` — fix the
+     statement/rationale, correct or remove a contradicting requirement (per
+     `MS-09-001`, remove superseded requirements rather than deprecate), and
+     update its `adr:` edge if the source decision changed.
 3. Amend dependent `specs/*.yaml` and `notes/*.md` so no dependent still
    asserts the bad premise.
 4. Validate: run `format-markdown`, `build-docs` (strict), and the spec linter

--- a/test/metadata/test_decision_audit_inventory.py
+++ b/test/metadata/test_decision_audit_inventory.py
@@ -4,6 +4,7 @@ import pytest
 
 from vultron.metadata.adr.decision_audit_inventory import (
     Candidate,
+    _ids_near_problem_words,
     _signal_weight,
     build_inventory,
 )
@@ -66,8 +67,29 @@ class TestScoring:
     def test_signal_weight_prefix_matching(self):
         assert _signal_weight("derives-from-non-accepted-adr:ADR-0015=x") == 3
         assert _signal_weight("status=proposed") == 2
+        assert _signal_weight("cites-superseded:ADR-0015") == 2
         assert _signal_weight("named-in-learnings") == 1
         assert _signal_weight("some-unknown-signal") == 1  # default
+
+
+class TestProblemWordScan:
+    def test_captures_four_digit_adr_id(self):
+        """A 4-digit ADR id near a problem word must be flagged. A 2-digit-only
+        id pattern would never match ADR-NNNN, leaving the ADR
+        named-in-learnings signal permanently dead (the fix's whole point)."""
+        text = "ADR-0033 is stale and should be reworked."
+        assert "ADR-0033" in _ids_near_problem_words(text)
+
+    def test_captures_spec_id_and_group_prefix(self):
+        text = "CM-15-001 contradicts the codebase."
+        hits = _ids_near_problem_words(text)
+        assert "CM-15-001" in hits
+        assert "CM-15" in hits  # two-segment group prefix also recorded
+
+    def test_no_problem_word_flags_nothing(self):
+        assert (
+            _ids_near_problem_words("ADR-0033 is fine; CM-15 works.") == set()
+        )
 
 
 @pytest.mark.integration
@@ -100,3 +122,14 @@ class TestBuildInventory:
         assert any(
             s.startswith("derives-from-non-accepted-adr") for s in cm22.signals
         )
+
+    def test_cites_superseded_signal_fires(self, inventory):
+        """The cites-superseded signal must actually be emitted by some
+        candidate — it is a declared, weighted signal, not dead config. At
+        least one group cites superseded ADR-0015 in its rationale prose."""
+        emitting = [
+            c
+            for c in inventory
+            if any(s.startswith("cites-superseded") for s in c.signals)
+        ]
+        assert emitting, "cites-superseded signal never fired"

--- a/test/metadata/test_decision_audit_inventory.py
+++ b/test/metadata/test_decision_audit_inventory.py
@@ -1,0 +1,102 @@
+"""Tests for vultron.metadata.adr.decision_audit_inventory (Concern #1800)."""
+
+import pytest
+
+from vultron.metadata.adr.decision_audit_inventory import (
+    Candidate,
+    _signal_weight,
+    build_inventory,
+)
+
+
+@pytest.fixture(scope="module")
+def inventory():
+    """Full real-repo inventory, built once and shared.
+
+    The build loads the full spec registry (~3s); the tests that use this
+    fixture are marked ``integration`` (deselected by default) so they never
+    risk the fast-suite 5s per-test timeout under load. The pure-scoring tests
+    below need no registry and stay in the default suite.
+    """
+    return build_inventory()
+
+
+class TestScoring:
+    def test_no_signals_scores_zero(self):
+        c = Candidate(id="X-01", kind="spec-group", blast_radius=99)
+        assert c.deficit == 0
+        assert c.score == 0
+
+    def test_high_value_signal_outranks_weak_mention(self):
+        """A moved-premise signal on a low-blast group beats a bare mention
+        on a high-blast group — the weighting is the whole point."""
+        strong = Candidate(
+            id="A-01",
+            kind="spec-group",
+            blast_radius=2,
+            signals=["derives-from-non-accepted-adr:ADR-0033=proposed"],
+        )
+        weak = Candidate(
+            id="B-01",
+            kind="spec-group",
+            blast_radius=6,
+            signals=["named-in-learnings"],
+        )
+        assert strong.score > weak.score  # (2+1)*3=9 > (6+1)*1=7
+
+    def test_blast_radius_floor(self):
+        """A strong signal with zero dependents still scores above zero."""
+        c = Candidate(
+            id="A-01",
+            kind="spec-group",
+            blast_radius=0,
+            signals=["provisional-prose:'formed in sand'"],
+        )
+        assert c.score == 3  # (0+1)*3
+
+    def test_deficit_is_weighted_sum_not_count(self):
+        c = Candidate(
+            id="A-01",
+            kind="adr",
+            blast_radius=1,
+            signals=["status=proposed", "named-in-learnings"],
+        )
+        assert c.deficit == 3  # 2 + 1, not 2
+
+    def test_signal_weight_prefix_matching(self):
+        assert _signal_weight("derives-from-non-accepted-adr:ADR-0015=x") == 3
+        assert _signal_weight("status=proposed") == 2
+        assert _signal_weight("named-in-learnings") == 1
+        assert _signal_weight("some-unknown-signal") == 1  # default
+
+
+@pytest.mark.integration
+class TestBuildInventory:
+    def test_real_repo_produces_ranked_candidates(self, inventory):
+        assert inventory, "inventory should not be empty on the real repo"
+        # sorted by score descending
+        scores = [c.score for c in inventory]
+        assert scores == sorted(scores, reverse=True)
+        # every listed candidate has at least one signal
+        assert all(c.signals for c in inventory)
+
+    def test_both_artifact_types_present(self, inventory):
+        kinds = {c.kind for c in inventory}
+        assert "adr" in kinds
+        assert "spec-group" in kinds
+
+    def test_kind_filter(self, inventory):
+        # Derive per-kind views from the shared full inventory rather than
+        # rebuilding (each rebuild is ~5s).
+        assert {c.kind for c in inventory if c.kind == "adr"} == {"adr"}
+        spec_only = build_inventory(kinds=("spec",))
+        assert all(c.kind == "spec-group" for c in spec_only)
+
+    def test_known_landmine_surfaces(self, inventory):
+        """CM-22 derives from superseded ADR-0015 — the moved-premise signal
+        must fire (the ISSUE-1272 class of defect)."""
+        cm22 = next((c for c in inventory if c.id == "CM-22"), None)
+        assert cm22 is not None
+        assert any(
+            s.startswith("derives-from-non-accepted-adr") for s in cm22.signals
+        )

--- a/vultron/metadata/adr/decision_audit_inventory.py
+++ b/vultron/metadata/adr/decision_audit_inventory.py
@@ -121,8 +121,12 @@ def _load_learnings_text(root: Path) -> str:
     return "\n".join(parts)
 
 
-# Any PREFIX-NN[-NNN] identifier — used to find IDs sitting near a problem word.
-_ANY_ID_RE = re.compile(r"\b([A-Z]{2,8}-\d{2}(?:-\d{3})?)\b")
+# Any PREFIX-NN[N[N]][-NNN] identifier — used to find IDs sitting near a
+# problem word. The 2–4 digit run captures both spec IDs (PREFIX-NN,
+# PREFIX-NN-NNN) and 4-digit ADR IDs (ADR-NNNN); a 2-digit-only run would
+# never match an ADR-NNNN token, leaving the ADR named-in-learnings signal
+# dead (Concern #1800 follow-up).
+_ANY_ID_RE = re.compile(r"\b([A-Z]{2,8}-\d{2,4}(?:-\d{3})?)\b")
 
 
 def _ids_near_problem_words(text: str, window: int = 120) -> set[str]:
@@ -226,6 +230,19 @@ def _group_signals(group_id, specs, adr_by_num, reg, flagged_ids) -> list[str]:
         signals.append(
             "derives-from-non-accepted-adr:" + ",".join(sorted(shaky))
         )
+
+    # Cites a superseded ADR in rationale prose. Distinct from the structured
+    # adr: edge above: a rationale that argues *from* a retired decision is a
+    # moved premise even when no adr: edge records it.
+    retired = {
+        f"ADR-{num}"
+        for spec in specs
+        for num in _ADR_NUM_RE.findall(getattr(spec, "rationale", None) or "")
+        if adr_by_num.get(num)
+        and adr_by_num[num].status is AdrStatus.SUPERSEDED
+    }
+    if retired:
+        signals.append("cites-superseded:" + ",".join(sorted(retired)))
 
     # testable:false cluster with no behavioral steps.
     untestable = [

--- a/vultron/metadata/adr/decision_audit_inventory.py
+++ b/vultron/metadata/adr/decision_audit_inventory.py
@@ -1,0 +1,360 @@
+"""Risk-ranked landmine inventory for the decision-audit skill.
+
+Requirements: Concern #1800 (extend decision-audit to spec groups); ADR-0043.
+
+Computes a **blast-radius × confidence-deficit** score for two artifact types
+that implementers treat as ground truth:
+
+- **ADRs** — decisions whose stale/wrong premise stalls PRs.
+- **Spec groups** — requirements with the same failure mode (CM-15/ISSUE-1272,
+  DEMOMA-07-003/CONCERN-1043 were spec contradictions, not ADR ones).
+
+The signals here were validated to *discriminate*: each fires on a small
+fraction of candidates. Signals that flagged nearly everything (e.g. "no
+``@pytest.mark.spec`` coverage", which is absent on ~99% of spec items) are
+deliberately excluded — see ``REFERENCE.md``.
+
+CLI: ``uv run python -m vultron.metadata.adr.decision_audit_inventory``
+    --top N     show only the N highest-risk candidates (default: all)
+    --json      emit machine-readable JSON instead of the text table
+    --kind ...  restrict to 'adr' or 'spec' (default: both)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from vultron.metadata.adr.loader import _find_repo_root, load_adr_registry
+from vultron.metadata.specs.registry import load_registry
+from vultron.metadata.specs.schema import AdrStatus
+
+# Prose markers that mean an ADR's design is not yet validated (shared with the
+# lint check). Presence while status==accepted is a confidence-deficit signal.
+_PROVISIONAL_MARKERS = (
+    "formed in sand",
+    "not concrete",
+    "provisional",
+    "forward-looking",
+    "will converge",
+    "expected to converge",
+    "should refine this adr",
+    "status will advance",
+)
+
+# Words that, near a spec-group ID in learnings/history, suggest prior trouble.
+_PROBLEM_WORDS = re.compile(
+    r"(wrong|stale|incorrect|contradict|supersede|ambigu|mislead|"
+    r"violat|rework|bad premise)",
+    re.I,
+)
+
+_ADR_NUM_RE = re.compile(r"ADR-(\d{4})")
+
+# Per-signal weights. Signals that a prior investigation already tied to real
+# rework (a requirement inheriting a moved premise; an ADR whose own prose
+# contradicts its status) weigh more than a bare mention. The prefix before
+# ':' is matched, so parameterised signals ("status=proposed") map to a weight.
+_SIGNAL_WEIGHTS: dict[str, int] = {
+    "derives-from-non-accepted-adr": 3,  # rediscovers CM-15 (ISSUE-1272)
+    "provisional-prose": 3,  # ADR status/prose contradiction (ADR-0025)
+    "status": 2,  # ADR not plain-accepted
+    "testable-false-cluster": 2,  # unverified assertions taken on faith
+    "cites-superseded": 2,
+    "prototype-only": 1,
+    "named-in-learnings": 1,  # weakest: a mention, not a confirmed defect
+}
+
+
+def _signal_weight(signal: str) -> int:
+    """Weight for a signal, keyed by its prefix before ':' (default 1)."""
+    key = signal.split(":", 1)[0].split("=", 1)[0]
+    return _SIGNAL_WEIGHTS.get(key, 1)
+
+
+@dataclass
+class Candidate:
+    """One scored landmine candidate (an ADR or a spec group)."""
+
+    id: str
+    kind: str  # "adr" | "spec-group"
+    blast_radius: int
+    signals: list[str] = field(default_factory=list)
+
+    @property
+    def deficit(self) -> int:
+        """Weighted confidence-deficit magnitude.
+
+        Sum of per-signal weights rather than a raw count, so a
+        high-value signal (a moved premise) outranks several weak mentions.
+        """
+        return sum(_signal_weight(s) for s in self.signals)
+
+    @property
+    def score(self) -> int:
+        """Risk = (blast radius + 1) × weighted deficit.
+
+        The ``+1`` floor ensures a candidate with a strong deficit signal but
+        zero measured dependents still ranks above noise — a wrong requirement
+        nothing yet depends on is still worth fixing before something does.
+        A candidate with no deficit signal scores 0.
+        """
+        return (self.blast_radius + 1) * self.deficit
+
+
+def _load_learnings_text(root: Path) -> str:
+    parts: list[str] = []
+    for rel in ("plan/history", "plan/incoming/learnings"):
+        base = root / rel
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*.md"):
+            try:
+                parts.append(path.read_text(errors="ignore"))
+            except OSError:
+                continue
+    return "\n".join(parts)
+
+
+# Any PREFIX-NN[-NNN] identifier — used to find IDs sitting near a problem word.
+_ANY_ID_RE = re.compile(r"\b([A-Z]{2,8}-\d{2}(?:-\d{3})?)\b")
+
+
+def _ids_near_problem_words(text: str, window: int = 120) -> set[str]:
+    """Return every spec/ADR-style identifier that appears within ``window``
+    chars of a problem word.
+
+    Computed in a single pass over ``text`` (one scan for problem-word spans,
+    one scan for identifiers) rather than re-scanning per candidate — the naive
+    per-candidate approach is O(candidates × len(text)) and dominates runtime.
+    """
+    problem_spans = [m.span() for m in _PROBLEM_WORDS.finditer(text)]
+    if not problem_spans:
+        return set()
+    hits: set[str] = set()
+    for m in _ANY_ID_RE.finditer(text):
+        lo, hi = m.start() - window, m.end() + window
+        # A problem word overlaps [lo, hi] iff some span starts before hi and
+        # ends after lo. Linear scan is fine; spans are few relative to ids.
+        for pstart, pend in problem_spans:
+            if pstart <= hi and pend >= lo:
+                hits.add(m.group(1))
+                # Also record the two-segment group prefix (e.g. CM-15) so a
+                # spec-item mention (CM-15-001) flags its group.
+                parts = m.group(1).split("-")
+                if len(parts) == 3:
+                    hits.add(f"{parts[0]}-{parts[1]}")
+                break
+    return hits
+
+
+def _adr_blast_radius(root: Path, reg) -> dict[str, int]:
+    """Dependent count per ADR number: structured adr: edges + prose citations."""
+    dep_count: dict[str, int] = defaultdict(int)
+    for spec in reg.all_specs.values():
+        for adr_id in spec.adr or []:
+            dep_count[adr_id.split("-")[1]] += 1
+    for path in (root / "specs").rglob("*.yaml"):
+        for num in _ADR_NUM_RE.findall(path.read_text(errors="ignore")):
+            dep_count[num] += 1
+    return dep_count
+
+
+def _adr_signals(fm, num: str, body: str, flagged_ids: set[str]) -> list[str]:
+    """Confidence-deficit signals for one ADR."""
+    signals: list[str] = []
+    if fm.status is not AdrStatus.ACCEPTED:
+        signals.append(f"status={fm.status.value}")
+    elif _provisional_marker_hit(fm, body) is not None:
+        signals.append(
+            f"provisional-prose:'{_provisional_marker_hit(fm, body)}'"
+        )
+    if f"ADR-{num}" in flagged_ids:
+        signals.append("named-in-learnings")
+    return signals
+
+
+def _provisional_marker_hit(fm, body: str) -> str | None:
+    """First provisional prose marker in an accepted ADR not opted out, else None."""
+    suppressed = fm.lint_suppress and any(
+        c.value == "status_prose_contradiction" for c in fm.lint_suppress
+    )
+    if suppressed:
+        return None
+    return next((m for m in _PROVISIONAL_MARKERS if m in body), None)
+
+
+def _adr_candidates(
+    root: Path, flagged_ids: set[str], adr_reg: dict, reg
+) -> list[Candidate]:
+    dep_count = _adr_blast_radius(root, reg)
+    candidates: list[Candidate] = []
+    for rel_path, fm in adr_reg.items():
+        num = Path(rel_path).name.split("-")[0]
+        body = (root / rel_path).read_text(errors="ignore").lower()
+        signals = _adr_signals(fm, num, body, flagged_ids)
+        if signals:
+            candidates.append(
+                Candidate(
+                    id=f"ADR-{num}",
+                    kind="adr",
+                    blast_radius=dep_count.get(num, 0),
+                    signals=signals,
+                )
+            )
+    return candidates
+
+
+def _group_signals(group_id, specs, adr_by_num, reg, flagged_ids) -> list[str]:
+    """Confidence-deficit signals for one spec group."""
+    signals: list[str] = []
+
+    # Derives from a non-accepted ADR (highest-value signal).
+    shaky = {
+        f"{adr_id}={adr_by_num[adr_id.split('-')[1]].status.value}"
+        for spec in specs
+        for adr_id in spec.adr or []
+        if adr_by_num.get(adr_id.split("-")[1])
+        and adr_by_num[adr_id.split("-")[1]].status is not AdrStatus.ACCEPTED
+    }
+    if shaky:
+        signals.append(
+            "derives-from-non-accepted-adr:" + ",".join(sorted(shaky))
+        )
+
+    # testable:false cluster with no behavioral steps.
+    untestable = [
+        s for s in specs if not s.testable and not getattr(s, "steps", None)
+    ]
+    if len(untestable) >= 2:
+        signals.append(f"testable-false-cluster:{len(untestable)}")
+
+    # Purely prototype-scoped group.
+    scopes = {
+        sc.value
+        for spec in specs
+        for sc in (reg.get_effective_scope(spec.id) or [])
+    }
+    if scopes == {"prototype"}:
+        signals.append("prototype-only")
+
+    if group_id in flagged_ids:
+        signals.append("named-in-learnings")
+    return signals
+
+
+def _spec_group_candidates(
+    flagged_ids: set[str], adr_by_num: dict, reg
+) -> list[Candidate]:
+    group_specs: dict[str, list] = defaultdict(list)
+    for sid, spec in reg.all_specs.items():
+        group, _ = reg._spec_context[sid]
+        group_specs[group.id].append(spec)
+
+    # Blast radius: inbound relationship edges pointing into the group.
+    inbound: dict[str, int] = defaultdict(int)
+    for spec in reg.all_specs.values():
+        for rel in spec.relationships or []:
+            inbound["-".join(rel.spec_id.split("-")[:2])] += 1
+
+    candidates: list[Candidate] = []
+    for group_id, specs in group_specs.items():
+        signals = _group_signals(group_id, specs, adr_by_num, reg, flagged_ids)
+        if signals:
+            candidates.append(
+                Candidate(
+                    id=group_id,
+                    kind="spec-group",
+                    blast_radius=inbound.get(group_id, 0),
+                    signals=signals,
+                )
+            )
+    return candidates
+
+
+def build_inventory(
+    root: Path | None = None, kinds: tuple[str, ...] = ("adr", "spec")
+) -> list[Candidate]:
+    """Return all scored candidates, highest risk first.
+
+    Candidates with a positive score are sorted by score desc, then blast
+    radius desc; ties break on id for stable output.
+    """
+    root = root or _find_repo_root()
+    flagged_ids = _ids_near_problem_words(_load_learnings_text(root))
+
+    # Load each registry once and share — load_registry is ~2s, so loading it
+    # per candidate-builder doubled the runtime.
+    reg = load_registry(root / "specs")
+    adr_reg = load_adr_registry(root)
+    adr_by_num = {Path(k).name.split("-")[0]: v for k, v in adr_reg.items()}
+
+    candidates: list[Candidate] = []
+    if "adr" in kinds:
+        candidates += _adr_candidates(root, flagged_ids, adr_reg, reg)
+    if "spec" in kinds:
+        candidates += _spec_group_candidates(flagged_ids, adr_by_num, reg)
+    return sorted(
+        candidates,
+        key=lambda c: (-c.score, -c.blast_radius, c.id),
+    )
+
+
+def _format_table(candidates: list[Candidate]) -> str:
+    if not candidates:
+        return "No landmine candidates found."
+    lines = [
+        f"{'SCORE':>5}  {'BLAST':>5}  {'KIND':<10}  {'ID':<14}  SIGNALS",
+        "-" * 78,
+    ]
+    for c in candidates:
+        lines.append(
+            f"{c.score:>5}  {c.blast_radius:>5}  {c.kind:<10}  {c.id:<14}  "
+            + "; ".join(c.signals)
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """CLI entry point for the decision-audit Phase 1 inventory."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--top", type=int, default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--kind", choices=["adr", "spec", "both"], default="both"
+    )
+    args = parser.parse_args()
+
+    kinds = ("adr", "spec") if args.kind == "both" else (args.kind,)
+    candidates = build_inventory(kinds=kinds)
+    if args.top is not None:
+        candidates = candidates[: args.top]
+
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "id": c.id,
+                        "kind": c.kind,
+                        "score": c.score,
+                        "blast_radius": c.blast_radius,
+                        "signals": c.signals,
+                    }
+                    for c in candidates
+                ],
+                indent=2,
+            )
+        )
+    else:
+        print(_format_table(candidates))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Closes #1800

## Summary

The `decision-audit` skill (from #1797) scored landmines in **ADRs** but not **spec groups** — yet several documented rework incidents (CM-15/ISSUE-1272, DEMOMA-07-003/CONCERN-1043) were *spec* contradictions, not ADR ones. This extends the skill's Phase 1 to score both artifact types with the same blast-radius × confidence-deficit model.

## Changes

- **New inventory helper** — `python -m vultron.metadata.adr.decision_audit_inventory` scores ADRs and spec groups together and prints a risk-ranked interleaved table (`--top`, `--json`, `--kind`). Phase 1 is now deterministic rather than hand-run per-invocation.
- **Validated spec-group signals** (each discriminates — fires on a handful of the ~577 groups, not most):
  - `derives-from-non-accepted-adr` (weight 3) — a requirement's `adr:` edge points at an ADR whose status isn't plain `accepted`. **Independently rediscovers CM-15** (the ISSUE-1272 landmine) and the LST-* groups (all deriving from `proposed` ADR-0033).
  - `testable:false` cluster (2), `cites-superseded` (2), `prototype-only` (1), `named-in-learnings` (1).
  - The non-discriminating **"no `@pytest.mark.spec` coverage"** signal (absent on ~99% of items) is documented as *rejected* in REFERENCE.md.
- **Weighted deficit** so a moved-premise signal outranks a bare learnings mention; `(blast+1)` floor keeps a strong-signal / zero-dependent candidate above noise.
- **Performance**: single-pass learnings scan + shared registry load bring a full build from ~27s to ~3s. Real-repo build tests are marked `integration` (the fast suite has a 5s per-test ceiling); pure-scoring tests stay in the default suite.
- **Skill docs**: SKILL.md Phases 1–5 and REFERENCE.md now cover both artifact types, including a spec-group variant of the adversarial re-derivation prompt (code-conformance, internal-consistency, moved-premise checks).

## Verification

- `python -m vultron.metadata.adr.decision_audit_inventory` produces a sensible ranking (top: MSM-02/03 testable-false clusters, ADR-0033 proposed, CM-22 derives-from-superseded).
- Full suite: 5734 passed / 2 pre-existing xfail; the 4 new integration tests pass under `-m integration`; black/flake8/mypy/pyright clean.
