### PR TITLE
docs: plan concern #1832 — correct CP-05-003 context/in_reply_to field assignment on Create(VulnerabilityCase)

### DIFF
--- a/docs/adr/0023-case-proposal-protocol.md
+++ b/docs/adr/0023-case-proposal-protocol.md
@@ -124,3 +124,21 @@ the proximate causal decision. The proposal is embedded inline in the Accept's
 - Notes: `notes/case-proposal.md`
 
 Generated spec requirements: `specs/case-proposal.yaml` CP-01 through CP-07.
+
+## Field Assignment Correction (2026-07-30)
+
+The original decision above specified `context = Accept(CaseProposal) URI` on
+`Create(VulnerabilityCase)` to record the proximate causal link. This was later
+found to violate AS2 semantics (context is a scoping key, not a causal
+antecedent) and to conflict with the inbox deferral router's assumption that
+`context` always carries the case URI.
+
+**Corrected assignment** (see ADR-0045):
+
+- `context` = URI of the new `VulnerabilityCase` (AS2 scoping key; consistent
+  with all other case-scoped activities)
+- `in_reply_to` = URI of the `Accept(CaseProposal)` activity (AS2 causal
+  antecedent field)
+
+The rest of this ADR — the `CaseProposal` vocabulary type, the two-activity
+positive-path flow, and the reject path — remains correct and unaffected.

