### PR TITLE
Skill process improvements: reflect-cycle macro, review-priorities consolidation, board-id resolver

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -29,10 +29,11 @@ bug is being fixed and why.
    (freeform), synthesize a title, and create the issue:
 
    ```bash
+   BUG_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Bug)
    ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
      --title "${BUG_TITLE}" \
      --body "${BUG_BODY}" \
-     --issue-type-id "IT_kwDOAjf0s84AcFLq")
+     --issue-type-id "${BUG_TYPE_ID}")
    ```
 
 4. Fetch the issue body and comments. Use the content as bug context
@@ -83,6 +84,7 @@ Ask one targeted question before locking in scope:
   file each remaining concern as a new Bug-type issue:
 
   ```bash
+  BUG_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Bug)
   .agents/skills/manage-github-issue/manage_github_issue.sh \
     --title "<short bug title>" \
     --body "## Symptoms
@@ -93,7 +95,7 @@ Ask one targeted question before locking in scope:
 
   ## Components involved
   - \`path/to/module.py\`" \
-    --issue-type-id "IT_kwDOAjf0s84AcFLq"
+    --issue-type-id "${BUG_TYPE_ID}"
   ```
 
   Confirm the narrowed scope before proceeding.

--- a/.agents/skills/check-priority-status/REFERENCE.md
+++ b/.agents/skills/check-priority-status/REFERENCE.md
@@ -9,15 +9,15 @@ status check.
 
 ## Project Board Constants
 
-| Name | Value |
+| Name | Resolver |
 |---|---|
-| Project node ID | `PVT_kwDOAjf0s84BZnre` |
-| Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Schedule: Focus | `6bca50d7` |
-| Schedule: Now | `22e6679d` |
-| Schedule: Next | `1c1ed63d` |
-| Schedule: Later | `520032ef` |
-| Schedule: Someday | `a890eacc` |
+| Project node ID | `bash .agents/skills/shared/board-id.sh project` |
+| Schedule field ID | `bash .agents/skills/shared/board-id.sh schedule-field` |
+| Schedule: Focus | `bash .agents/skills/shared/board-id.sh schedule Focus` |
+| Schedule: Now | `bash .agents/skills/shared/board-id.sh schedule Now` |
+| Schedule: Next | `bash .agents/skills/shared/board-id.sh schedule Next` |
+| Schedule: Later | `bash .agents/skills/shared/board-id.sh schedule Later` |
+| Schedule: Someday | `bash .agents/skills/shared/board-id.sh schedule Someday` |
 
 ## Data Model
 
@@ -153,9 +153,12 @@ unblocked open sub-issue with no open PR.
 
 ### All items in Project #24 with Schedule tier
 
+Resolve `$PROJECT_ID` first via `bash .agents/skills/shared/board-id.sh project`,
+then substitute it into the query:
+
 ```graphql
 {
-  node(id: "PVT_kwDOAjf0s84BZnre") {
+  node(id: "$PROJECT_ID") {
     ... on ProjectV2 {
       items(first: 100) {
         nodes {

--- a/.agents/skills/check-priority-status/SKILL.md
+++ b/.agents/skills/check-priority-status/SKILL.md
@@ -58,8 +58,9 @@ Run the check-priority-status skill. The skill will:
 ### Querying Project #24 by Schedule Tier
 
 ```bash
+PROJECT_ID=$(bash .agents/skills/shared/board-id.sh project)
 gh api graphql -f query='{
