### PR TITLE
Implement create_deploy_fix_tree: full deployment BT with guard nodes and call-out seams

### DIFF
--- a/notes/bt-fuzzer-rm-fix.md
+++ b/notes/bt-fuzzer-rm-fix.md
@@ -69,14 +69,17 @@ the process of deploying a developed fix or mitigation to affected systems.
   `NewDeploymentInfoSentinel` agent (see stub entry below). The external agent seam is at the
   Sentinel (event subscription or polling hook), not at this BT condition check.
   (Category 2 per issue #1199 triage — consumes a flag written by an upstream Sentinel.)
-- **Factory-fn placement**: Planned for implementation issue from #1248 —
-  `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree` —
+- **Factory-fn placement**: Implemented in #1825 (Idea #1248) as
+  `CheckNoNewDeploymentInfoNode` in
+  `vultron.core.behaviors.report.nodes.deploy_fix` —
   ProtocolInternal condition check in the `_ShouldStayInRmDeferred` Sequence
-  arm of the `DeployFixBT` Fallback. Reads a blackboard key written by the
-  upstream `NewDeploymentInfoSentinel` (FUZZ-08f); defaults to SUCCESS when
-  the key is absent. Not a factory param — no injection seam at this node.
-  Note: Phase 1 stub (PR #1357) did not include this node; the full tree
-  replaces the stub.
+  arm of the `DeployFixBT` Fallback built by
+  `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`.
+  Reads the blackboard key `new_deployment_info` (`NEW_DEPLOYMENT_INFO_KEY`)
+  written by the upstream `NewDeploymentInfoSentinel` (FUZZ-08f); defaults to
+  SUCCESS when the key is absent. Not a factory param — no injection seam at
+  this node. The full tree replaced the Phase 1 stub (PR #1357), which did not
+  include this node.
 
 ### `NewDeploymentInfoSentinel` *(upstream Sentinel stub)*
 
@@ -124,14 +127,14 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **Medium** — CVSS environmental scores, EPSS, and asset criticality data are automatable inputs; final prioritization decision may require human approval, especially for production systems.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.PrioritizeDeployment`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: Phase 1 stub exists as of PR #1357
-  (`prioritize_deployment_factory` param). Full placement: planned in
-  implementation issue from #1248 —
+- **Factory-fn placement**: Implemented in #1825 (Idea #1248) —
   `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`
   (`prioritize_deployment_factory` in 4-field `DeployFixCallOutBundle`) —
   Evaluator action node in the `_DeployFixIfReady` Sequence, before
   `CheckCSFixNotYetDeployed` and `DeployFix`. Note: mitigation nodes removed
   from this tree; mitigation arm tracked in separate Idea (peer to #1248).
+  Phase 1 stub (PR #1357) wired `prioritize_deployment_factory`; the full
+  tree restructured the Sequence context.
 
 ### `MitigationDeployed`
 
@@ -187,9 +190,10 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.DeployMitigation`
 - **Call-out point shape**: Evaluator
 - **Factory-fn placement**: Scoped OUT of `create_deploy_fix_tree` (#1248).
-  Phase 1 stub (PR #1357) included `deploy_mitigation_factory` — that field
-  is removed in the full tree (4-field bundle). Mitigation deployment belongs
-  to a distinct `create_deploy_mitigation_tree` (separate Idea, peer to #1248).
+  Phase 1 stub (PR #1357) included `deploy_mitigation_factory`; that field was
+  removed from the bundle in the full tree (#1825, 4-field bundle). Mitigation
+  deployment belongs to a distinct `create_deploy_mitigation_tree` (separate
+  Idea, peer to #1248).
 
 ### `MonitoringRequirement`
 
@@ -206,12 +210,12 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **High** — policy rule evaluation against case context (severity, asset class, environment); fully automatable as a policy engine check.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MonitoringRequirement`
 - **Call-out point shape**: Evaluator — evaluates whether organizational policy requires post-deployment monitoring for this case by applying policy rules against case context (severity, asset class, environment); a policy judgment call, not a binary condition monitor.
-- **Factory-fn placement**: Planned in implementation issue from #1248 —
+- **Factory-fn placement**: Implemented in #1825 (Idea #1248) —
   `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`
   (`monitoring_requirement_factory` in 4-field `DeployFixCallOutBundle`) —
   Evaluator condition guard in the `_MonitorDeploymentIfDesired` Sequence arm
   of the `DeployFixBT` Fallback; SUCCESS proceeds to `MonitorDeployment`.
-  Phase 1 stub (PR #1357) wired this param but the full tree restructures the
+  Phase 1 stub (PR #1357) wired this param; the full tree restructured the
   Sequence context.
 
 ### `MonitorDeployment`
@@ -234,13 +238,13 @@ the process of deploying a developed fix or mitigation to affected systems.
   the side effect in the external monitoring system is the seam. This is a fire-and-confirm
   action node, not a continuous monitor running outside the BT — the BT tick reaches this node
   once per `MonitoringRequirement` pass and asks the external system to begin tracking.
-- **Factory-fn placement**: Planned in implementation issue from #1248 —
+- **Factory-fn placement**: Implemented in #1825 (Idea #1248) —
   `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`
   (`monitor_deployment_factory` in 4-field `DeployFixCallOutBundle`) —
   Actuator action node in the `_MonitorDeploymentIfDesired` Sequence arm,
   after `MonitoringRequirement` succeeds; fires the external monitoring
   registration call and confirms activation.
-  Phase 1 stub (PR #1357) wired this param but the full tree restructures the
+  Phase 1 stub (PR #1357) wired this param; the full tree restructured the
   Sequence context.
 
 ### `DeployFix`
@@ -258,13 +262,13 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **Medium** — release pipeline and patch distribution can be automated (CI/CD, package repositories); human approval gate is commonly required for production releases.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.DeployFix`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: Planned in implementation issue from #1248 —
+- **Factory-fn placement**: Implemented in #1825 (Idea #1248) —
   `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`
   (`deploy_fix_factory` in 4-field `DeployFixCallOutBundle`) —
   Evaluator action node in the `_DeployFixIfReady` Sequence arm, after
   `PrioritizeDeployment` succeeds; the primary patch deployment step
   (distinct from mitigation deployment, which is scoped out to a peer Idea).
-  Phase 1 stub (PR #1357) wired this param but the full tree restructures the
-  Sequence context and removes `deploy_mitigation_factory` from the bundle.
+  Phase 1 stub (PR #1357) wired this param; the full tree restructured the
+  Sequence context and removed `deploy_mitigation_factory` from the bundle.
 
 ---

--- a/plan/history/2607/implementation/ISSUE-1825.md
+++ b/plan/history/2607/implementation/ISSUE-1825.md
@@ -1,0 +1,32 @@
+---
+source: ISSUE-1825
+timestamp: '2026-07-30T19:27:00.817092+00:00'
+title: create_deploy_fix_tree full deployment BT
+type: implementation
+---
+
+## Issue #1825 — Implement create_deploy_fix_tree: full deployment BT with guard nodes and call-out seams
+
+PR: <https://github.com/CERTCC/Vultron/pull/1838>
+
+Replaced the Phase 1 `create_deploy_fix_tree` stub (PR #1357) with the full
+production `DeployFixBT` Fallback, mirroring the sibling `create_develop_fix_tree`
+(#1818). Closes Concern #1813 (stub lacked role/CS/RM guard nodes).
+
+### Delivered
+
+- Four-arm `DeployFixBT` Selector: `CSinStateFixDeployed` early-exit,
+  `_ShouldStayInRmDeferred`, `_DeployFixIfReady`, `_MonitorDeploymentIfDesired`.
+- Six new production-layer nodes in `report/nodes/deploy_fix.py`.
+- `DeployFixCallOutBundle` reduced 5→4 fields (removed `deploy_mitigation_factory`).
+- Extracted shared `resolve_case_manager_id` into `participant/common.py`;
+  `develop_fix.py` refactored to use it (DRY).
+- ~15 new tests; full suite green; black/flake8/mypy/pyright clean.
+
+### Notes
+
+- Pre-PR code review caught a VFD state-machine bug: `CheckCSFixNotYetDeployed`
+  now requires exactly `VFd` (fix-ready-not-deployed) so a deployer cannot jump
+  `vfd`/`Vfd` → `VFD` under a SUCCESS-returning DeployFix backend. Fixed before merge.
+- Intentional scope deviation: legacy non-vendor "public aware" deploy
+  precondition omitted per AC-1's enumerated guard set.

--- a/plan/incoming/learnings/20260730-1825-checkcsfixnotyetdeployed-guard-strength.md
+++ b/plan/incoming/learnings/20260730-1825-checkcsfixnotyetdeployed-guard-strength.md
@@ -1,0 +1,30 @@
+---
+title: "AC-3 guard name understated the required VFD precondition"
+type: learning
+timestamp: 2026-07-30
+source: ISSUE-1825
+signal: spec-ambiguity
+---
+
+Issue #1825 AC-3 said to "Create `CheckCSFixNotYetDeployed` guard node." Read
+literally, that name only requires the D bit to be unset (SUCCESS for `vfd`,
+`Vfd`, or `VFd`). But the node guards the `_DeployFixIfReady` arm, whose action
+node `TransitionCStoFixDeployed` performs the VFD `d→D` transition — which the
+state machine (`_vfd_transitions`, `vultron/core/states/cs.py`) permits **only**
+from `VFd`. The literal guard would let a deployer in `vfd`/`Vfd` jump straight
+to `VFD` under any SUCCESS-returning `DeployFix` backend (e.g. STOCHASTIC),
+producing an invalid status snapshot.
+
+Resolution: implemented `CheckCSFixNotYetDeployed` to require exactly `VFd`
+(fix-ready AND not-deployed), matching the legacy
+`CSinStateVendorAwareFixReadyFixNotDeployed` guard. Caught by pre-PR code
+review, not by the AC text.
+
+**Why:** ACs that name a guard by its "not-yet-X" symptom can understate the
+real precondition, which is set by the state-machine transition the guarded
+action performs.
+
+**How to apply:** when an AC names a CS/RM/EM guard, derive its SUCCESS
+condition from the source state(s) of the transition the guarded action
+triggers, not from the guard's name. Cross-check against the legacy simulation
+tree's equivalent guard.

--- a/plan/incoming/learnings/20260730-1825-create-participant-status-skips-transition-validation.md
+++ b/plan/incoming/learnings/20260730-1825-create-participant-status-skips-transition-validation.md
@@ -1,0 +1,31 @@
+---
+title: "CreateParticipantStatusNode persists VFD state without transition validation"
+type: learning
+timestamp: 2026-07-30
+source: ISSUE-1825
+signal: concern
+---
+
+`CreateParticipantStatusNode.update` (`vultron/core/behaviors/case/nodes/
+participant/status.py`) constructs `VfdDimension(state=<target>)` directly and
+persists it, never calling `VfdDimension.transition()` or
+`is_valid_vfd_transition`. So the validity of a VFD/RM/PXA state change is
+enforced **only** by whatever guard node precedes the transition node in the
+tree — nothing at the persistence boundary rejects an illegal jump (e.g.
+`vfd → VFD`).
+
+This surfaced in #1825: the first-draft `CheckCSFixNotYetDeployed` guard was too
+weak and would have allowed an invalid `vfd/Vfd → VFD` snapshot. The guard was
+strengthened, but the underlying fragility remains for every tree that writes
+status via this node.
+
+**Why:** state-machine validity lives in the dimension objects
+(`.transition()`), but the write path bypasses it — a fail-open design that
+relies on upstream BT guards being correct.
+
+**How to apply:** consider having `CreateParticipantStatusNode` (or a shared
+helper) validate the requested state against the participant's current state
+via the dimension `transition()` machinery, returning FAILURE on an invalid
+transition. That would make invalid jumps fail-closed regardless of guard
+coverage. Worth a GitHub Concern issue if not already tracked.
+See [[20260730-1825-checkcsfixnotyetdeployed-guard-strength]].

--- a/plan/incoming/learnings/20260730-1825-deploy-fix-dropped-public-aware-precondition.md
+++ b/plan/incoming/learnings/20260730-1825-deploy-fix-dropped-public-aware-precondition.md
@@ -1,0 +1,29 @@
+---
+title: "create_deploy_fix_tree omits legacy non-vendor public-aware deploy gate"
+type: learning
+timestamp: 2026-07-30
+source: ISSUE-1825
+signal: design-question
+---
+
+The legacy `Deployment` tree gated deployment ability via
+`_DecideAbilityToDeploy` = `RoleIsVendor OR CSinStateNotDeployedButPublicAware`
+(`vultron/bt/report_management/_behaviors/deploy_fix.py`): a non-vendor deployer
+could only deploy a fix after the case was public. Issue #1825 AC-1 enumerates
+the `_DeployFixIfReady` guard set as `CheckDeployerRoleNode` +
+`CheckRMStateAccepted` + `CheckCSFixNotYetDeployed` + call-outs — with no
+public-aware check. The new `create_deploy_fix_tree` therefore gates only on the
+deployer role and drops the public-aware precondition for non-vendor deployers.
+
+Decision: honoured AC-1 as written (best-judgment call, unattended); did not
+re-introduce the legacy gate, to avoid unscoped protocol-behavior expansion.
+
+**Why:** this is a protocol-behavior difference from the legacy simulation, not
+a bug in this PR — but it is a latent gap: a non-vendor deployer can now deploy
+before public awareness.
+
+**How to apply:** if MPCVD correctness requires the public-aware precondition
+for non-vendor deployers, file a follow-up issue to add a
+`CSinStateNotDeployedButPublicAware`-equivalent guard to the deploy arm (or
+confirm in the spec that vendor-role gating alone is sufficient). See
+[[20260730-1825-checkcsfixnotyetdeployed-guard-strength]].

--- a/test/core/behaviors/report/test_deploy_fix_tree.py
+++ b/test/core/behaviors/report/test_deploy_fix_tree.py
@@ -668,26 +668,99 @@ def test_stay_deferred_short_circuits(
     bt_scenario: BTTestScenario,
     case_with_deployer: VultronCase,
 ) -> None:
-    """Deferred deployer, no new info → _ShouldStayInRmDeferred SUCCESS."""
+    """Deferred deployer, no new info → _ShouldStayInRmDeferred SUCCESS.
+
+    Asserts SUCCESS *and* that no VFD status was appended — proving arm 2
+    (stay-deferred) produced the SUCCESS, not the always-succeeding monitor
+    arm masking a broken deploy arm.
+    """
     _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, rm=RM.DEFERRED)
+    case = bt_scenario.dl.read(CASE_ID)
+    assert isinstance(case, VultronCase)
+    participant_id = case.actor_participant_index[DEPLOYER_ACTOR_ID]
+    participant = bt_scenario.dl.read(participant_id)
+    assert isinstance(participant, CaseParticipant)
+    before = len(participant.participant_statuses)
+
     tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
     result = bt_scenario.run(tree, actor_id=DEPLOYER_ACTOR_ID)
     assert result.status == Status.SUCCESS
 
+    # No deployment side effects: the deploy arm must not have run.
+    participant = bt_scenario.dl.read(participant_id)
+    assert isinstance(participant, CaseParticipant)
+    assert len(participant.participant_statuses) == before
+    assert bt_scenario.dl.outbox_list_for_actor(DEPLOYER_ACTOR_ID) == []
 
-def test_full_deploy_path_succeeds(
+
+def test_full_deploy_arm_completes_and_emits_cd(
     bt_scenario: BTTestScenario,
     case_with_deployer_and_case_manager: VultronCase,
 ) -> None:
-    """Deployer, RM ACCEPTED, fix ready-not-deployed → deploy arm runs to CD.
+    """Deployer, RM ACCEPTED, fix ready-not-deployed, DeployFix SUCCEEDS.
 
-    Uses the DETERMINISTIC bundle (PrioritizeDeployment=AlwaysSucceed,
-    DeployFix=AlwaysFail). Because DeployFix defaults to AlwaysFail, the
-    deploy arm fails and the Fallback falls through to the monitor arm — which
-    succeeds (MonitoringRequirement + MonitorDeployment both AlwaysSucceed).
-    So the overall tree SUCCEEDS.
+    Injects ``deploy_fix_factory=AlwaysSucceed`` so the ``_DeployFixIfReady``
+    Sequence runs to completion (guards pass → PrioritizeDeployment → DeployFix
+    → TransitionCStoFixDeployed → EmitCDActivity).  Asserts the deploy arm's
+    two production action nodes actually fired: a new VFD ``ParticipantStatus``
+    was appended and a CD activity was queued to the deployer's outbox.
+
+    This is the integration coverage the DETERMINISTIC default cannot provide
+    (its ``deploy_fix_factory`` is AlwaysFail, so the arm never reaches the
+    transition/emit nodes).
     """
     _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFd)
+    case = bt_scenario.dl.read(CASE_ID)
+    assert isinstance(case, VultronCase)
+    participant_id = case.actor_participant_index[DEPLOYER_ACTOR_ID]
+    participant = bt_scenario.dl.read(participant_id)
+    assert isinstance(participant, CaseParticipant)
+    before = len(participant.participant_statuses)
+
+    bundle = DeployFixCallOutBundle(
+        deploy_fix_factory=lambda n: AlwaysSucceed(n),  # type: ignore[arg-type]
+    )
+    tree = create_deploy_fix_tree(
+        case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID, call_out=bundle
+    )
+    result = bt_scenario.run(tree, actor_id=DEPLOYER_ACTOR_ID)
+    assert result.status == Status.SUCCESS
+
+    # TransitionCStoFixDeployed appended a new VFD (fix-deployed) status.
+    participant = bt_scenario.dl.read(participant_id)
+    assert isinstance(participant, CaseParticipant)
+    assert len(participant.participant_statuses) == before + 1
+    assert participant.participant_statuses[-1].vfd.state == CS_vfd.VFD
+
+    # EmitCDActivity queued a CD activity to the deployer's outbox.
+    outbox = bt_scenario.dl.outbox_list_for_actor(DEPLOYER_ACTOR_ID)
+    assert len(outbox) == 1
+
+
+def test_deploy_arm_falls_through_to_monitor_when_deployfix_fails(
+    bt_scenario: BTTestScenario,
+    case_with_deployer_and_case_manager: VultronCase,
+) -> None:
+    """DETERMINISTIC DeployFix=AlwaysFail → deploy arm fails, monitor arm wins.
+
+    Documents the default-bundle behavior: the deploy arm fails at DeployFix
+    (before the transition/emit nodes), so no VFD status is written, and the
+    overall SUCCESS comes from the always-succeeding monitor arm.
+    """
+    _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFd)
+    case = bt_scenario.dl.read(CASE_ID)
+    assert isinstance(case, VultronCase)
+    participant_id = case.actor_participant_index[DEPLOYER_ACTOR_ID]
+    participant = bt_scenario.dl.read(participant_id)
+    assert isinstance(participant, CaseParticipant)
+    before = len(participant.participant_statuses)
+
     tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
     result = bt_scenario.run(tree, actor_id=DEPLOYER_ACTOR_ID)
     assert result.status == Status.SUCCESS
+
+    # DeployFix (AlwaysFail) short-circuited the arm before the transition node.
+    participant = bt_scenario.dl.read(participant_id)
+    assert isinstance(participant, CaseParticipant)
+    assert len(participant.participant_statuses) == before
+    assert bt_scenario.dl.outbox_list_for_actor(DEPLOYER_ACTOR_ID) == []

--- a/test/core/behaviors/report/test_deploy_fix_tree.py
+++ b/test/core/behaviors/report/test_deploy_fix_tree.py
@@ -11,134 +11,683 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Tests for the deploy-fix behavior tree (Phase 1 stub).
+"""Tests for the deploy-fix behavior tree and its production nodes.
 
-Verifies BT-18-004/BT-23-003: bundle parameter is accepted and used;
-DETERMINISTIC default uses AlwaysSucceed/AlwaysFail per ceiling/floor rule;
-STOCHASTIC bundle produces the correct fuzzer classes.
+Covers all acceptance criteria from issue #1825:
+
+- AC-1: DeployFixBT Fallback with four arms (early-exit, stay-deferred,
+  deploy-if-ready, monitor-if-desired)
+- AC-2: DeployFixCallOutBundle reduced to 4 fields (deploy_mitigation removed)
+- AC-3: CheckDeployerRoleNode reused; CheckRMStateAccepted reused;
+  CheckCSFixNotYetDeployed new guard node
+- AC-4: CheckNoNewDeploymentInfoNode reads blackboard flag; defaults SUCCESS
+- AC-5: TransitionCStoFixDeployed + EmitCDActivity
+- AC-7: Bundle injection, tree structure, guard presence, factory seams,
+  early-exit short-circuit
 """
 
-import pytest
 import py_trees
+import pytest
+from py_trees.common import Status
 
+from test.core.behaviors.bt_harness import BTTestScenario
+from vultron.core.behaviors.call_out.bundles.deploy_fix import (
+    DEPLOY_FIX_DETERMINISTIC,
+    DeployFixCallOutBundle,
+)
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckDeployerRoleNode,
+)
 from vultron.core.behaviors.report.deploy_fix_tree import (
     create_deploy_fix_tree,
 )
-from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
-from vultron.demo.fuzzer.bundles.deploy_fix import (
-    DEPLOY_FIX_DETERMINISTIC,
-    DEPLOY_FIX_STOCHASTIC,
-    DeployFixCallOutBundle,
+from vultron.core.behaviors.report.nodes.deploy_fix import (
+    NEW_DEPLOYMENT_INFO_KEY,
+    CheckCSFixNotYetDeployed,
+    CheckNoNewDeploymentInfoNode,
+    CSinStateFixDeployed,
+    EmitCDActivity,
+    RMinStateDeferred,
+    TransitionCStoFixDeployed,
 )
-from vultron.demo.fuzzer.report_management.deploy_fix import (
-    DeployFix,
-    DeployMitigation,
-    MonitorDeployment,
-    MonitoringRequirement,
-    PrioritizeDeployment,
+from vultron.core.behaviors.report.nodes.develop_fix import (
+    CheckRMStateAccepted,
 )
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.dimensions import RmDimension, VfdDimension
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.vultron_types import VultronCase, VultronParticipant
+from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
+from vultron.enums.roles import CVDRole
 
-CASE_ID = "https://example.org/cases/test-001"
+CASE_ID = "https://example.org/cases/test-deploy-001"
+DEPLOYER_ACTOR_ID = "https://example.org/actors/deployer-001"
+VENDOR_ACTOR_ID = "https://example.org/actors/vendor-001"
+CASE_MANAGER_ACTOR_ID = "https://example.org/actors/case-manager-001"
 
 
-def _marker_factory(label):
-    def factory(name):
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def deployer_participant() -> VultronParticipant:
+    return VultronParticipant(
+        id_="https://example.org/participants/deployer-cp-001",
+        attributed_to=DEPLOYER_ACTOR_ID,
+        context=CASE_ID,
+        case_roles=[CVDRole.DEPLOYER],
+    )
+
+
+@pytest.fixture
+def case_manager_participant() -> VultronParticipant:
+    return VultronParticipant(
+        id_="https://example.org/participants/cm-cp-001",
+        attributed_to=CASE_MANAGER_ACTOR_ID,
+        context=CASE_ID,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+
+
+@pytest.fixture
+def case_with_deployer(
+    bt_scenario: BTTestScenario,
+    deployer_participant: VultronParticipant,
+) -> VultronCase:
+    case = VultronCase(
+        id_=CASE_ID,
+        name="Test Case",
+        case_participants=[deployer_participant.id_],
+        actor_participant_index={DEPLOYER_ACTOR_ID: deployer_participant.id_},
+    )
+    bt_scenario.seed(deployer_participant, case)
+    return case
+
+
+@pytest.fixture
+def case_with_deployer_and_case_manager(
+    bt_scenario: BTTestScenario,
+    deployer_participant: VultronParticipant,
+    case_manager_participant: VultronParticipant,
+) -> VultronCase:
+    case = VultronCase(
+        id_=CASE_ID,
+        name="Test Case",
+        case_participants=[
+            deployer_participant.id_,
+            case_manager_participant.id_,
+        ],
+        actor_participant_index={
+            DEPLOYER_ACTOR_ID: deployer_participant.id_,
+            CASE_MANAGER_ACTOR_ID: case_manager_participant.id_,
+        },
+    )
+    bt_scenario.seed(deployer_participant, case_manager_participant, case)
+    return case
+
+
+def _seed_status(
+    bt_scenario: BTTestScenario,
+    case_id: str,
+    actor_id: str,
+    rm: RM = RM.ACCEPTED,
+    vfd: CS_vfd = CS_vfd.VFd,
+) -> None:
+    """Seed a ParticipantStatus record with the given RM and VFD states."""
+    status = ParticipantStatus(
+        context=case_id,
+        attributed_to=actor_id,
+        rm=RmDimension(state=rm),
+        vfd=VfdDimension(state=vfd),
+    )
+    bt_scenario.dl.create(status)
+
+    case = bt_scenario.dl.read(case_id)
+    if not isinstance(case, VultronCase):
+        return
+    participant_id = case.actor_participant_index.get(actor_id)
+    if participant_id:
+        participant = bt_scenario.dl.read(participant_id)
+        if isinstance(participant, CaseParticipant):
+            participant.participant_statuses.append(status)
+            bt_scenario.dl.save(participant)
+
+
+# ---------------------------------------------------------------------------
+# AC-1: create_deploy_fix_tree factory + tree structure
+# ---------------------------------------------------------------------------
+
+
+def test_create_deploy_fix_tree_returns_behaviour():
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_create_deploy_fix_tree_root_name():
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    assert tree.name == "DeployFixBT"
+
+
+def test_tree_root_is_fallback():
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    assert isinstance(tree, py_trees.composites.Selector)
+
+
+def test_tree_has_four_arms():
+    """DeployFixBT Fallback has exactly 4 arms (AC-1)."""
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    assert len(tree.children) == 4
+    assert isinstance(tree.children[0], CSinStateFixDeployed)
+    assert tree.children[1].name == "_ShouldStayInRmDeferred"
+    assert tree.children[2].name == "_DeployFixIfReady"
+    assert tree.children[3].name == "_MonitorDeploymentIfDesired"
+
+
+def test_should_stay_deferred_arm_composition():
+    """_ShouldStayInRmDeferred = RMinStateDeferred + CheckNoNewDeploymentInfo."""
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    arm = tree.children[1]
+    assert isinstance(arm, py_trees.composites.Sequence)
+    assert len(arm.children) == 2
+    assert isinstance(arm.children[0], RMinStateDeferred)
+    assert isinstance(arm.children[1], CheckNoNewDeploymentInfoNode)
+
+
+def test_deploy_if_ready_arm_composition():
+    """_DeployFixIfReady arm: 3 guards + 2 call-outs + transition + emit."""
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    arm = tree.children[2]
+    assert isinstance(arm, py_trees.composites.Sequence)
+    assert len(arm.children) == 7
+    assert isinstance(arm.children[0], CheckDeployerRoleNode)
+    assert isinstance(arm.children[1], CheckRMStateAccepted)
+    assert isinstance(arm.children[2], CheckCSFixNotYetDeployed)
+    assert arm.children[3].name == "PrioritizeDeployment"
+    assert arm.children[4].name == "DeployFix"
+    assert isinstance(arm.children[5], TransitionCStoFixDeployed)
+    assert isinstance(arm.children[6], EmitCDActivity)
+
+
+def test_monitor_arm_composition():
+    """_MonitorDeploymentIfDesired arm: MonitoringRequirement + MonitorDeployment."""
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    arm = tree.children[3]
+    assert isinstance(arm, py_trees.composites.Sequence)
+    assert len(arm.children) == 2
+    assert arm.children[0].name == "MonitoringRequirement"
+    assert arm.children[1].name == "MonitorDeployment"
+
+
+# ---------------------------------------------------------------------------
+# AC-2 / AC-7: DeployFixCallOutBundle has exactly 4 fields
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_has_four_fields():
+    """DeployFixCallOutBundle reduced to 4 fields (deploy_mitigation removed)."""
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(DeployFixCallOutBundle)}
+    assert field_names == {
+        "prioritize_deployment_factory",
+        "deploy_fix_factory",
+        "monitoring_requirement_factory",
+        "monitor_deployment_factory",
+    }
+    assert "deploy_mitigation_factory" not in field_names
+
+
+def test_default_call_out_children_are_deterministic():
+    """DETERMINISTIC: ceiling/floor of each node's stochastic p (BT-23-002)."""
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    deploy_arm = tree.children[2]
+    monitor_arm = tree.children[3]
+    # PrioritizeDeployment p=0.90 → AlwaysSucceed
+    assert isinstance(deploy_arm.children[3], AlwaysSucceed)
+    # DeployFix p=0.10 → AlwaysFail
+    assert isinstance(deploy_arm.children[4], AlwaysFail)
+    # MonitoringRequirement p=0.70 → AlwaysSucceed
+    assert isinstance(monitor_arm.children[0], AlwaysSucceed)
+    # MonitorDeployment p=1.0 → AlwaysSucceed
+    assert isinstance(monitor_arm.children[1], AlwaysSucceed)
+
+
+def test_bundle_parameter_accepted():
+    tree = create_deploy_fix_tree(
+        case_id=CASE_ID,
+        actor_id=DEPLOYER_ACTOR_ID,
+        call_out=DEPLOY_FIX_DETERMINISTIC,
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_deterministic_deploy_fix_is_instance_of_bundle():
+    assert isinstance(DEPLOY_FIX_DETERMINISTIC, DeployFixCallOutBundle)
+
+
+# ---------------------------------------------------------------------------
+# AC-7: Each call-out factory seam is individually replaceable
+# ---------------------------------------------------------------------------
+
+
+def _marker_factory(label: str):
+    def factory(name: str) -> py_trees.behaviour.Behaviour:
         class _Marker(py_trees.behaviour.Behaviour):
-            def update(self):
-                return py_trees.common.Status.SUCCESS
+            def update(self) -> Status:
+                return Status.SUCCESS
 
         return _Marker(name=label)
 
     return factory
 
 
-def test_create_deploy_fix_tree_returns_behaviour():
-    tree = create_deploy_fix_tree(case_id=CASE_ID)
-    assert isinstance(tree, py_trees.behaviour.Behaviour)
-
-
-def test_create_deploy_fix_tree_root_name():
-    tree = create_deploy_fix_tree(case_id=CASE_ID)
-    assert tree.name == "DeployFixBT"
-
-
-def test_default_children_are_deterministic():
-    """DETERMINISTIC: ceiling/floor of each node's stochastic p (BT-23-002)."""
-    tree = create_deploy_fix_tree(case_id=CASE_ID)
-    assert len(tree.children) == 5
-    assert isinstance(
-        tree.children[0], AlwaysSucceed
-    )  # PrioritizeDeployment p=0.90
-    assert isinstance(
-        tree.children[1], AlwaysSucceed
-    )  # DeployMitigation p=0.75
-    assert isinstance(
-        tree.children[2], AlwaysSucceed
-    )  # MonitoringRequirement p=0.70
-    assert isinstance(tree.children[3], AlwaysFail)  # DeployFix p=0.10
-    assert isinstance(
-        tree.children[4], AlwaysSucceed
-    )  # MonitorDeployment p=1.0
-
-
-def test_stochastic_bundle_children_are_fuzzer_nodes():
-    """STOCHASTIC bundle produces the correct fuzzer-class nodes."""
-    tree = create_deploy_fix_tree(
-        case_id=CASE_ID, call_out=DEPLOY_FIX_STOCHASTIC
-    )
-    assert len(tree.children) == 5
-    assert isinstance(tree.children[0], PrioritizeDeployment)
-    assert isinstance(tree.children[1], DeployMitigation)
-    assert isinstance(tree.children[2], MonitoringRequirement)
-    assert isinstance(tree.children[3], DeployFix)
-    assert isinstance(tree.children[4], MonitorDeployment)
-
-
-_BUNDLE_FIELDS = [
-    ("prioritize_deployment_factory", "PD", 0),
-    ("deploy_mitigation_factory", "DM", 1),
-    ("monitoring_requirement_factory", "MR", 2),
-    ("deploy_fix_factory", "DF", 3),
-    ("monitor_deployment_factory", "MD", 4),
+# (field, label, arm_index, child_index within arm)
+_CALL_OUT_SEAMS = [
+    ("prioritize_deployment_factory", "PD", 2, 3),
+    ("deploy_fix_factory", "DF", 2, 4),
+    ("monitoring_requirement_factory", "MR", 3, 0),
+    ("monitor_deployment_factory", "MD", 3, 1),
 ]
 
 
-@pytest.mark.parametrize("field,label,index", _BUNDLE_FIELDS)
-def test_each_factory_is_wired(field, label, index):
-    """Each factory field in a bundle is individually wired into the tree."""
+@pytest.mark.parametrize("field,label,arm_idx,child_idx", _CALL_OUT_SEAMS)
+def test_each_factory_is_wired(field, label, arm_idx, child_idx):
+    """Each of the 4 factory fields is individually wired into the tree."""
     sentinel = {"called": False}
 
-    def custom_factory(name):
+    def custom_factory(name: str) -> py_trees.behaviour.Behaviour:
         sentinel["called"] = True
 
         class _Marker(py_trees.behaviour.Behaviour):
-            def update(self):
-                return py_trees.common.Status.SUCCESS
+            def update(self) -> Status:
+                return Status.SUCCESS
 
         return _Marker(name=label)
 
     bundle = DeployFixCallOutBundle(**{field: custom_factory})  # type: ignore[arg-type]
-    tree = create_deploy_fix_tree(case_id=CASE_ID, call_out=bundle)
+    tree = create_deploy_fix_tree(
+        case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID, call_out=bundle
+    )
     assert sentinel["called"]
-    assert tree.children[index].name == label
+    assert tree.children[arm_idx].children[child_idx].name == label
 
 
 def test_all_factories_replaceable():
     bundle = DeployFixCallOutBundle(
         prioritize_deployment_factory=_marker_factory("PD"),  # type: ignore[arg-type]
-        deploy_mitigation_factory=_marker_factory("DM"),  # type: ignore[arg-type]
         monitoring_requirement_factory=_marker_factory("MR"),  # type: ignore[arg-type]
         deploy_fix_factory=_marker_factory("DF"),  # type: ignore[arg-type]
         monitor_deployment_factory=_marker_factory("MD"),  # type: ignore[arg-type]
     )
-    tree = create_deploy_fix_tree(case_id=CASE_ID, call_out=bundle)
+    tree = create_deploy_fix_tree(
+        case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID, call_out=bundle
+    )
     tree_str = py_trees.display.ascii_tree(tree)
-    for label in ("PD", "DM", "MR", "DF", "MD"):
+    for label in ("PD", "MR", "DF", "MD"):
         assert label in tree_str
 
 
-def test_deterministic_singleton_accepted():
-    tree = create_deploy_fix_tree(
-        case_id=CASE_ID, call_out=DEPLOY_FIX_DETERMINISTIC
+def test_stochastic_bundle_children_are_fuzzer_nodes():
+    """STOCHASTIC bundle produces the correct fuzzer-class nodes."""
+    from vultron.demo.fuzzer.bundles.deploy_fix import DEPLOY_FIX_STOCHASTIC
+    from vultron.demo.fuzzer.report_management.deploy_fix import (
+        DeployFix,
+        MonitorDeployment,
+        MonitoringRequirement,
+        PrioritizeDeployment,
     )
-    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+    tree = create_deploy_fix_tree(
+        case_id=CASE_ID,
+        actor_id=DEPLOYER_ACTOR_ID,
+        call_out=DEPLOY_FIX_STOCHASTIC,
+    )
+    deploy_arm = tree.children[2]
+    monitor_arm = tree.children[3]
+    assert isinstance(deploy_arm.children[3], PrioritizeDeployment)
+    assert isinstance(deploy_arm.children[4], DeployFix)
+    assert isinstance(monitor_arm.children[0], MonitoringRequirement)
+    assert isinstance(monitor_arm.children[1], MonitorDeployment)
+
+
+# ---------------------------------------------------------------------------
+# AC-3 / AC-1: CSinStateFixDeployed early-exit guard
+# ---------------------------------------------------------------------------
+
+
+class TestCSinStateFixDeployed:
+    def test_success_when_fix_deployed(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFD)
+        result = bt_scenario.run(
+            CSinStateFixDeployed(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_failure_when_not_deployed(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFd)
+        result = bt_scenario.run(
+            CSinStateFixDeployed(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+    def test_failure_when_case_missing(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            CSinStateFixDeployed(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+    def test_failure_when_actor_not_participant(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        result = bt_scenario.run(
+            CSinStateFixDeployed(case_id=CASE_ID, actor_id=VENDOR_ACTOR_ID),
+            actor_id=VENDOR_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+
+class TestCheckCSFixNotYetDeployed:
+    def test_success_when_fix_ready_not_deployed(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        """SUCCESS only for VFd (fix ready, not yet deployed)."""
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFd)
+        result = bt_scenario.run(
+            CheckCSFixNotYetDeployed(
+                case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID
+            ),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.SUCCESS
+
+    @pytest.mark.parametrize("vfd", [CS_vfd.vfd, CS_vfd.Vfd])
+    def test_failure_when_fix_not_ready(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+        vfd: CS_vfd,
+    ) -> None:
+        """FAILURE when fix is not yet ready — d→D requires VFd source.
+
+        Guards against an invalid vfd/Vfd → VFD state-machine jump.
+        """
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=vfd)
+        result = bt_scenario.run(
+            CheckCSFixNotYetDeployed(
+                case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID
+            ),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+    def test_failure_when_already_deployed(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFD)
+        result = bt_scenario.run(
+            CheckCSFixNotYetDeployed(
+                case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID
+            ),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+    def test_failure_when_case_missing(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            CheckCSFixNotYetDeployed(
+                case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID
+            ),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+
+class TestRMinStateDeferred:
+    def test_success_when_deferred(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, rm=RM.DEFERRED)
+        result = bt_scenario.run(
+            RMinStateDeferred(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_failure_when_accepted(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, rm=RM.ACCEPTED)
+        result = bt_scenario.run(
+            RMinStateDeferred(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+    def test_failure_when_case_missing(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            RMinStateDeferred(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# AC-4: CheckNoNewDeploymentInfoNode blackboard flag
+# ---------------------------------------------------------------------------
+
+
+class TestCheckNoNewDeploymentInfoNode:
+    def test_success_when_flag_absent(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Defaults SUCCESS when the blackboard key is absent (AC-4)."""
+        result = bt_scenario.run(
+            CheckNoNewDeploymentInfoNode(), actor_id=DEPLOYER_ACTOR_ID
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_success_when_flag_falsy(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            CheckNoNewDeploymentInfoNode(),
+            actor_id=DEPLOYER_ACTOR_ID,
+            **{NEW_DEPLOYMENT_INFO_KEY: False},
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_failure_when_flag_truthy(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """FAILURE when the sentinel wrote a truthy new-info flag."""
+        result = bt_scenario.run(
+            CheckNoNewDeploymentInfoNode(),
+            actor_id=DEPLOYER_ACTOR_ID,
+            **{NEW_DEPLOYMENT_INFO_KEY: True},
+        )
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# AC-5: TransitionCStoFixDeployed + EmitCDActivity
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionCStoFixDeployed:
+    def test_success_and_creates_vfd_status(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFd)
+        result_out: dict = {}
+        node = TransitionCStoFixDeployed(
+            case_id=CASE_ID,
+            actor_id=DEPLOYER_ACTOR_ID,
+            result_out=result_out,
+        )
+        result = bt_scenario.run(node, actor_id=DEPLOYER_ACTOR_ID)
+        assert result.status == Status.SUCCESS
+        assert "status_id" in result_out
+        assert "participant_id" in result_out
+
+    def test_failure_when_case_missing(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            TransitionCStoFixDeployed(
+                case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID
+            ),
+            actor_id=DEPLOYER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+
+class TestEmitCDActivity:
+    def test_success_emits_cd_activity(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer_and_case_manager: VultronCase,
+    ) -> None:
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFd)
+        result_out: dict = {}
+        transition_node = TransitionCStoFixDeployed(
+            case_id=CASE_ID,
+            actor_id=DEPLOYER_ACTOR_ID,
+            result_out=result_out,
+        )
+        tr = bt_scenario.run(transition_node, actor_id=DEPLOYER_ACTOR_ID)
+        assert tr.status == Status.SUCCESS
+        assert "status_id" in result_out
+
+        emit_node = EmitCDActivity(
+            case_id=CASE_ID,
+            actor_id=DEPLOYER_ACTOR_ID,
+            result_out=result_out,
+        )
+        result = bt_scenario.run(emit_node, actor_id=DEPLOYER_ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_failure_when_result_out_empty(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        node = EmitCDActivity(
+            case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID, result_out={}
+        )
+        result = bt_scenario.run(node, actor_id=DEPLOYER_ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_failure_when_no_case_manager(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+    ) -> None:
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFd)
+        result_out: dict = {}
+        transition_node = TransitionCStoFixDeployed(
+            case_id=CASE_ID,
+            actor_id=DEPLOYER_ACTOR_ID,
+            result_out=result_out,
+        )
+        bt_scenario.run(transition_node, actor_id=DEPLOYER_ACTOR_ID)
+
+        emit_node = EmitCDActivity(
+            case_id=CASE_ID,
+            actor_id=DEPLOYER_ACTOR_ID,
+            result_out=result_out,
+        )
+        result = bt_scenario.run(emit_node, actor_id=DEPLOYER_ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# AC-7: Early-exit arm short-circuits the deploy/monitor arms
+# ---------------------------------------------------------------------------
+
+
+def test_early_exit_when_fix_already_deployed(
+    bt_scenario: BTTestScenario,
+    case_with_deployer_and_case_manager: VultronCase,
+) -> None:
+    """Fix already deployed → CSinStateFixDeployed SUCCESS → Fallback succeeds.
+
+    The deploy arm's TransitionCStoFixDeployed must NOT run (no duplicate
+    status). We assert SUCCESS and that no new VFD status was appended.
+    """
+    _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFD)
+    case = bt_scenario.dl.read(CASE_ID)
+    assert isinstance(case, VultronCase)
+    participant_id = case.actor_participant_index[DEPLOYER_ACTOR_ID]
+    participant = bt_scenario.dl.read(participant_id)
+    assert isinstance(participant, CaseParticipant)
+    before = len(participant.participant_statuses)
+
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    result = bt_scenario.run(tree, actor_id=DEPLOYER_ACTOR_ID)
+    assert result.status == Status.SUCCESS
+
+    participant = bt_scenario.dl.read(participant_id)
+    assert isinstance(participant, CaseParticipant)
+    assert len(participant.participant_statuses) == before
+
+
+def test_stay_deferred_short_circuits(
+    bt_scenario: BTTestScenario,
+    case_with_deployer: VultronCase,
+) -> None:
+    """Deferred deployer, no new info → _ShouldStayInRmDeferred SUCCESS."""
+    _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, rm=RM.DEFERRED)
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    result = bt_scenario.run(tree, actor_id=DEPLOYER_ACTOR_ID)
+    assert result.status == Status.SUCCESS
+
+
+def test_full_deploy_path_succeeds(
+    bt_scenario: BTTestScenario,
+    case_with_deployer_and_case_manager: VultronCase,
+) -> None:
+    """Deployer, RM ACCEPTED, fix ready-not-deployed → deploy arm runs to CD.
+
+    Uses the DETERMINISTIC bundle (PrioritizeDeployment=AlwaysSucceed,
+    DeployFix=AlwaysFail). Because DeployFix defaults to AlwaysFail, the
+    deploy arm fails and the Fallback falls through to the monitor arm — which
+    succeeds (MonitoringRequirement + MonitorDeployment both AlwaysSucceed).
+    So the overall tree SUCCEEDS.
+    """
+    _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFd)
+    tree = create_deploy_fix_tree(case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID)
+    result = bt_scenario.run(tree, actor_id=DEPLOYER_ACTOR_ID)
+    assert result.status == Status.SUCCESS

--- a/test/demo/fuzzer/test_stochastic_bundle_scenario.py
+++ b/test/demo/fuzzer/test_stochastic_bundle_scenario.py
@@ -187,22 +187,30 @@ def test_three_mode_comparison():
     from vultron.demo.fuzzer.report_management.deploy_fix import DeployFix
 
     case_id = "https://example.org/cases/demo-001"
+    actor_id = "https://example.org/actors/deployer-001"
+
+    # DeployFix is the 5th child (index 4) of the _DeployFixIfReady Sequence,
+    # which is the 3rd top-level arm (index 2) of the DeployFixBT Fallback.
+    def _deploy_fix_node(tree):
+        return tree.children[2].children[4]
 
     # DETERMINISTIC mode (ceiling/floor defaults)
-    det_tree = create_deploy_fix_tree(case_id=case_id)
-    assert isinstance(det_tree.children[3], AlwaysFail)  # DeployFix p=0.10
+    det_tree = create_deploy_fix_tree(case_id=case_id, actor_id=actor_id)
+    assert isinstance(
+        _deploy_fix_node(det_tree), AlwaysFail
+    )  # DeployFix p=0.10
 
     # Explicit DETERMINISTIC singleton — same result
     det_tree2 = create_deploy_fix_tree(
-        case_id=case_id, call_out=DEPLOY_FIX_DETERMINISTIC
+        case_id=case_id, actor_id=actor_id, call_out=DEPLOY_FIX_DETERMINISTIC
     )
-    assert isinstance(det_tree2.children[3], AlwaysFail)
+    assert isinstance(_deploy_fix_node(det_tree2), AlwaysFail)
 
     # STOCHASTIC mode — probabilistic fuzzer nodes
     sto_tree = create_deploy_fix_tree(
-        case_id=case_id, call_out=DEPLOY_FIX_STOCHASTIC
+        case_id=case_id, actor_id=actor_id, call_out=DEPLOY_FIX_STOCHASTIC
     )
-    assert isinstance(sto_tree.children[3], DeployFix)
+    assert isinstance(_deploy_fix_node(sto_tree), DeployFix)
 
     # CUSTOM mode — per-field override
     def _custom_deploy_fix(name):
@@ -215,7 +223,9 @@ def test_three_mode_comparison():
     custom_bundle = DeployFixCallOutBundle(
         deploy_fix_factory=_custom_deploy_fix  # type: ignore[arg-type]
     )
-    cust_tree = create_deploy_fix_tree(case_id=case_id, call_out=custom_bundle)
-    assert cust_tree.children[3].name == "CustomDeployFix"
+    cust_tree = create_deploy_fix_tree(
+        case_id=case_id, actor_id=actor_id, call_out=custom_bundle
+    )
+    assert _deploy_fix_node(cust_tree).name == "CustomDeployFix"
 
     logger.info("Three-mode comparison complete for deploy-fix domain.")

--- a/vultron/core/behaviors/call_out/bundles/deploy_fix.py
+++ b/vultron/core/behaviors/call_out/bundles/deploy_fix.py
@@ -21,10 +21,14 @@ lives in the simulation layer
 Ceiling/floor mapping (BT-23-002):
 
 - ``prioritize_deployment_factory``  — PrioritizeDeployment  (p=0.90) → AlwaysSucceed
-- ``deploy_mitigation_factory``      — DeployMitigation      (p=0.75) → AlwaysSucceed
-- ``monitoring_requirement_factory`` — MonitoringRequirement (p=0.70) → AlwaysSucceed
 - ``deploy_fix_factory``             — DeployFix             (p=0.10) → AlwaysFail
+- ``monitoring_requirement_factory`` — MonitoringRequirement (p=0.70) → AlwaysSucceed
 - ``monitor_deployment_factory``     — MonitorDeployment     (p=1.0) → AlwaysSucceed
+
+Mitigation deployment (``DeployMitigation``) is scoped OUT of this bundle
+(#1248) — it belongs to a distinct ``create_deploy_mitigation_tree`` (a peer
+Idea).  The Phase 1 stub's ``deploy_mitigation_factory`` field was removed when
+the full tree landed (#1825).
 """
 
 from __future__ import annotations
@@ -54,9 +58,6 @@ class DeployFixCallOutBundle:
     """
 
     prioritize_deployment_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
-    )
-    deploy_mitigation_factory: CallOutBackendFactory = field(
         default=_always_succeed  # type: ignore[assignment]
     )
     monitoring_requirement_factory: CallOutBackendFactory = field(

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -211,6 +211,46 @@ def resolve_participant_state_from_dl(
     return RM.START, CS_vfd.vfd
 
 
+def resolve_case_manager_id(
+    case: VulnerabilityCase,
+    dl: CasePersistence,
+) -> str | None:
+    """Return the actor ID of the CASE_MANAGER participant, or None.
+
+    Checks ``actor_participant_index`` first (fast path), then falls back to
+    iterating ``case_participants`` for bootstrap-phase inline objects.
+
+    Behaviors-layer twin of
+    ``vultron.core.use_cases._helpers._resolve_case_manager_id``; kept here so
+    BT nodes (e.g. ``EmitCFActivity``, ``EmitCDActivity``) resolve the Case
+    Actor without a behaviors→use_cases import (BTND-04-003).
+    """
+    for p_id in case.actor_participant_index.values():
+        p = dl.read(p_id)
+        if not isinstance(p, CaseParticipant):
+            continue
+        if CVDRole.CASE_MANAGER in p.roles:
+            return _as_id(getattr(p, "attributed_to", None))
+
+    indexed_ids = set(case.actor_participant_index.values())
+    for p_ref in case.case_participants:
+        if not isinstance(p_ref, str):
+            if (
+                isinstance(p_ref, CaseParticipant)
+                and CVDRole.CASE_MANAGER in p_ref.roles
+            ):
+                return _as_id(getattr(p_ref, "attributed_to", None))
+            continue
+        if p_ref in indexed_ids:
+            continue
+        p = dl.read(p_ref)
+        if not isinstance(p, CaseParticipant):
+            continue
+        if CVDRole.CASE_MANAGER in p.roles:
+            return _as_id(getattr(p, "attributed_to", None))
+    return None
+
+
 def _queue_participant_add_notification(
     dl: CasePersistence,
     node_name: str,

--- a/vultron/core/behaviors/report/deploy_fix_tree.py
+++ b/vultron/core/behaviors/report/deploy_fix_tree.py
@@ -11,34 +11,74 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Fix deployment behavior tree composition (Phase 1 stub).
+"""Fix deployment behavior tree composition.
 
-This module provides :func:`create_deploy_fix_tree`, which hosts five
-fix-deployment call-out points wired per ADR-0025 / BT-18-004:
+This module provides :func:`create_deploy_fix_tree`, which composes the full
+fix-deployment workflow as a ``DeployFixBT`` Fallback:
 
-Evaluator nodes:
-- ``PrioritizeDeployment``
-- ``DeployMitigation``
-- ``MonitoringRequirement``
-- ``DeployFix``
+.. code-block:: text
 
-Actuator node:
-- ``MonitorDeployment``
+    DeployFixBT (Fallback)
+    ├─ CSinStateFixDeployed                 # short-circuit: fix already deployed
+    ├─ _ShouldStayInRmDeferred (Sequence)
+    │  ├─ RMinStateDeferred
+    │  └─ CheckNoNewDeploymentInfoNode
+    ├─ _DeployFixIfReady (Sequence)
+    │  ├─ CheckDeployerRoleNode
+    │  ├─ CheckRMStateAccepted
+    │  ├─ CheckCSFixNotYetDeployed
+    │  ├─ <PrioritizeDeployment call-out>   # Evaluator, injected
+    │  ├─ <DeployFix call-out>              # Evaluator, injected
+    │  ├─ TransitionCStoFixDeployed
+    │  └─ EmitCDActivity
+    └─ _MonitorDeploymentIfDesired (Sequence)
+       ├─ <MonitoringRequirement call-out>  # Evaluator, injected
+       └─ <MonitorDeployment call-out>      # Actuator, injected
 
-Phase 1 contains only the injectable call-out points as a stub Sequence.
-The full deployment workflow (no-new-info early exit, mitigation arm,
-monitoring arm, fix deployment arm) is deferred to a future issue.
+This replaces the Phase 1 stub (PR #1357) which exposed the call-out points in
+a flat Sequence with no guard nodes (Concern #1813).
+
+Call-out injection seams (ADR-0025 / BT-18-004)
+-----------------------------------------------
+Four factories on :class:`DeployFixCallOutBundle`:
+
+- **PrioritizeDeployment** — ``prioritize_deployment_factory`` (Evaluator,
+  p=0.90 → AlwaysSucceed)
+- **DeployFix** — ``deploy_fix_factory`` (Evaluator, p=0.10 → AlwaysFail)
+- **MonitoringRequirement** — ``monitoring_requirement_factory`` (Evaluator,
+  p=0.70 → AlwaysSucceed)
+- **MonitorDeployment** — ``monitor_deployment_factory`` (Actuator,
+  p=1.0 → AlwaysSucceed)
 
 References
 ----------
+- Issue: #1825
+- Source Idea: #1248
+- Concern: #1813 (Phase 1 stub missing guard nodes)
 - ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
-- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-06-001, BT-18-004
+- Notes: ``notes/bt-fuzzer-rm-fix.md``
 """
 
 import logging
 from typing import TYPE_CHECKING
 
 import py_trees
+
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckDeployerRoleNode,
+)
+from vultron.core.behaviors.report.nodes.deploy_fix import (
+    CheckCSFixNotYetDeployed,
+    CheckNoNewDeploymentInfoNode,
+    CSinStateFixDeployed,
+    EmitCDActivity,
+    RMinStateDeferred,
+    TransitionCStoFixDeployed,
+)
+from vultron.core.behaviors.report.nodes.develop_fix import (
+    CheckRMStateAccepted,
+)
 
 if TYPE_CHECKING:
     from vultron.core.behaviors.call_out.bundles.deploy_fix import (
@@ -50,39 +90,94 @@ logger = logging.getLogger(__name__)
 
 def create_deploy_fix_tree(
     case_id: str,
+    actor_id: str,
     call_out: "DeployFixCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
-    """Create behavior tree for the fix deployment workflow (Phase 1 stub).
+    """Create behavior tree for the fix deployment workflow.
 
-    Phase 1 exposes the four Evaluator call-out points and the MonitorDeployment
-    Actuator as a stub Sequence.  The full workflow (no-new-info early exit,
-    mitigation arm, monitoring arm, fix deployment arm) is deferred to a
-    future issue.
+    Mirrors the legacy ``Deployment`` Fallback from
+    ``vultron/bt/report_management/_behaviors/deploy_fix.py`` with all guards
+    and protocol-action nodes implemented as production-layer ``py_trees``
+    nodes.  Replaces the Phase 1 stub (PR #1357) that lacked guard nodes
+    (Concern #1813).
+
+    The tree short-circuits (returns SUCCESS) when the fix is already deployed
+    or when a deferred deployer has no new deployment information.  Deployers
+    whose RM state is ACCEPTED and whose fix is not yet deployed proceed
+    through the ``_DeployFixIfReady`` Sequence.
+
+    Call-out injection seams (ADR-0025 / BT-18-004):
+
+    - ``PrioritizeDeployment`` — ``prioritize_deployment_factory``
+    - ``DeployFix`` — ``deploy_fix_factory``
+    - ``MonitoringRequirement`` — ``monitoring_requirement_factory``
+    - ``MonitorDeployment`` — ``monitor_deployment_factory``
 
     Args:
         case_id: ID of VulnerabilityCase being processed.
+        actor_id: ID of the actor running this tree.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.deploy_fix.DEPLOY_FIX_DETERMINISTIC`
+            Defaults to
+            :data:`~vultron.core.behaviors.call_out.bundles.deploy_fix.DEPLOY_FIX_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
-        Root node of the deploy-fix behavior tree (Phase 1 stub Sequence).
+        Root node of the deploy-fix behavior tree (Fallback).
     """
     from vultron.core.behaviors.call_out.bundles.deploy_fix import (
         DEPLOY_FIX_DETERMINISTIC,
     )
 
     bundle = call_out if call_out is not None else DEPLOY_FIX_DETERMINISTIC
-    root = py_trees.composites.Sequence(
-        name="DeployFixBT",
+
+    result_out: dict = {}
+
+    should_stay_deferred = py_trees.composites.Sequence(
+        name="_ShouldStayInRmDeferred",
         memory=False,
         children=[
+            RMinStateDeferred(case_id=case_id, actor_id=actor_id),
+            CheckNoNewDeploymentInfoNode(),
+        ],
+    )
+
+    deploy_fix_if_ready = py_trees.composites.Sequence(
+        name="_DeployFixIfReady",
+        memory=False,
+        children=[
+            CheckDeployerRoleNode(case_id=case_id, actor_id=actor_id),
+            CheckRMStateAccepted(case_id=case_id, actor_id=actor_id),
+            CheckCSFixNotYetDeployed(case_id=case_id, actor_id=actor_id),
             bundle.prioritize_deployment_factory("PrioritizeDeployment"),
-            bundle.deploy_mitigation_factory("DeployMitigation"),
-            bundle.monitoring_requirement_factory("MonitoringRequirement"),
             bundle.deploy_fix_factory("DeployFix"),
+            TransitionCStoFixDeployed(
+                case_id=case_id, actor_id=actor_id, result_out=result_out
+            ),
+            EmitCDActivity(
+                case_id=case_id, actor_id=actor_id, result_out=result_out
+            ),
+        ],
+    )
+
+    monitor_deployment_if_desired = py_trees.composites.Sequence(
+        name="_MonitorDeploymentIfDesired",
+        memory=False,
+        children=[
+            bundle.monitoring_requirement_factory("MonitoringRequirement"),
             bundle.monitor_deployment_factory("MonitorDeployment"),
         ],
     )
-    logger.info(f"Created DeployFixBT (Phase 1 stub) for case={case_id}")
+
+    root = py_trees.composites.Selector(
+        name="DeployFixBT",
+        memory=False,
+        children=[
+            CSinStateFixDeployed(case_id=case_id, actor_id=actor_id),
+            should_stay_deferred,
+            deploy_fix_if_ready,
+            monitor_deployment_if_desired,
+        ],
+    )
+
+    logger.info("Created DeployFixBT for case=%s actor=%s", case_id, actor_id)
     return root

--- a/vultron/core/behaviors/report/nodes/__init__.py
+++ b/vultron/core/behaviors/report/nodes/__init__.py
@@ -25,6 +25,8 @@ Submodules:
 - ``rm_transitions``: Report-management transition action nodes
 - ``case_creation``: Case creation and Create(Case) activity nodes
 - ``participant``: Case participant RM transition action nodes
+- ``develop_fix``: Fix-development guard/action nodes (DevelopFixBT)
+- ``deploy_fix``: Fix-deployment guard/action nodes (DeployFixBT)
 - ``emit``: Outbound report activity emission nodes
 - ``storage``: Idempotent storage nodes for inbound report objects
 """
@@ -43,6 +45,21 @@ from vultron.core.behaviors.report.nodes.conditions import (
     EvaluateCasePriority,
     EvaluateReportCredibility,
     EvaluateReportValidity,
+)
+from vultron.core.behaviors.report.nodes.deploy_fix import (
+    CheckCSFixNotYetDeployed,
+    CheckNoNewDeploymentInfoNode,
+    CSinStateFixDeployed,
+    EmitCDActivity,
+    RMinStateDeferred,
+    TransitionCStoFixDeployed,
+)
+from vultron.core.behaviors.report.nodes.develop_fix import (
+    CheckCSFixNotYetReady,
+    CheckIsVendorRoleNode,
+    CheckRMStateAccepted,
+    EmitCFActivity,
+    TransitionCStoFixReady,
 )
 from vultron.core.behaviors.report.nodes.emit import (
     EmitCloseReportActivity,
@@ -86,6 +103,19 @@ __all__ = [
     # participant
     "TransitionParticipantRMtoAccepted",
     "TransitionParticipantRMtoDeferred",
+    # develop_fix
+    "CheckIsVendorRoleNode",
+    "CheckCSFixNotYetReady",
+    "CheckRMStateAccepted",
+    "TransitionCStoFixReady",
+    "EmitCFActivity",
+    # deploy_fix
+    "CSinStateFixDeployed",
+    "CheckCSFixNotYetDeployed",
+    "RMinStateDeferred",
+    "CheckNoNewDeploymentInfoNode",
+    "TransitionCStoFixDeployed",
+    "EmitCDActivity",
     # emit
     "EmitInvalidateReportActivity",
     "EmitCloseReportActivity",

--- a/vultron/core/behaviors/report/nodes/deploy_fix.py
+++ b/vultron/core/behaviors/report/nodes/deploy_fix.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Production-layer BT nodes for the fix deployment workflow.
+
+Six nodes implement the ``DeployFixBT`` guard/action logic:
+
+- :class:`CSinStateFixDeployed` — short-circuit: fix already deployed
+- :class:`RMinStateDeferred` — guard: actor RM is DEFERRED (stay-deferred arm)
+- :class:`CheckNoNewDeploymentInfoNode` — ProtocolInternal condition reading a
+  change-detection flag written by the upstream ``NewDeploymentInfoSentinel``
+- :class:`CheckCSFixNotYetDeployed` — guard: fix not yet deployed (d bit unset)
+- :class:`TransitionCStoFixDeployed` — persist VFD VFD snapshot (d→D)
+- :class:`EmitCDActivity` — emit CD (Fix Deployed) to the Case Actor
+
+``CheckDeployerRoleNode`` (d→D role guard) is reused from
+``vultron.core.behaviors.case.nodes.vfd_role_guards`` (AC-3), and
+``CheckRMStateAccepted`` is reused from
+``vultron.core.behaviors.report.nodes.develop_fix`` (AC-3).
+
+References
+----------
+- Issue: #1825
+- Source Idea: #1248
+- Concern: #1813 (Phase 1 stub missing guard nodes)
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-06-001, BT-18-004
+- ADR-0021 CLP-10-001: fix-deployment activities route to the Case Actor
+- ADR-0025: factory injection seam
+- Notes: ``notes/bt-fuzzer-rm-fix.md``
+"""
+
+import logging
+from typing import cast
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.case.nodes.participant.common import (
+    resolve_case_manager_id,
+    resolve_participant_state_from_dl,
+)
+from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.dimensions import VfdDimension
+from vultron.core.ports.case_persistence import (
+    CaseOutboxPersistence,
+    CasePersistence,
+)
+from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
+
+logger = logging.getLogger(__name__)
+
+# Blackboard key written by the upstream NewDeploymentInfoSentinel (FUZZ-08f).
+# When present and truthy, new deployment-relevant information has arrived and
+# the deployer should re-evaluate rather than stay deferred.  When the key is
+# absent, CheckNoNewDeploymentInfoNode defaults to SUCCESS (no new info).
+NEW_DEPLOYMENT_INFO_KEY = "new_deployment_info"
+
+
+def _resolve_vfd_state(
+    dl: CasePersistence,
+    case: VulnerabilityCase,
+    actor_id: str,
+    node_name: str,
+) -> CS_vfd | None:
+    """Return the actor's current VFD state in *case*, or None on lookup error.
+
+    Returns ``None`` (caller returns FAILURE) when the actor has no participant
+    record in the case.
+    """
+    participant_id = case.actor_participant_index.get(actor_id)
+    if participant_id is None:
+        logger.warning(
+            "%s: actor '%s' not in case '%s'",
+            node_name,
+            actor_id,
+            case.id_,
+        )
+        return None
+    _, vfd_state = resolve_participant_state_from_dl(dl, participant_id)
+    return vfd_state
+
+
+class CSinStateFixDeployed(DataLayerCondition):
+    """Short-circuit guard: fix already deployed means nothing to do.
+
+    Returns ``SUCCESS`` when the actor's VFD state is already fix-deployed
+    (``CS_vfd.VFD``) — the ``DeployFixBT`` Fallback short-circuits and reports
+    SUCCESS to the parent.  Returns ``FAILURE`` when the fix is NOT yet
+    deployed, allowing the deployment arms to proceed.
+
+    Per AC-1 (issue #1825); mirrors ``CheckCSFixNotYetReady`` from
+    ``develop_fix.py`` but keyed on the fix-deployed (D) bit.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._actor_id = actor_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.logger.warning(
+                "%s: case '%s' not found", self.name, self._case_id
+            )
+            return Status.FAILURE
+
+        vfd_state = _resolve_vfd_state(
+            self.datalayer, case, self._actor_id, self.name
+        )
+        if vfd_state is None:
+            return Status.FAILURE
+
+        if VfdDimension(state=vfd_state).is_fix_deployed():
+            self.logger.debug(
+                "%s: VFD state=%s is fix-deployed — short-circuit SUCCESS",
+                self.name,
+                vfd_state,
+            )
+            return Status.SUCCESS
+
+        self.logger.debug(
+            "%s: VFD state=%s is not fix-deployed — proceed to deployment",
+            self.name,
+            vfd_state,
+        )
+        return Status.FAILURE
+
+
+class CheckCSFixNotYetDeployed(DataLayerCondition):
+    """Guard: fix must be READY but NOT yet deployed (VFD state == ``VFd``).
+
+    Returns ``SUCCESS`` only when the actor's VFD state is fix-ready and the
+    fix is not yet deployed — i.e. exactly ``CS_vfd.VFd``.  Returns ``FAILURE``
+    when the fix is not yet ready (``vfd``/``Vfd``) or already deployed
+    (``VFD``).
+
+    This enforces the VFD state-machine precondition for the d→D transition,
+    which is valid **only** from ``VFd`` (``_vfd_transitions`` in
+    ``vultron/core/states/cs.py``).  A weaker "D bit not set" check would let a
+    deployer in ``vfd``/``Vfd`` jump straight to ``VFD`` via
+    :class:`TransitionCStoFixDeployed`, producing an invalid status snapshot.
+    Mirrors the legacy ``CSinStateVendorAwareFixReadyFixNotDeployed`` guard in
+    ``_DeployFixWhenReady``.
+
+    Per AC-3 (issue #1825); guards the ``_DeployFixIfReady`` Sequence.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._actor_id = actor_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.logger.warning(
+                "%s: case '%s' not found", self.name, self._case_id
+            )
+            return Status.FAILURE
+
+        vfd_state = _resolve_vfd_state(
+            self.datalayer, case, self._actor_id, self.name
+        )
+        if vfd_state is None:
+            return Status.FAILURE
+
+        dim = VfdDimension(state=vfd_state)
+        if not dim.is_fix_ready():
+            self.feedback_message = (
+                f"Actor '{self._actor_id}' fix not yet ready"
+                f" (VFD state={vfd_state!r}) — d→D transition requires VFd"
+            )
+            self.logger.debug("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        if dim.is_fix_deployed():
+            self.feedback_message = (
+                f"Actor '{self._actor_id}' fix already deployed"
+                f" (VFD state={vfd_state!r}) — d→D transition blocked"
+            )
+            self.logger.debug("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        self.logger.debug(
+            "%s: VFD state=%s is fix-ready-not-deployed — proceed",
+            self.name,
+            vfd_state,
+        )
+        return Status.SUCCESS
+
+
+class RMinStateDeferred(DataLayerCondition):
+    """Guard: actor RM state must be DEFERRED (stay-deferred arm).
+
+    Returns ``SUCCESS`` when the actor's latest RM state is ``RM.DEFERRED``.
+    Returns ``FAILURE`` otherwise.  Used as the first child of the
+    ``_ShouldStayInRmDeferred`` Sequence: a deferred deployer with no new
+    deployment info should stay deferred (short-circuit the Fallback).
+
+    Per AC-1 (issue #1825); mirrors ``CheckRMStateAccepted`` from
+    ``develop_fix.py`` but keyed on ``RM.DEFERRED``.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._actor_id = actor_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.logger.warning(
+                "%s: case '%s' not found", self.name, self._case_id
+            )
+            return Status.FAILURE
+
+        participant_id = case.actor_participant_index.get(self._actor_id)
+        if participant_id is None:
+            self.logger.warning(
+                "%s: actor '%s' not in case '%s'",
+                self.name,
+                self._actor_id,
+                self._case_id,
+            )
+            return Status.FAILURE
+
+        rm_state, _ = resolve_participant_state_from_dl(
+            self.datalayer, participant_id
+        )
+
+        if rm_state == RM.DEFERRED:
+            self.logger.debug(
+                "%s: RM state is DEFERRED for actor '%s'",
+                self.name,
+                self._actor_id,
+            )
+            return Status.SUCCESS
+
+        self.feedback_message = (
+            f"Actor '{self._actor_id}' RM state is {rm_state!r},"
+            f" expected RM.DEFERRED"
+        )
+        self.logger.debug("%s: %s", self.name, self.feedback_message)
+        return Status.FAILURE
+
+
+class CheckNoNewDeploymentInfoNode(DataLayerCondition):
+    """ProtocolInternal condition: no new deployment info has arrived.
+
+    Reads the blackboard flag ``new_deployment_info`` written by the upstream
+    ``NewDeploymentInfoSentinel`` (FUZZ-08f).  Returns ``SUCCESS`` when the
+    flag is absent or falsy (no new info — safe to stay deferred) and
+    ``FAILURE`` when the flag is truthy (new info arrived — re-evaluate
+    deployment).
+
+    This node is NOT a call-out injection seam — the external agent seam is at
+    the Sentinel that writes the flag, not at this consuming condition
+    (see ``notes/bt-fuzzer-rm-fix.md`` § ``NoNewDeploymentInfo``).  Defaulting
+    to SUCCESS when the key is absent matches the legacy fuzzer's
+    ``UsuallySucceed`` (p=0.75) happy path: most ticks have no new info.
+
+    Per AC-4 (issue #1825).
+    """
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key=NEW_DEPLOYMENT_INFO_KEY, access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        try:
+            new_info = self.blackboard.get(NEW_DEPLOYMENT_INFO_KEY)
+        except KeyError:
+            new_info = None
+
+        if new_info:
+            self.feedback_message = (
+                "new deployment info present — re-evaluate deployment"
+            )
+            self.logger.debug("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        self.logger.debug(
+            "%s: no new deployment info — stay deferred", self.name
+        )
+        return Status.SUCCESS
+
+
+class TransitionCStoFixDeployed(DataLayerAction):
+    """Persist a VFD ParticipantStatus snapshot for the actor in this case.
+
+    Advances the actor's VFD dimension to ``CS_vfd.VFD`` (fix deployed) and
+    persists the new ``ParticipantStatus`` record via the DataLayer, appending
+    it to the ``CaseParticipant.participant_statuses`` list.
+
+    Per AC-5 (issue #1825); follows the ``TransitionCStoFixReady`` pattern from
+    ``develop_fix.py`` but targets the d→D transition.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id: str,
+        result_out: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._actor_id = actor_id
+        self._result_out = result_out if result_out is not None else {}
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        from vultron.core.behaviors.case.nodes.participant.status import (
+            CreateParticipantStatusNode,
+        )
+
+        node = CreateParticipantStatusNode(
+            case_id=self._case_id,
+            actor_id=self._actor_id,
+            rm_state=None,
+            vfd_state=CS_vfd.VFD,
+            pxa_state=None,
+            result_out=self._result_out,
+            name=f"{self.name}._Create",
+        )
+        node.datalayer = self.datalayer
+
+        try:
+            status = node.update()
+            if status == Status.SUCCESS:
+                self.logger.info(
+                    "%s: VFD → VFD (fix deployed) for actor '%s' in case '%s'",
+                    self.name,
+                    self._actor_id,
+                    self._case_id,
+                )
+            return status
+        except Exception as e:
+            self.logger.error(
+                "%s: Error transitioning to VFD: %s", self.name, e
+            )
+            return Status.FAILURE
+
+
+class EmitCDActivity(DataLayerAction):
+    """Emit a CD (Fix Deployed) ``Add(ParticipantStatus)`` to the Case Actor.
+
+    Calls ``trigger_activity_factory.add_participant_status_to_participant``
+    with the status and participant IDs written to *result_out* by
+    :class:`TransitionCStoFixDeployed` and queues the resulting activity ID
+    via ``record_outbox_item``.
+
+    Per ADR-0021 CLP-10-001: trigger trees MUST address fix-deployment
+    activities to the Case Actor (CASE_MANAGER) so the CaseActor can commit
+    a canonical ledger entry.
+
+    Per AC-5 (issue #1825); mirrors ``EmitCFActivity`` from ``develop_fix.py``.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id: str,
+        result_out: dict,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._actor_id = actor_id
+        self._result_out = result_out
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        if (f := self._require_factory()) is not None:
+            self.logger.warning(
+                "%s: no TriggerActivityPort — cannot emit CD activity",
+                self.name,
+            )
+            return f
+
+        assert self.datalayer is not None
+        assert self.trigger_activity_factory is not None
+
+        status_id = self._result_out.get("status_id")
+        participant_id = self._result_out.get("participant_id")
+        if not status_id or not participant_id:
+            self.feedback_message = (
+                "status_id or participant_id missing from result_out"
+                " — TransitionCStoFixDeployed must precede EmitCDActivity"
+            )
+            self.logger.error("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.logger.warning(
+                "%s: case '%s' not found", self.name, self._case_id
+            )
+            return Status.FAILURE
+
+        case_manager_id = resolve_case_manager_id(case, self.datalayer)
+        if not case_manager_id:
+            self.feedback_message = (
+                f"No CASE_MANAGER found for case '{self._case_id}'"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        # When actor IS the case manager (single-actor scenario) to=None means
+        # the activity is self-addressed; no external delivery needed.
+        to = [case_manager_id] if case_manager_id != self._actor_id else None
+
+        try:
+            activity_id = self.trigger_activity_factory.add_participant_status_to_participant(
+                status_id=status_id,
+                participant_id=participant_id,
+                actor=self._actor_id,
+                to=to,
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self._actor_id, activity_id
+            )
+            self.logger.info(
+                "%s: CD activity '%s' emitted for actor '%s' in case '%s'",
+                self.name,
+                activity_id,
+                self._actor_id,
+                self._case_id,
+            )
+            return Status.SUCCESS
+        except Exception as e:
+            self.logger.error(
+                "%s: Error emitting CD activity: %s", self.name, e
+            )
+            return Status.FAILURE
+
+
+__all__ = [
+    "CSinStateFixDeployed",
+    "CheckCSFixNotYetDeployed",
+    "RMinStateDeferred",
+    "CheckNoNewDeploymentInfoNode",
+    "TransitionCStoFixDeployed",
+    "EmitCDActivity",
+    "NEW_DEPLOYMENT_INFO_KEY",
+]

--- a/vultron/core/behaviors/report/nodes/develop_fix.py
+++ b/vultron/core/behaviors/report/nodes/develop_fix.py
@@ -35,11 +35,11 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.behaviors.case.nodes.participant.common import (
+    resolve_case_manager_id,
     resolve_participant_state_from_dl,
 )
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
-from vultron.core.models._helpers import _as_id
 from vultron.core.models.dimensions import VfdDimension
 from vultron.core.ports.case_persistence import (
     CasePersistence,
@@ -50,44 +50,6 @@ from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 
 logger = logging.getLogger(__name__)
-
-
-def _resolve_case_manager_id(
-    case: VulnerabilityCase,
-    dl: CasePersistence,
-) -> str | None:
-    """Return the actor ID of the CASE_MANAGER participant, or None.
-
-    Checks ``actor_participant_index`` first (fast path), then falls back to
-    iterating ``case_participants`` for bootstrap-phase inline objects.
-
-    Inlined from ``vultron.core.use_cases._helpers._resolve_case_manager_id``
-    to avoid a behaviors→use_cases import (BTND-04-003).
-    """
-    for p_id in case.actor_participant_index.values():
-        p = dl.read(p_id)
-        if not isinstance(p, CaseParticipant):
-            continue
-        if CVDRole.CASE_MANAGER in p.roles:
-            return _as_id(getattr(p, "attributed_to", None))
-
-    indexed_ids = set(case.actor_participant_index.values())
-    for p_ref in case.case_participants:
-        if not isinstance(p_ref, str):
-            if (
-                isinstance(p_ref, CaseParticipant)
-                and CVDRole.CASE_MANAGER in p_ref.roles
-            ):
-                return _as_id(getattr(p_ref, "attributed_to", None))
-            continue
-        if p_ref in indexed_ids:
-            continue
-        p = dl.read(p_ref)
-        if not isinstance(p, CaseParticipant):
-            continue
-        if CVDRole.CASE_MANAGER in p.roles:
-            return _as_id(getattr(p, "attributed_to", None))
-    return None
 
 
 def _resolve_actor_roles(
@@ -422,7 +384,7 @@ class EmitCFActivity(DataLayerAction):
             )
             return Status.FAILURE
 
-        case_manager_id = _resolve_case_manager_id(case, self.datalayer)
+        case_manager_id = resolve_case_manager_id(case, self.datalayer)
         if not case_manager_id:
             self.feedback_message = (
                 f"No CASE_MANAGER found for case '{self._case_id}'"

--- a/vultron/demo/fuzzer/bundles/deploy_fix.py
+++ b/vultron/demo/fuzzer/bundles/deploy_fix.py
@@ -21,9 +21,8 @@ here for backward-compatible import paths.
 Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
 - ``prioritize_deployment_factory``  — PrioritizeDeployment  (p=0.90) → AlwaysSucceed
-- ``deploy_mitigation_factory``      — DeployMitigation      (p=0.75) → AlwaysSucceed
-- ``monitoring_requirement_factory`` — MonitoringRequirement (p=0.70) → AlwaysSucceed
 - ``deploy_fix_factory``             — DeployFix             (p=0.10) → AlwaysFail
+- ``monitoring_requirement_factory`` — MonitoringRequirement (p=0.70) → AlwaysSucceed
 - ``monitor_deployment_factory``     — MonitorDeployment     (p=1.0) → AlwaysSucceed
 """
 
@@ -45,14 +44,6 @@ def _stochastic_prioritize_deployment(
     )
 
     return PrioritizeDeployment(name)
-
-
-def _stochastic_deploy_mitigation(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.deploy_fix import (
-        DeployMitigation,
-    )
-
-    return DeployMitigation(name)
 
 
 def _stochastic_monitoring_requirement(
@@ -81,7 +72,6 @@ def _stochastic_monitor_deployment(name: str) -> py_trees.behaviour.Behaviour:
 
 DEPLOY_FIX_STOCHASTIC = DeployFixCallOutBundle(
     prioritize_deployment_factory=_stochastic_prioritize_deployment,  # type: ignore[arg-type]
-    deploy_mitigation_factory=_stochastic_deploy_mitigation,  # type: ignore[arg-type]
     monitoring_requirement_factory=_stochastic_monitoring_requirement,  # type: ignore[arg-type]
     deploy_fix_factory=_stochastic_deploy_fix,  # type: ignore[arg-type]
     monitor_deployment_factory=_stochastic_monitor_deployment,  # type: ignore[arg-type]


### PR DESCRIPTION
- Closes #1825
- Closes #1813

## Summary

Replaces the Phase 1 `create_deploy_fix_tree` stub (PR #1357) with the full
production `DeployFixBT` Fallback: a four-arm tree with guard nodes, protocol
action nodes, and injectable call-out seams that mirrors the sibling
`create_develop_fix_tree` (#1818). Closes Concern #1813 (stub was missing the
role / CS / RM guard nodes and would invoke all call-out points regardless of
actor role or case state).

## Changes

- **`vultron/core/behaviors/report/deploy_fix_tree.py`**: full `DeployFixBT`
  Selector with four arms — `CSinStateFixDeployed` early-exit,
  `_ShouldStayInRmDeferred` (RM.DEFERRED + no-new-info), `_DeployFixIfReady`
  (deployer-role + RM-accepted + fix-ready-not-deployed guards → Prioritize →
  DeployFix → transition → emit CD), and `_MonitorDeploymentIfDesired`. New
  required `actor_id` parameter.
- **`vultron/core/behaviors/report/nodes/deploy_fix.py`** (new): six
  production-layer nodes — `CSinStateFixDeployed`, `CheckCSFixNotYetDeployed`,
  `RMinStateDeferred`, `CheckNoNewDeploymentInfoNode`,
  `TransitionCStoFixDeployed`, `EmitCDActivity` — plus the
  `NEW_DEPLOYMENT_INFO_KEY` blackboard-flag constant.
- **`vultron/core/behaviors/case/nodes/participant/common.py`**: extract
  `resolve_case_manager_id` (previously duplicated in `develop_fix.py`) so
  both fix trees share one behaviors-layer Case Actor resolver (DRY, BTND-04-003).
- **`vultron/core/behaviors/report/nodes/develop_fix.py`**: use the shared
  `resolve_case_manager_id`; drop the now-dead local copy and `_as_id` import.
- **`vultron/core/behaviors/report/nodes/__init__.py`**: re-export the new
  deploy-fix and (previously missing) develop-fix node classes (BTND-07-003).
- **`vultron/core/behaviors/call_out/bundles/deploy_fix.py`** &
  **`vultron/demo/fuzzer/bundles/deploy_fix.py`**: reduce
  `DeployFixCallOutBundle` from 5 to 4 fields (remove `deploy_mitigation_factory`;
  mitigation deployment is scoped to a peer Idea).
- **`test/core/behaviors/report/test_deploy_fix_tree.py`**: full rewrite —
  tree structure, arm composition, guard polarity, all four call-out seams
  individually replaceable, DETERMINISTIC/STOCHASTIC/custom bundles, and
  early-exit / stay-deferred / full-deploy short-circuit paths.
- **`test/demo/fuzzer/test_stochastic_bundle_scenario.py`**: update the
  deploy-fix three-mode comparison for the new nested tree shape and `actor_id`.
- **`notes/bt-fuzzer-rm-fix.md`**: mark the deploy-fix factory placements as
  implemented in #1825.

## Verification

- Full unit suite passes (6791+ tests; ~15 new deploy-fix tests)
- Black, flake8, mypy, pyright clean
- [x] AC-1: four-arm `DeployFixBT` Fallback with the specified guard/action nodes
- [x] AC-2: `DeployFixCallOutBundle` reduced to 4 fields (deploy_mitigation removed)
- [x] AC-3: reuses `CheckDeployerRoleNode` and `CheckRMStateAccepted`; adds
  `CheckCSFixNotYetDeployed` (guards the valid VFd→VFD transition)
- [x] AC-4: `CheckNoNewDeploymentInfoNode` reads the sentinel flag; defaults SUCCESS when absent
- [x] AC-5: `TransitionCStoFixDeployed` (d→D) + `EmitCDActivity`
- [x] AC-6: the four call-out nodes retain their ADR-0025 shape mixins and `output_keys`
- [x] AC-7: unit tests cover bundle injection, tree structure, guard presence, seam replaceability, early-exit
- [x] AC-8: Concern #1813 closed (guard nodes now present in the production tree)

## Notes for reviewers

- **Pre-PR code review caught and fixed a state-machine bug**: the first draft
  of `CheckCSFixNotYetDeployed` only checked the D bit was unset, which under a
  SUCCESS-returning `DeployFix` backend (e.g. STOCHASTIC) would let an actor in
  `vfd`/`Vfd` jump illegally to `VFD`. It now requires exactly `VFd`
  (fix-ready-not-deployed), matching the VFD `VFd→VFD` transition and the
  legacy `CSinStateVendorAwareFixReadyFixNotDeployed` guard.
- **Intentional deviation from legacy**: the legacy `_DecideAbilityToDeploy`
  also gated non-vendor deployers on a "public aware" precondition
  (`CSinStateNotDeployedButPublicAware`). Issue #1825's AC-1 enumerates the
  `_DeployFixIfReady` guard set without that check, so it is deliberately out
  of scope here; the deployer-role gate remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)