### PR TITLE
fix(demo): wrap coverage waits in demo_check; add close_case anchor before tail read

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1772.md
+++ b/plan/history/2607/implementation/ISSUE-1772.md
@@ -1,0 +1,25 @@
+---
+source: ISSUE-1772
+timestamp: '2026-07-29T18:47:30.261290+00:00'
+title: 'fix flaky invariant harness: wrap coverage waits in demo_check; add close_case
+  anchor'
+type: implementation
+---
+
+Issue #1772 (primary) + #1802 (downstream crash symptom).
+
+Symptoms: Demo scenario runs produced either (A) exit code 1 with no JSONL artifact, or (B) JSONL artifact with a gapped ledger that the invariant harness then rejected.
+
+Root cause A (#1802): All wait_for_contiguous_ledger_coverage calls in _phase_sync_verification and_phase_case_closure were bare (not in demo_check). A polling timeout raised an uncaught AssertionError → exit 1 → no artifact.
+
+Root cause B (#1772): The authoritative-actor tail index was read immediately after wait_for_all_participants_rm_closed. The close_case ledger entry is committed asynchronously by EmitCloseCaseNode after the last RM.CLOSED (a BackgroundTasks dispatch). Reading the tail too early snapshots a stale tail that excludes close_case, so replica coverage succeeds against the wrong tail, the JSONL is gapped, and the invariant harness fails.
+
+Fix: (1) Wrap all coverage waits in demo_check so timeouts accumulate to_demo_failures rather than crashing. (2) Add wait_for_event_type_in_ledger(close_case) before the tail read in each close phase so close_case is always included in the tail before replica coverage begins.
+
+New helper: wait_for_event_type_in_ledger in vultron/demo/helpers/polling.py.
+
+Regression tests in test/demo/test_fvv_demo.py: TestCoverageWaitInsideDemoCheck (Bug A) + TestWaitForEventTypeInLedger x4 (Bug B).
+
+All 7 scenario files patched: fv, fvv, fcv, fvcv-extension, fvcv-handoff, fccv-extension, fccv-handoff.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1819>

--- a/test/demo/test_fvv_demo.py
+++ b/test/demo/test_fvv_demo.py
@@ -32,7 +32,10 @@ from fastapi.testclient import TestClient
 import vultron.demo.scenario.fvv_demo as demo
 from test.demo._helpers import make_client, make_testclient_call
 from vultron.demo.cli import main
-from vultron.demo.helpers.polling import wait_for_contiguous_ledger_coverage
+from vultron.demo.helpers.polling import (
+    wait_for_contiguous_ledger_coverage,
+    wait_for_event_type_in_ledger,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -331,3 +334,229 @@ class TestWaitForContiguousLedgerCoverage:
                 timeout_seconds=0.1,
                 poll_interval=0.05,
             )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: Bug A — coverage-wait timeout must not crash demo
+# (issue #1772, #1802)
+# ---------------------------------------------------------------------------
+
+
+class TestCoverageWaitInsideDemoCheck:
+    """Regression: bare wait_for_contiguous_ledger_coverage outside demo_check
+    crashes demo with exit code 1 when it times out.
+
+    After the fix, a timeout should accumulate to _demo_failures and allow
+    _phase_dump_case_ledgers to run (exit 0 with a failure summary).
+    """
+
+    def test_coverage_wait_timeout_accumulates_to_demo_failures_not_raises(
+        self,
+    ):
+        """A timed-out coverage wait inside _phase_case_closure must NOT raise.
+
+        Bug A: the bare wait_for_contiguous_ledger_coverage call propagated
+        AssertionError through _phase_case_closure, crashing the demo runner.
+        After the fix, every coverage wait is inside a demo_check context,
+        so the timeout is recorded in _demo_failures and the phase returns
+        normally.
+
+        We verify this by patching wait_for_contiguous_ledger_coverage to
+        always raise AssertionError and confirming _phase_case_closure does
+        not propagate the exception.
+        """
+        import vultron.demo.utils as utils_module  # noqa: PLC0415
+
+        utils_module.reset_demo_failures()
+
+        case_id = "https://example.org/cases/bug-a-regression"
+
+        # Build minimal mocks that satisfy _phase_case_closure's early calls
+        # (actor_closes_case, wait_for_all_participants_rm_closed, verify_case_closed,
+        # _get_log_entries_for_case) without triggering real HTTP.
+        client = MagicMock()
+        actor = MagicMock()
+        actor.id_ = "https://example.org/actors/test-actor"
+
+        case = MagicMock()
+        case.id_ = case_id
+
+        # _get_log_entries_for_case reads from /datalayer/CaseLedgerEntrys/
+        # Return a single entry so the tail-read branch is taken.
+        client.get.return_value = {
+            "e0": {
+                "case_id": case_id,
+                "log_index": 0,
+                "entry_hash": "hash0000",
+                "event_type": "close_case",
+            }
+        }
+
+        initial_failures = len(utils_module._demo_failures)
+
+        with (
+            patch("vultron.demo.scenario.fvv_demo.actor_closes_case"),
+            patch(
+                "vultron.demo.scenario.fvv_demo.wait_for_all_participants_rm_closed"
+            ),
+            patch("vultron.demo.scenario.fvv_demo.verify_case_closed"),
+            patch(
+                "vultron.demo.scenario.fvv_demo.wait_for_event_type_in_ledger"
+            ),
+            patch(
+                "vultron.demo.scenario.fvv_demo.wait_for_contiguous_ledger_coverage",
+                side_effect=AssertionError(
+                    "contiguous ledger coverage timeout"
+                ),
+            ),
+        ):
+            try:
+                demo._phase_case_closure(
+                    finder_client=client,
+                    vendor_client=client,
+                    vendor2_client=client,
+                    vendor=actor,
+                    vendor_in_vendor=actor,
+                    vendor2=actor,
+                    vendor2_in_vendor2=actor,
+                    finder=actor,
+                    finder_in_finder=actor,
+                    case=case,
+                )
+            except AssertionError as exc:
+                pytest.fail(
+                    f"Bug A regression: AssertionError propagated out of "
+                    f"_phase_case_closure: {exc}"
+                )
+
+        # The failure must be accumulated, not raised.
+        assert (
+            len(utils_module._demo_failures) > initial_failures
+        ), "Expected the coverage-wait timeout to be recorded in _demo_failures"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: Bug B — wait_for_event_type_in_ledger helper
+# (issue #1772)
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForEventTypeInLedger:
+    """Regression: the close phase must wait for close_case to appear on the
+    authoritative actor before reading the tail index for replica coverage.
+
+    Without this wait, the tail excludes close_case (committed asynchronously
+    after the last RM.CLOSED); coverage 'succeeds' for the wrong tail; the
+    dump runs before close_case replicates; invariant harness fails.
+    """
+
+    def _make_entries(self, case_id: str, event_types: list[str]) -> dict:
+        return {
+            f"e{i}": {
+                "case_id": case_id,
+                "log_index": i,
+                "entry_hash": f"hash{i:04d}",
+                "event_type": et,
+            }
+            for i, et in enumerate(event_types)
+        }
+
+    def test_returns_when_event_type_present(self):
+        """Returns immediately when the target event_type is already in the log."""
+        case_id = "https://example.org/cases/bug-b-present"
+        client = MagicMock()
+        client.get.return_value = self._make_entries(
+            case_id, ["validate_report", "close_case"]
+        )
+
+        wait_for_event_type_in_ledger(
+            client=client,
+            case_id=case_id,
+            event_type="close_case",
+            timeout_seconds=1.0,
+        )
+        assert client.get.call_count >= 1
+
+    def test_raises_when_event_type_absent(self):
+        """Raises AssertionError when target event_type never appears."""
+        case_id = "https://example.org/cases/bug-b-absent"
+        client = MagicMock()
+        client.get.return_value = self._make_entries(
+            case_id,
+            ["validate_report", "add_participant_status_to_participant"],
+        )
+
+        with pytest.raises(AssertionError, match="close_case"):
+            wait_for_event_type_in_ledger(
+                client=client,
+                case_id=case_id,
+                event_type="close_case",
+                timeout_seconds=0.1,
+                poll_interval=0.05,
+            )
+
+    def test_ignores_entries_from_other_cases(self):
+        """Does not count close_case entries from other cases."""
+        case_id = "https://example.org/cases/bug-b-target"
+        other_case_id = "https://example.org/cases/bug-b-other"
+        client = MagicMock()
+        entries = self._make_entries(case_id, ["validate_report"])
+        other_entries = {
+            "other-e0": {
+                "case_id": other_case_id,
+                "log_index": 0,
+                "entry_hash": "hashOther",
+                "event_type": "close_case",
+            }
+        }
+        client.get.return_value = {**entries, **other_entries}
+
+        with pytest.raises(AssertionError, match="close_case"):
+            wait_for_event_type_in_ledger(
+                client=client,
+                case_id=case_id,
+                event_type="close_case",
+                timeout_seconds=0.1,
+                poll_interval=0.05,
+            )
+
+    def test_eventually_returns_when_event_arrives(self):
+        """Returns once the event_type appears after a few polls."""
+        case_id = "https://example.org/cases/bug-b-eventual"
+        call_count = 0
+        no_close_entries = {
+            "e0": {
+                "case_id": case_id,
+                "log_index": 0,
+                "entry_hash": "hash0000",
+                "event_type": "validate_report",
+            }
+        }
+        with_close_entries = {
+            **no_close_entries,
+            "e1": {
+                "case_id": case_id,
+                "log_index": 1,
+                "entry_hash": "hash0001",
+                "event_type": "close_case",
+            },
+        }
+
+        def _get_side_effect(path: str) -> dict:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return no_close_entries
+            return with_close_entries
+
+        client = MagicMock()
+        client.get.side_effect = _get_side_effect
+
+        wait_for_event_type_in_ledger(
+            client=client,
+            case_id=case_id,
+            event_type="close_case",
+            timeout_seconds=5.0,
+            poll_interval=0.05,
+        )
+        assert call_count >= 3

--- a/test/demo/test_fvv_demo.py
+++ b/test/demo/test_fvv_demo.py
@@ -542,7 +542,7 @@ class TestWaitForEventTypeInLedger:
             },
         }
 