--- a/docs/adr/0045-create-vulnerability-case-field-assignment.md
+++ b/docs/adr/0045-create-vulnerability-case-field-assignment.md
@@ -1,0 +1,120 @@
+---
+status: accepted
+date: 2026-07-30
+deciders: [adh, Claude Sonnet 4.6]
+---
+
+# ADR-0045: Correct Field Assignment on `Create(VulnerabilityCase)` — `context` to Case URI, `inReplyTo` to Accept URI
+
+## Context and Problem Statement
+
+ADR-0023 established the two-activity positive-path response to a
+`Create(as_CaseProposal)`: first `Accept(as_CaseProposal)`, then
+`Create(VulnerabilityCase)`. For the second activity, ADR-0023 specified:
+
+> "Setting `context` on `Create(VulnerabilityCase)` to the
+> `Accept(CaseProposal)` URI was preferred over the `CaseProposal` URI
+> directly, because the Accept is the proximate causal decision."
+
+This field assignment has two problems:
+
+1. **AS2 semantic violation**: AS2 defines `context` as a scoping/grouping key
+   ("not specific to the activity but generally applicable") and `inReplyTo` as
+   the field for causal antecedents ("one or more Objects for which the object
+   is considered a response"). Placing the Accept URI in `context` puts a causal
+   antecedent in the scoping slot.
+
+2. **Infrastructure conflict**: The inbox deferral router uses `context` to
+   determine case identity (`_activity_context_id()` in
+   `vultron/adapters/driving/fastapi/inbox_pending_queue.py`). When
+   `context = Accept URI`, the router reads the Accept URI as the "case ID",
+   finds no `VulnerabilityCase` under that key, and defers the bootstrap
+   `Create(VulnerabilityCase)` — causing a deadlock, since nothing will ever
+   unblock the deferred queue for a case that will never be created.
+
+The root cause: at the time ADR-0023 was written, the 29-site `context = case
+URI` convention and the deferral router's context-reading behavior had not yet
+been articulated as a system-wide invariant. CONCERN-1832 surfaced the conflict.
+
+## Decision Drivers
+
+- AS2 semantic correctness: `context` = scoping/grouping key; `inReplyTo` =
+  causal antecedent
+- Infrastructure correctness: the inbox deferral router assumes `context` is
+  the case URI for all case-scoped activities
+- Consistency with the 29-site `context = case URI` convention across the
+  codebase (enforced by CLP-07-007 for payloadSnapshot fields)
+- No information loss: causal traceability to the Accept and the original
+  `as_CaseProposal` is fully preserved via `in_reply_to` → Accept → `object_`
+
+## Considered Options
+
+1. **Correct the field assignment** (chosen): `context = case URI`,
+   `in_reply_to = Accept URI`. Aligns with AS2 semantics, restores deferral
+   routing, consistent with all other case-scoped activities. Requires updating
+   CP-05-003, `case_proposal_received_tree.py`, `VultronCreateCaseActivity`,
+   the deferral guard, and related tests.
+
+2. **Keep `context = Accept URI`, fix the router**: Exempt `CREATE_CASE` from
+   context-based deferral; resolve case ID from inline `object_.id_` instead.
+   Works operationally but enshrines the AS2 semantic violation permanently and
+   makes `Create(VulnerabilityCase)` the sole exception to the 29-site
+   convention.
+
+3. **Keep `context = Accept URI`, add belt-and-braces object-based fallback**:
+   `_activity_context_id()` already falls back to `event.context_id` then raw
+   `context` attribute. Adding a third fallback for `CREATE_CASE` to use
+   `object_.id_` is technically possible but adds branching logic to a
+   conceptually simple function, and still leaves the semantic violation.
+
+## Decision Outcome
+
+**Chosen option: correct the field assignment (Option 1).**
+
+`Create(VulnerabilityCase)` emitted by the CaseActor MUST carry:
+
+- `context` = URI of the new `VulnerabilityCase` (consistent with all other
+  case-scoped activities; required for inbox deferral routing)
+- `in_reply_to` = URI of the `Accept(CaseProposal)` activity (causal
+  antecedent in the AS2-correct field)
+
+The full causal chain is preserved transitively: `in_reply_to` → Accept →
+`object_` (inline `as_CaseProposal` embedded at Accept time per CP-05-003).
+
+Additionally, the deferral guard MUST exempt `MessageSemantics.CREATE_CASE`
+alongside `ANNOUNCE_VULNERABILITY_CASE` as a bootstrap message type — both
+introduce a case that does not yet exist in the DataLayer when they first arrive.
+
+### Consequences
+
+- Good: AS2 field semantics are correct. `context` is a scoping key; `inReplyTo`
+  is the causal link.
+- Good: Inbox deferral routing works without special-casing: `context = case URI`
+  passes the guard naturally after the `CREATE_CASE` bootstrap exemption is added.
+- Good: `Create(VulnerabilityCase)` is structurally consistent with all other
+  case-scoped activities.
+- Good: No information loss — the causal chain Accept → CaseProposal is
+  recoverable via `in_reply_to`.
+- Neutral: `context` and `object_.id_` both carry the case URI on
+  `Create(VulnerabilityCase)`, making `context` redundant with `object_`. This
+  is acceptable: redundancy for structural consistency is a lower cost than an
+  AS2 semantic violation.
+- Neutral: The `PendingCreateCaseActivity` retry marker's `create_activity_payload`
+  format changes. Existing persisted markers with the old format will replay the
+  old field assignment; this is acceptable for the prototype (no migration
+  tooling required).
+
+## More Information
+
+- Source concern: CONCERN-1832
+- Supersedes (in part): `docs/adr/0023-case-proposal-protocol.md` — field
+  assignment section only; the CaseProposal vocabulary type, two-activity flow,
+  and reject path in ADR-0023 remain correct and unaffected.
+- Spec: `specs/case-proposal.yaml` CP-05-003 (amended)
+- Notes: `notes/case-proposal.md` (amended), `notes/activitystreams-semantics.md`
+  (new section: "AS2 Field Conventions: context vs inReplyTo")
+- Implementation: `vultron/core/behaviors/case/case_proposal_received_tree.py`,
+  `vultron/core/models/activity.py`, `vultron/adapters/driving/fastapi/inbox_handler.py`,
+  `vultron/adapters/driving/fastapi/inbox_pipeline.py`
+
+Generated spec requirements: `specs/case-proposal.yaml` CP-05-003 (amended).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -90,6 +90,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0042 Deliver All Inter-Actor Communication over HTTP; Retire the In-Process ASGI Delivery Shortcut](0042-http-only-inter-actor-delivery.md)
 - [ADR-0043 Use the ADR `status` Field as the Confidence Signal (Extend Its Vocabulary Rather Than Add a New Field)](0043-adr-status-as-confidence-signal.md)
 - [ADR-0044 Adopt py_trees Typed Ports for BT Node Blackboard Contracts](0044-py-trees-typed-ports-adoption.md)
