### PR TITLE
docs: plan #1249 — add factory-fn Idea to BT-20-001 tracking_issue

### DIFF
--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -654,7 +654,7 @@ groups:
       in granular boolean flags that are unnecessary in production. Collapsing to two call-out points (Retriever + Evaluator)
       reduces seam count while keeping the exploit-repo query independently swappable. Implemented by issue #1309 (PR #1566).
       See `notes/bt-fuzzer-nodes-report-management.md` § "Production Collapse 1: Exploit-strategy subtree" and ADR-0027.'
-    tracking_issue: '#1200 (planning); #1309 (implementation — closed by PR #1566)'
+    tracking_issue: '#1200 (planning); #1249 (factory-fn Idea — already implemented on main); #1309 (implementation — closed by PR #1566)'
     adr:
     - ADR-0027
   - id: BT-20-002


### PR DESCRIPTION
- Closes #1249

## Summary

Issue #1249 (factory function for exploit acquisition BT) was **already fully
implemented on `main`** before this planning session. All four acceptance
criteria were satisfied by existing code:

- `create_acquire_exploit_strategy_tree` exists in
  `vultron/core/behaviors/report/` with call-out injection seams ✓
- `HaveExploit` Retriever + `EvaluateExploitStrategy` Evaluator wired per
  ADR-0025 / ADR-0027 ✓
- Factory accepts `AcquireExploitCallOutBundle` (defaults to
  `ACQUIRE_EXPLOIT_DETERMINISTIC`) per BT-18-004 / BT-23-003 ✓
- 28 unit tests verify tree structure and call-out injection ✓

The issue was never closed because the implementing PR (#1566 / commit
`9b9e043b`) carried no `Closes #1249` footer.

## Changes

- `specs/behavior-tree-integration.yaml`: adds `#1249` to the
  `BT-20-001.tracking_issue` field so the spec traces back to both planning
  threads (#1200, #1249) and the implementation (#1309).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)