-        def _get_side_effect(path: str) -> dict:
+        def _get_side_effect(path: str):
             nonlocal call_count
             call_count += 1
             if call_count < 3:

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -265,6 +265,62 @@ def wait_for_finder_log_entry(
     )
 
 
+def wait_for_event_type_in_ledger(
+    client: DataLayerClient,
+    case_id: str,
+    event_type: str,
+    timeout_seconds: float = 20.0,
+    poll_interval: float = 0.5,
+) -> None:
+    """Poll *client*'s DataLayer until a ``CaseLedgerEntry`` with *event_type* appears.
+
+    Use this before reading the authoritative tail index in close phases to
+    ensure the ``close_case`` entry (committed asynchronously by the CaseActor's
+    auto-close BT after the last RM.CLOSED) is present before we snapshot the
+    tail.  Without this wait, the tail index may exclude ``close_case``, causing
+    a coverage-wait 'success' for the wrong tail and a gapped ledger dump
+    (issue #1772 Bug B).
+
+    Args:
+        client: DataLayerClient connected to the authoritative container.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
+        event_type: The ``event_type`` value to wait for (e.g. ``"close_case"``).
+        timeout_seconds: Maximum time to wait before raising.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If no entry with *event_type* appears within
+            *timeout_seconds*.
+    """
+
+    def _check() -> bool:
+        raw = client.get("/datalayer/CaseLedgerEntrys/")
+        if not isinstance(raw, dict):
+            return False
+        for v in raw.values():
+            if (
+                isinstance(v, dict)
+                and v.get("case_id") == case_id
+                and v.get("event_type") == event_type
+            ):
+                logger.info(
+                    "Event type %r found in ledger for case %s",
+                    event_type,
+                    case_id,
+                )
+                return True
+        return False
+
+    _poll_until(
+        _check,
+        timeout_seconds,
+        poll_interval,
+        f"Timed out waiting for event_type={event_type!r} to appear in ledger "
+        f"for case {case_id!r} — auto-close replication may not have completed",
+        swallow_exceptions=True,
+    )
+
+
 def wait_for_contiguous_ledger_coverage(
     client: DataLayerClient,
     case_id: str,

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -86,6 +86,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_on_container,
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
+    wait_for_event_type_in_ledger,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -523,11 +524,14 @@ def _phase_sync_verification(
             (c2_client, "C2"),
             (vendor_client, "Vendor"),
         ]:
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=c1_tail_index,
-            )
+            with demo_check(
+                f"{label} ledger coverage (sync-verification phase)"
+            ):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=c1_tail_index,
+                )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, c2_client, vendor_client):
@@ -837,6 +841,12 @@ def _phase_case_closure(
             case_id=case.id_,
         )
 
