### PR TITLE
test: add concurrent-isolation smoke test for slimmed receive_report_case_tree

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1820.md
+++ b/plan/history/2607/implementation/ISSUE-1820.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-1820
+timestamp: '2026-07-31T15:05:44.194173+00:00'
+title: add concurrent-isolation smoke test for slimmed receive_report_case_tree
+type: implementation
+---
+
+## Issue #1820 — test: add concurrent-isolation smoke test for slimmed receive_report_case_tree
+
+Added `TestConcurrentExecution` class to `test/core/behaviors/case/test_receive_report_case_tree.py` covering BTND-03-004 (blackboard isolation for concurrent BT executions).
+
+Two test methods verify the ADR-0041 slimmed tree under concurrency:
+
+- `test_two_threads_both_succeed`: both threads return `Status.SUCCESS` under `_BT_GLOBAL_LOCK` serialisation
+- `test_two_threads_produce_distinct_links`: each thread produces a distinct `VultronReportCaseLink` record
+
+Code-review findings fixed before PR: `activity=None` replaced with per-thread `offer` param, `is_alive()` deadlock detection added after each `join()`, `threading.Lock` guards shared `errors` list.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1860>

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -592,50 +592,42 @@ class TestConcurrentExecution:
     holds even when two bridge instances race on the global lock.
     """
 
-    def test_two_threads_both_succeed(
-        self,
-        datalayer,
-        actor,
-        reporter_actor_id,
+    @staticmethod
+    def _make_report_offer(
+        datalayer, reporter_actor_id, actor_id, report_id, name, content
     ):
-        """Both threads complete with Status.SUCCESS (BTND-03-004)."""
-        from vultron.adapters.driven.trigger_activity_adapter import (
-            TriggerActivityAdapter,
-        )
         from vultron.wire.as2.factories import rm_submit_report_activity
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
             as_VulnerabilityReport,
         )
 
-        report_a = as_VulnerabilityReport(
-            id_="https://example.org/reports/CONCURRENT-A",
-            name="Concurrent Report A",
-            content="Test content A",
+        report = as_VulnerabilityReport(
+            id_=report_id, name=name, content=content
         )
-        report_b = as_VulnerabilityReport(
-            id_="https://example.org/reports/CONCURRENT-B",
-            name="Concurrent Report B",
-            content="Test content B",
+        datalayer.create(report)
+        offer = rm_submit_report_activity(
+            report=report, actor=reporter_actor_id, to=actor_id
         )
-        datalayer.create(report_a)
-        datalayer.create(report_b)
+        datalayer.create(offer)
+        return report, offer
 
-        offer_a = rm_submit_report_activity(
-            report=report_a,
-            actor=reporter_actor_id,
-            to=actor.id_,
+    @staticmethod
+    def _spawn_and_join(datalayer, actor_id, reporter_actor_id, pairs):
+        """Spawn one thread per (report, offer, key) pair; join all; return results dict.
+
+        ``pairs`` is a list of ``(report_obj, offer_obj, key_str)`` tuples.
+        Returns ``{key: Status}`` for each thread that completed successfully.
+        Asserts no deadlock (``is_alive()`` after join) and no thread errors.
+        Both ``results`` and ``errors`` are written under the same lock so
+        all inter-thread writes are consistently protected.
+        """
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
         )
-        offer_b = rm_submit_report_activity(
-            report=report_b,
-            actor=reporter_actor_id,
-            to=actor.id_,
-        )
-        datalayer.create(offer_a)
-        datalayer.create(offer_b)
 
         results: dict[str, Status] = {}
-        _lock = threading.Lock()
         errors: list[str] = []
+        _lock = threading.Lock()
 
         def _run(
             report_id: str, offer_id: str, offer: object, key: str
@@ -651,29 +643,59 @@ class TestConcurrentExecution:
                     reporter_actor_id=reporter_actor_id,
                 )
                 result = bridge.execute_with_setup(
-                    tree=tree, actor_id=actor.id_, activity=offer
+                    tree=tree, actor_id=actor_id, activity=offer
                 )
-                results[key] = result.status
+                with _lock:
+                    results[key] = result.status
             except Exception as exc:
                 with _lock:
                     errors.append(f"{key}: {exc}")
 
-        t_a = threading.Thread(
-            target=_run,
-            args=(report_a.id_, offer_a.id_, offer_a, "a"),
-        )
-        t_b = threading.Thread(
-            target=_run,
-            args=(report_b.id_, offer_b.id_, offer_b, "b"),
-        )
-        t_a.start()
-        t_b.start()
-        t_a.join(timeout=10)
-        t_b.join(timeout=10)
+        threads = [
+            threading.Thread(target=_run, args=(r.id_, o.id_, o, k))
+            for r, o, k in pairs
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
 
-        assert not t_a.is_alive(), "Thread A timed out — possible deadlock"
-        assert not t_b.is_alive(), "Thread B timed out — possible deadlock"
+        for i, t in enumerate(threads):
+            assert (
+                not t.is_alive()
+            ), f"Thread {i} timed out — possible deadlock"
         assert not errors, f"Thread errors: {errors}"
+        return results
+
+    def test_two_threads_both_succeed(
+        self,
+        datalayer,
+        actor,
+        reporter_actor_id,
+    ):
+        """Both threads complete with Status.SUCCESS (BTND-03-004)."""
+        report_a, offer_a = self._make_report_offer(
+            datalayer,
+            reporter_actor_id,
+            actor.id_,
+            "https://example.org/reports/CONCURRENT-A",
+            "Concurrent Report A",
+            "Test content A",
+        )
+        report_b, offer_b = self._make_report_offer(
+            datalayer,
+            reporter_actor_id,
+            actor.id_,
+            "https://example.org/reports/CONCURRENT-B",
+            "Concurrent Report B",
+            "Test content B",
+        )
+        results = self._spawn_and_join(
+            datalayer,
+            actor.id_,
+            reporter_actor_id,
+            [(report_a, offer_a, "a"), (report_b, offer_b, "b")],
+        )
         assert (
             results.get("a") == Status.SUCCESS
         ), f"Thread A status: {results.get('a')}"
@@ -688,79 +710,28 @@ class TestConcurrentExecution:
         reporter_actor_id,
     ):
         """Each thread writes its own VultronReportCaseLink; two distinct records exist."""
-        from vultron.adapters.driven.trigger_activity_adapter import (
-            TriggerActivityAdapter,
+        report_a, offer_a = self._make_report_offer(
+            datalayer,
+            reporter_actor_id,
+            actor.id_,
+            "https://example.org/reports/LINK-A",
+            "Link Report A",
+            "Content A",
         )
-        from vultron.wire.as2.factories import rm_submit_report_activity
-        from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            as_VulnerabilityReport,
+        report_b, offer_b = self._make_report_offer(
+            datalayer,
+            reporter_actor_id,
+            actor.id_,
+            "https://example.org/reports/LINK-B",
+            "Link Report B",
+            "Content B",
         )
-
-        report_a = as_VulnerabilityReport(
-            id_="https://example.org/reports/LINK-A",
-            name="Link Report A",
-            content="Content A",
+        self._spawn_and_join(
+            datalayer,
+            actor.id_,
+            reporter_actor_id,
+            [(report_a, offer_a, "a"), (report_b, offer_b, "b")],
         )
-        report_b = as_VulnerabilityReport(
-            id_="https://example.org/reports/LINK-B",
-            name="Link Report B",
-            content="Content B",
-        )
-        datalayer.create(report_a)
-        datalayer.create(report_b)
-
-        offer_a = rm_submit_report_activity(
-            report=report_a,
-            actor=reporter_actor_id,
-            to=actor.id_,
-        )
-        offer_b = rm_submit_report_activity(
-            report=report_b,
-            actor=reporter_actor_id,
-            to=actor.id_,
-        )
-        datalayer.create(offer_a)
-        datalayer.create(offer_b)
-
-        _lock = threading.Lock()
-        errors: list[str] = []
-
-        def _run(
-            report_id: str, offer_id: str, offer: object, key: str
-        ) -> None:
-            try:
-                bridge = BTBridge(
-                    datalayer=datalayer,
-                    trigger_activity=TriggerActivityAdapter(datalayer),
-                )
-                tree = create_receive_report_case_tree(
-                    report_id=report_id,
-                    offer_id=offer_id,
-                    reporter_actor_id=reporter_actor_id,
-                )
-                bridge.execute_with_setup(
-                    tree=tree, actor_id=actor.id_, activity=offer
-                )
-            except Exception as exc:
-                with _lock:
-                    errors.append(f"{key}: {exc}")
-
-        t_a = threading.Thread(
-            target=_run,
-            args=(report_a.id_, offer_a.id_, offer_a, "a"),
-        )
-        t_b = threading.Thread(
-            target=_run,
-            args=(report_b.id_, offer_b.id_, offer_b, "b"),
-        )
-        t_a.start()
-        t_b.start()
-        t_a.join(timeout=10)
-        t_b.join(timeout=10)
-
-        assert not t_a.is_alive(), "Thread A timed out — possible deadlock"
-        assert not t_b.is_alive(), "Thread B timed out — possible deadlock"
-        assert not errors, f"Thread errors: {errors}"
 
         link_a = datalayer.read(VultronReportCaseLink.build_id(report_a.id_))
         link_b = datalayer.read(VultronReportCaseLink.build_id(report_b.id_))

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -22,18 +22,23 @@ The tree no longer creates a VulnerabilityCase.  Instead it:
    (ProposeReportCaseToActorNode).
 
 Tests are grouped by concern:
-- TestTreeStructure   — root shape, child count, node types
-- TestPolicyGate      — auto_create_case=False skips the flow
-- TestHappyPath       — link written + proposal queued
-- TestIdempotency     — second run is a no-op (CP-04-001)
+- TestTreeStructure       — root shape, child count, node types
+- TestPolicyGate          — auto_create_case=False skips the flow
+- TestHappyPath           — link written + proposal queued
+- TestIdempotency         — second run is a no-op (CP-04-001)
+- TestConcurrentExecution — two parallel invocations don't corrupt each other
+                            (BTND-03-004)
 
 Fixtures defined in conftest.py and shared with sibling tree test files.
 """
 
