### PR TITLE
fix: DETERMINISTIC publication bundle silently skipped all arms; close #1251

### DIFF
--- a/plan/history/2607/idea/IDEA-1251.md
+++ b/plan/history/2607/idea/IDEA-1251.md
@@ -1,0 +1,33 @@
+---
+source: IDEA-1251
+timestamp: '2026-07-30T20:01:58.696217+00:00'
+title: 'create_publication_tree: factory function for vulnerability publication BT'
+type: idea
+---
+
+## Summary
+
+Add a `create_publication_tree` factory function in
+`vultron/core/behaviors/report/` that composes the publication workflow
+as a prototype BT subtree.
+
+The idea requested a collapsed production BT (Production Collapses 2 + 4)
+implementing ADR-0028 and ADR-0030:
+
+1. `PrioritizePublicationIntents` (Evaluator) writes a `PublicationIntentDecision`
+   record whose boolean fields gate three named per-artifact arms.
+2. Each arm is gated by a `ShouldPublish*` ProtocolInternal condition node and
+   runs a `Prepare*` Composer followed by the draft-review-submit pipeline from
+   `create_publish_artifact_tree`.
+3. `PublicationCallOutBundle` with `PUBLICATION_DETERMINISTIC` /
+   `PUBLICATION_STOCHASTIC` singletons wired per ADR-0025 / BT-23.
+
+**Processed**: 2026-07-30 — fully implemented by prior PRs (#1310 Production
+Collapse 2, #1312 Production Collapse 4). Issue was open only because those
+PRs lacked `Closes #1251` footers. All 4 ACs verified on `main` before
+opening this history-only PR.
+
+All BT-18 blackboard contract requirements satisfied:
+`PrioritizePublicationIntents.output_keys` is a named `PublicationIntentDecision`
+dataclass (BT-20-002), not `str`; downstream arms read typed boolean fields
+directly (no flag-check-in-disguise).

--- a/test/core/behaviors/report/test_publication_tree.py
+++ b/test/core/behaviors/report/test_publication_tree.py
@@ -285,6 +285,69 @@ def test_full_tick_with_stochastic_evaluator_writes_intent_record():
     assert isinstance(decision, PublicationIntentDecision)
 
 
+def test_full_tick_with_deterministic_bundle_writes_intent_record_and_runs_fix_report_arms():
+    """DETERMINISTIC default writes the intent record and executes fix + report arms.
+
+    Regression test for the DETERMINISTIC-bundle silent-skip bug: with the
+    default ``PUBLICATION_DETERMINISTIC`` bundle, ``PrioritizePublicationIntents``
+    must write a :class:`PublicationIntentDecision` to the blackboard so the
+    ``ShouldPublish*`` gate nodes can read it.  Without this write, all three arms
+    silently take the Inverter-skip path and nothing gets published.
+
+    Uses stub factories for all prepare/publish nodes so the tree ticks to SUCCESS
+    deterministically regardless of protocol state.  Verifies:
+
+    1. The tree reaches ``Status.SUCCESS``.
+    2. A :class:`PublicationIntentDecision` is present on the blackboard after ticking.
+    3. The fix arm's ``DoFix`` Sequence reaches SUCCESS (not silently skipped).
+    4. The report arm's ``DoReport`` Sequence reaches SUCCESS (not silently skipped).
+    5. The exploit arm gracefully skips (``publish_exploit=False`` by default).
+    """
+    from vultron.core.behaviors.call_out.bundles.publication import (
+        PublicationCallOutBundle,
+    )
+
+    bundle = PublicationCallOutBundle(
+        prepare_exploit_factory=_marker_factory("PrepExploit"),  # type: ignore[arg-type]
+        prepare_fix_factory=_marker_factory("PrepFix"),  # type: ignore[arg-type]
+        prepare_report_factory=_marker_factory("PrepReport"),  # type: ignore[arg-type]
+        draft_advisory_artifact_factory=_marker_factory("Draft"),  # type: ignore[arg-type]
+        review_advisory_draft_factory=_marker_factory("Review"),  # type: ignore[arg-type]
+        revise_advisory_draft_factory=_marker_factory("Revise"),  # type: ignore[arg-type]
+        submit_advisory_artifact_factory=_marker_factory("Submit"),  # type: ignore[arg-type]
+    )
+    tree = create_publication_tree(case_id=CASE_ID, call_out=bundle)
+    tree.setup_with_descendants()
+    tree.tick_once()
+
+    # 1. Tree reaches SUCCESS.
+    assert tree.status == Status.SUCCESS
+
+    # 2. Intent record written to blackboard.
+    storage_key = f"/{INTENT_DECISION_KEY}"
+    assert storage_key in py_trees.blackboard.Blackboard.storage
+    decision = py_trees.blackboard.Blackboard.storage[storage_key]
+    assert isinstance(decision, PublicationIntentDecision)
+
+    # 3. Fix arm DoFix Sequence ran (SUCCESS), not skipped.
+    fix_arm = tree.children[2]
+    do_fix = fix_arm.children[0]
+    assert do_fix.status == Status.SUCCESS
+
+    # 4. Report arm DoReport Sequence ran (SUCCESS), not skipped.
+    report_arm = tree.children[3]
+    do_report = report_arm.children[0]
+    assert do_report.status == Status.SUCCESS
+
+    # 5. Exploit arm gracefully skipped (default publish_exploit=False).
+    exploit_arm = tree.children[1]
+    do_exploit = exploit_arm.children[0]
+    # DoExploit fails because ShouldPublishExploit returns FAILURE; arm succeeds
+    # via the Inverter skip guard.
+    assert exploit_arm.status == Status.SUCCESS
+    assert do_exploit.status == Status.FAILURE
+
+
 # ---------------------------------------------------------------------------
 # AC-1 + AC-2: eliminated nodes are absent as leaves anywhere in the tree
 # ---------------------------------------------------------------------------

--- a/vultron/core/behaviors/call_out/bundles/publication.py
+++ b/vultron/core/behaviors/call_out/bundles/publication.py
@@ -25,7 +25,7 @@ and
 
 Ceiling/floor mapping (BT-23-002):
 
-- ``prioritize_publication_intents_factory`` — PrioritizePublicationIntents (p=1.0) → AlwaysSucceed
+- ``prioritize_publication_intents_factory`` — PrioritizePublicationIntents (p=1.0) → _DeterministicPrioritizePublicationIntents
 - ``prepare_exploit_factory``               — PrepareExploit               (p=0.90) → AlwaysSucceed
 - ``prepare_fix_factory``                   — PrepareFix                   (p=0.90) → AlwaysSucceed
 - ``prepare_report_factory``                — PrepareReport                (p=0.90) → AlwaysSucceed
@@ -38,8 +38,10 @@ Ceiling/floor mapping (BT-23-002):
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 import py_trees
+from py_trees.common import Access, Status
 
 from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
@@ -47,6 +49,56 @@ from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
 
 def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
     return AlwaysSucceed(name)
+
+
+class _DeterministicPrioritizePublicationIntents(AlwaysSucceed):
+    """DETERMINISTIC PrioritizePublicationIntents: always succeeds and writes the default intent record.
+
+    Writes :class:`~vultron.core.behaviors.report.publication_tree.PublicationIntentDecision`
+    (``publish_fix=True``, ``publish_report=True``, ``publish_exploit=False``) to
+    :data:`~vultron.core.behaviors.report.publication_tree.INTENT_DECISION_KEY`
+    on SUCCESS so that the ``ShouldPublish*`` gate nodes can read it.
+
+    This is the core-layer DETERMINISTIC backend for the
+    ``prioritize_publication_intents_factory`` call-out point (BT-23-002). It
+    encodes the standard CVD outcome: publish the fix and advisory, withhold the
+    exploit.  A real Evaluator backend overrides these per case policy via
+    ``call_out=PUBLICATION_STOCHASTIC`` (or a custom :class:`PublicationCallOutBundle`).
+
+    Uses lazy imports to avoid a circular import with
+    ``vultron.core.behaviors.report.publication_tree`` (which imports this
+    module's :data:`PUBLICATION_DETERMINISTIC` singleton).
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        from vultron.core.behaviors.report.publication_tree import (
+            INTENT_DECISION_KEY,
+        )
+
+        self._intent_key = INTENT_DECISION_KEY
+        self._intent_bb = self.attach_blackboard_client(
+            name=f"{self.__class__.__name__}_writer"
+        )
+        self._intent_bb.register_key(self._intent_key, Access.WRITE)
+
+    def update(self) -> Status:
+        status = super().update()
+        if status == Status.SUCCESS and hasattr(self, "_intent_bb"):
+            from vultron.core.behaviors.report.publication_tree import (
+                PublicationIntentDecision,
+            )
+
+            setattr(
+                self._intent_bb, self._intent_key, PublicationIntentDecision()
+            )
+        return status
+
+
+def _deterministic_prioritize_intents(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    return _DeterministicPrioritizePublicationIntents(name)
 
 
 @dataclass(frozen=True)
@@ -60,7 +112,7 @@ class PublicationCallOutBundle:
     """
 
     prioritize_publication_intents_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
+        default=_deterministic_prioritize_intents  # type: ignore[assignment]
     )
     prepare_exploit_factory: CallOutBackendFactory = field(
         default=_always_succeed  # type: ignore[assignment]
@@ -86,9 +138,17 @@ class PublicationCallOutBundle:
 
 
 PUBLICATION_DETERMINISTIC = PublicationCallOutBundle()
-"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
+"""Deterministic bundle: happy-path default for production use (BT-23-001, BT-23-002).
+
+``prioritize_publication_intents_factory`` uses
+:class:`_DeterministicPrioritizePublicationIntents` which returns SUCCESS and
+writes the standard CVD default intent record
+(:class:`~vultron.core.behaviors.report.publication_tree.PublicationIntentDecision`)
+to the blackboard. All other factories use :class:`~vultron.core.behaviors.call_out.nodes.AlwaysSucceed`.
+"""
 
 __all__ = [
     "PublicationCallOutBundle",
     "PUBLICATION_DETERMINISTIC",
+    "_DeterministicPrioritizePublicationIntents",
 ]

--- a/vultron/core/behaviors/call_out/bundles/publication.py
+++ b/vultron/core/behaviors/call_out/bundles/publication.py
@@ -45,6 +45,10 @@ from py_trees.common import Access, Status
 
 from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
+from vultron.core.behaviors.report.publication_tree import (
+    INTENT_DECISION_KEY,
+    PublicationIntentDecision,
+)
 
 
 def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
@@ -65,17 +69,17 @@ class _DeterministicPrioritizePublicationIntents(AlwaysSucceed):
     exploit.  A real Evaluator backend overrides these per case policy via
     ``call_out=PUBLICATION_STOCHASTIC`` (or a custom :class:`PublicationCallOutBundle`).
 
-    Uses lazy imports to avoid a circular import with
-    ``vultron.core.behaviors.report.publication_tree`` (which imports this
-    module's :data:`PUBLICATION_DETERMINISTIC` singleton).
+    Blackboard contract (BT-18-001):
+      Output keys: ``publication_intent_decision``: :class:`PublicationIntentDecision`
     """
+
+    #: BT-18-001: declared output keys written on SUCCESS (mirrors PrioritizePublicationIntents).
+    output_keys: dict[str, type] = {
+        INTENT_DECISION_KEY: PublicationIntentDecision
+    }
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
-        from vultron.core.behaviors.report.publication_tree import (
-            INTENT_DECISION_KEY,
-        )
-
         self._intent_key = INTENT_DECISION_KEY
         self._intent_bb = self.attach_blackboard_client(
             name=f"{self.__class__.__name__}_writer"
@@ -85,10 +89,6 @@ class _DeterministicPrioritizePublicationIntents(AlwaysSucceed):
     def update(self) -> Status:
         status = super().update()
         if status == Status.SUCCESS and hasattr(self, "_intent_bb"):
-            from vultron.core.behaviors.report.publication_tree import (
-                PublicationIntentDecision,
-            )
-
             setattr(
                 self._intent_bb, self._intent_key, PublicationIntentDecision()
             )
@@ -150,5 +150,4 @@ to the blackboard. All other factories use :class:`~vultron.core.behaviors.call_
 __all__ = [
     "PublicationCallOutBundle",
     "PUBLICATION_DETERMINISTIC",
-    "_DeterministicPrioritizePublicationIntents",
 ]


### PR DESCRIPTION
Closes #1251

## Summary

- All 4 acceptance criteria for `create_publication_tree` (issue #1251) verified
  as implemented by prior PRs (#1310, #1312) — the issue was open only because
  those PRs lacked `Closes #1251` footers
- **Bug fix**: `PUBLICATION_DETERMINISTIC`'s `prioritize_publication_intents_factory`
  defaulted to bare `AlwaysSucceed`, which writes nothing to the blackboard.
  All three `ShouldPublish*` gates found no `INTENT_DECISION_KEY` and returned
  FAILURE → all arms silently took the Inverter-skip path → tree returned SUCCESS
  but published nothing on the happy-path default.

## Changes

- `vultron/core/behaviors/call_out/bundles/publication.py`: replace `AlwaysSucceed`
  default for `prioritize_publication_intents_factory` with new
  `_DeterministicPrioritizePublicationIntents` — a subclass that writes the
  standard CVD default `PublicationIntentDecision` (`publish_fix=True`,
  `publish_report=True`, `publish_exploit=False`) to `INTENT_DECISION_KEY` on
  SUCCESS, matching the `EvaluatorCallOutPoint` contract already satisfied by
  the STOCHASTIC layer.
- `test/core/behaviors/report/test_publication_tree.py`: adds
  `test_full_tick_with_deterministic_bundle_writes_intent_record_and_runs_fix_report_arms`
  — regression test verifying the DETERMINISTIC bundle actually executes the
  fix and report arms (not silently skips them)
- History entry for IDEA-1251

## Verification

- 2766 tests pass; 0 failures
- New regression test confirms: fix + report arms run, exploit arm gracefully
  skips (`publish_exploit=False` default), intent record present on blackboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)