+- [ADR-0045 Correct Field Assignment on `Create(VulnerabilityCase)` — `context` to Case URI, `inReplyTo` to Accept URI](0045-create-vulnerability-case-field-assignment.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -262,6 +262,7 @@ nav:
       - HTTP-Only Inter-Actor Delivery: 'adr/0042-http-only-inter-actor-delivery.md'
       - ADR Status as Confidence Signal: 'adr/0043-adr-status-as-confidence-signal.md'
       - Adopt py_trees Typed Ports: 'adr/0044-py-trees-typed-ports-adoption.md'
+      - Correct Create(VulnerabilityCase) Field Assignment: 'adr/0045-create-vulnerability-case-field-assignment.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/activitystreams-semantics.md
+++ b/notes/activitystreams-semantics.md
@@ -104,6 +104,42 @@ The key distinction is:
 
 ---
 
+## AS2 Field Conventions: `context` vs `inReplyTo`
+
+AS2 defines `context` and `inReplyTo` for related but distinct purposes.
+Conflating them causes inbox routing failures.
+
+### `context` — scoping/grouping key
+
+AS2 defines `context` as identifying something "not specific to the activity
+but generally applicable to one or more objects" — a **grouping or scoping
+key**, not a causal antecedent.
+
+**Rule**: `context` on any case-scoped Vultron activity MUST be the case URI.
+This convention holds across all 29+ case-scoped activity sites and is required
+for correct inbox deferral routing: `_activity_context_id()` reads `context` to
+determine which case an activity belongs to. Placing a non-case URI in `context`
+causes the deferral guard to treat the activity as belonging to an unknown case
+and queue it indefinitely — a bootstrap deadlock for `Create(VulnerabilityCase)`.
+
+**MUST NOT**: Do not place causal antecedents (the Accept that authorised an
+action, the Offer being responded to) in `context`. Use `inReplyTo` instead.
+
+### `inReplyTo` — causal antecedent
+
+AS2 defines `inReplyTo` as referencing "one or more Objects for which the
+object is considered a response." It is the correct field for recording **what
+prompted this activity**.
+
+**Rule**: When a case-actor emits `Create(VulnerabilityCase)` in response to an
+`Accept(CaseProposal)`, the Accept URI MUST appear in `in_reply_to`, not in
+`context`. The full causal chain is recoverable: `in_reply_to` → Accept →
+`object_` (inline `as_CaseProposal`).
+
+**Source**: CONCERN-1832; spec: CP-05-003; ADR: 0045.
+
+---
+
 ## Response Activity Conventions
 
 ### inReplyTo

--- a/notes/case-proposal.md
+++ b/notes/case-proposal.md
@@ -72,7 +72,8 @@ Vendor                              CaseActor Service
   |                                       |
   | <-- Create(VulnerabilityCase) ------- |
   |         actor: case-actor URI         |
-  |         context: Accept URI           |
+  |         context: case URI             |
+  |         in_reply_to: Accept URI       |
   |         [inline participants]         |
   |                                       |
   |    -- OR --                           |
@@ -105,12 +106,16 @@ activities back to the vendor:
 
 2. **`Create(VulnerabilityCase)`** — the actual case creation announcement.
    - `actor` = case-actor URI (preserving AS2 "I created this" semantics)
-   - `context` = URI of the `Accept(CaseProposal)` activity (proximate cause)
+   - `context` = URI of the new `VulnerabilityCase` (consistent with all
+     other case-scoped activities; required for inbox deferral routing)
+   - `in_reply_to` = URI of the `Accept(CaseProposal)` activity (causal
+     antecedent, in the AS2-correct field for responses)
 
-Setting `context` to the Accept URI (not the CaseProposal URI directly) was
-chosen because the `Accept` is the proximate causal decision. The proposal
-is already embedded in the Accept's `object_`, so causal traceability is
-preserved transitively.
+`in_reply_to` carries the Accept URI rather than putting it in `context`.
+AS2 defines `context` as a **scoping/grouping key** and `inReplyTo` as the
+field for **causal antecedents** (what this activity is responding to).
+The full causal chain is recoverable: `in_reply_to` → Accept → `object_`
+(inline `as_CaseProposal`). See ADR-0045.
 
 ### Step 2b: Case-actor rejects
 

--- a/plan/history/2607/learning/CONCERN-1832.md
+++ b/plan/history/2607/learning/CONCERN-1832.md
@@ -1,0 +1,45 @@
+---
+source: CONCERN-1832
+timestamp: '2026-07-30T18:31:34.090912+00:00'
+title: CONCERN-1832 — AS2 context vs inReplyTo on Create(VulnerabilityCase)
+type: learning
+---
+
+## Summary
+
+CP-05-003 incorrectly placed the `Accept(CaseProposal)` URI in the `context`
+field of `Create(VulnerabilityCase)`. AS2 defines `context` as a
+scoping/grouping key (must be the case URI for all case-scoped activities)
+and `inReplyTo` as the causal antecedent field.
+
+## Root Cause
+
+The original ADR-0023 choice predated two system-wide invariants that were
+established later:
+
+1. The 29-site `context = case URI` convention across all case-scoped activities
+2. The inbox deferral router's assumption that `context` always carries the case
+   URI (`_activity_context_id()` in `inbox_pending_queue.py`)
+
+When `context = Accept URI`, the deferral guard reads the Accept URI as the
+"case ID", finds no `VulnerabilityCase` under that key, and defers the bootstrap
+`Create(VulnerabilityCase)` — causing a deadlock: nothing will ever unblock the
+deferred queue for a case that will never be created.
+
+## Resolution
+
+- Amended CP-05-003 (`specs/case-proposal.yaml`): `context` MUST be the case URI;
+  `in_reply_to` MUST carry the `Accept(CaseProposal)` URI
+- Added ADR-0045 recording the corrected field assignment and rationale
+- Appended "Field Assignment Correction" section to ADR-0023 clarifying its
+  remaining valid scope (protocol structure, not field assignment)
+- Corrected `notes/case-proposal.md` protocol flow and rationale
+- Added "AS2 Field Conventions: context vs inReplyTo" section to
+  `notes/activitystreams-semantics.md`
+
+## References
+
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/1833>
+- Implementation issue: #1834
+- ADR: `docs/adr/0045-create-vulnerability-case-field-assignment.md`
+- Spec: `specs/case-proposal.yaml` CP-05-003 (amended)

--- a/specs/case-proposal.yaml
+++ b/specs/case-proposal.yaml
@@ -123,10 +123,13 @@ groups:
     kind: protocol
     statement: 'When accepting a proposal, the case-actor service MUST send two activities in sequence: first `Accept(as_CaseProposal)`
       (with the `as_CaseProposal` inline as `object_`), then `Create(VulnerabilityCase)` (with `actor` set to the case-actor
-      URI and `context` set to the URI of the `Accept(CaseProposal)` activity).'
+      URI, `context` set to the URI of the new `VulnerabilityCase`, and `in_reply_to` set to the URI of the
+      `Accept(CaseProposal)` activity).'
     rationale: '`Accept(CaseProposal)` acknowledges the vendor''s proposal. `Create(VulnerabilityCase)` with `actor=case-actor`
       preserves AS2 "I created this" semantics: only the authoritative creator MUST be the `actor` of a `Create` activity.
-      Setting `context` to the Accept URI establishes the proximate causal link.'
+      `context` MUST be the case URI (consistent with all other case-scoped activities; required for inbox deferral routing).
+      `in_reply_to` carries the causal antecedent (the Accept URI) in the AS2-correct field for responses.
+      See ADR-0045.'
   - id: CP-05-004
     priority: MUST
     kind: protocol


### PR DESCRIPTION
- Closes #1832

## Summary

- Amends CP-05-003 (`specs/case-proposal.yaml`): `context` on
  `Create(VulnerabilityCase)` MUST now be the case URI; `in_reply_to` carries
  the `Accept(CaseProposal)` URI
- Adds ADR-0045 recording the corrected field assignment and why the original
  ADR-0023 choice was reversed
- Appends "Field Assignment Correction" section to ADR-0023 so it accurately
  describes its remaining valid scope
- Corrects `notes/case-proposal.md` protocol flow diagram and rationale text
- Adds "AS2 Field Conventions: context vs inReplyTo" section to
  `notes/activitystreams-semantics.md`
- Updates `docs/adr/index.md` and `mkdocs.yml` with ADR-0045

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Implementation Issues

- #1834