### PR TITLE
docs: plan #1252 — sentinel supersedes inline report-to-others BT loop

### DIFF
--- a/docs/adr/0047-report-to-others-sentinel-over-inline-bt.md
+++ b/docs/adr/0047-report-to-others-sentinel-over-inline-bt.md
@@ -1,0 +1,93 @@
+---
+status: accepted
+date: 2026-07-30
+deciders: [adh]
+---
+
+# Report-to-Others Party Discovery: Sentinel Over Inline BT Loop
+
+## Context and Problem Statement
+
+The `MaybeReportToOthers` simulator BT models party identification and
+notification as an inline tick-driven loop: identify vendors/coordinators/others
+→ iterate → send RS to each. Production Collapse 3 (ADR-0029, issue #1311)
+replaced the `InjectParticipant` family with calls to the `suggest-actor-to-case`
+trigger, but retained the outer loop structure with typed blackboard queues
+(`identified_vendors`, `identified_coordinators`, `identified_others`).
+
+Planning of issue #1252 surfaced a fundamental gap: those queues have no
+production mechanism to populate them. The identification step
+(`IdentifyVendors`, `IdentifyCoordinators`, `IdentifyOthers`) remained as
+stub call-out factories with no real implementation path. The `SuggestXTrigger`
+factories require a specific actor ID on the blackboard — something only the
+STOCHASTIC fuzzer stub provides.
+
+The design question is: **should party discovery and invitation be an inline
+tick-driven BT subtree, or should it be driven by an external Sentinel
+coordination agent?**
+
+## Decision Drivers
+
+- The downstream suggest-actor-to-case protocol cascade (ADR-0026, ADR-0029)
+  already handles the Offer → CaseActor → CaseOwner → Invite → Accept → Record
+  flow correctly; no new BT leaf is needed for the invitation itself
+- Populating typed queues (vendor IDs, coordinator IDs) from CPE/NVD/SBOM
+  lookups or LLM evaluation is an inherently external, latency-variable
+  operation — poorly suited to a tick-driven inline BT that must return
+  quickly
+- The Sentinel coordination agent pattern (ADR-0024, issue #1143) explicitly
+  covers "monitors a condition; when met, calls a trigger endpoint"; this is
+  exactly the party-discovery model
+- The existing `create_report_to_others_tree` module (from #1311) has no
+  production callers — it exists only in tests — confirming it was never wired
+  into the real protocol cascade
+
+## Considered Options
+
+1. **Inline BT loop** — retain the three-typed-sub-loop tree; fill in real
+   Retriever implementations (CPE/NVD lookups) for `IdentifyX` factories so
+   the loop executes against real data on every tick
+2. **External Sentinel** — replace the inline loop entirely; a Sentinel
+   coordination agent that runs periodically or event-triggered, inspects
+   the case, and calls `suggest-actor-to-case` for each uninvited candidate
+3. **Hybrid** — inline BT provides a single-pass Retriever seam (one
+   call-out that returns all candidates at once); Sentinel calls this subtree;
+   no tick loop
+
+## Decision Outcome
+
+Chosen option: **Option 2 — External Sentinel**, because it matches the
+coordination agent taxonomy (ADR-0024), avoids coupling external I/O latency
+into the BT tick loop, and the downstream trigger cascade already handles the
+rest. No inline BT loop is needed.
+
+The `create_report_to_others_tree` module from #1311 is an implementation
+artifact of the intermediate Production Collapse 3 design and is tracked for
+removal (see `notes/bt-fuzzer-rm-reporting.md` § "Sentinel supersession note").
+
+### Consequences
+
+- Good, because party discovery becomes a proper coordination agent — observable,
+  auditable, and independently replaceable without changing the BT tree structure
+- Good, because the downstream suggest-actor-to-case cascade already works; no
+  new BT machinery is required
+- Good, because the Sentinel can use arbitrarily slow external queries (CPE
+  lookups, LLM evaluation) without blocking the BT tick loop
+- Bad, because the Sentinel architecture (#1143) has open design questions
+  (invocation model, authentication, per-case vs global) that must be resolved
+  before a concrete implementation can be built
+- Neutral, because the tick-driven `create_report_to_others_tree` module must
+  be removed to avoid confusion; tests and bundles go with it
+
+## More Information
+
+- ADR-0024: Coordination Agent Taxonomy (Sentinel pattern)
+- ADR-0026: CaseActor-Routed Actor Suggestion and Invitation Flow
+- ADR-0029: Notification Loop Collapse (Production Collapse 3)
+- Issue #1143: Sentinel coordination agent design (open)
+- Issue #1147: Coordination Agents epic
+- Issue #1252: Idea planning session that surfaced this decision (closed)
+- `notes/bt-fuzzer-rm-reporting.md` § "Sentinel supersession note"
+
+Generated spec requirements: `specs/behavior-tree-integration.yaml` BT-20-003
+  (amended to record sentinel direction).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -92,6 +92,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0044 Adopt py_trees Typed Ports for BT Node Blackboard Contracts](0044-py-trees-typed-ports-adoption.md)
 - [ADR-0045 Correct Field Assignment on `Create(VulnerabilityCase)` — `context` to Case URI, `inReplyTo` to Accept URI](0045-create-vulnerability-case-field-assignment.md)
 - [ADR-0046 Two-Seam Authorization Model for Received-Side CaseStatus Canonicalization](0046-received-status-authorization.md) *(provisional)*
+- [ADR-0047 Report-to-Others Party Discovery: Sentinel Over Inline BT Loop](0047-report-to-others-sentinel-over-inline-bt.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -264,6 +264,7 @@ nav:
       - Adopt py_trees Typed Ports: 'adr/0044-py-trees-typed-ports-adoption.md'
       - Correct Create(VulnerabilityCase) Field Assignment: 'adr/0045-create-vulnerability-case-field-assignment.md'
       - Two-Seam Received-Side Status Authorization: 'adr/0046-received-status-authorization.md'
+      - Report-to-Others Party Discovery Sentinel: 'adr/0047-report-to-others-sentinel-over-inline-bt.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/bt-fuzzer-rm-reporting.md
+++ b/notes/bt-fuzzer-rm-reporting.md
@@ -525,3 +525,46 @@ coordinated disclosure.
   with `CVDRole.OTHER` (Production Collapse 3, ADR-0029).
 
 ---
+
+## Sentinel supersession note (2026-07-30)
+
+Planning session for #1252 surfaced a design mismatch between the
+`create_report_to_others_tree` module (from Production Collapse 3, #1311,
+ADR-0029) and the production process model.
+
+**The mismatch**: the three-typed-sub-loop tree (vendor / coordinator / other
+sub-loops) assumes pre-populated blackboard queues (`identified_vendors`,
+`identified_coordinators`, `identified_others`). No production mechanism
+populates those queues — the `IdentifyX` call-out factories are stubs with
+no real implementation path. The `SuggestXTrigger` factories fire
+`suggest-actor-to-case`, but require an actor ID on the blackboard that
+only the stub provides in STOCHASTIC mode.
+
+**The correct production model** (resolved during #1252 planning): the party
+identification and invitation step belongs in a **Sentinel coordination agent**
+(see #1147 / #1143) that:
+
+1. Periodically or event-triggered inspects the case for actors who are known
+   but not yet participants (e.g., via CPE/NVD lookup, SBOM analysis, or an
+   LLM-backed evaluator)
+2. Fires `suggest-actor-to-case` for each candidate actor
+3. The downstream Offer → CaseActor → CaseOwner → Invite → Accept → Record
+   cascade handles the rest
+
+No inline tick-driven BT loop is required at the outer level. The
+`create_report_to_others_tree` module is an implementation artifact of the
+intermediate design and is tracked for removal in a follow-on Task (see
+BT-20-003 note in `specs/behavior-tree-integration.yaml`).
+
+**Files to remove** (tracked as a follow-on Task, not this PR):
+
+- `vultron/core/behaviors/report/report_to_others_tree.py`
+- `vultron/core/behaviors/call_out/bundles/report_to_others.py`
+- `vultron/demo/fuzzer/bundles/report_to_others.py`
+- `test/core/behaviors/report/test_report_to_others_tree.py`
+
+None of these have production callers outside their own test file.
+
+**New work**: a new Idea under #1147 tracks the participant discovery Sentinel
+design. When that Idea is planned, it should mine #1252 for any residual
+questions about whether an inline BT subtree is needed alongside the sentinel.

--- a/plan/history/2607/idea/IDEA-1252.md
+++ b/plan/history/2607/idea/IDEA-1252.md
@@ -1,0 +1,32 @@
+---
+source: IDEA-1252
+timestamp: '2026-07-30T20:26:29.096924+00:00'
+title: 'report-to-others party discovery: Sentinel supersedes inline BT loop'
+type: idea
+---
+
+## Outcome
+
+Planning #1252 surfaced a fundamental design mismatch: `create_report_to_others_tree`
+(Production Collapse 3, #1311) relies on typed blackboard queues (`identified_vendors`,
+`identified_coordinators`, `identified_others`) that have no production population
+mechanism. The tree has no production callers outside tests.
+
+**Decision (ADR-0047)**: External Sentinel coordination agent supersedes the inline
+tick-driven BT loop for report-to-others party discovery. The Sentinel queries the
+case for uninvited actors and fires `suggest-actor-to-case` for each candidate;
+the downstream cascade (ADR-0026, ADR-0029) handles the rest.
+
+## Artifacts
+
+- PR: <https://github.com/CERTCC/Vultron/pull/1847>
+- ADR: `docs/adr/0047-report-to-others-sentinel-over-inline-bt.md`
+- Spec: `specs/behavior-tree-integration.yaml` BT-20-003 (amended)
+- Notes: `notes/bt-fuzzer-rm-reporting.md` § "Sentinel supersession note"
+
+## Follow-on
+
+- #1848: Task — remove `create_report_to_others_tree` module and companion bundles/tests
+- #1142: Participant Discovery (Retriever + Evaluator) — updated with refined sentinel
+  understanding; discovery logic lives here, Sentinel scheduling in #1143
+- When planning #1142, mine #1252 for design questions about any remaining inline behavior

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -678,19 +678,26 @@ groups:
   - id: BT-20-003
     priority: SHOULD
     kind: project
-    statement: The production `create_report_to_others_tree` factory SHOULD retain the outer loop structure (party identification
-      Retrievers, effort-gate Evaluators, typed vendor/coordinator/other sub-loops), and SHOULD invoke the `suggest-actor-to-case`
-      trigger in place of `InjectParticipant` family nodes. The `suggest-actor-to-case` trigger MUST be called with an explicit
-      role parameter (`CVDRole.VENDOR`, `CVDRole.COORDINATOR`, or `CVDRole.OTHER`) matching the sub-loop type; the current
-      assumption that all suggestions use `CVDRole.VENDOR` MUST be generalized.
-    rationale: 'The `InjectParticipant` family is a direct case-management write that bypasses the protocol''s
-      invite/accept handshake. In production the `suggest-actor-to-case` protocol (Offer → Invite → Accept → Record cascade)
-      replaces it. The outer loop remains because the BT must still ask "should we notify additional parties?" and iterate
-      through identified candidates. See `notes/bt-fuzzer-nodes-report-management.md` § "Production Collapse 3: Notification
-      loop" and ADR-0029.'
-    tracking_issue: '#1311 (implemented)'
+    statement: The production report-to-others workflow SHOULD be driven by a Sentinel coordination agent that proactively
+      queries the case for actors who are not yet participants but should be (party discovery), then fires `suggest-actor-to-case`
+      for each candidate. The `suggest-actor-to-case` protocol (Offer → CaseActor → CaseOwner → Invite → Accept → Record
+      cascade) handles the downstream flow; no inline tick-driven BT loop is needed at the outer level. If an inline subtree
+      is required (e.g. for a single-pass trigger-driven invocation), it SHOULD consist of a Retriever call-out that returns
+      candidate (actor_id, role) pairs and an Actuator per pair that fires `suggest-actor-to-case` with the explicit
+      `CVDRole` parameter.
+    rationale: >
+      The original Production Collapse 3 design (#1311, ADR-0029) retained a three-typed-sub-loop BT structure whose
+      inner blackboard queues (identified_vendors, identified_coordinators, identified_others) had no production
+      mechanism to populate them. Planning of #1252 surfaced that the identification step belongs in a Sentinel
+      coordination agent (see #1147/#1143) that periodically or event-triggered inspects the case and asynchronously
+      fires suggest-actor-to-case for each uninvited candidate. The downstream accept/invite/bootstrap cascade already
+      works; no inline BT loop is required. The tick-driven `create_report_to_others_tree` module from #1311 is an
+      implementation artifact of the intermediate design and is tracked for removal in a follow-on Task (see
+      notes/bt-fuzzer-rm-reporting.md § "Sentinel supersession note").
+    tracking_issue: '#1311 (partial implementation, superseded); #1252 (planning — closed; sentinel approach adopted)'
     adr:
     - ADR-0029
+    - ADR-0047
   - id: BT-20-004
     priority: SHOULD
     kind: project


### PR DESCRIPTION
- Closes #1252

## Summary

Planning session for #1252 surfaced a fundamental design mismatch: the
`create_report_to_others_tree` module (from Production Collapse 3, #1311)
relies on typed blackboard queues (`identified_vendors`, etc.) that have no
production population mechanism. This PR records the decision to supersede
the inline BT loop with an external Sentinel coordination agent, documents
its consequences, and amends the relevant spec requirement.

## Changes

- `docs/adr/0047-report-to-others-sentinel-over-inline-bt.md` — new ADR
  (Decision: External Sentinel over inline BT loop; three options evaluated)
- `docs/adr/index.md` — added ADR-0047; fixed duplicate ADR-0046 entry
- `mkdocs.yml` — added nav entry for ADR-0047 (required by MS-14-003)
- `notes/bt-fuzzer-rm-reporting.md` — sentinel supersession note: documents
  design mismatch and lists files for follow-on removal Task
- `specs/behavior-tree-integration.yaml` — BT-20-003 rewritten: production
  report-to-others SHOULD be driven by a Sentinel; references ADR-0047

## Implementation Issues

- #1848 (Task: remove `report_to_others_tree` module and companion bundles/tests)