### PR TITLE
docs: plan issue #1253 — close-report seam redesign

### DIFF
--- a/notes/bt-fuzzer-rm-closure.md
+++ b/notes/bt-fuzzer-rm-closure.md
@@ -5,6 +5,8 @@ description: >
   Catalog of fuzzer (stub) BT nodes for Report Closure (`CloseReportBt`)
   and Other Work (`RMDoWorkBt`) sub-workflows: close-case eligibility,
   transition guards, and extensibility stub nodes used in simulation.
+  Includes design rationale for the trigger-driven closure model and
+  Close Readiness Monitoring pattern.
 related_specs:
   - specs/behavior-tree-integration.yaml
 related_notes:
@@ -40,13 +42,17 @@ complete (or otherwise concluded).
 - **Automation potential**: **Low** — site-specific; closure criteria vary widely by organization and case context; typically requires human policy evaluation or explicit sign-off.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.close_report.OtherCloseCriteriaMet`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+- **Factory-fn placement**: Implemented as a call-out seam stub in
   `vultron.core.behaviors.report.close_report_tree.create_close_report_tree`
-  (`other_close_criteria_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.report.create_close_report_tree`
-  (issue #1253) — Evaluator precondition guard in the `RMCloseBt` Sequence;
-  evaluated before `PreCloseAction`; blocks closure until site-specific
-  criteria are satisfied
+  (`other_close_criteria_factory` param; DETERMINISTIC default = `AlwaysFail`).
+  This tree is a seam-only stub — it is **not invoked autonomously**. Case
+  closure is always Case Owner-triggered via
+  `create_close_report_trigger_tree`. The `OtherCloseCriteriaMet` Evaluator
+  seam is the injection point for a future Close Readiness Monitoring Sentinel
+  (see epic #1147 / #1143 Sentinel agent type) that observes protocol state
+  and posts an observational note to the Case Owner when objective closure
+  criteria are met; the Case Owner then issues `Leave(VulnerabilityCase)`
+  directly. Resolved by IDEA-1253 (plan/1253-close-report-seam).
 
 ### `PreCloseAction`
 
@@ -64,10 +70,86 @@ complete (or otherwise concluded).
 - **Automation potential**: **Medium** — archiving and standard notification steps can be automated; QA review and final approvals typically require human involvement.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.close_report.PreCloseAction`
 - **Call-out point shape**: Actuator — fires integration hooks before case closure; invokes QA pipeline checks, final notification APIs, and case-archiving services. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_close_report_tree`
-  (issue #1253) — Actuator effect node after `OtherCloseCriteriaMet`;
-  last node before the RM → CLOSED state transition fires
+- **Factory-fn placement**: Belongs in `create_close_report_trigger_tree`
+  (issue T1 from IDEA-1253 planning) — wired as an Actuator node between
+  `CheckReportNotClosed` (or equivalent guard) and `TransitionRMtoClosed`.
+  The DETERMINISTIC default is `AlwaysSucceed` (pre-close hooks are
+  optional infrastructure; absence of a real implementation must not block
+  closure). Not placed in `create_close_report_tree` — that tree is a
+  seam-only stub for autonomous monitoring, not the trigger path.
+
+---
+
+## Design Rationale: Trigger-Driven Closure Model (IDEA-1253)
+
+Derived from IDEA-1253 planning session (2026-07-31).
+
+### Case closure is always Case Owner-triggered
+
+There is no autonomous close path in Vultron. Case closure always requires
+an explicit decision by the Case Owner (or Case Manager acting on their
+behalf). The standard simulator closure criteria — CS.DEPLOYED across all
+vendors, RM.DEFERRED, RM.INVALID — do not fire the `Leave(VulnerabilityCase)`
+activity autonomously because:
+
+- **CS.P → EM teardown cascade risk**: `CS.P` (public awareness) already
+  triggers embargo teardown via the `#1836/#1841/#1842` mechanics. If
+  `EM.EXITED + CS.P` were wired as an autonomous close trigger, every public
+  disclosure would close the case — which is wrong. Coordination often
+  continues after embargo exit and public disclosure.
+- **Case Owner policy governs**: "nothing left to do, no reason to hold it
+  open" is an organizational policy judgment, not a universal protocol signal.
+  Standard protocol states (deployed, deferred, invalid) are necessary but not
+  sufficient conditions; the Case Owner still decides when to close.
+
+### `create_close_report_tree` is a call-out seam stub
+
+`vultron.core.behaviors.report.close_report_tree.create_close_report_tree`
+is intentionally a seam-only stub. It is **not called by any use case**. Its
+`OtherCloseCriteriaMet` Evaluator seam is the injection point for a future
+Close Readiness Monitoring Sentinel (see **Close Readiness Monitoring** below).
+
+### `PreCloseAction` belongs in the trigger tree
+
+`PreCloseAction` (Actuator) fires *after* the Case Owner has decided to close
+— it belongs in `create_close_report_trigger_tree`, wired between the
+not-already-closed guard and `TransitionRMtoClosed`. It is a pre-close hook
+for QA pipelines, archiving, and final notification. The DETERMINISTIC default
+is `AlwaysSucceed`; pre-close hooks must not block closure when no real
+backend is injected.
+
+### `Leave(VulnerabilityCase)` is correctly overloaded
+
+`_RmCloseCaseActivity` (`as_Leave` of `as_VulnerabilityCase`) is used by both
+Case Owners and non-owner participants:
+
+- **Case Owner** sends it → case closes for all participants.
+- **Non-owner participant** sends it → they are removed from case participants.
+
+The distinction is enforced by the Case Owner role, not a separate message
+type. No vocabulary change is needed.
+
+### Close Readiness Monitoring (future — epic #1147 / #1143)
+
+When a future Sentinel coordination agent is implemented, the intended pattern
+is:
+
+1. A Sentinel observes protocol state for objective preconditions (e.g.,
+   all vendors at CS.DEPLOYED, embargo exited and no pending activity for N
+   days, all participants at RM.DEFERRED or RM.INVALID).
+2. When preconditions are met, the Sentinel posts an **observational note** to
+   the VulnerabilityCase (not a formal protocol question). The note surfaces
+   the evidence and suggests the Case Owner consider closing.
+3. The Case Owner reads the note and issues `Leave(VulnerabilityCase)` when
+   ready. There is no protocol-level reply to the note.
+
+This pattern avoids inventing a new `Question` → `Answer` message exchange.
+The Sentinel fires into `OtherCloseCriteriaMet` seam in
+`create_close_report_tree`; the Case Owner's subsequent `Leave` flows through
+`create_close_report_trigger_tree` as usual.
+
+Track under epic #1147 (Coordination Agents), linked to #1143 (Sentinel
+agent type).
 
 ---
 

