### PR TITLE
test: guard CREATE_CASE_PROPOSAL phrase against dangling target slot

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1787.md
+++ b/plan/history/2607/implementation/ISSUE-1787.md
@@ -1,0 +1,29 @@
+---
+source: ISSUE-1787
+timestamp: '2026-07-29T21:02:29.907460+00:00'
+title: CREATE_CASE_PROPOSAL phrase regression tests
+type: implementation
+---
+
+**Issue:** #1787 — CREATE_CASE_PROPOSAL phrase had an unused `{target}` slot
+that rendered as a trailing em-dash (`"Vendor proposed a case to —"`).
+
+**Root cause:** The registry phrase `"{actor} proposed a case to {target}"`
+referenced a `{target}` slot, but `create_case_proposal_activity` builds a
+`Create(as_CaseProposal)` with no `target` field, so the slot always fell back
+to the em-dash placeholder in `vultron/demo/report.py`.
+
+**State on arrival:** The code fix (phrase → `"{actor} proposed a new case"`)
+had already landed on `main` in commit `f415f83a` via a docs/learn PR that
+carried no `Closes #1787` footer, so the issue stayed open with no regression
+guard.
+
+**Fix:** Added two regression tests — a root-cause guard in
+`test/test_semantic_registry.py` asserting the phrase carries no `{target}`
+slot, and a symptom-level render test in `test/demo/test_report.py` asserting
+`CaseTimelineEvent.summary` produces `"Vendor proposed a new case"` with no
+`"—"`. Both fail on the old phrase and pass on current `main`. The existing
+SE-07 phrase tests could not catch this because they fill every slot via a
+`defaultdict`. Recorded two learnings (process-issue + concern).
+
+**PR:** <https://github.com/CERTCC/Vultron/pull/1828>

--- a/plan/incoming/learnings/20260729-1787-already-fixed-no-closes-footer.md
+++ b/plan/incoming/learnings/20260729-1787-already-fixed-no-closes-footer.md
@@ -1,5 +1,5 @@
 ---
-title: Bug #1787 was already fixed on main but left open with no Closes footer
+title: "Bug #1787 was already fixed on main but left open with no Closes footer"
 type: learning
 timestamp: 2026-07-29
 source: ISSUE-1787

--- a/plan/incoming/learnings/20260729-1787-already-fixed-no-closes-footer.md
+++ b/plan/incoming/learnings/20260729-1787-already-fixed-no-closes-footer.md
@@ -1,0 +1,27 @@
+---
+title: Bug #1787 was already fixed on main but left open with no Closes footer
+type: learning
+timestamp: 2026-07-29
+source: ISSUE-1787
+signal: process-issue
+---
+
+Issue #1787 (CREATE_CASE_PROPOSAL phrase `{target}` slot) described a bug that
+had **already been fixed** on `main` before the bugfix session started. The
+phrase was changed to `"{actor} proposed a new case"` in commit `f415f83a`
+("docs: promote learnings…", 2026-07-28), which merged as part of a docs PR.
+The issue's own comment said "Will close when the docs PR merges" — but that PR
+carried no `Closes #1787` footer, so the issue stayed OPEN after merge.
+
+This is the AGENTS.md pitfall "Verify Issue ACs Against Current Code Before
+Starting" (sources ISSUE-1510, ISSUE-1484) recurring again. The code fix
+needed nothing; the real remaining gap was a **missing regression test** (the
+phrase could silently regress — see the companion learning on defaultdict
+masking).
+
+**How to apply:** When a bugfix issue references a fix that a prior branch/PR
+claims to have made, `git log -S "<fix string>" -- <file>` against `origin/main`
+before writing any code. If the fix is present, pivot the session to what is
+actually missing (usually a regression test) rather than re-applying the fix,
+and ensure the closing PR carries `Closes #N`. When a docs/learn PR fixes a bug
+as a side effect, it MUST include the `Closes #N` footer for that bug issue.

--- a/plan/incoming/learnings/20260729-phrase-defaultdict-masks-unfillable-slots.md
+++ b/plan/incoming/learnings/20260729-phrase-defaultdict-masks-unfillable-slots.md
@@ -1,0 +1,34 @@
+---
+title: defaultdict-based phrase tests cannot catch unfillable slot bugs
+type: learning
+timestamp: 2026-07-29
+source: ISSUE-1787
+signal: concern
+---
+
+The two SE-07 phrase tests in `test/test_semantic_registry.py`
+(`test_every_entry_has_non_empty_phrase`,
+`test_phrase_format_map_with_defaults_returns_non_empty`) render each phrase via
+`phrase.format_map(defaultdict(lambda: "X"))`. Because a `defaultdict` supplies
+a value for **every** slot name, these tests structurally cannot detect the
+bug class from issue 1787: a phrase that references a slot the real render
+pipeline (`vultron/demo/report.py` `event_phrase()` /
+`CaseTimelineEvent.summary`) never populates. The buggy
+`"{actor} proposed a case to {target}"` passed both tests while rendering
+`"Vendor proposed a case to —"` in production.
+
+The runtime render pipeline only ever fills `actor` (always) and
+`object`/`target` (only when a `target_label` resolves). Slots `context`,
+`origin`, and `inner_object` are never filled with real data. A naive
+"no phrase renders a trailing em-dash" guard is **not** viable: SUBMIT_REPORT,
+the three OFFER_* entries, and ADD_PARTICIPANT_STATUS_TO_PARTICIPANT
+legitimately end in `{object}`/`{target}` that the renderer fills from
+`target_label`. So the correct regression test is per-event and asserts the
+specific slot is absent, not a blanket structural rule.
+
+**How to apply:** When adding or auditing a registry `phrase`, confirm every
+slot it references is one the render pipeline actually populates for that event
+type. Do not rely on the defaultdict SE-07 tests as a slot-correctness guard —
+they only prove non-emptiness. For a phrase whose event carries no target
+(e.g. `Create(as_CaseProposal)`, where the factory sets no `target`), assert
+`"{target}" not in entry.phrase` and add a symptom-level `summary` render test.

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -520,6 +520,27 @@ class TestFriendlyNaming:
         assert event.actor_uri is None
         assert event.summary == "Validated the report"
 