+    with demo_check("close_case entry present on authoritative actor (c1)"):
+        wait_for_event_type_in_ledger(
+            client=c1_client,
+            case_id=case.id_,
+            event_type="close_case",
+        )
     c1_entries = _get_log_entries_for_case(c1_client, case.id_)
     if c1_entries:
         c1_tail = max(c1_entries, key=lambda e: e["log_index"])
@@ -848,16 +858,17 @@ def _phase_case_closure(
             c1_tail_hash[:16],
             c1_tail_index,
         )
-        for replica_client in (
-            finder_client,
-            c2_client,
-            vendor_client,
-        ):
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=c1_tail_index,
-            )
+        for replica_client, label in [
+            (finder_client, "Finder"),
+            (c2_client, "C2"),
+            (vendor_client, "Vendor"),
+        ]:
+            with demo_check(f"{label} ledger coverage (close phase)"):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=c1_tail_index,
+                )
 
 
 def _phase_dump_case_ledgers(

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -85,6 +85,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_on_container,
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
+    wait_for_event_type_in_ledger,
     wait_for_object_stored,
     wait_for_participant_vfd_state,
 )
@@ -579,11 +580,14 @@ def _phase_sync_verification(
             (c2_client, "C2"),
             (vendor_client, "Vendor"),
         ]:
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=c1_tail_index,
-            )
+            with demo_check(
+                f"{label} ledger coverage (sync-verification phase)"
+            ):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=c1_tail_index,
+                )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, c2_client, vendor_client):
@@ -893,6 +897,12 @@ def _phase_case_closure(
             case_id=case.id_,
         )
 
