### PR TITLE
docs: plan issue #1247 — create_develop_fix_tree factory function

### DIFF
--- a/plan/history/2607/idea/IDEA-1247.md
+++ b/plan/history/2607/idea/IDEA-1247.md
@@ -1,0 +1,33 @@
+---
+source: IDEA-1247
+timestamp: '2026-07-29T17:28:41.890804+00:00'
+title: 'create_develop_fix_tree: factory function for fix development BT'
+type: idea
+---
+
+Add a `create_develop_fix_tree` factory function in
+`vultron/core/behaviors/report/` that composes the fix development workflow
+as a production BT subtree.
+
+The tree mirrors the `DevelopFix` fallback structure from the legacy simulator
+(`vultron/bt/report_management/_behaviors/develop_fix.py`) with full
+production-layer guard/action nodes: `CheckIsVendorRoleNode`,
+`CheckCSFixNotYetReady`, `CheckRMStateAccepted`, `TransitionCStoFixReady`,
+and `EmitCFActivity`. Only actors holding `CVDRole.VENDOR` in the case
+activate the tree; non-vendor actors and already-fix-ready cases short-circuit.
+
+The single call-out point is `CreateFix` (Composer shape, p=0.90,
+`output_keys = {"fix_artifact": str}`), injected via `DevelopFixCallOutBundle`
+per ADR-0025 / BT-18-004.
+
+Key planning decisions:
+
+- Full fallback scope (not Phase 1 stub) — resolves runtime gating question
+  via `CheckIsVendorRoleNode` reading `CaseParticipant.case_roles`.
+- No new ADR — ADR-0025 fully covers the pattern applied here.
+- No new spec or notes file — BT-18 and BT-23 already cover all normative
+  requirements; `notes/call-out-configuration.md` covers the bundle pattern.
+- Peer Concern #1813 created for `deploy_fix_tree.py` Phase 1 stub's
+  missing guard nodes (same issue discovered during this planning session).
+
+**Processed**: 2026-07-29 — implementation tracked in #1812.

--- a/plan/history/2607/idea/IDEA-1247.md
+++ b/plan/history/2607/idea/IDEA-1247.md
@@ -31,3 +31,4 @@ Key planning decisions:
   missing guard nodes (same issue discovered during this planning session).
 
 **Processed**: 2026-07-29 — implementation tracked in #1812.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1814>.


### PR DESCRIPTION
- Closes #1247

## Summary

Plans issue #1247 (Idea): `create_develop_fix_tree` factory function for the
fix development BT workflow.

Key decisions from the grill-me interview:

- **Full fallback scope** (not Phase 1 stub): the implementation issue will
  include both the `CreateFix` Composer call-out point *and* the full
  production-layer guard/action nodes (`CheckIsVendorRoleNode`,
  `CheckCSFixNotYetReady`, `CheckRMStateAccepted`, `TransitionCStoFixReady`,
  `EmitCFActivity`). This resolves the runtime gating question — only actors
  holding `CVDRole.VENDOR` in the case will run the tree.
- **No new ADR** — ADR-0025 (accepted) fully covers the factory injection
  pattern applied here.
- **No new spec or notes file** — BT-18 and BT-23 already cover all normative
  requirements; `notes/call-out-configuration.md` covers the bundle pattern.
- **Peer Concern** #1813 created for `deploy_fix_tree.py` Phase 1 stub gap
  (missing same guard nodes — surfaced during this planning session).

## Implementation Issues

- #1812