--- a/plan/history/2607/idea/IDEA-1253.md
+++ b/plan/history/2607/idea/IDEA-1253.md
@@ -1,0 +1,47 @@
+---
+source: IDEA-1253
+timestamp: '2026-07-31T15:26:23.640748+00:00'
+title: close_report_tree seam redesign — no autonomous close path
+type: idea
+---
+
+Planning session substantially revised the original scope away from the
+simulator's `RMCloseBt` structure.
+
+## Outcome
+
+- `create_close_report_tree` is a seam-only stub, not a workflow. It is not
+  called by any use case. Its `OtherCloseCriteriaMet` Evaluator is the
+  injection point for a future Close Readiness Monitoring Sentinel.
+- No autonomous close path exists. Case closure is always Case Owner-triggered
+  via `Leave(VulnerabilityCase)` → `create_close_report_trigger_tree`.
+  `CS.P` already triggers embargo teardown; wiring `EM.EXITED + CS.P` as an
+  auto-close signal would close every case on public disclosure.
+- `PreCloseAction` (Actuator) belongs in `create_close_report_trigger_tree`,
+  not the seam stub — it fires after the Case Owner decides to close.
+- `Leave(VulnerabilityCase)` overloading is correct and sufficient: Case Owner
+  send = close-for-all; non-owner send = remove-participant. No new message
+  type needed.
+- `demo_close_case` was found to be architecturally wrong — it stamps
+  RM.CLOSED via `add_participant_status` directly, bypassing the protocol.
+  Demo puppeteering must invoke a triggerable use case, never write directly
+  to the actor's DataLayer or outbox.
+
+## Docs
+
+PR: <https://github.com/CERTCC/Vultron/pull/1853>
+
+- `vultron/core/behaviors/report/close_report_tree.py` — docstring rewritten
+  as Close Readiness Monitoring seam stub design rationale
+- `notes/bt-fuzzer-rm-closure.md` — Design Rationale section added
+- `specs/multi-actor-demo.yaml` — DEMOMA-05-004 added (puppeteering rule)
+
+## Implementation Issues
+
+- T1 #1854: Wire `PreCloseAction` + `CheckCaseOwner` guard + rename
+  `SvcCloseReportUseCase` → `SvcCloseCaseUseCase` and
+  `create_close_report_trigger_tree` → `create_close_case_trigger_tree`
+- T3 #1856: Close Readiness Monitoring Sentinel (under epic #1147 / #1143);
+  also includes seam stub rename (absorbs #1855)
+- T4 #1858: Implement `SvcLeaveCaseUseCase` + fix `demo_close_case`
+  puppeteering; blocked-by T1

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -184,6 +184,26 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-05-001
+  - id: DEMOMA-05-004
+    priority: MUST_NOT
+    kind: project
+    statement: >-
+      Demo trigger endpoints and demo helper functions MUST NOT manipulate an actor's
+      DataLayer directly (e.g., calling `add_participant_status` or equivalent) or write
+      directly to an actor's outbox as a substitute for invoking a triggerable use case.
+      Puppeteering an actor means calling a trigger endpoint that invokes the actor's own
+      use case, which in turn emits the correct protocol message and awaits any required
+      round-trip confirmation (e.g., a CaseActor ledger entry).
+    rationale: >-
+      Direct DataLayer writes bypass the protocol entirely: no ActivityStreams message is
+      emitted, no CaseActor ledger round-trip occurs, and the actor's local state is never
+      established through the protocol. This produces demos that appear to work but do not
+      exercise the real protocol path. For example, a demo that stamps RM.CLOSED directly
+      via `add_participant_status` gives the appearance that the participant left the case,
+      but no `Leave(VulnerabilityCase)` message was ever sent or confirmed by the CaseActor.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-05-001
 - id: DEMOMA-06
   title: FV Scenario Workflow
   trigger:

--- a/test/core/behaviors/report/test_close_report_tree.py
+++ b/test/core/behaviors/report/test_close_report_tree.py
@@ -82,7 +82,7 @@ def test_custom_factory_used():
 
 
 def test_pre_close_action_factory_accepted():
-    """pre_close_action_factory is accepted (Phase 2 reserved, BT-18-004)."""
+    """pre_close_action_factory field exists on bundle; PreCloseAction belongs in trigger tree (IDEA-1253 T1)."""
     tree = create_close_report_tree(case_id=CASE_ID)
     assert tree is not None
 

--- a/vultron/core/behaviors/report/close_report_tree.py
+++ b/vultron/core/behaviors/report/close_report_tree.py
@@ -11,25 +11,46 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Report closure behavior tree composition (Phase 1 stub).
+"""Close Readiness Monitoring seam tree.
 
-This module provides :func:`create_close_report_tree`, which hosts the
-close-report call-out points wired per ADR-0025 / BT-18-004:
+This module provides :func:`create_close_report_tree`, which exposes the
+``OtherCloseCriteriaMet`` call-out point as an injection seam for a future
+Close Readiness Monitoring Sentinel (see epic #1147 / #1143 Sentinel agent
+type).
 
-Evaluator node:
-- ``OtherCloseCriteriaMet``
+**Design note — no autonomous close path**
 
-Actuator node (reserved for Phase 2 — accepted but not yet wired):
-- ``PreCloseAction``
+Case closure in Vultron is always Case Owner-triggered: the Case Owner (or
+Case Manager acting on their behalf) issues a ``Leave(VulnerabilityCase)``
+activity, which flows through :func:`create_close_report_trigger_tree`.
+There is no autonomous close path because:
 
-Phase 1 contains only the ``OtherCloseCriteriaMet`` Evaluator as a stub
-tree.  The full close-report workflow (deployed/deferred/invalid short-circuit
-arms, pre-close actions) is deferred to a future issue.
+- Standard simulator closure criteria (CS.DEPLOYED, RM.DEFERRED, RM.INVALID)
+  are necessary but not sufficient — the Case Owner judges when to close.
+- ``CS.P`` already triggers embargo teardown; wiring ``EM.EXITED + CS.P`` as
+  an auto-close signal would close every case on public disclosure.
+
+This tree is therefore a **seam-only stub**, not called by any use case.
+Its intended future use is: a Sentinel backend injected via
+``other_close_criteria_factory`` that observes case state, detects that
+objective close conditions are met, and posts an observational note to the
+Case Owner.  The Case Owner then issues the ``Leave`` voluntarily.
+
+``PreCloseAction`` (the pre-close Actuator) belongs in
+:func:`create_close_report_trigger_tree`, wired between the
+``CheckReportNotClosed`` guard and ``TransitionRMtoClosed`` (issue #1253 T1).
+
+Nodes hosted here
+-----------------
+- ``OtherCloseCriteriaMet`` — Evaluator seam; DETERMINISTIC default =
+  ``AlwaysFail`` (correct: seam fires only when a real Sentinel is injected)
 
 References
 ----------
+- IDEA-1253: planning rationale for this design
 - ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
 - Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004
+- Notes: ``notes/bt-fuzzer-rm-closure.md`` § "Design Rationale"
 """
 
 import logging
@@ -49,31 +70,33 @@ def create_close_report_tree(
     case_id: str,
     call_out: "CloseReportCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
-    """Create behavior tree for the report closure workflow (Phase 1 stub).
+    """Build the Close Readiness Monitoring seam tree.
 
-    Phase 1 exposes the ``OtherCloseCriteriaMet`` Evaluator call-out point
-    as a stub root node.  The ``pre_close_action_factory`` Actuator parameter
-    is accepted for BT-18-004 compliance but reserved for Phase 2 when the
-    full pre-close sequence is built.  The full workflow (deployed/deferred/
-    invalid short-circuit arms, pre-close actions, RM state transition) is
-    deferred to a future issue.
+    Exposes the ``OtherCloseCriteriaMet`` Evaluator call-out point as the
+    injection seam for a future Close Readiness Monitoring Sentinel.  The
+    DETERMINISTIC default (``AlwaysFail``) is correct: this tree should not
+    fire unless a real Sentinel backend is injected — case closure is always
+    Case Owner-triggered via :func:`create_close_report_trigger_tree`.
+
+    The ``pre_close_action_factory`` bundle field is not wired here;
+    ``PreCloseAction`` belongs in :func:`create_close_report_trigger_tree`
+    (see IDEA-1253 T1 and ``notes/bt-fuzzer-rm-closure.md``).
 
     Args:
         case_id: ID of VulnerabilityCase being processed.
         call_out: Bundle of call-out backend factories for this domain.
-            Defaults to :data:`~vultron.core.behaviors.call_out.bundles.close_report.CLOSE_REPORT_DETERMINISTIC`
+            Defaults to
+            :data:`~vultron.core.behaviors.call_out.bundles.close_report.CLOSE_REPORT_DETERMINISTIC`
             (BT-23-003, BT-23-005).
 
     Returns:
-        Root node of the close-report behavior tree (Phase 1 stub).
+        Root node of the close readiness monitoring seam tree.
     """
     from vultron.core.behaviors.call_out.bundles.close_report import (
         CLOSE_REPORT_DETERMINISTIC,
     )
 
     bundle = call_out if call_out is not None else CLOSE_REPORT_DETERMINISTIC
-    # Phase 2: bundle.pre_close_action_factory is reserved for the full pre-close
-    # sequence.
     root = bundle.other_close_criteria_factory("OtherCloseCriteriaMet")
-    logger.info(f"Created CloseReportBT (Phase 1 stub) for case={case_id}")
+    logger.info("Created CloseReadinessMonitoringBT for case=%s", case_id)
     return root


### PR DESCRIPTION
- Closes #1253

## Summary

Planning session for IDEA-1253 (`create_close_report_tree`) revealed the
original autonomous-close framing is superseded by the event-driven
architecture. This PR documents the corrected design and clears the stale
Phase 1/Phase 2 scaffolding.

Key design decisions established in interview:

- **No autonomous close path.** Case closure is always Case Owner-triggered
  via `create_close_report_trigger_tree`. Standard protocol criteria
  (CS.DEPLOYED, RM.DEFERRED, RM.INVALID) are necessary but not sufficient;
  the Case Owner judges when to close.
- **CS.P → embargo teardown cascade risk.** Wiring EM.EXITED + CS.P as an
  auto-close trigger would close every case on public disclosure — wrong.
- **`create_close_report_tree` is a seam-only stub.** Its
  `OtherCloseCriteriaMet` Evaluator is the injection point for a future
  Close Readiness Monitoring Sentinel (epic #1147 / #1143). Not called by
  any use case.
- **`PreCloseAction` belongs in the trigger tree**, wired between the
  not-already-closed guard and `TransitionRMtoClosed` (implementation task T1).
- **`Leave(VulnerabilityCase)` overloading is correct.** Case Owner send =
  close-for-all; non-owner send = participant exits. No new message type needed.

## Changes

- `vultron/core/behaviors/report/close_report_tree.py` — remove Phase 1/Phase 2
  framing; document as Close Readiness Monitoring seam stub with design rationale
- `notes/bt-fuzzer-rm-closure.md` — update `OtherCloseCriteriaMet` and
  `PreCloseAction` factory-fn placements; add "Design Rationale" section covering
  trigger-driven closure model, PreCloseAction placement, Leave/Close overloading,
  and Close Readiness Monitoring pattern

## Implementation Issues

- #1854 — Wire PreCloseAction into close-case trigger tree; rename SvcCloseReportUseCase → SvcCloseCaseUseCase; converge demo path
- #1855 — Rename create_close_report_tree to reflect seam-stub purpose
- #1856 — [Idea] Close Readiness Monitoring Sentinel (under epic #1147)