+    with demo_check("close_case entry present on authoritative actor (c1)"):
+        wait_for_event_type_in_ledger(
+            client=c1_client,
+            case_id=case.id_,
+            event_type="close_case",
+        )
     c1_entries = _get_log_entries_for_case(c1_client, case.id_)
     if c1_entries:
         c1_tail = max(c1_entries, key=lambda e: e["log_index"])
@@ -904,12 +914,17 @@ def _phase_case_closure(
             c1_tail_hash[:16],
             c1_tail_index,
         )
-        for replica_client in (finder_client, c2_client, vendor_client):
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=c1_tail_index,
-            )
+        for replica_client, label in [
+            (finder_client, "Finder"),
+            (c2_client, "C2"),
+            (vendor_client, "Vendor"),
+        ]:
+            with demo_check(f"{label} ledger coverage (close phase)"):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=c1_tail_index,
+                )
 
 
 def _phase_dump_case_ledgers(

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -81,6 +81,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_on_container,
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
+    wait_for_event_type_in_ledger,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -353,11 +354,14 @@ def _phase_sync_verification(
             (finder_client, "Finder"),
             (vendor_client, "Vendor"),
         ]:
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=coord_tail_index,
-            )
+            with demo_check(
+                f"{label} ledger coverage (sync-verification phase)"
+            ):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=coord_tail_index,
+                )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, vendor_client):
@@ -624,6 +628,14 @@ def _phase_case_closure(
             case_id=case.id_,
         )
 
+    with demo_check(
+        "close_case entry present on authoritative actor (coordinator)"
+    ):
+        wait_for_event_type_in_ledger(
+            client=coordinator_client,
+            case_id=case.id_,
+            event_type="close_case",
+        )
     coordinator_entries = _get_log_entries_for_case(
         coordinator_client, case.id_
     )
