### PR TITLE
docs: plan issue #1246 — create_assign_cve_id_tree full CVE ID assignment BT

### DIFF
--- a/notes/bt-fuzzer-rm-id-assignment.md
+++ b/notes/bt-fuzzer-rm-id-assignment.md
@@ -37,11 +37,18 @@ to a validated report.
   the main workflow; in production this is a simple metadata check
 - **Automation potential**: **High** — simple query against case metadata or a vulnerability registry; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.IdAssigned`
-- **Call-out point shape**: Retriever — synchronous on-demand query to case metadata or an external vulnerability registry (e.g., CVE database); returns SUCCESS if an identifier has already been assigned to this vulnerability, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel (see BT-18-006).
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
-  early-exit Retriever guard at the top of `AssignVulID` Fallback Selector;
-  returns SUCCESS if an ID is already assigned, short-circuiting assignment work
+- **Call-out point shape**: Retriever — synchronous on-demand query to case
+  metadata or an external vulnerability registry (e.g., CVE database); returns
+  SUCCESS if an identifier has already been assigned to this vulnerability,
+  writing the existing ID to `output_keys = {"assigned_vul_id": str}` so the
+  parent tree has a guaranteed key on any successful path. A boolean is the
+  simplest structured fact (ADR-0024); the on-demand query pattern makes this a
+  Retriever, not a Sentinel (see BT-18-006).
+- **Factory-fn placement**: Implemented in
+  `vultron.core.behaviors.report.assign_cve_id_tree.create_assign_cve_id_tree`
+  (issue #1246) — early-exit Retriever guard at the top of `AssignVulID`
+  Fallback Selector; returns SUCCESS if an ID is already assigned,
+  short-circuiting assignment work
 
 ### `InScope`
 
@@ -58,12 +65,10 @@ to a validated report.
 - **Automation potential**: **High** — scope rules for well-defined ID spaces (e.g., CVE CNA rules) can be encoded as a policy check and automated; may require human review for ambiguous cases.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.InScope`
 - **Call-out point shape**: Evaluator — evaluates whether the vulnerability falls within the applicable ID namespace by comparing vulnerability attributes against CNA scope rules or a product/component registry; returns a policy judgment (in-scope or out-of-scope), not a binary monitor.
-- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
-  `vultron.core.behaviors.report.assign_vul_id_tree.create_assign_vul_id_tree`
-  (`in_scope_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
-  Evaluator condition guard early in `AssignVulID` Sequence, before the
-  authority-check nodes
+- **Factory-fn placement**: Implemented in
+  `vultron.core.behaviors.report.assign_cve_id_tree.create_assign_cve_id_tree`
+  (issue #1246) — Evaluator condition guard early in `_AssignIdIfInScope`
+  Sequence, before the authority-check nodes
 
 ### `IsIDAssignmentAuthority`
 
@@ -87,10 +92,11 @@ to a validated report.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.IsIDAssignmentAuthority`
 - **Call-out point shape**: ProtocolInternal — reads a deployment-time configuration constant (`CVDRole.CVE_NUMBERING_AUTHORITY` on this participant's `case_roles`); the value is set at participant registration, not queried from an external system at runtime. There is no agent seam here: the check resolves entirely within the protocol's own DataLayer.
   (Category 2 per issue #1199 triage — reads a flag written by the protocol's own deployment-time setup.)
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
-  ProtocolInternal condition check in `AssignVulID` Sequence; evaluates
-  participant role metadata before `IdAssignable` and `AssignId`
+- **Factory-fn placement**: Implemented in
+  `vultron.core.behaviors.report.assign_cve_id_tree.create_assign_cve_id_tree`
+  (issue #1246) — ProtocolInternal condition check in `_AssignIdIfPossible`
+  Sequence; evaluates participant role metadata before `ProductInCNAScope`,
+  `IsMostAppropriateCNA`, `IdAssignable`, and `AssignId`
 
 ### `IdAssignable`
 
@@ -117,13 +123,15 @@ to a validated report.
   (`CVDRole.CVE_NUMBERING_AUTHORITY` participant) has assignment
   authority for this specific vulnerability by matching vulnerability
   attributes against CNA scope rules and product-to-CNA mappings;
-  a scope-matching evaluation, not a binary condition monitor.
-- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
-  `vultron.core.behaviors.report.assign_vul_id_tree.create_assign_vul_id_tree`
-  (`id_assignable_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
-  Evaluator condition guard in the assign-direct path Sequence, after
-  `IsIDAssignmentAuthority` succeeds
+  a scope-matching evaluation, not a binary condition monitor. In the
+  full production tree (issue #1246) `IdAssignable` is a SequenceNode
+  subtree of 9 child nodes (exclusion guards, positive conditions, duplicate
+  check, evidence bar, and holistic judgment), not a single leaf.
+- **Factory-fn placement**: Implemented in
+  `vultron.core.behaviors.report.assign_cve_id_tree.create_assign_cve_id_tree`
+  (issue #1246) — the `IdAssignable` SequenceNode subtree is composed
+  inline within `_AssignIdIfPossible`, after `IsMostAppropriateCNA`
+  succeeds; factory seams are on each of its 9 child call-out points
 
 ### `RequestId`
 
@@ -139,11 +147,11 @@ to a validated report.
 - **Notes**: Could be fully automated via the CVE Services API
 - **Automation potential**: **High** — can be fully automated as an API call to the CVE Services endpoint or equivalent ID-request interface.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.RequestId`
-- **Call-out point shape**: Retriever — queries an external ID assignment authority (e.g., CVE Services API) with a reservation/assignment request and writes the resulting assigned ID to the case record; SUCCESS = ID retrieved and recorded.
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
-  Retriever action node in the request-external-id Sequence, used when
-  `IsIDAssignmentAuthority` fails (non-CNA path)
+- **Call-out point shape**: Retriever — queries an external ID assignment authority (e.g., CVE Services API) with a reservation/assignment request and writes the resulting assigned ID to the case record; `output_keys = {"assigned_id": str}`; SUCCESS = ID retrieved and recorded.
+- **Factory-fn placement**: Implemented in
+  `vultron.core.behaviors.report.assign_cve_id_tree.create_assign_cve_id_tree`
+  (issue #1246) — Retriever action node in `_AssignOrRequestId` Fallback,
+  used when `_AssignIdIfPossible` fails (non-CNA or out-of-scope path)
 
 ### `AssignId`
 
@@ -159,10 +167,186 @@ to a validated report.
   API calls or database writes
 - **Automation potential**: **High** — can be fully automated as an API call (reserve/assign) to the ID assignment authority or an internal ID pool management system.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.AssignId`
-- **Call-out point shape**: Composer — generates a new vulnerability identifier from this participant's own ID pool via the ID management system or CVE Services reserve/assign endpoint; the produced artifact is the newly assigned ID recorded in the case.
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
-  Composer action node in the direct-assign Sequence, used when
-  `IdAssignable` succeeds (CNA-direct path)
+- **Call-out point shape**: Composer — generates a new vulnerability identifier from this participant's own ID pool via the ID management system or CVE Services reserve/assign endpoint; `output_keys = {"assigned_vul_id": str}`; the produced artifact is the newly assigned ID recorded in the case.
+- **Factory-fn placement**: Implemented in
+  `vultron.core.behaviors.report.assign_cve_id_tree.create_assign_cve_id_tree`
+  (issue #1246) — Composer action node at the end of `_AssignIdIfPossible`
+  Sequence, used when `IdAssignable` subtree succeeds (CNA-direct path)
+
+---
+
+## New nodes added in issue #1246 (full CVE ID assignment tree)
+
+The following call-out points are part of the expanded `IdAssignable` SequenceNode
+subtree and the `_AssignIdIfPossible` authority-gate section introduced by
+`create_assign_cve_id_tree` (issue #1246), grounded in CNA Operational Rules v4.1.0.
+
+### `ProductInCNAScope`
+
+- **Node name**: `ProductInCNAScope`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `_AssignIdIfPossible` (authority gate)
+- **Semantic function**: Condition — evaluate whether the affected product
+  is within this CNA's declared scope (§3.1, §4.2.16.1).
+- **Automation potential**: **High** — scope lists are machine-readable.
+- **Call-out point shape**: Evaluator — evaluates the product against the
+  CNA's scope registry and returns a policy judgment with rationale.
+  `output_keys = {"product_in_cna_scope": bool,
+  "product_in_cna_scope_rationale": str}`.
+- **Factory-fn placement**: Implemented in
+  `vultron.core.behaviors.report.assign_cve_id_tree.create_assign_cve_id_tree`
+  (issue #1246) — Evaluator in `_AssignIdIfPossible` Sequence, after
+  `IsIDAssignmentAuthority`, before `IsMostAppropriateCNA`
+
+### `IsMostAppropriateCNA`
+
+- **Node name**: `IsMostAppropriateCNA`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `_AssignIdIfPossible` (authority gate)
+- **Semantic function**: Condition — evaluate whether this CNA has
+  first-refusal authority for the affected product (§4.2.1.1, §4.2.16.6).
+- **Automation potential**: **High** — first-refusal registries are machine-readable.
+- **Call-out point shape**: Evaluator — evaluates the CNA first-refusal
+  registry and returns a judgment with rationale.
+  `output_keys = {"is_most_appropriate_cna": bool,
+  "is_most_appropriate_cna_rationale": str}`.
+- **Factory-fn placement**: Implemented in
+  `vultron.core.behaviors.report.assign_cve_id_tree.create_assign_cve_id_tree`
+  (issue #1246) — Evaluator in `_AssignIdIfPossible` Sequence, after
+  `ProductInCNAScope`, before the `IdAssignable` subtree
+
+### `IsNotMaliciousCode`
+
+- **Node name**: `IsNotMaliciousCode`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `IdAssignable` (exclusion guard, §4.1.8)
+- **Semantic function**: Exclusion guard — returns SUCCESS when the report
+  is NOT about deliberately malicious code (§4.1.8).
+- **Automation potential**: **High** — report classification flags are on the blackboard.
+- **Call-out point shape**: Evaluator — evaluates report metadata against
+  the §4.1.8 malicious-code exclusion criterion.
+  `output_keys = {"is_not_malicious_code_verdict": bool,
+  "is_not_malicious_code_rationale": str}`.
+- **Factory-fn placement**: Implemented in issue #1246 — first child of
+  `IdAssignable` Sequence (cheapest guard)
+
+### `IsNotDependencyUpdate`
+
+- **Node name**: `IsNotDependencyUpdate`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `IdAssignable` (exclusion guard, §4.1.12)
+- **Semantic function**: Exclusion guard — returns SUCCESS when the report
+  is NOT a dependency update without a security fix (§4.1.12).
+- **Automation potential**: **High** — report type flags are on the blackboard.
+- **Call-out point shape**: Evaluator.
+  `output_keys = {"is_not_dependency_update_verdict": bool,
+  "is_not_dependency_update_rationale": str}`.
+- **Factory-fn placement**: Implemented in issue #1246 — second child of
+  `IdAssignable` Sequence
+
+### `IsNotEOLStatusAlone`
+
+- **Node name**: `IsNotEOLStatusAlone`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `IdAssignable` (exclusion guard, §4.1.13)
+- **Semantic function**: Exclusion guard — returns SUCCESS when the report
+  is NOT solely about end-of-life status (§4.1.13).
+- **Automation potential**: **High** — report classification flags are on the blackboard.
+- **Call-out point shape**: Evaluator.
+  `output_keys = {"is_not_eol_status_alone_verdict": bool,
+  "is_not_eol_status_alone_rationale": str}`.
+- **Factory-fn placement**: Implemented in issue #1246 — third child of
+  `IdAssignable` Sequence
+
+### `IsNotDeliberatelyEducational`
+
+- **Node name**: `IsNotDeliberatelyEducational`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `IdAssignable` (exclusion guard, §4.2.18)
+- **Semantic function**: Exclusion guard — returns SUCCESS when the report
+  is NOT about deliberately educational content (§4.2.18).
+- **Automation potential**: **High** — report metadata flags are on the blackboard.
+- **Call-out point shape**: Evaluator.
+  `output_keys = {"is_not_deliberately_educational_verdict": bool,
+  "is_not_deliberately_educational_rationale": str}`.
+- **Factory-fn placement**: Implemented in issue #1246 — fourth child of
+  `IdAssignable` Sequence
+
+### `IsOrWillBePubliclyDisclosed`
+
+- **Node name**: `IsOrWillBePubliclyDisclosed`
+- **Source file**: *(ProtocolInternal — no factory seam)*
+- **Parent tree**: `AssignVulID` → `IdAssignable` (positive condition, §4.2.2.1.2)
+- **Semantic function**: ProtocolInternal gate — returns SUCCESS when the
+  vulnerability is already publicly disclosed (CS.P flag) or has an active
+  publication intent. Reads the disclosure plan flag and CS.P status from
+  the blackboard.
+- **Call-out point shape**: ProtocolInternal — OR-gate reading publication-intent
+  flag and CS.P blackboard status. No factory seam needed.
+- **Factory-fn placement**: Implemented in issue #1246 — fifth child of
+  `IdAssignable` Sequence (inline ProtocolInternal node)
+
+### `IsPubliclyAvailableProduct`
+
+- **Node name**: `IsPubliclyAvailableProduct`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `IdAssignable` (positive condition, §4.2.10)
+- **Semantic function**: Condition — returns SUCCESS when the affected product
+  is publicly available (§4.2.10).
+- **Automation potential**: **High** — product metadata flags are on the blackboard.
+- **Call-out point shape**: Evaluator.
+  `output_keys = {"is_publicly_available_product_verdict": bool,
+  "is_publicly_available_product_rationale": str}`.
+- **Factory-fn placement**: Implemented in issue #1246 — sixth child of
+  `IdAssignable` Sequence
+
+### `NoDuplicateCVE`
+
+- **Node name**: `NoDuplicateCVE`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `IdAssignable` (external duplicate check,
+  §4.2.6, §4.2.15)
+- **Semantic function**: Condition — returns SUCCESS when no existing CVE
+  already covers this vulnerability. Makes a judgment with evidence.
+- **Automation potential**: **High** — CVE corpus queries are automatable via API.
+- **Call-out point shape**: Evaluator — makes a deduplication judgment with
+  confidence/evidence (not a binary query). `output_keys =
+  {"no_duplicate_cve_verdict": bool, "no_duplicate_cve_rationale": str}`.
+- **Factory-fn placement**: Implemented in issue #1246 — seventh child of
+  `IdAssignable` Sequence
+
+### `MeetsEvidenceBar`
+
+- **Node name**: `MeetsEvidenceBar`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `IdAssignable` (evidence quality check,
+  §4.2.2.1.1)
+- **Semantic function**: Condition — returns SUCCESS when the report meets
+  the structural completeness / evidence quality bar for CVE assignment.
+- **Automation potential**: **High** — structural field checks are automatable.
+- **Call-out point shape**: Evaluator — evaluates report structural completeness
+  against a configurable evidence bar. `output_keys =
+  {"meets_evidence_bar_verdict": bool, "meets_evidence_bar_rationale": str}`.
+- **Factory-fn placement**: Implemented in issue #1246 — eighth child of
+  `IdAssignable` Sequence
+
+### `IsRealVulnerability`
+
+- **Node name**: `IsRealVulnerability`
+- **Source file**: `report_management/fuzzer/assign_vul_id.py`
+- **Parent tree**: `AssignVulID` → `IdAssignable` (holistic §4.1 judgment,
+  most expensive — placed last)
+- **Semantic function**: Holistic judgment — returns SUCCESS when the report
+  describes a genuine vulnerability per §4.1/§4.4. Distinct from
+  `MeetsEvidenceBar` (structural check); a structurally complete report
+  may describe a non-vulnerability.
+- **Automation potential**: **Medium** — well-structured reports may be
+  evaluated automatically; novel or ambiguous cases may require human judgment.
+- **Call-out point shape**: Evaluator — makes a holistic §4.1 judgment.
+  `output_keys = {"is_real_vul": bool, "is_real_vul_rationale": str}`.
+  Types are placeholder stubs marked for replacement with typed dataclasses
+  before issue #1558.
+- **Factory-fn placement**: Implemented in issue #1246 — ninth (last) child of
+  `IdAssignable` Sequence (most expensive, placed last per cheapest-first rule)
 
 ---

--- a/plan/history/2607/idea/IDEA-1246.md
+++ b/plan/history/2607/idea/IDEA-1246.md
@@ -1,0 +1,33 @@
+---
+source: IDEA-1246
+timestamp: '2026-07-29T18:13:00.829729+00:00'
+title: create_assign_cve_id_tree — full CVE ID assignment BT
+type: idea
+---
+
+## Outcome
+
+Planned the full production CVE ID assignment behavior tree factory function,
+grounded in CNA Operational Rules v4.1.0. The Phase 1 stub `create_assign_vul_id_tree`
+(2-node flat Sequence) is superseded by `create_assign_cve_id_tree` (16-node tree
+with a 9-child `IdAssignable` subtree).
+
+## Key decisions
+
+- `create_assign_vul_id_tree` → `create_assign_cve_id_tree` (rename, no backward shim)
+- `AssignVulIdCallOutBundle` → `AssignCveIdCallOutBundle` with 14 factory fields
+- `IsIDAssignmentAuthority` and `IsOrWillBePubliclyDisclosed` classified as
+  ProtocolInternal (no factory seam); all other condition nodes are Evaluators per ADR-0024
+- `AssignId` → Composer; `RequestId` → Retriever (both write ID to blackboard)
+- `IdAssignable` expanded from a single Evaluator leaf to a 9-child SequenceNode
+  subtree (exclusion guards cheapest-first, then positive conditions, duplicate
+  check, evidence bar, holistic §4.1 judgment last)
+- `IsRealVulnerability` output keys: `{is_real_vul: bool, is_real_vul_rationale: str}`
+  (placeholder stubs, to be refined before issue #1558)
+- No new ADR or spec group warranted (ADR-0024/ADR-0025 cover the pattern)
+
+## Artifacts
+
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/1816>
+- Implementation issue: #1817 (blocked-by #1246, child of epic #1285)
+- Notes updated: `notes/bt-fuzzer-rm-id-assignment.md` (6 entries updated + 10 new)


### PR DESCRIPTION
- Closes #1246

## Summary

Planning docs for issue #1246: expand the Phase 1 `create_assign_vul_id_tree` stub
into the full production CVE ID assignment behavior tree grounded in CNA Operational
Rules v4.1.0.

Changes to `notes/bt-fuzzer-rm-id-assignment.md`:

- Updated 6 existing node entries (`IdAssigned`, `InScope`, `IsIDAssignmentAuthority`,
  `IdAssignable`, `RequestId`, `AssignId`) with corrected call-out point shapes,
  `output_keys`, and factory-fn placement references pointing to
  `create_assign_cve_id_tree` (issue #1246).
- Added 11 new call-out point entries for the full CVE tree:
  `ProductInCNAScope`, `IsMostAppropriateCNA` (Evaluators in `_AssignIdIfPossible`
  authority gate); `IsNotMaliciousCode`, `IsNotDependencyUpdate`,
  `IsNotEOLStatusAlone`, `IsNotDeliberatelyEducational`,
  `IsOrWillBePubliclyDisclosed` (ProtocolInternal), `IsPubliclyAvailableProduct`,
  `NoDuplicateCVE`, `MeetsEvidenceBar`, `IsRealVulnerability` (Evaluators in
  `IdAssignable` subtree).

## Design decisions resolved

- `create_assign_vul_id_tree` renamed to `create_assign_cve_id_tree` (no backward shim)
- `AssignVulIdCallOutBundle` renamed to `AssignCveIdCallOutBundle` with 14 factory fields
- `IsIDAssignmentAuthority` and `IsOrWillBePubliclyDisclosed` classified as
  ProtocolInternal (read deployment-time config / blackboard CS.P state)
- All other condition nodes classified as Evaluators per ADR-0024
- `AssignId` → Composer; `RequestId` → Retriever (both write ID to blackboard)
- `IsRealVulnerability` output keys: `{is_real_vul: bool, is_real_vul_rationale: str}`
  (placeholder stubs, to be replaced with typed dataclasses before issue #1558)
- No new ADR or spec group warranted (pattern already covered by ADR-0024/ADR-0025)

## Implementation Issues

- #1817