### PR TITLE
Scan list-valued ActivityStreams fields in collect_actor_names

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1706.md
+++ b/plan/history/2607/implementation/ISSUE-1706.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1706
+timestamp: '2026-07-29T19:05:06.891688+00:00'
+title: collect_actor_names scans list-valued AS2 fields
+type: implementation
+---
+
+## Issue #1706 — Report: collect_actor_names does not scan list-valued ActivityStreams fields
+
+Fixed `_collect_actor_names_from_obj` to recurse into list-valued
+`actor`/`object`/`object_`/`target`/`origin` fields, which AS2 permits. Actor
+objects nested inside such lists were previously silently skipped and their
+`name` fields never harvested into the URI→name map. Added tests for
+list-valued actor, object, and target fields.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1822>

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -1492,6 +1492,65 @@ class TestActorNameResolution:
         names = collect_actor_names({"vendor": [entry]})
         assert _UUID_ACTOR_URI not in names
 
+    def test_collect_actor_names_scans_list_valued_actor_field(self):
+        """A list-valued ``actor`` field harvests names from each element."""
+        other_uri = "http://vendor:7999/api/v2/actors/other-uuid"
+        entry = _camel_entry(
+            payloadSnapshot={
+                "type": "Announce",
+                "actor": [
+                    {
+                        "id": _UUID_ACTOR_URI,
+                        "type": "Organization",
+                        "name": "Vendor",
+                    },
+                    {"id": other_uri, "type": "Person", "name": "Finder"},
+                ],
+                "object": {"id": "urn:uuid:r", "type": "VulnerabilityReport"},
+            }
+        )
+        names = collect_actor_names({"vendor": [entry]})
+        assert names[_UUID_ACTOR_URI] == "Vendor"
+        assert names[other_uri] == "Finder"
+
+    def test_collect_actor_names_scans_list_valued_object_field(self):
+        """A list-valued ``object`` field recurses into each element."""
+        entry = _camel_entry(
+            payloadSnapshot={
+                "type": "Create",
+                "actor": "http://vendor:7999/api/v2/actors/vendor",
+                "object": [
+                    {"id": "urn:uuid:r", "type": "VulnerabilityReport"},
+                    {
+                        "id": _UUID_ACTOR_URI,
+                        "type": "CaseActor",
+                        "name": "CaseManager",
+                    },
+                ],
+            }
+        )
+        names = collect_actor_names({"vendor": [entry]})
+        assert names[_UUID_ACTOR_URI] == "CaseManager"
+
+    def test_collect_actor_names_scans_list_valued_target_field(self):
+        """A list-valued ``target`` field recurses into each element."""
+        entry = _camel_entry(
+            payloadSnapshot={
+                "type": "Offer",
+                "actor": "http://vendor:7999/api/v2/actors/vendor",
+                "object": {"id": "urn:uuid:c", "type": "VulnerabilityCase"},
+                "target": [
+                    {
+                        "id": _UUID_ACTOR_URI,
+                        "type": "Person",
+                        "name": "Coordinator",
+                    },
+                ],
+            }
+        )
+        names = collect_actor_names({"vendor": [entry]})
+        assert names[_UUID_ACTOR_URI] == "Coordinator"
+
     def test_friendly_actor_name_uses_actor_names_map(self):
         names = {_UUID_ACTOR_URI: "Vendor"}
         assert (

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -1551,6 +1551,59 @@ class TestActorNameResolution:
         names = collect_actor_names({"vendor": [entry]})
         assert names[_UUID_ACTOR_URI] == "Coordinator"
 
+    def test_collect_actor_names_scans_list_valued_origin_field(self):
+        """A list-valued ``origin`` field recurses into each element."""
+        entry = _camel_entry(
+            payloadSnapshot={
+                "type": "Move",
+                "actor": "http://vendor:7999/api/v2/actors/vendor",
+                "origin": [
+                    {
+                        "id": _UUID_ACTOR_URI,
+                        "type": "Group",
+                        "name": "OriginGroup",
+                    },
+                ],
+            }
+        )
+        names = collect_actor_names({"vendor": [entry]})
+        assert names[_UUID_ACTOR_URI] == "OriginGroup"
+
+    def test_collect_actor_names_list_edge_cases_are_safe_noops(self):
+        """Empty, scalar, None, mixed, and nested lists never raise or leak."""
+        entry = _camel_entry(
+            payloadSnapshot={
+                "type": "Announce",
+                # empty list
+                "actor": [],
+                # list of scalars/None mixed with a valid actor dict
+                "object": [
+                    "http://vendor:7999/api/v2/actors/scalar",
+                    None,
+                    {
+                        "id": _UUID_ACTOR_URI,
+                        "type": "Person",
+                        "name": "MixedActor",
+                    },
+                ],
+                # nested list-of-lists still reaches the inner actor dict
+                "target": [
+                    [
+                        {
+                            "id": "http://vendor:7999/api/v2/actors/nested",
+                            "type": "Organization",
+                            "name": "NestedActor",
+                        },
+                    ],
+                ],
+            }
+        )
+        names = collect_actor_names({"vendor": [entry]})
+        assert names[_UUID_ACTOR_URI] == "MixedActor"
+        assert (
+            names["http://vendor:7999/api/v2/actors/nested"] == "NestedActor"
+        )
+
     def test_friendly_actor_name_uses_actor_names_map(self):
         names = {_UUID_ACTOR_URI: "Vendor"}
         assert (

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -224,9 +224,16 @@ def _collect_actor_names_from_obj(
         and obj_id not in out
     ):
         out[obj_id] = obj_name.strip()
-    # Recurse into common nested keys.
+    # Recurse into common nested keys.  ActivityStreams permits ``actor``,
+    # ``object``, ``target``, and ``origin`` to carry a list of objects (e.g.
+    # multiple recipients); scan each list element as well as scalar values.
     for key in ("actor", "object", "object_", "target", "origin"):
-        _collect_actor_names_from_obj(obj.get(key), out)
+        val = obj.get(key)
+        if isinstance(val, list):
+            for item in val:
+                _collect_actor_names_from_obj(item, out)
+        else:
+            _collect_actor_names_from_obj(val, out)
 
 
 def collect_actor_names(

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -209,6 +209,10 @@ def _collect_actor_names_from_obj(
     a given ``id`` is recorded (first-writer-wins so earlier, more authoritative
     entries dominate).
     """
+    if isinstance(obj, list):
+        for item in obj:
+            _collect_actor_names_from_obj(item, out)
+        return
     if not isinstance(obj, dict):
         return
     obj_type = obj.get("type") or obj.get("type_")
@@ -226,14 +230,10 @@ def _collect_actor_names_from_obj(
         out[obj_id] = obj_name.strip()
     # Recurse into common nested keys.  ActivityStreams permits ``actor``,
     # ``object``, ``target``, and ``origin`` to carry a list of objects (e.g.
-    # multiple recipients); scan each list element as well as scalar values.
+    # multiple recipients); the list branch at the top of this function scans
+    # each element, so a plain recursive call handles scalars and lists alike.
     for key in ("actor", "object", "object_", "target", "origin"):
-        val = obj.get(key)
-        if isinstance(val, list):
-            for item in val:
-                _collect_actor_names_from_obj(item, out)
-        else:
-            _collect_actor_names_from_obj(val, out)
+        _collect_actor_names_from_obj(obj.get(key), out)
 
 
 def collect_actor_names(


### PR DESCRIPTION
- Closes #1706

## Summary

`_collect_actor_names_from_obj` in `vultron/demo/report.py` bailed on any
non-dict value during recursion. ActivityStreams permits `actor`, `object`,
`target`, and `origin` to carry a **list** of objects (e.g. multiple
recipients). When any of these fields was a list, the actor objects inside it
were silently skipped and their `name` fields never harvested into the
URI→name map used by the demo report.

## Changes

- `vultron/demo/report.py`: in the recursion loop over
  `actor`/`object`/`object_`/`target`/`origin`, detect list-valued fields and
  recurse into each element (scalars/dicts/None handled as before). The
  existing non-dict guard makes non-dict list items safe no-ops.
- `test/demo/test_report.py`: added three tests covering list-valued `actor`,
  `object`, and `target` fields, asserting names are harvested from every list
  element.

## Verification

- `uv run black --check` / `flake8` / `mypy` / `pyright` — all clean
- `uv run pytest -m ""` — full suite passes (demo tests touched)
- `TestActorNameResolution` — 17 passed (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)