@@ -637,12 +649,16 @@ def _phase_case_closure(
             coord_tail_hash[:16],
             coord_tail_index,
         )
-        for replica_client in (finder_client, vendor_client):
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=coord_tail_index,
-            )
+        for replica_client, label in [
+            (finder_client, "Finder"),
+            (vendor_client, "Vendor"),
+        ]:
+            with demo_check(f"{label} ledger coverage (close phase)"):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=coord_tail_index,
+                )
 
 
 def _phase_dump_case_ledgers(

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -83,6 +83,7 @@ from vultron.demo.helpers.polling import (  # noqa: F401
     wait_for_case_participants,
     wait_for_finder_case,
     wait_for_contiguous_ledger_coverage,
+    wait_for_event_type_in_ledger,
     wait_for_finder_log_entry,
     wait_for_note_in_case,
     wait_for_participant_vfd_state,
@@ -574,11 +575,12 @@ def _phase_sync_verification(
             "Waiting for finder to replicate all vendor entries (0…%d)",
             vendor_tail_index,
         )
-        wait_for_contiguous_ledger_coverage(
-            client=finder_client,
-            case_id=case.id_,
-            expected_tail_index=vendor_tail_index,
-        )
+        with demo_check("Finder ledger coverage (sync-verification phase)"):
+            wait_for_contiguous_ledger_coverage(
+                client=finder_client,
+                case_id=case.id_,
+                expected_tail_index=vendor_tail_index,
+            )
 
     logger.info(
         "Verifying SYNC-2 replication by comparing vendor ↔ finder replica"
@@ -779,6 +781,17 @@ def _phase_case_closure(
     # close_case tail) before _phase_dump_case_ledgers writes devlog files.
     # AutoClose fans out Announce(CaseLedgerEntry) as an async BackgroundTask;
     # intermediate entries may arrive after the tail (issue #1434).
+    #
+    # Bug B fix: wait for close_case entry on the authoritative actor before
+    # reading the tail, so we don't snapshot a tail that omits close_case.
+    with demo_check(
+        "close_case entry present on authoritative actor (vendor)"
+    ):
+        wait_for_event_type_in_ledger(
+            client=vendor_client,
+            case_id=case.id_,
+            event_type="close_case",
+        )
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
@@ -788,11 +801,12 @@ def _phase_case_closure(
             " (0…%d)",
             vendor_tail_index,
         )
-        wait_for_contiguous_ledger_coverage(
-            client=finder_client,
-            case_id=case.id_,
-            expected_tail_index=vendor_tail_index,
-        )
+        with demo_check("Finder ledger coverage (close phase)"):
+            wait_for_contiguous_ledger_coverage(
+                client=finder_client,
+                case_id=case.id_,
+                expected_tail_index=vendor_tail_index,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -79,6 +79,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_on_container,
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
+    wait_for_event_type_in_ledger,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -532,11 +533,14 @@ def _phase_sync_verification(
             (coordinator_client, "Coordinator"),
             (vendor2_client, "Vendor2"),
         ]:
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=vendor_tail_index,
-            )
+            with demo_check(
+                f"{label} ledger coverage (sync-verification phase)"
+            ):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=vendor_tail_index,
+                )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, coordinator_client, vendor2_client):
@@ -872,6 +876,14 @@ def _phase_case_closure(
             case_id=case.id_,
         )
 
+    with demo_check(
+        "close_case entry present on authoritative actor (vendor1)"
+    ):
+        wait_for_event_type_in_ledger(
+            client=vendor_client,
+            case_id=case.id_,
+            event_type="close_case",
+        )
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
@@ -883,16 +895,17 @@ def _phase_case_closure(
             vendor_tail_hash[:16],
             vendor_tail_index,
         )
-        for replica_client in (
-            finder_client,
-            coordinator_client,
-            vendor2_client,
-        ):
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=vendor_tail_index,
-            )
+        for replica_client, label in [
+            (finder_client, "Finder"),
+            (coordinator_client, "Coordinator"),
+            (vendor2_client, "Vendor2"),
+        ]:
+            with demo_check(f"{label} ledger coverage (close phase)"):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=vendor_tail_index,
+                )
 
 
 def _phase_dump_case_ledgers(

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -82,6 +82,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_on_container,
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
+    wait_for_event_type_in_ledger,
     wait_for_object_stored,
     wait_for_participant_vfd_state,
 )