-import pytest
+import threading
+
 import py_trees
+import pytest
 from py_trees.common import Status
 
+from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.nodes import (
     CheckAutoCaseCreationEnabledNode,
     CheckPendingProposalExistsForReport,
@@ -567,3 +572,205 @@ class TestIdempotency:
         assert (
             count_after_retry > count_before_retry
         ), "Re-triggering after proposal_rejected=True must enqueue a new proposal"
+
+
+# ============================================================================
+# Concurrent execution tests (BTND-03-004)
+# ============================================================================
+
+
+class TestConcurrentExecution:
+    """Two parallel invocations with distinct report_ids don't corrupt each other.
+
+    The py_trees blackboard is process-global (BTND-03-004).  The slimmed
+    tree uses only constructor-injected ``report_id`` values (not inter-node
+    handoff blackboard keys), so concurrent executions for distinct reports
+    MUST NOT corrupt each other's DataLayer state.
+
+    This class exercises the ``_BT_GLOBAL_LOCK`` serialisation in
+    ``BTBridge.execute_with_setup`` and verifies that per-report isolation
+    holds even when two bridge instances race on the global lock.
+    """
+
+    def test_two_threads_both_succeed(
+        self,
+        datalayer,
+        actor,
+        reporter_actor_id,
+    ):
+        """Both threads complete with Status.SUCCESS (BTND-03-004)."""
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+        from vultron.wire.as2.factories import rm_submit_report_activity
+        from vultron.wire.as2.vocab.objects.vulnerability_report import (
+            as_VulnerabilityReport,
+        )
+
+        report_a = as_VulnerabilityReport(
+            id_="https://example.org/reports/CONCURRENT-A",
+            name="Concurrent Report A",
+            content="Test content A",
+        )
+        report_b = as_VulnerabilityReport(
+            id_="https://example.org/reports/CONCURRENT-B",
+            name="Concurrent Report B",
+            content="Test content B",
+        )
+        datalayer.create(report_a)
+        datalayer.create(report_b)
+
+        offer_a = rm_submit_report_activity(
+            report=report_a,
+            actor=reporter_actor_id,
+            to=actor.id_,
+        )
+        offer_b = rm_submit_report_activity(
+            report=report_b,
+            actor=reporter_actor_id,
+            to=actor.id_,
+        )
+        datalayer.create(offer_a)
+        datalayer.create(offer_b)
+
+        results: dict[str, Status] = {}
+        _lock = threading.Lock()
+        errors: list[str] = []
+
+        def _run(
+            report_id: str, offer_id: str, offer: object, key: str
+        ) -> None:
+            try:
+                bridge = BTBridge(
+                    datalayer=datalayer,
+                    trigger_activity=TriggerActivityAdapter(datalayer),
+                )
+                tree = create_receive_report_case_tree(
+                    report_id=report_id,
+                    offer_id=offer_id,
+                    reporter_actor_id=reporter_actor_id,
+                )
+                result = bridge.execute_with_setup(
+                    tree=tree, actor_id=actor.id_, activity=offer
+                )
+                results[key] = result.status
+            except Exception as exc:
+                with _lock:
+                    errors.append(f"{key}: {exc}")
+
+        t_a = threading.Thread(
+            target=_run,
+            args=(report_a.id_, offer_a.id_, offer_a, "a"),
+        )
+        t_b = threading.Thread(
+            target=_run,
+            args=(report_b.id_, offer_b.id_, offer_b, "b"),
+        )
+        t_a.start()
+        t_b.start()
+        t_a.join(timeout=10)
+        t_b.join(timeout=10)
+
+        assert not t_a.is_alive(), "Thread A timed out — possible deadlock"
+        assert not t_b.is_alive(), "Thread B timed out — possible deadlock"
+        assert not errors, f"Thread errors: {errors}"
+        assert (
+            results.get("a") == Status.SUCCESS
+        ), f"Thread A status: {results.get('a')}"
+        assert (
+            results.get("b") == Status.SUCCESS
+        ), f"Thread B status: {results.get('b')}"
+
+    def test_two_threads_produce_distinct_links(
+        self,
+        datalayer,
+        actor,
+        reporter_actor_id,
+    ):
+        """Each thread writes its own VultronReportCaseLink; two distinct records exist."""
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+        from vultron.wire.as2.factories import rm_submit_report_activity
+        from vultron.wire.as2.vocab.objects.vulnerability_report import (
+            as_VulnerabilityReport,
+        )
+
+        report_a = as_VulnerabilityReport(
+            id_="https://example.org/reports/LINK-A",
+            name="Link Report A",
+            content="Content A",
+        )
+        report_b = as_VulnerabilityReport(
+            id_="https://example.org/reports/LINK-B",
+            name="Link Report B",
+            content="Content B",
+        )
+        datalayer.create(report_a)
+        datalayer.create(report_b)
+
+        offer_a = rm_submit_report_activity(
+            report=report_a,
+            actor=reporter_actor_id,
+            to=actor.id_,
+        )
+        offer_b = rm_submit_report_activity(
+            report=report_b,
+            actor=reporter_actor_id,
+            to=actor.id_,
+        )
+        datalayer.create(offer_a)
+        datalayer.create(offer_b)
+
+        _lock = threading.Lock()
+        errors: list[str] = []
+
+        def _run(
+            report_id: str, offer_id: str, offer: object, key: str
+        ) -> None:
+            try:
+                bridge = BTBridge(
+                    datalayer=datalayer,
+                    trigger_activity=TriggerActivityAdapter(datalayer),
+                )
+                tree = create_receive_report_case_tree(
+                    report_id=report_id,
+                    offer_id=offer_id,
+                    reporter_actor_id=reporter_actor_id,
+                )
+                bridge.execute_with_setup(
+                    tree=tree, actor_id=actor.id_, activity=offer
+                )
+            except Exception as exc:
+                with _lock:
+                    errors.append(f"{key}: {exc}")
+
+        t_a = threading.Thread(
+            target=_run,
+            args=(report_a.id_, offer_a.id_, offer_a, "a"),
+        )
+        t_b = threading.Thread(
+            target=_run,
+            args=(report_b.id_, offer_b.id_, offer_b, "b"),
+        )
+        t_a.start()
+        t_b.start()
+        t_a.join(timeout=10)
+        t_b.join(timeout=10)
+
+        assert not t_a.is_alive(), "Thread A timed out — possible deadlock"
+        assert not t_b.is_alive(), "Thread B timed out — possible deadlock"
+        assert not errors, f"Thread errors: {errors}"
+
+        link_a = datalayer.read(VultronReportCaseLink.build_id(report_a.id_))
+        link_b = datalayer.read(VultronReportCaseLink.build_id(report_b.id_))
+
+        assert isinstance(
+            link_a, VultronReportCaseLink
+        ), "VultronReportCaseLink for report A must exist"
+        assert isinstance(
+            link_b, VultronReportCaseLink
+        ), "VultronReportCaseLink for report B must exist"
+        assert link_a.report_id == report_a.id_
+        assert link_b.report_id == report_b.id_
+        assert link_a.id_ != link_b.id_, "Links must be distinct records"


### PR DESCRIPTION
- Closes #1820

## Summary

Adds `TestConcurrentExecution` to `test_receive_report_case_tree.py`, covering BTND-03-004 (blackboard isolation under concurrent BT executions). Two threads run the ADR-0041 slimmed tree against distinct `report_id` values and verify neither corrupts the other's DataLayer state.

## Changes

- **`test/core/behaviors/case/test_receive_report_case_tree.py`**: adds `TestConcurrentExecution` with two test methods. `test_two_threads_both_succeed` asserts both threads complete with `Status.SUCCESS` under `_BT_GLOBAL_LOCK` serialisation. `test_two_threads_produce_distinct_links` asserts each thread writes its own `VultronReportCaseLink` record. Each `_run` closure receives its own `offer` object (matching the pattern used by existing tests), a `threading.Lock` guards the shared `errors` list, and `is_alive()` checks after `join(timeout=10)` detect deadlocks explicitly. Also adds `import threading` and `from vultron.core.behaviors.bridge import BTBridge` to module-level imports.

## Verification

- 5936 tests pass (2 new in `TestConcurrentExecution`), 2 xfail, 265 skipped
- Black, flake8, mypy, pyright all clean
- [x] Two concurrent executions with distinct `report_id` values both return `Status.SUCCESS`
- [x] Two distinct `VultronReportCaseLink` records written, one per `report_id`
- [x] Deadlock detection via `is_alive()` post-join