+    def test_summary_create_case_proposal_has_no_dangling_target(self):
+        """CREATE_CASE_PROPOSAL renders without a dangling em-dash (#1787).
+
+        The proposal ``Create`` has no ``target``, so the old
+        ``"{actor} proposed a case to {target}"`` phrase rendered
+        ``"Vendor proposed a case to —"``.  The summary must read as a
+        complete sentence with no trailing/dangling ``"—"``.
+        """
+        raw = _camel_entry(
+            eventType="create_case_proposal",
+            payloadSnapshot={
+                "type": "Create",
+                "actor": "http://vendor:7999/api/v2/actors/vendor",
+                "object": {"id": "urn:uuid:cp1", "type": "as_CaseProposal"},
+                "context": "urn:case:1",
+            },
+        )
+        event = CaseTimelineEvent.from_raw(raw)
+        assert event.summary == "Vendor proposed a new case"
+        assert "—" not in event.summary
+
 
 # ---------------------------------------------------------------------------
 # DRPT-05-005 — _format_delta unit tests (AC-6)

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -533,7 +533,6 @@ class TestFriendlyNaming:
             payloadSnapshot={
                 "type": "Create",
                 "actor": "http://vendor:7999/api/v2/actors/vendor",
-                "object": {"id": "urn:uuid:cp1", "type": "as_CaseProposal"},
                 "context": "urn:case:1",
             },
         )

--- a/test/test_semantic_registry.py
+++ b/test/test_semantic_registry.py
@@ -221,3 +221,20 @@ def test_phrase_format_map_with_defaults_returns_non_empty(entry):
     assert (
         result
     ), f"{entry.semantics.name} phrase produced empty string after format_map"
+
+
+def test_create_case_proposal_phrase_has_no_target_slot():
+    """CREATE_CASE_PROPOSAL must not reference a ``{target}`` slot (#1787).
+
+    ``create_case_proposal_activity`` builds a ``Create(as_CaseProposal)`` with
+    no ``target`` field, so a ``{target}`` slot can never be filled at render
+    time and always resolves to the em-dash fallback — producing a dangling
+    ``"proposed a case to —"``.  The two SE-07 tests above do not catch this:
+    they fill every slot from a ``defaultdict``, so an unfillable slot still
+    renders non-empty.  Pin the phrase to a form that carries no ``{target}``.
+    """
+    entry = lookup_entry(MessageSemantics.CREATE_CASE_PROPOSAL)
+    assert "{target}" not in entry.phrase, (
+        "CREATE_CASE_PROPOSAL phrase references {target}, but the factory "
+        "sets no target; the slot renders as a dangling em-dash. See #1787."
+    )


### PR DESCRIPTION
- Closes #1787

## Summary

Adds regression tests locking in the #1787 fix: the `CREATE_CASE_PROPOSAL`
registry phrase must not reference a `{target}` slot, because
`create_case_proposal_activity` sets no `target` and the slot would render as a
dangling em-dash (`"Vendor proposed a case to —"`). The code fix (phrase
changed to `"{actor} proposed a new case"`) already landed on `main` in commit
`f415f83a` via a docs/learn PR that carried no `Closes #1787` footer, leaving
the issue open with no guard against regression.

## Motivation

The two existing SE-07 phrase tests fill **every** slot from a `defaultdict`,
so a phrase referencing an unfillable slot still renders non-empty and passes.
That class of bug — a slot the runtime render pipeline never populates — was
therefore unguarded. Both new tests fail on the old buggy phrase and pass on
the current fix.

## Changes

- **`test/test_semantic_registry.py`**: add
  `test_create_case_proposal_phrase_has_no_target_slot` — root-cause guard
  asserting the phrase carries no `{target}` slot.
- **`test/demo/test_report.py`**: add
  `test_summary_create_case_proposal_has_no_dangling_target` — symptom-level
  render test through `CaseTimelineEvent.summary`; a `Create(as_CaseProposal)`
  with an actor but no target must render `"Vendor proposed a new case"` with
  no `"—"`.
- **`plan/incoming/learnings/`**: two learnings — #1787 was already fixed on
  main with no `Closes` footer (process-issue), and defaultdict phrase tests
  mask unfillable-slot bugs (concern).

## Verification

- All new tests fail on the pre-fix phrase and pass on current `main` (verified
  by temporarily reverting the phrase).
- Full suite: 6737 passed, 265 skipped, 3 xfailed (pre-existing, unrelated).
- Black, flake8, mypy, pyright clean.
- [x] Regression test added guarding the unfillable-slot bug class (per the
  bugfix regression-test rule).