@@ -587,11 +588,14 @@ def _phase_sync_verification(
             (coordinator_client, "Coordinator"),
             (vendor2_client, "Vendor2"),
         ]:
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=vendor_tail_index,
-            )
+            with demo_check(
+                f"{label} ledger coverage (sync-verification phase)"
+            ):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=vendor_tail_index,
+                )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, coordinator_client, vendor2_client):
@@ -931,6 +935,14 @@ def _phase_case_closure(
             case_id=case.id_,
         )
 
+    with demo_check(
+        "close_case entry present on authoritative actor (vendor1)"
+    ):
+        wait_for_event_type_in_ledger(
+            client=vendor_client,
+            case_id=case.id_,
+            event_type="close_case",
+        )
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
@@ -942,16 +954,17 @@ def _phase_case_closure(
             vendor_tail_hash[:16],
             vendor_tail_index,
         )
-        for replica_client in (
-            finder_client,
-            coordinator_client,
-            vendor2_client,
-        ):
-            wait_for_contiguous_ledger_coverage(
-                client=replica_client,
-                case_id=case.id_,
-                expected_tail_index=vendor_tail_index,
-            )
+        for replica_client, label in [
+            (finder_client, "Finder"),
+            (coordinator_client, "Coordinator"),
+            (vendor2_client, "Vendor2"),
+        ]:
+            with demo_check(f"{label} ledger coverage (close phase)"):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=vendor_tail_index,
+                )
 
 
 def _phase_dump_case_ledgers(

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -78,6 +78,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_on_container,
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
+    wait_for_event_type_in_ledger,
     wait_for_finder_case,
     wait_for_participant_vfd_state,
 )
@@ -305,21 +306,23 @@ def _phase_sync_verification(
             vendor_tail_hash[:16],
             vendor_tail_index,
         )
-        wait_for_contiguous_ledger_coverage(
-            client=finder_client,
-            case_id=case.id_,
-            expected_tail_index=vendor_tail_index,
-        )
+        with demo_check("Finder ledger coverage (sync-verification phase)"):
+            wait_for_contiguous_ledger_coverage(
+                client=finder_client,
+                case_id=case.id_,
+                expected_tail_index=vendor_tail_index,
+            )
         logger.info(
             "Waiting for Vendor2 to replicate Vendor1 tail (hash=%s… index=%d)",
             vendor_tail_hash[:16],
             vendor_tail_index,
         )