-  node(id: "PVT_kwDOAjf0s84BZnre") {
+  node(id: "'"$PROJECT_ID"'") {
     ... on ProjectV2 {
       items(first: 100) {
         nodes {

--- a/.agents/skills/create-epic/SKILL.md
+++ b/.agents/skills/create-epic/SKILL.md
@@ -93,16 +93,10 @@ echo "${EPIC_NUMBER}"
 ## Constraints
 
 - Always check for an existing open Epic before creating a new one.
-- The `Epic` issue type ID for `CERTCC/Vultron` is `IT_kwDOAjf0s84B_E1A`.
-  If this ID changes (e.g. after repo transfer), re-query:
-
-  ```bash
-  gh api graphql -f query='{ repository(owner:"CERTCC", name:"Vultron") {
-    issueTypes(first:10) { nodes { id name } } } }'
-  ```
-
-- The repo node ID for `CERTCC/Vultron` is `R_kgDOIn77fA`.
-- Board IDs (project node, Schedule field, Schedule option IDs including
-  `Focus`) are **not** duplicated here — they live in one place,
-  `.agents/skills/shared/README.md`, and are applied by
-  `.agents/skills/shared/add-to-project.sh`, which `create_epic.sh` calls.
+- Board IDs are **never hardcoded** here — they rotate and are resolved by name
+  at runtime via `.agents/skills/shared/board-id.sh` (see
+  `.agents/skills/shared/README.md`). `create_epic.sh` resolves the repo node ID
+  and the `Epic` issue-type ID through it, and delegates scheduling to
+  `.agents/skills/shared/add-to-project.sh`.
+  - Epic issue-type ID: `bash .agents/skills/shared/board-id.sh issue-type Epic`
+  - Repo node ID: `bash .agents/skills/shared/board-id.sh repo`

--- a/.agents/skills/create-epic/create_epic.sh
+++ b/.agents/skills/create-epic/create_epic.sh
@@ -20,9 +20,11 @@ SCHEDULE="${3:-Someday}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ADD_TO_PROJECT="${SCRIPT_DIR}/../shared/add-to-project.sh"
+BOARD_ID="${SCRIPT_DIR}/../shared/board-id.sh"
 
-REPO_NODE_ID="R_kgDOIn77fA"
-EPIC_TYPE_ID="IT_kwDOAjf0s84B_E1A"
+# Board IDs are resolved live-and-cached via board-id.sh — never hardcoded.
+REPO_NODE_ID=$(bash "$BOARD_ID" repo)
+EPIC_TYPE_ID=$(bash "$BOARD_ID" issue-type Epic)
 
 # JSON-encode title and body for safe GraphQL embedding
 TITLE_JSON=$(printf '%s' "${EPIC_TITLE}" \

--- a/.agents/skills/dev-status/REFERENCE.md
+++ b/.agents/skills/dev-status/REFERENCE.md
@@ -4,14 +4,14 @@ Exact queries used by the `dev-status` skill.
 
 ## GitHub Issue Type IDs (CERTCC/Vultron)
 
-| Type | ID |
+| Type | Resolver |
 |---|---|
-| Task | `IT_kwDOAjf0s84AcFLo` |
-| Bug | `IT_kwDOAjf0s84AcFLq` |
-| Feature | `IT_kwDOAjf0s84AcFLs` |
-| Idea | `IT_kwDOAjf0s84B_EoA` |
-| Epic | `IT_kwDOAjf0s84B_E1A` |
-| Concern | `IT_kwDOAjf0s84B_2VT` |
+| Task | `bash .agents/skills/shared/board-id.sh issue-type Task` |
+| Bug | `bash .agents/skills/shared/board-id.sh issue-type Bug` |
+| Feature | `bash .agents/skills/shared/board-id.sh issue-type Feature` |
+| Idea | `bash .agents/skills/shared/board-id.sh issue-type Idea` |
+| Epic | `bash .agents/skills/shared/board-id.sh issue-type Epic` |
+| Concern | `bash .agents/skills/shared/board-id.sh issue-type Concern` |
 
 Re-query if the repo is transferred or recreated:
 
@@ -59,6 +59,7 @@ For the full list (not just count), omit `| length` and add
 
 ```bash
 # Get all project items with Schedule=Someday
+PROJECT_ID=$(bash .agents/skills/shared/board-id.sh project)
 gh api graphql --jq '
   [ .data.node.items.nodes[]
     | select(
@@ -71,7 +72,7 @@ gh api graphql --jq '
     | .content.number
   ] | length
 ' -f query='{
-  node(id: "PVT_kwDOAjf0s84BZnre") {
+  node(id: "'"$PROJECT_ID"'") {
     ... on ProjectV2 {
       items(first: 200) {
         nodes {
@@ -96,6 +97,7 @@ gh api graphql --jq '
 
 ```bash
 # Step 1: get Now-Epic numbers in board order
+PROJECT_ID=$(bash .agents/skills/shared/board-id.sh project)
 gh api graphql --jq '
   [ .data.node.items.nodes[]
     | select(
@@ -109,7 +111,7 @@ gh api graphql --jq '
     | .content.number
   ][]
 ' -f query='{
-  node(id: "PVT_kwDOAjf0s84BZnre") {
+  node(id: "'"$PROJECT_ID"'") {
     ... on ProjectV2 {
       items(first: 100) {
         nodes {
@@ -187,7 +189,7 @@ empty (only `.gitkeep` present or directory missing).
 
 | Queue                 | Count | Skill                |
 |-----------------------|-------|----------------------|
-| Incoming Learnings    |  {n}  | learn                |
+| Incoming Learnings    |  {n}  | learn / reflect-cycle |
 | Ideas (open)          |  {n}  | plan-issue           |
 | Bugs (open)           |  {n}  | bugfix               |
 | Concerns (open)       |  {n}  | process-concerns     |

--- a/.agents/skills/dev-status/SKILL.md
+++ b/.agents/skills/dev-status/SKILL.md
@@ -52,7 +52,7 @@ Print a single table followed by a "Next up" callout:
 
 | Queue                  | Count | Skill                |
 |------------------------|-------|----------------------|
-| Incoming Learnings     |   2   | learn                |
+| Incoming Learnings     |   2   | learn / reflect-cycle |
 | Ideas (open)           |   1   | plan-issue           |
 | Bugs (open)            |   3   | bugfix               |
 | Concerns (open)        |   0   | —                    |
@@ -77,14 +77,24 @@ Now: #691 Migrate project tracking | #476 Bug Fixes and Demo Polish
 Ranked priority (first matching condition wins for the primary recommendation;
 list all non-zero conditions as `ask_user` choices):
 
-1. `learn` — plan/incoming/learnings/ has files
-2. `process-concerns` — open Concern issues
-3. `plan-issue` — open Idea or Concern issues
-4. `bugfix` — open Bug issues
-5. `pr-ship` — open PRs > 0
-6. `review-priorities` — triage items > 0 (Schedule=Someday with no Epic)
-7. `build` — ready-to-build count > 0
-8. *(stop)* — all queues empty, nothing actionable
+1. `reflect-cycle` — **prefer over `learn` alone** when the full reflection
+   pass is warranted: incoming learnings exist **and** at least one downstream
+   phase also has input (open Concerns, or a triage backlog). Offer `learn`
+   alone as the narrower alternative.
+2. `learn` — plan/incoming/learnings/ has files (and `reflect-cycle` was not
+   the primary pick)
+3. `process-concerns` — open Concern issues
+4. `plan-issue` — open Idea or Concern issues
+5. `bugfix` — open Bug issues
+6. `pr-ship` — open PRs > 0
+7. `review-priorities` — triage items > 0 (Schedule=Someday with no Epic)
+8. `build` — ready-to-build count > 0
+9. *(stop)* — all queues empty, nothing actionable
+
+**Macro-vs-atomic rule:** when a higher-level skill covers the same input as an
+atomic one, recommend the macro as the primary choice and list the atomic skill
+as the narrower alternative — never both as equals. The two pairings today are
+`reflect-cycle` over `learn`, and `pr-ship` over the individual `pr-*` phases.
 
 Always include "Nothing — just show the report" as a final choice.
 

--- a/.agents/skills/manage-github-issue/REFERENCE.md
+++ b/.agents/skills/manage-github-issue/REFERENCE.md
@@ -294,13 +294,13 @@ These are the stable node IDs for `CERTCC/Vultron`. If the repository is
 transferred or recreated, re-query using the commands in
 **API Discovery** below.
 
-| Name | Value |
+| Name | Resolver |
 |---|---|
-| Repo node ID | `R_kgDOIn77fA` |
-| Task issue type ID | `IT_kwDOAjf0s84AcFLo` |
-| Bug issue type ID | `IT_kwDOAjf0s84AcFLq` |
-| Epic issue type ID | `IT_kwDOAjf0s84B_E1A` |
-| Idea issue type ID | `IT_kwDOAjf0s84B_EoA` |
+| Repo node ID | `bash .agents/skills/shared/board-id.sh repo` |
+| Task issue type ID | `bash .agents/skills/shared/board-id.sh issue-type Task` |
+| Bug issue type ID | `bash .agents/skills/shared/board-id.sh issue-type Bug` |
+| Epic issue type ID | `bash .agents/skills/shared/board-id.sh issue-type Epic` |
+| Idea issue type ID | `bash .agents/skills/shared/board-id.sh issue-type Idea` |
 
 ## API Discovery
 

--- a/.agents/skills/new-item/SKILL.md
+++ b/.agents/skills/new-item/SKILL.md
@@ -89,9 +89,10 @@ Use `.agents/skills/manage-github-issue/manage_github_issue.sh`.
 Add new issues to Project #24 **without** setting Schedule (leave unset):
 
 ```bash
+PROJECT_ID=$(bash .agents/skills/shared/board-id.sh project)
 gh api graphql -f query="mutation {
   addProjectV2ItemById(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    projectId: \"${PROJECT_ID}\"
     contentId: \"${ISSUE_NODE_ID}\"
   }) { item { id } }
 }"

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -65,10 +65,11 @@ Ask the user to describe the idea (`ask_user`, freeform). Synthesize a
 short title, then create the issue via the `manage-github-issue` helper:
 
 ```bash
+IDEA_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Idea)
 ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
   --title "${TITLE}" \
   --body "${BODY}" \
-  --issue-type-id "IT_kwDOAjf0s84B_EoA")
+  --issue-type-id "${IDEA_TYPE_ID}")
 ```
 
 ### Phase 0b — Sync

--- a/.agents/skills/plan-issue/epic.md
+++ b/.agents/skills/plan-issue/epic.md
@@ -49,9 +49,11 @@ Docs updates are optional. Skip if Phase A found no gaps.
 Create one Task sub-issue per decomposition cluster from Phase B. Wire each as:
 
 - `--blocked-by <N>` for any sequencing constraints
-- `--issue-type-id IT_kwDOAjf0s84AcFLo` (Task type)
+- `--issue-type-id "$(bash .agents/skills/shared/board-id.sh issue-type Task)"`
+  (Task type)
 
 ```bash
+TASK_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Task)
 TASK_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
   --title "<task title from Phase B>" \
   --body "## Summary
@@ -63,7 +65,7 @@ TASK_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
 ## Reference
 Epic: #${ISSUE_NUMBER}" \
   --label "size:<S|M|L>" \
-  --issue-type-id "IT_kwDOAjf0s84AcFLo" \
+  --issue-type-id "${TASK_TYPE_ID}" \
   --parent "${ISSUE_NUMBER}" \
   [--blocked-by "<prerequisite task number>"])
 bash .agents/skills/shared/add-to-project.sh "${TASK_NUMBER}"

--- a/.agents/skills/process-concerns/SKILL.md
+++ b/.agents/skills/process-concerns/SKILL.md
@@ -21,9 +21,17 @@ before creating anything.
 
 ```text
 REPO           = CERTCC/Vultron
-REPO_NODE_ID   = R_kgDOIn77fA
-CONCERN_TYPE   = IT_kwDOAjf0s84B_2VT
-TASK_TYPE      = IT_kwDOAjf0s84AcFLo
+REPO_NODE_ID   = resolve via `bash .agents/skills/shared/board-id.sh repo`
+CONCERN_TYPE   = resolve via `bash .agents/skills/shared/board-id.sh issue-type Concern`
+TASK_TYPE      = resolve via `bash .agents/skills/shared/board-id.sh issue-type Task`
+```
+
+Resolve these into shell variables before the mutations below:
+
+```bash
+REPO_NODE_ID=$(bash .agents/skills/shared/board-id.sh repo)
+CONCERN_TYPE=$(bash .agents/skills/shared/board-id.sh issue-type Concern)
+TASK_TYPE=$(bash .agents/skills/shared/board-id.sh issue-type Task)
 ```
 
 ---

--- a/.agents/skills/reflect-cycle/REFERENCE.md
+++ b/.agents/skills/reflect-cycle/REFERENCE.md
@@ -1,0 +1,121 @@
+---
+title: reflect-cycle Reference
+---
+
+# Reflect Cycle — Reference
+
+Router that sequences the reflection-half skills with a human-confirmation stop
+between each. Owns no domain logic of its own — it only assesses inputs, orders
+phases, and dispatches.
+
+## Architecture
+
+```text
+reflect-cycle (router)
+  ├─ Assess phase inputs (read-only, parallel checks)
+  ├─ Propose sequence via ask_user (user may trim phases)
+  └─ Loop: dispatch ONE phase → phase runs to completion (grill + PR) →
+           return here → ask_user (next / skip / stop)
+
+Dispatched skills (each independently invokable, each owns its mechanics):
+  learn → update-plan → [decision-audit] → review-priorities
+```
+
+Contrast with `pr-ship`: that runs its sub-skills unattended in one pass
+because none has a mid-pipeline human gate. Every phase here does, so the loop
+re-confirms between phases and never chains on its own.
+
+## Phase Gate Checks
+
+Run these in parallel before proposing the sequence. All are read-only.
+
+### Incoming learnings (gates `learn`)
+
+```bash
+find plan/incoming/learnings -maxdepth 1 -name '*.md' ! -name '.gitkeep' | wc -l
+```
+
+Non-zero → `learn` has input.
+
+### Open Concern issues (also gates `learn`)
+
+```bash
+gh issue list --repo CERTCC/Vultron --state open --limit 200 \
+  --json number,title,issueType \
+  --jq '[.[] | select(.issueType.name == "Concern")] | length'
+```
+
+Non-zero → `learn` has Concern input even if the learnings dir is empty.
+
+### Triage backlog (informs `review-priorities` as closer)
+
+```bash
+bash .agents/skills/shared/query-now-epics.sh   # context on current Now work
+# Someday/triage count comes from check-priority-status, invoked by review-priorities
+```
+
+### decision-audit recency (gates `decision-audit`)
+
+There is no queue for this; it is periodic. Propose it when:
+
+- recent learnings or PRs touched a premise recorded in an ADR or spec group, or
+- it has not run in several reflection cycles.
+
+Default to **off** — include only with a stated reason. Check recent history:
+
+```bash
+uv run show-history --month "$(date +%y%m)" 2>/dev/null | grep -i 'decision-audit' || echo "no recent decision-audit"
+```
+
+(Do not call `date` inside a workflow script — this command is for interactive
+use in the skill run only.)
+
+## Dispatch Loop (pseudocode)
+
+```python
+sequence = propose_sequence(gate_checks)          # e.g. [learn, update-plan, review-priorities]
+sequence = ask_user_to_trim(sequence)             # user may drop decision-audit, etc.
+
+for phase in sequence:
+    choice = ask_user(
+        question=f"Next phase: {phase}. Proceed?",
+        choices=["Proceed", f"Skip {phase}", "Stop reflect-cycle"],
+    )
+    if choice == "Stop reflect-cycle":
+        break
+    if choice.startswith("Skip"):
+        continue
+    invoke_skill(phase)          # runs to completion, incl. its grill-me and PR
+    report_one_line_result(phase)
+    # loop returns here; next iteration re-confirms before the following phase
+```
+
+The `ask_user` **before** each dispatch is mandatory — it is the gate that
+keeps this a router, not an autopilot.
+
+## Ordering (load-bearing)
+
+1. `learn` first — writes specs/notes/AGENTS.md from build learnings + Concerns.
+2. `update-plan` next — gap-analyzes those specs/notes against code, files
+   GitHub Issues for gaps. Must follow `learn`.
+3. `decision-audit` (optional) — before ranking, catch stale ADR/spec-group
+   premises so you do not schedule work built on a bad assumption.
+4. `review-priorities` last — schedules the issues the middle phases created.
+
+Do not reorder. `review-priorities` before `update-plan` would rank a board
+that is missing the new gap issues.
+
+## PR Isolation
+
+`learn` and `decision-audit` each open their own docs-only PR (labels
+`specs-notes` and the decision-audit default respectively). Let each phase
+create its PR before dispatching the next, so two phases' doc edits do not share
+a branch. `update-plan` and `review-priorities` do not open PRs (they create
+issues / apply live board changes), so no branch isolation is needed for them.
+
+## What this skill must NOT do
+
+- Do not run two phases without a user confirmation between them.
+- Do not re-implement any phase's logic — dispatch the real skill.
+- Do not open its own PR — each dispatched phase owns its own.
+- Do not mutate specs, notes, issues, or the board directly.

--- a/.agents/skills/reflect-cycle/SKILL.md
+++ b/.agents/skills/reflect-cycle/SKILL.md
@@ -23,7 +23,6 @@ skills so you do not have to remember the order or the hand-offs — but it is a
 >
 > - `learn` and `decision-audit` each run a `grill-me` interview and open their
 >   own docs-only PR.
-> - `plan-issue` (if reached) runs a `grill-me` interview.
 > - `review-priorities` is interactive per board change.
 >
 > Collapsing those gates into one unattended run would defeat their purpose.

--- a/.agents/skills/reflect-cycle/SKILL.md
+++ b/.agents/skills/reflect-cycle/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: reflect-cycle
+description: >
+  Guided router for the reflection half of the development cycle — folding what
+  the build process learned back into durable docs, plans, and priorities. Runs
+  learn → update-plan → decision-audit → review-priorities as a sequence of
+  phases, but STOPS between each phase because every one contains a human gate
+  (a grill-me interview and/or its own PR). Use after a batch of build/bugfix
+  work, when you want to consolidate learnings and re-rank what's next, or say
+  "close the loop" / "reflect on recent work".
+---
+
+# Skill: Reflect Cycle
+
+The mirror image of `build`/`pr-ship`: those turn plans into shipped code; this
+turns shipped code back into refined plans. It sequences the four reflection
+skills so you do not have to remember the order or the hand-offs — but it is a
+**router, not an autopilot**.
+
+> **Why this stops between phases (read first).** Unlike `pr-ship`, this macro
+> must **not** run straight through. Each phase it dispatches contains a human
+> gate the design put there on purpose:
+>
+> - `learn` and `decision-audit` each run a `grill-me` interview and open their
+>   own docs-only PR.
+> - `plan-issue` (if reached) runs a `grill-me` interview.
+> - `review-priorities` is interactive per board change.
+>
+> Collapsing those gates into one unattended run would defeat their purpose.
+> This skill therefore dispatches **one phase, then returns here** to confirm
+> before dispatching the next. It never chains a second phase on its own.
+
+## The reflection sequence
+
+```text
+learn            → promote build learnings into specs/notes/AGENTS.md   (grill + PR)
+   ↓
+update-plan      → gap analysis specs/notes vs. code → new GitHub Issues
+   ↓
+decision-audit   → hunt stale/wrong ADRs & spec groups before they bite (grill + PR)  [periodic]
+   ↓
+review-priorities→ re-rank the board now that new issues exist           (interactive)
+```
+
+Not every session needs all four. `learn` and `update-plan` are the common
+pair after a build batch; `decision-audit` is periodic (not every cycle);
+`review-priorities` runs last, once new issues from the middle phases exist.
+
+## Quick Start
+
+Run the reflect-cycle skill. It will:
+
+1. **Assess** which phases are worth running this session (see Phase Gate
+   Logic) and print a short plan.
+2. **Confirm** the sequence with you via `ask_user`, letting you drop phases
+   you do not want (e.g. skip `decision-audit`).
+3. **Dispatch one phase**, then **stop and return here**. After that phase
+   completes (including any PR it opened), re-confirm before dispatching the
+   next.
+4. Repeat until the confirmed sequence is done or you exit.
+
+## Phase Gate Logic
+
+Before proposing the sequence, check what actually has input. Run these read
+checks in parallel (see REFERENCE.md for exact commands):
+
+| Phase | Include when… |
+|---|---|
+| `learn` | `plan/incoming/learnings/` has unprocessed `.md` files, **or** open `type:Concern` issues exist |
+| `update-plan` | Always a reasonable follow-up after `learn`; also run periodically to realign issues with code |
+| `decision-audit` | Periodic — propose it if it has not run recently, or if recent learnings touched an ADR/spec-group premise. Default to **off** unless there is a reason |
+| `review-priorities` | Include as the closer whenever any earlier phase created new issues, or the board has a triage backlog |
+
+Present the assembled sequence as the default; let the user trim it.
+
+## Dispatch Model
+
+**One phase per dispatch, then stop.** This is the core rule.
+
+1. Announce the next phase and why.
+2. Invoke that skill and let it run to completion — including its `grill-me`
+   interview and any PR it opens. Do **not** interrupt a phase mid-flight.
+3. When the phase returns, come back here. Print a one-line result and the
+   remaining sequence.
+4. Ask via `ask_user`: proceed to the next phase / skip it / stop.
+5. Only on explicit confirmation, dispatch the next phase.
+
+Never dispatch two phases without a user confirmation between them, even in
+autopilot or background mode.
+
+## Ordering Constraints
+
+- `update-plan` runs **after** `learn` (it consumes the specs/notes `learn`
+  wrote) and **before** `review-priorities` (which schedules the issues
+  `update-plan` files). This ordering is load-bearing — do not reorder.
+- `decision-audit`, when included, slots **after** `update-plan` and **before**
+  `review-priorities`: catch stale decisions before you rank work that might
+  build on them.
+- Each of `learn` and `decision-audit` opens its **own** PR. Let each land (or
+  at least be created) before starting the next phase, so their docs changes do
+  not tangle on one branch.
+
+## When NOT to use this
+
+- Single learning to promote, nothing else → just run `learn`.
+- Just want to re-rank the board → run `review-priorities` directly.
+- You want a report, not changes → use `velocity-report` / `project-report` /
+  `requirements-retrospective` (those mutate nothing).
+- Turning one external Idea into a plan → `plan-issue`, not this.
+
+## Relationship to dev-status
+
+`dev-status` is the whole-cycle entry point: it looks at every queue (including
+build and PR work) and recommends a single next skill. `reflect-cycle` is
+narrower — it drives only the reflection phases, end to end. A common pattern:
+`dev-status` recommends `learn`; if you know you want the full consolidation
+pass, run `reflect-cycle` instead of `learn` alone.

--- a/.agents/skills/review-priorities/REFERENCE.md
+++ b/.agents/skills/review-priorities/REFERENCE.md
@@ -4,65 +4,64 @@ title: review-priorities Reference
 
 # Review Priorities — Reference
 
-Technical implementation details for the combined audit-and-update workflow.
+`review-priorities` is a thin coordinator. It owns no board mechanics and no
+constants of its own — it sequences the granular board skills and helps you
+interpret the audit between them.
 
 ## Architecture
 
 ```text
 review-priorities (coordinator)
-  ├─ Phase 1: Invoke check-priority-status
+  ├─ Phase 1: Invoke check-priority-status  (read-only audit)
   │  └─ Output: Status report (by tier, per Epic, coverage, health)
-  ├─ Phase 2: Summarize significant findings for user
+  ├─ Phase 2: Summarize significant findings for the user
   ├─ Phase 3: Interactive update loop (ask_user per action)
-  │  ├─ Move item between tiers (API mutation)
-  │  ├─ Promote triage item (API mutation)
-  │  ├─ Reshape epic roadmap (invoke calve-epics: route/calve/recrystallize)
-  │  └─ Archive Epic (invoke archive-history, close issue)
-  └─ Phase 4: Commit if notes/history files changed
+  │  ├─ Move item between tiers        → invoke update-priorities
+  │  ├─ Promote triage item            → invoke update-priorities
+  │  ├─ Add off-board issue to board   → invoke update-priorities
+  │  ├─ Reshape epic roadmap           → invoke calve-epics
+  │  └─ Archive completed Epic         → invoke update-priorities
+  └─ Phase 4: Commit iff a delegated action wrote a file
 ```
 
-## Project Board Constants
+The design mirrors `pr-ship` over `pr-triage`/`pr-execute`/`pr-verify`: the
+coordinator adds the review-and-decide layer; the granular skills remain
+independently invokable and hold the implementation.
 
-| Name | Value |
+## Where the constants and mechanics live
+
+Do **not** duplicate any of these into this skill.
+
+| What | Canonical home |
 |---|---|
-| Project node ID | `PVT_kwDOAjf0s84BZnre` |
-| Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Focus option ID | `6bca50d7` |
-| Now option ID | `22e6679d` |
-| Next option ID | `1c1ed63d` |
-| Later option ID | `520032ef` |
-| Someday option ID | `a890eacc` |
+| Board node/field/option/issue-type IDs | resolve by name via `.agents/skills/shared/board-id.sh` (see `shared/README.md`) |
+| Move item between tiers (GraphQL mutation) | `update-priorities` |
+| Promote triage / add to board | `update-priorities` |
+| Archive a completed Epic | `update-priorities` → `archive-history` |
+| Board audit queries | `check-priority-status` |
+| Epic roadmap shaping (route / calve / recrystallize) | `calve-epics` → `create-epic` + `manage-github-issue` |
 
-## Phase 1: Run check-priority-status
+> **Never hardcode board IDs.** They are server-generated and rotate when the
+> Schedule field's options are edited. Resolve them at runtime via
+> `board-id.sh`; a pasted literal drifts stale. This has caused a real
+> mis-scheduling bug before.
 
-Invoke the `check-priority-status` skill and capture its output. The report
-provides:
+## Phase 1: Audit
 
-- Items per tier (Now/Next/Later/Someday)
-- Per-Epic sub-issue progress
-- Coverage (issues on board vs. off board)
-- Triage count (Someday items needing scheduling)
-- Stale items (>7 days no activity)
-- Orphaned PRs
+Invoke `check-priority-status`; capture its report. It provides items per tier,
+per-Epic sub-issue progress, coverage (on-board vs. off-board), triage count,
+stale items (>7 days), and orphaned PRs. This skill adds nothing to the query
+set — if the audit is missing something, fix it in `check-priority-status`.
 
 ## Phase 2: Summarize Findings
 
-Surface significant findings via plain text before asking for action:
-
-```text
-📊 Board status:
-  Now:     3 Epics (12 open sub-issues, 2 blocked)
-  Next:    2 Epics (8 open sub-issues)
-  Later:   1 Epic  (4 open sub-issues)
-  Someday: 7 items (triage needed)
-
-⚠ 14 open issues not yet on board
-⚠ 3 stale items (>1 week inactive)
-```
+Surface significant findings in plain text before asking for any action (empty
+tiers, overcrowded Now, triage backlog, off-board issues, blocked Now items,
+stale items). Recommend, do not act.
 
 ## Phase 3: Interactive Update Loop
 
-Use `ask_user` for every choice — never ask questions in plain text.
+Use `ask_user` for every choice — never ask in plain prose.
 
 ```python
 while True:
@@ -71,76 +70,40 @@ while True:
         choices=[
             "Move item(s) between Schedule tiers (Recommended)",
             "Promote Triage items to Now/Next/Later",
-            "Create a new Epic for uncovered issues",
+            "Add an off-board issue to the board",
+            "Reshape the epic roadmap (route / calve / recrystallize)",
             "Archive a completed Epic",
             "No changes, exit",
-        ]
+        ],
     )
     if action == "No changes, exit":
         break
-    # ... delegate to sub-workflow
+    # Delegate to the owning skill — do NOT inline the mutation:
+    #   move / promote / add-to-board / archive  → update-priorities
+    #   reshape epic roadmap                     → calve-epics
 ```
-
-### Move Item Between Tiers
-
-1. Ask which issue/Epic number to move.
-2. Ask which tier (Now / Next / Later / Someday).
-3. Look up the item's project item ID via board items query.
-4. Call `updateProjectV2ItemFieldValue` with the chosen option ID.
-5. Confirm to user.
-
-### Promote Triage Items
-
-1. List all Someday items for user to choose from.
-2. Ask which tier to promote to.
-3. Apply the move (same mutation as above).
 
 ### Reshape the Epic Roadmap
 
-1. Invoke the `calve-epics` skill — it owns the route / calve / recrystallize
-   judgment and gates epic creation on human confirmation of the design-grain
-   fracture line.
-2. `calve-epics` delegates the mechanics to `create-epic` (epic creation +
-   sub-issue wiring + board placement) and `manage-github-issue` (re-parenting).
-   Do not invoke `create-epic` directly from this workflow.
+Invoke the `calve-epics` skill — it owns the route / calve / recrystallize
+judgment and gates epic creation on human confirmation of the design-grain
+fracture line. `calve-epics` delegates the mechanics to `create-epic` (epic
+creation + sub-issue wiring + board placement) and `manage-github-issue`
+(re-parenting). Do **not** invoke `create-epic` directly from this workflow, and
+never mint an epic inline.
 
-### Archive Completed Epic
-
-1. Confirm all sub-issues are closed.
-2. Invoke `archive-history` skill with type `priority`.
-3. Close the Epic: `gh issue close <N> --repo CERTCC/Vultron`.
+Each delegated skill collects its own parameters (which issue, which tier, epic
+details) and applies the change live. Loop back to the menu after each.
 
 ## Phase 4: Commit (if needed)
 
 Board changes (Schedule field updates) happen live via API — no file commit
-needed.
-
-If `archive-history` was invoked (creates a file under `plan/history/`),
-or if notes files were modified, invoke the `commit` skill.
+needed. If a delegated action wrote a file under `plan/history/` (via
+`archive-history`) or modified notes, invoke the `commit` skill.
 
 ## Error Handling
 
-### GitHub API Failure
-
-```text
-❌ Failed to fetch board items
-   Cause: No token or insufficient permissions
-   Action: Exit with guidance ("Check your GitHub token")
-```
-
-### Item Not on Board
-
-If the user references an issue not in Project #24, offer to add it first
-with `Schedule=Someday` before moving it to the desired tier.
-
-## Configuration
-
-```bash
-GITHUB_TOKEN=ghp_...   # Required for API access
-```
-
-## Rollback
-
-- Board moves: re-run the move mutation with the previous tier option ID.
-- Closed Epics: `gh issue reopen <N> --repo CERTCC/Vultron`.
-- History entries: immutable; document corrections in a new entry.
+Delegated skills own their own error handling (auth failures, item-not-on-board
+offers to add it first, etc.). This coordinator only needs to stop cleanly if
+`check-priority-status` cannot produce a report — without the audit there is
+nothing to review.

--- a/.agents/skills/review-priorities/SKILL.md
+++ b/.agents/skills/review-priorities/SKILL.md
@@ -1,156 +1,119 @@
 ---
 name: review-priorities
 description: >
-  Audit and update Project #24 ("Vultron Planning") in one workflow. Runs a
-  comprehensive status check against the board and open issues/PRs, then
-  offers interactive options to move items between Schedule tiers (Now/Next/
-  Later/Someday), promote Triage items, archive completed Epics, and wire
-  sub-issue relationships. Use when you want to review where the project
-  stands and make any necessary board updates.
+  Audit and update Project #24 ("Vultron Planning") in one guided workflow.
+  Delegates to check-priority-status for the read-only audit, reviews the
+  findings with you, then delegates to update-priorities (tier moves, promote
+  triage, add to board, archive Epics) and calve-epics (epic roadmap shaping)
+  for any changes. Use when you want to review where the project stands and
+  make any necessary board updates in a single session.
 ---
 
 # Review Priorities
 
-Complete audit-and-update workflow for GitHub Project #24 ("Vultron
-Planning"). Combines status checking and interactive updates into a single
-guided workflow.
+Guided coordinator over the granular board skills. It runs the audit, helps you
+interpret it, then applies whatever changes you decide on — without
+re-implementing any of them. Think of it as `pr-ship` for the board:
+`check-priority-status` → review → `update-priorities` / `calve-epics`, all in
+one pass.
+
+> **Single source of truth.** This skill does **not** carry its own copy of
+> board constants or API mutations. The audit lives in `check-priority-status`;
+> tier moves / promote / archive live in `update-priorities`; epic roadmap
+> shaping lives in `calve-epics`; board IDs are resolved by name via
+> `.agents/skills/shared/board-id.sh` (see `.agents/skills/shared/README.md`).
+> If you need a constant, resolve it there — do not hardcode one here.
+
+## When to use which board skill
+
+| You want to… | Run |
+|---|---|
+| Just see where things stand (no changes) | `check-priority-status` |
+| Apply specific tier moves you already know you want | `update-priorities` |
+| Shape the epic roadmap (route / calve / recrystallize) | `calve-epics` |
+| Audit **and** decide **and** apply, in one session | `review-priorities` (this) |
 
 ## Quick Start
 
-Run the review-priorities skill. The skill will:
+Run the review-priorities skill. It will:
 
-1. **Check status** (via `check-priority-status`):
-   - Audit current board tiers against open GitHub issues and PRs
-   - Generate report: tier coverage, per-Epic progress, triage count,
-     stale items
-2. **Review findings** with you:
-   - Highlight significant gaps, empty tiers, stale items, triage backlog
-   - Offer insights on what might need updating
-3. **Offer interactive update options**:
-   - Move items between Schedule tiers (Now / Next / Later / Someday)
-   - Promote Triage (Someday) items to a schedule tier
-   - Reshape the epic roadmap via `calve-epics` (route / calve / recrystallize)
-   - Archive a completed Epic (close issue + log history entry)
-   - Skip updates and just review
-4. **Commit** any notes or history changes made (board changes happen live
-   via API — no file commit needed for pure scheduling changes)
+1. **Audit** — invoke `check-priority-status` and capture its report.
+2. **Review with you** — surface the significant findings (empty tiers, stale
+   items, triage backlog, off-board issues, blocked Now items) in plain text.
+3. **Update** — for any change you choose, invoke the owning skill
+   (`update-priorities`, `calve-epics`) to apply it live. Loop until done.
+4. **Commit** — only if a delegated action wrote a file (e.g. an
+   `archive-history` entry). Pure board moves are live and need no commit.
 
-## Workflows
+## Workflow
 
-### Typical Session: Review Only
+### Phase 1 — Audit (delegate)
 
-1. Run skill → review report → exit (no changes needed)
+Invoke the `check-priority-status` skill. It queries Project #24 by Schedule
+tier, resolves live issue/PR state and formal blockers, and prints the full
+report (summary, per-tier progress, coverage audit, health check). Capture
+that output — it is the input to Phase 2.
 
-### Typical Session: Schedule Triage Items
+Do not re-query the board here; `check-priority-status` **is** the audit.
 
-1. Run skill → review triage backlog
-2. For each Someday item that is ready: move to Now / Next / Later
-3. Done (changes applied live via API)
+### Phase 2 — Review Findings
 
-### Typical Session: Rebalance Tiers
+Summarize the findings that likely warrant action, before asking for any
+change. Example:
 
-1. Run skill → see Now tier is overcrowded
-2. Move lower-urgency Epics from Now → Next
-3. Preview changes → confirm → apply
+```text
+📊 Board status:
+  Now:     3 Epics (12 open sub-issues, 2 blocked)
+  Next:    2 Epics (8 open sub-issues)
+  Later:   1 Epic  (4 open sub-issues)
+  Someday: 7 items (triage needed)
 
-## Report Sections (from check-priority-status)
+⚠ 14 open issues not yet on board
+⚠ 3 stale items (>1 week inactive)
+```
 
-### Summary
+Offer your read on what might need updating, but make no changes yet.
 
-- Items per tier (Now / Next / Later / Someday), triage count
-- Coverage % (open issues on board vs. off board)
-- Stale items (no activity for 1 week)
+### Phase 3 — Update Loop (delegate)
 
-### Per-Tier Progress
-
-Table: each Epic's sub-issue progress by tier.
-
-### Coverage Audit
-
-- Issues not yet on board
-- Empty tiers / Epics with no open sub-issues
-- Orphaned PRs
-
-### Health Check
-
-- Stale items, long-pending PRs, open blockers
-
-## Interactive Update Options
-
-After reviewing the status report:
+Ask, via `ask_user`, what to do. For any action other than "exit", invoke the
+owning skill — do not inline the GraphQL mutation here.
 
 ```text
 What would you like to do?
-  [A] Move item(s) between Schedule tiers
-  [B] Promote Triage items to Now/Next/Later
-  [C] Reshape the epic roadmap (route / calve / recrystallize)
-  [D] Archive a completed Epic
-  [E] No changes, exit
+  [A] Move item(s) between Schedule tiers        → update-priorities
+  [B] Promote Triage items to Now/Next/Later     → update-priorities
+  [C] Add an off-board issue to the board        → update-priorities
+  [D] Reshape the epic roadmap                    → calve-epics
+  [E] Archive a completed Epic                    → update-priorities
+  [F] No changes, exit
 ```
 
-### Move Item Between Tiers
+- `update-priorities` owns the move / promote / add-to-board / archive
+  mechanics and their (resolved, never hardcoded) constants.
+- `calve-epics` owns epic roadmap shaping: routing uncovered leaves onto the
+  epic they match, calving a new epic off an over-accumulated theme, or
+  recrystallizing a muddled forest. It gates epic creation on a human
+  confirming the design-grain fracture line, then delegates mechanics to
+  `create-epic` and `manage-github-issue`. **Never mint an epic inline here.**
 
-```bash
-# Set Schedule field on an Epic or issue in Project #24
-ITEM_ID=$(gh api graphql -f query='{
-  node(id:"PVT_kwDOAjf0s84BZnre") {
-    ... on ProjectV2 {
-      items(first:100) {
-        nodes {
-          id
-          content { ... on Issue { number } }
-        }
-      }
-    }
-  }
-}' --jq ".data.node.items.nodes[] | select(.content.number == ${ISSUE_NUMBER}) | .id")
+Loop back to this menu after each action until the user chooses exit.
 
-gh api graphql -f query="mutation {
-  updateProjectV2ItemFieldValue(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
-    itemId: \"${ITEM_ID}\"
-    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
-    value: { singleSelectOptionId: \"${SCHEDULE_OPTION_ID}\" }
-  }) { projectV2Item { id } }
-}"
-```
+### Phase 4 — Commit (if needed)
 
-Schedule option IDs:
+Board changes (Schedule field updates) take effect immediately via API — no
+file commit is needed for pure scheduling changes.
 
-- Focus: `6bca50d7`
-- Now: `22e6679d`
-- Next: `1c1ed63d`
-- Later: `520032ef`
-- Someday: `a890eacc`
-
-### Reshape the Epic Roadmap
-
-Do **not** mint an epic on the spot here. Creating, fusing, splitting, or
-dissolving an epic is *calving* — an architectural act that must be gated on a
-human confirming the design-grain fracture line. Invoke the **`calve-epics`**
-skill, which owns that judgment:
-
-- **Route** uncovered leaf issues onto the epic they match (Mode 1).
-- **Calve** a new epic off an over-accumulated theme, after confirming the
-  one-sentence design idea (Mode 2).
-- **Recrystallize** a muddled forest — fuse redundant epics, eject cross-grain
-  children, split overgrown ones (Mode 3).
-
-`calve-epics` delegates the mechanics to `create-epic` and
-`manage-github-issue`; this skill never mints epics inline.
-
-### Archive a Completed Epic
-
-1. Verify all sub-issues are closed.
-2. Invoke `archive-history` skill with type `priority`.
-3. Close the Epic issue via `gh issue close`.
+If a delegated action wrote a file under `plan/history/` (via
+`archive-history`) or modified notes, invoke the `commit` skill.
 
 ## Notes
 
-- **Review-first**: Always check status before updating. Findings inform
-  decisions.
-- **User control**: No automatic changes — you decide what to update.
-- **Board changes are live**: Schedule moves take effect immediately via API.
-  No file commit is needed for pure scheduling changes.
-- **Undo**: Board moves can be undone by moving the item back. Closed Epics
-  can be reopened with `gh issue reopen`.
+- **Review-first**: Always audit before updating. Findings inform decisions.
+- **User control**: No automatic changes — you decide each update.
+- **No duplication**: This skill coordinates; it never re-implements the audit,
+  the mutations, or epic shaping. When board mechanics change, only
+  `check-priority-status`, `update-priorities`, `calve-epics`, and `shared/`
+  need editing.
+- **Undo**: Board moves reverse by moving the item back; closed Epics reopen
+  with `gh issue reopen`.

--- a/.agents/skills/shared/README.md
+++ b/.agents/skills/shared/README.md
@@ -16,23 +16,37 @@ Shared scripts and reference documents referenced by multiple skills.
 |---|---|---|
 | `sync-check.sh` | Verify worktree is synced to `origin/main` | `bash .agents/skills/shared/sync-check.sh` |
 | `claim-issue.sh` | Sync + create branch + assign + post claim comment | `bash .agents/skills/shared/claim-issue.sh <N> <prefix> <slug>` |
-| `add-to-project.sh` | Add issue to Project #24 with Schedule | `bash .agents/skills/shared/add-to-project.sh <N> [Now\|Next\|Later\|Someday]` |
+| `add-to-project.sh` | Add issue to Project #24 with Schedule | `bash .agents/skills/shared/add-to-project.sh <N> [Focus\|Now\|Next\|Later\|Someday]` |
 | `query-now-epics.sh` | List open Epics with Schedule=Now | `bash .agents/skills/shared/query-now-epics.sh` |
+| `board-id.sh` | Resolve any board node/field/option/issue-type ID **by name** (TTL-cached) | `bash .agents/skills/shared/board-id.sh <category> [<Name>]` |
 
-## Constants (CERTCC/Vultron)
+## Board IDs — never hardcode them
 
-| Name | Value |
+GitHub board IDs (repo node ID, project node ID, Schedule field/option IDs,
+issue-type IDs) are **server-generated and mutable** — editing a ProjectV2
+single-select field's options rotates every option ID. Any value pasted into a
+skill drifts stale and silently mis-schedules issues (this has bitten us
+before).
+
+**Resolve them at runtime by name** via `board-id.sh`, which fetches from the
+live board and caches to `board-ids.json` with a 24h TTL (override with the
+`BOARD_ID_TTL` env var in seconds; `--refresh` forces a re-fetch). No skill
+should contain a raw ID.
+
+| What you need | Command |
 |---|---|
-| Repo node ID | `R_kgDOIn77fA` |
-| Project #24 ID | `PVT_kwDOAjf0s84BZnre` |
-| Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Schedule: Focus | `6bca50d7` |
-| Schedule: Now | `22e6679d` |
-| Schedule: Next | `1c1ed63d` |
-| Schedule: Later | `520032ef` |
-| Schedule: Someday | `a890eacc` |
-| Task issue type ID | `IT_kwDOAjf0s84AcFLo` |
-| Bug issue type ID | `IT_kwDOAjf0s84AcFLq` |
-| Epic issue type ID | `IT_kwDOAjf0s84B_E1A` |
-| Idea issue type ID | `IT_kwDOAjf0s84B_EoA` |
-| Concern issue type ID | `IT_kwDOAjf0s84B_2VT` |
+| Repo node ID | `bash .agents/skills/shared/board-id.sh repo` |
+| Project #24 node ID | `bash .agents/skills/shared/board-id.sh project` |
+| Schedule field ID | `bash .agents/skills/shared/board-id.sh schedule-field` |
+| A Schedule option ID | `bash .agents/skills/shared/board-id.sh schedule Now` (or `Focus`/`Next`/`Later`/`Someday`/`Completed`) |
+| An issue-type ID | `bash .agents/skills/shared/board-id.sh issue-type Epic` (or `Task`/`Bug`/`Feature`/`Idea`/`Concern`) |
+| Whole cache as JSON | `bash .agents/skills/shared/board-id.sh --dump` |
+
+The only stable, human-meaningful facts (the bootstrap inputs, hardcoded in
+`board-id.sh` alone) are `owner=CERTCC`, `repo=Vultron`, and project number
+`24`. Everything opaque is derived from those.
+
+`board-ids.json` is a regenerable cache: it is committed so first-run/offline
+use works, but if it is ever wrong, `bash .agents/skills/shared/board-id.sh
+--refresh --dump` rebuilds it and every consumer picks up the new values at
+once — no per-skill edits.

--- a/.agents/skills/shared/add-to-project.sh
+++ b/.agents/skills/shared/add-to-project.sh
@@ -8,17 +8,15 @@ set -euo pipefail
 ISSUE_NUMBER="${1:?Usage: add-to-project.sh <ISSUE_NUMBER> [SCHEDULE]}"
 SCHEDULE="${2:-Someday}"
 
-PROJECT_ID="PVT_kwDOAjf0s84BZnre"
-SCHEDULE_FIELD_ID="PVTSSF_lADOAjf0s84BZnrezhUlFOM"
-
-case "$SCHEDULE" in
-  Focus)   SCHEDULE_OPTION_ID="6bca50d7" ;;
-  Now)     SCHEDULE_OPTION_ID="22e6679d" ;;
-  Next)    SCHEDULE_OPTION_ID="1c1ed63d" ;;
-  Later)   SCHEDULE_OPTION_ID="520032ef" ;;
-  Someday) SCHEDULE_OPTION_ID="a890eacc" ;;
-  *) echo "❌ Unknown schedule value: $SCHEDULE (use Focus|Now|Next|Later|Someday)" >&2; exit 1 ;;
-esac
+# All board IDs are resolved live-and-cached via board-id.sh — never hardcoded
+# (they rotate when the Schedule field's options are edited).
+BOARD_ID="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/board-id.sh"
+PROJECT_ID=$(bash "$BOARD_ID" project)
+SCHEDULE_FIELD_ID=$(bash "$BOARD_ID" schedule-field)
+if ! SCHEDULE_OPTION_ID=$(bash "$BOARD_ID" schedule "$SCHEDULE"); then
+  echo "❌ Unknown schedule value: $SCHEDULE (use Focus|Now|Next|Later|Someday)" >&2
+  exit 1
+fi
 
 NODE_ID=$(gh api graphql -f query='{
   repository(owner:"CERTCC", name:"Vultron") {

--- a/.agents/skills/shared/board-id.sh
+++ b/.agents/skills/shared/board-id.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# board-id.sh — resolve GitHub board constants (node IDs, field/option IDs,
+# issue-type IDs) by human-readable name, backed by a TTL cache.
+#
+# These IDs are server-generated and MUTABLE — editing a ProjectV2 single-select
+# field's options rotates every option ID. Hardcoding them anywhere drifts
+# stale. This script derives them from the live board and caches the result, so
+# no skill ever needs to name a raw ID.
+#
+# Bootstrap inputs (stable, human-meaningful — the only hardcoded values):
+#   owner=CERTCC  repo=Vultron  project number=24
+#
+# Usage:
+#   board-id.sh repo                     # repo node ID
+#   board-id.sh project                  # Project #24 node ID
+#   board-id.sh schedule-field           # Schedule field ID
+#   board-id.sh schedule <Name>          # Schedule option ID (Now|Next|Later|Someday|Focus|Completed)
+#   board-id.sh issue-type <Name>        # issue-type ID (Task|Bug|Feature|Idea|Epic|Concern)
+#   board-id.sh --refresh [<args...>]    # force re-fetch, then resolve (args optional)
+#   board-id.sh --dump                   # print the whole cache as JSON
+#
+# Exit codes: 0 ok; 1 usage/resolution error; 2 network/API error.
+set -euo pipefail
+
+OWNER="CERTCC"
+REPO="Vultron"
+PROJECT_NUMBER=24
+TTL_SECONDS=${BOARD_ID_TTL:-86400}   # 24h; override with BOARD_ID_TTL env
+
+CACHE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/board-ids.json"
+
+# --- cache freshness ---------------------------------------------------------
+cache_fresh() {
+  [ -f "$CACHE" ] || return 1
+  local fetched now age
+  fetched=$(jq -r '.fetched_at_epoch // 0' "$CACHE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  age=$(( now - fetched ))
+  [ "$age" -ge 0 ] && [ "$age" -lt "$TTL_SECONDS" ]
+}
+
+# --- fetch + rewrite cache ---------------------------------------------------
+refresh_cache() {
+  local now data
+  now=$(date +%s)
+
+  # One query for everything derivable from owner/name/project-number.
+  data=$(gh api graphql -f query='
+    query($owner:String!, $repo:String!, $number:Int!) {
+      repository(owner:$owner, name:$repo) {
+        id
+        issueTypes(first:50) { nodes { id name } }
+      }
+      organization(login:$owner) {
+        projectV2(number:$number) {
+          id
+          field(name:"Schedule") {
+            ... on ProjectV2SingleSelectField { id options { id name } }
+          }
+        }
+      }
+    }' \
+    -f owner="$OWNER" -f repo="$REPO" -F number="$PROJECT_NUMBER" 2>/dev/null) || {
+      echo "❌ board-id: GraphQL query failed (auth/network?)." >&2
+      return 2
+    }
+
+  # Reshape into a flat lookup cache. Fail loudly if the board shape is empty.
+  echo "$data" | jq --argjson now "$now" '
+    {
+      fetched_at_epoch: $now,
+      repo:            .data.repository.id,
+      project:         .data.organization.projectV2.id,
+      "schedule-field": .data.organization.projectV2.field.id,
+      schedule:        (.data.organization.projectV2.field.options
+                          | map({(.name): .id}) | add // {}),
+      "issue-type":    (.data.repository.issueTypes.nodes
+                          | map({(.name): .id}) | add // {})
+    }
+    | if (.repo == null or .project == null or .schedule == {} or ."issue-type" == {})
+      then error("board-id: live board returned empty/unexpected shape")
+      else . end
+  ' > "$CACHE.tmp" || {
+      echo "❌ board-id: could not parse board response." >&2
+      rm -f "$CACHE.tmp"
+      return 2
+    }
+  mv "$CACHE.tmp" "$CACHE"
+}
+
+# --- resolution --------------------------------------------------------------
+resolve() {
+  local category="${1:-}" name="${2:-}"
+  case "$category" in
+    repo|project|schedule-field)
+      jq -er --arg k "$category" '.[$k] // empty' "$CACHE"
+      ;;
+    schedule|issue-type)
+      [ -n "$name" ] || { echo "❌ board-id: '$category' needs a name argument." >&2; return 1; }
+      jq -er --arg c "$category" --arg n "$name" '.[$c][$n] // empty' "$CACHE"
+      ;;
+    *)
+      echo "❌ board-id: unknown category '$category'." >&2
+      echo "   Categories: repo | project | schedule-field | schedule <Name> | issue-type <Name>" >&2
+      return 1
+      ;;
+  esac
+}
+
+# --- main --------------------------------------------------------------------
+FORCE=0
+if [ "${1:-}" = "--refresh" ]; then FORCE=1; shift; fi
+
+if [ "${1:-}" = "--dump" ]; then
+  { [ "$FORCE" = 1 ] || ! cache_fresh; } && refresh_cache
+  cat "$CACHE"; exit 0
+fi
+
+if [ "$FORCE" = 1 ] || ! cache_fresh; then
+  refresh_cache
+fi
+
+# A cache miss on a valid-looking name may mean the board changed since last
+# fetch — refresh once and retry before giving up.
+if ! val=$(resolve "$@"); then
+  exit 1
+fi
+if [ -z "$val" ]; then
+  refresh_cache
+  val=$(resolve "$@") || exit 1
+  if [ -z "$val" ]; then
+    echo "❌ board-id: no match for '$*' even after refresh." >&2
+    exit 1
+  fi
+fi
+printf '%s\n' "$val"

--- a/.agents/skills/shared/board-id.sh
+++ b/.agents/skills/shared/board-id.sh
@@ -88,16 +88,32 @@ refresh_cache() {
   mv "$CACHE.tmp" "$CACHE"
 }
 
+# Refresh, but tolerate failure when a usable cache already exists: a stale
+# cache beats a hard exit (e.g. offline, or the committed cache aged past its
+# TTL). Only a missing-and-unfetchable cache is fatal.
+ensure_cache() {
+  if refresh_cache; then
+    return 0
+  fi
+  if [ -f "$CACHE" ]; then
+    echo "⚠️  board-id: refresh failed; using existing (possibly stale) cache." >&2
+    return 0
+  fi
+  return 2
+}
+
 # --- resolution --------------------------------------------------------------
 resolve() {
   local category="${1:-}" name="${2:-}"
   case "$category" in
     repo|project|schedule-field)
-      jq -er --arg k "$category" '.[$k] // empty' "$CACHE"
+      # No -e: a miss prints empty and still exits 0, so the caller can tell a
+      # valid-but-absent name (empty output) apart from a usage error (below).
+      jq -r --arg k "$category" '.[$k] // empty' "$CACHE"
       ;;
     schedule|issue-type)
       [ -n "$name" ] || { echo "❌ board-id: '$category' needs a name argument." >&2; return 1; }
-      jq -er --arg c "$category" --arg n "$name" '.[$c][$n] // empty' "$CACHE"
+      jq -r --arg c "$category" --arg n "$name" '.[$c][$n] // empty' "$CACHE"
       ;;
     *)
       echo "❌ board-id: unknown category '$category'." >&2
@@ -112,12 +128,18 @@ FORCE=0
 if [ "${1:-}" = "--refresh" ]; then FORCE=1; shift; fi
 
 if [ "${1:-}" = "--dump" ]; then
-  { [ "$FORCE" = 1 ] || ! cache_fresh; } && refresh_cache
+  { [ "$FORCE" = 1 ] || ! cache_fresh; } && ensure_cache
   cat "$CACHE"; exit 0
 fi
 
+# Bare `--refresh` with no category: refresh-only, then exit (args are optional).
+if [ "$FORCE" = 1 ] && [ -z "${1:-}" ]; then
+  ensure_cache && echo "board-id: cache refreshed." >&2
+  exit 0
+fi
+
 if [ "$FORCE" = 1 ] || ! cache_fresh; then
-  refresh_cache
+  ensure_cache
 fi
 
 # A cache miss on a valid-looking name may mean the board changed since last
@@ -126,7 +148,7 @@ if ! val=$(resolve "$@"); then
   exit 1
 fi
 if [ -z "$val" ]; then
-  refresh_cache
+  ensure_cache
   val=$(resolve "$@") || exit 1
   if [ -z "$val" ]; then
     echo "❌ board-id: no match for '$*' even after refresh." >&2

--- a/.agents/skills/shared/board-ids.json
+++ b/.agents/skills/shared/board-ids.json
@@ -1,0 +1,22 @@
+{
+  "fetched_at_epoch": 1785347617,
+  "repo": "R_kgDOIn77fA",
+  "project": "PVT_kwDOAjf0s84BZnre",
+  "schedule-field": "PVTSSF_lADOAjf0s84BZnrezhUlFOM",
+  "schedule": {
+    "Focus": "6bca50d7",
+    "Now": "22e6679d",
+    "Next": "1c1ed63d",
+    "Later": "520032ef",
+    "Someday": "a890eacc",
+    "Completed": "3cd503f1"
+  },
+  "issue-type": {
+    "Task": "IT_kwDOAjf0s84AcFLo",
+    "Bug": "IT_kwDOAjf0s84AcFLq",
+    "Feature": "IT_kwDOAjf0s84AcFLs",
+    "Idea": "IT_kwDOAjf0s84B_EoA",
+    "Epic": "IT_kwDOAjf0s84B_E1A",
+    "Concern": "IT_kwDOAjf0s84B_2VT"
+  }
+}

--- a/.agents/skills/shared/query-now-epics.sh
+++ b/.agents/skills/shared/query-now-epics.sh
@@ -4,6 +4,9 @@
 # Usage: bash .agents/skills/shared/query-now-epics.sh
 set -euo pipefail
 
+# Board IDs are resolved live-and-cached via board-id.sh — never hardcoded.
+PROJECT_ID=$(bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/board-id.sh" project)
+
 gh api graphql --jq '
   .data.node.items.nodes[]
   | select(
@@ -17,7 +20,7 @@ gh api graphql --jq '
     )
   | "#\(.content.number): \(.content.title)"
 ' -f query='{
-  node(id: "PVT_kwDOAjf0s84BZnre") {
+  node(id: "'"$PROJECT_ID"'") {
     ... on ProjectV2 {
       items(first: 100) {
         nodes {

--- a/.agents/skills/update-priorities/REFERENCE.md
+++ b/.agents/skills/update-priorities/REFERENCE.md
@@ -8,21 +8,22 @@ Technical details for the priority update workflow.
 
 ## Project Board Constants
 
-| Name | Value |
-|---|---|
-| Project node ID | `PVT_kwDOAjf0s84BZnre` |
-| Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Focus option ID | `6bca50d7` |
-| Now option ID | `22e6679d` |
-| Next option ID | `1c1ed63d` |
-| Later option ID | `520032ef` |
-| Someday option ID | `a890eacc` |
+Board IDs are **never hardcoded** — resolve them by name via `board-id.sh`
+(see `.agents/skills/shared/README.md`). They rotate when the Schedule field's
+options are edited, so any pasted literal drifts stale.
+
+```bash
+PROJECT_ID=$(bash .agents/skills/shared/board-id.sh project)
+SCHEDULE_FIELD_ID=$(bash .agents/skills/shared/board-id.sh schedule-field)
+SCHEDULE_OPTION_ID=$(bash .agents/skills/shared/board-id.sh schedule "${TIER}")  # Focus|Now|Next|Later|Someday
+```
 
 ## Querying All Board Items
 
 ```bash
+PROJECT_ID=$(bash .agents/skills/shared/board-id.sh project)
 gh api graphql -f query='{
-  node(id: "PVT_kwDOAjf0s84BZnre") {
+  node(id: "'"$PROJECT_ID"'") {
     ... on ProjectV2 {
       items(first: 100) {
         nodes {
@@ -46,11 +47,14 @@ gh api graphql -f query='{
 # Look up item ID by issue number (from items query above)
 ITEM_ID="<project item node ID>"
 
+PROJECT_ID=$(bash .agents/skills/shared/board-id.sh project)
+SCHEDULE_FIELD_ID=$(bash .agents/skills/shared/board-id.sh schedule-field)
+SCHEDULE_OPTION_ID=$(bash .agents/skills/shared/board-id.sh schedule "${TIER}")
 gh api graphql -f query="mutation {
   updateProjectV2ItemFieldValue(input: {
-    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    projectId: \"${PROJECT_ID}\"
     itemId: \"${ITEM_ID}\"
-    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+    fieldId: \"${SCHEDULE_FIELD_ID}\"
     value: { singleSelectOptionId: \"${SCHEDULE_OPTION_ID}\" }
   }) { projectV2Item { id } }
 }"

--- a/.agents/skills/update-priorities/SKILL.md
+++ b/.agents/skills/update-priorities/SKILL.md
@@ -31,26 +31,29 @@ The skill will:
 
 ## Project Board Constants
 
-| Name | Value |
-|---|---|
-| Project node ID | `PVT_kwDOAjf0s84BZnre` |
-| Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
-| Focus option ID | `6bca50d7` |
-| Now option ID | `22e6679d` |
-| Next option ID | `1c1ed63d` |
-| Later option ID | `520032ef` |
-| Someday option ID | `a890eacc` |
+Board IDs (project node ID, Schedule field ID, Schedule option IDs) are
+**never hardcoded** — they rotate when the field's options are edited. Resolve
+them by name at runtime via `board-id.sh`; see
+`.agents/skills/shared/README.md` for the full interface:
+
+```bash
+PROJECT_ID=$(bash .agents/skills/shared/board-id.sh project)
+SCHEDULE_FIELD_ID=$(bash .agents/skills/shared/board-id.sh schedule-field)
+# Option ID for a given tier (Focus|Now|Next|Later|Someday):
+SCHEDULE_OPTION_ID=$(bash .agents/skills/shared/board-id.sh schedule "${TIER}")
+```
 
 ## Workflows
 
 ### Move Item to a Different Tier
 
 1. Identify the issue or Epic number.
-2. Find the item's project item ID:
+2. Resolve board IDs and find the item's project item ID:
 
    ```bash
+   PROJECT_ID=$(bash .agents/skills/shared/board-id.sh project)
    ITEM_ID=$(gh api graphql -f query='{
-     node(id:"PVT_kwDOAjf0s84BZnre") {
+     node(id:"'"$PROJECT_ID"'") {
        ... on ProjectV2 {
          items(first:100) {
            nodes {
@@ -64,14 +67,17 @@ The skill will:
      | select(.content.number == ${ISSUE_NUMBER}) | .id")
    ```
 
-3. Apply the Schedule field update:
+3. Apply the Schedule field update (resolve the target tier's option ID by
+   name, e.g. `bash .agents/skills/shared/board-id.sh schedule Now`):
 
    ```bash
+   SCHEDULE_FIELD_ID=$(bash .agents/skills/shared/board-id.sh schedule-field)
+   SCHEDULE_OPTION_ID=$(bash .agents/skills/shared/board-id.sh schedule "${TIER}")
    gh api graphql -f query="mutation {
      updateProjectV2ItemFieldValue(input: {
-       projectId: \"PVT_kwDOAjf0s84BZnre\"
+       projectId: \"${PROJECT_ID}\"
        itemId: \"${ITEM_ID}\"
-       fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+       fieldId: \"${SCHEDULE_FIELD_ID}\"
        value: { singleSelectOptionId: \"${SCHEDULE_OPTION_ID}\" }
      }) { projectV2Item { id } }
    }"
@@ -88,8 +94,9 @@ bash .agents/skills/shared/add-to-project.sh "${ISSUE_NUMBER}" "${SCHEDULE:-Some
 ```
 
 To **re-tier an item already on the board**, resolve its existing project item
-ID and set the Schedule field directly (the option IDs are listed in the
-Reference table below and in `.agents/skills/shared/README.md`).
+ID and set the Schedule field directly (resolve every ID by name via
+`board-id.sh` — see the "Move Item to a Different Tier" workflow above and
+`.agents/skills/shared/README.md`).
 
 ### Archive a Completed Epic
 


### PR DESCRIPTION
## Summary

Three related improvements to the process-improvement skill suite, plus a fix
for a recurring class of bug.

### 1. `board-id.sh` — resolve board IDs at runtime, never hardcode them

GitHub board IDs (project/field/Schedule-option/issue-type node IDs) are
server-generated and **rotate** whenever a ProjectV2 single-select field's
options are edited. Copies pasted into skills drift stale and silently
mis-schedule issues — this has bitten the project before (the stale Schedule
option IDs fixed in `b8d609ab`/`cfe2a14a` were the same root cause).

New `.agents/skills/shared/board-id.sh` resolves any board ID **by name**,
backed by a TTL-cached `board-ids.json` (24h default; `--refresh` forces a
re-fetch; `BOARD_ID_TTL` overrides). The only hardcoded facts are the stable
bootstrap inputs (`owner=CERTCC`, `repo=Vultron`, project `#24`); everything
opaque is derived live. Every consumer — the shared scripts, `create_epic.sh`,
and all skill docs — now resolves IDs through it. `shared/README.md` documents
it as the single source of truth. Result: **zero raw board IDs** anywhere
except the resolver's bootstrap and the regenerable cache.

### 2. `review-priorities` — delegate instead of duplicate

`review-priorities` had re-implemented the tier-move mutation and constants
inline, duplicating `check-priority-status` (audit) and `update-priorities`
(mutations). Rewritten as a thin coordinator — the `pr-ship` pattern for the
board: **audit → review → update**, delegating each phase to its owning skill
(`check-priority-status`, `update-priorities`, `calve-epics`) and never
inlining a mutation. Adds a "when to use which board skill" table to resolve
the "which of these do I run?" confusion.

### 3. `reflect-cycle` — the reflection-half macro

New guided router over the reflection half of the dev cycle:
`learn → update-plan → decision-audit → review-priorities`. Unlike `pr-ship`,
it **stops between phases** because each contains a human gate (a `grill-me`
interview and/or its own PR) — it dispatches one phase, then re-confirms before
the next. `dev-status` now recommends it via a **macro-vs-atomic rule** (prefer
`reflect-cycle` over `learn`, and `pr-ship` over individual `pr-*` phases, when
the macro covers the same input).

## Verification

- All migrated scripts run correctly against the live board; bad inputs fail
  cleanly.
- `board-id.sh` verified: fresh-cache offline hit (no `gh` call), TTL expiry
  re-fetch, all categories return correct live values.
- `grep` for every raw board-ID pattern across `.agents/skills` → clean
  (resolver bootstrap + cache only).
- `markdownlint-cli2` on all 18 changed/new markdown files → 0 issues.
- Pre-commit hooks (markdownlint, flake8) pass on every commit.

## Commits

1. `chore(skills)`: board-id.sh resolver + migrate all consumers
2. `refactor(review-priorities)`: delegate to granular skills
3. `feat(reflect-cycle)`: reflection-half macro + dev-status routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)