-        wait_for_contiguous_ledger_coverage(
-            client=vendor2_client,
-            case_id=case.id_,
-            expected_tail_index=vendor_tail_index,
-        )
+        with demo_check("Vendor2 ledger coverage (sync-verification phase)"):
+            wait_for_contiguous_ledger_coverage(
+                client=vendor2_client,
+                case_id=case.id_,
+                expected_tail_index=vendor_tail_index,
+            )
 
     wait_for_case_participants(
         vendor_client=finder_client,
@@ -632,6 +635,18 @@ def _phase_case_closure(
     # Announce(CaseLedgerEntry) activities are delivered independently and an
     # intermediate entry can arrive after the tail (issue #1363).  We therefore
     # verify full contiguous coverage (0…tail_index) before dumping logs.
+    #
+    # Bug B fix: wait for the async close_case entry on the authoritative actor
+    # before reading the tail index, so we don't snapshot a stale tail that
+    # excludes the close_case entry itself.
+    with demo_check(
+        "close_case entry present on authoritative actor (vendor1)"
+    ):
+        wait_for_event_type_in_ledger(
+            client=vendor_client,
+            case_id=case.id_,
+            event_type="close_case",
+        )
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
@@ -643,16 +658,18 @@ def _phase_case_closure(
             vendor_tail_hash[:16],
             vendor_tail_index,
         )
-        wait_for_contiguous_ledger_coverage(
-            client=finder_client,
-            case_id=case.id_,
-            expected_tail_index=vendor_tail_index,
-        )
-        wait_for_contiguous_ledger_coverage(
-            client=vendor2_client,
-            case_id=case.id_,
-            expected_tail_index=vendor_tail_index,
-        )
+        with demo_check("Finder ledger coverage (close phase)"):
+            wait_for_contiguous_ledger_coverage(
+                client=finder_client,
+                case_id=case.id_,
+                expected_tail_index=vendor_tail_index,
+            )
+        with demo_check("Vendor2 ledger coverage (close phase)"):
+            wait_for_contiguous_ledger_coverage(
+                client=vendor2_client,
+                case_id=case.id_,
+                expected_tail_index=vendor_tail_index,
+            )
 
 
 def _phase_dump_case_ledgers(


### PR DESCRIPTION
- Closes #1772

## Summary

Fixes two related bugs in demo scenario orchestration that caused flaky invariant harness runs:

**Bug A (crash mode — #1802):** All `wait_for_contiguous_ledger_coverage` calls in `_phase_sync_verification` and `_phase_case_closure` were bare — not wrapped in `demo_check`. A timeout raised an uncaught `AssertionError`, exited with code 1, and prevented the JSONL artifact from being written. Fixed in all 7 affected scenario files (`fv`, `fvv`, `fcv`, `fvcv-extension`, `fvcv-handoff`, `fccv-extension`, `fccv-handoff`).

**Bug B (silent gap mode — #1772):** In close phases, the authoritative-actor tail index was read immediately after `wait_for_all_participants_rm_closed`. The `close_case` ledger entry is committed asynchronously by `EmitCloseCaseNode` after the last `RM.CLOSED` transition (a `BackgroundTasks` dispatch in `demo_triggers.py`). Reading the tail before that entry lands snapshots a stale tail that excludes `close_case`, causing replica coverage to succeed for the wrong tail and the invariant harness to detect a gapped ledger. Fix: wait for a `close_case` event_type entry on the authoritative actor before reading the tail.

**New helper:** `wait_for_event_type_in_ledger` added to `vultron/demo/helpers/polling.py` — polls until a `CaseLedgerEntry` with a given `event_type` appears on the authoritative actor's DataLayer.

## Changes

- `vultron/demo/helpers/polling.py` — add `wait_for_event_type_in_ledger`
- `vultron/demo/scenario/fv_demo.py` — Bug A + Bug B fix in close phase; Bug A fix in sync-verification phase
- `vultron/demo/scenario/fvv_demo.py` — Bug A + Bug B fix in close phase; Bug A fix in sync-verification phase
- `vultron/demo/scenario/fcv_demo.py` — Bug A + Bug B fix in close phase; Bug A fix in sync-verification phase
- `vultron/demo/scenario/fvcv_extension_demo.py` — Bug A + Bug B fix in close phase; Bug A fix in sync-verification phase
- `vultron/demo/scenario/fvcv_handoff_demo.py` — Bug A + Bug B fix in close phase; Bug A fix in sync-verification phase
- `vultron/demo/scenario/fccv_extension_demo.py` — Bug A + Bug B fix in close phase; Bug A fix in sync-verification phase
- `vultron/demo/scenario/fccv_handoff_demo.py` — Bug A + Bug B fix in close phase; Bug A fix in sync-verification phase
- `test/demo/test_fvv_demo.py` — regression tests: `TestCoverageWaitInsideDemoCheck` (Bug A) + `TestWaitForEventTypeInLedger` (Bug B, 4 tests)

## Verification

- [x] `TestWaitForEventTypeInLedger` — 4 unit tests for the new polling helper (pass)
- [x] `TestCoverageWaitInsideDemoCheck` — Bug A regression: confirms `wait_for_contiguous_ledger_coverage` timeout accumulates to `_demo_failures` rather than propagating (passes post-fix)
- [x] Full test suite: `uv run pytest --tb=short` — 5737 passed, 265 skipped, 2 xfailed

References #1802 (downstream crash symptom of Bug A; remaining inter-container timeout flakiness tracked in #1823)

🤖 Generated with [Claude Code](https://claude.com/claude-code)