### PR TITLE
docs: plan issue #1859 — demo CI post-merge validation on main

### DIFF
--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -85,3 +85,68 @@ When a scenario phase is added or removed, update both:
 Both MUST change in the same PR per DEMOMA-16-008. Failure to update the spec
 is a latent silent-failure risk; failure to update the test means the new spec
 requirement is untested.
+
+---
+
+## Post-Merge Validation on `main` (DEMOCI-05)
+
+**Problem**: `demo-integration.yml` originally triggered only on
+`pull_request`, so the demo + invariant harness validated only the *ephemeral
+merge commit* (PR head merged onto `main` at test time) — never the actual
+merged `main` HEAD. Two PRs each green in isolation can interact to break
+`main`, and nothing re-ran the demos/invariants against the real merged result.
+Because the trigger is path-filtered, a broken `main` could persist untested
+until a *later* PR happened to touch a filtered path. The default branch had no
+demo/invariant baseline at all — the classic "green PRs, red main" failure mode
+(CONCERN-1859).
+
+**Design**: `demo-integration.yml` also triggers on `push` to `main` with the
+**same path filter** as the `pull_request` trigger (DEMOCI-02-003,
+DEMOCI-05-001). The on-main run executes the full demo + invariant-harness
+matrix against the merged `main` HEAD, producing a per-commit pass/fail signal.
+
+### Why `push` (with concurrency) rather than a cron schedule
+
+`push` gives an immediate per-commit signal with no blind window and preserves
+single-commit failure attribution for bisection. A `schedule:` cron was
+considered but rejected for this concern: it introduces up to a multi-hour
+blind window, runs even when nothing merged, and attributes failures to a
+commit *range* rather than a single commit. GitHub Actions has no native
+"run at most once every N hours" throttle for `push`; the cost is bounded
+instead by (a) the path filter — docs/spec-only merges cost nothing — and
+(b) the concurrency group.
+
+### Concurrency (DEMOCI-02-011, DEMOCI-05-002)
+
+A single workflow file serves both triggers, so `cancel-in-progress` is an
+expression: `true` off the default branch (PR bursts collapse to the newest
+commit), `false` on `main` (every qualifying merge runs to completion and keeps
+its own signal). Keyed on `${{ github.workflow }}-${{ github.ref }}`:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+```
+
+Note: DEMOCI-02-011 was authored as a SHOULD but never implemented — neither
+workflow carried a `concurrency` block before CONCERN-1859. It is now a MUST
+and is wired on both triggers.
+
+### Cache-warm workflow removal (DEMOCI-05-003)
+
+`demo-image-cache-warm.yml` existed *only* because `demo-integration.yml` did
+not run on `main`: it built the demo images on push-to-main and exported them
+to the `demo-integration-main` GHA cache scope so new PR branches got a warm
+fallback cache (PR-branch caches are not visible across branches). Once the
+on-main run of `demo-integration.yml` exports that same scope, the dedicated
+cache-warm workflow is a redundant second image build and is **removed**. One
+on-main build now both validates the demo and warms the cache.
+
+### Out of scope: merge queue
+
+The concurrent-merge *interaction* gap (two green PRs that break `main` when
+combined) is only fully closed by a GitHub **merge queue**, which re-runs
+required checks against the actual merged result before landing. That is a
+larger branch-protection / required-checks decision tracked separately as a
+follow-up Idea; DEMOCI-05 only adds the post-merge baseline signal.

--- a/plan/history/2607/learning/CONCERN-1859.md
+++ b/plan/history/2607/learning/CONCERN-1859.md
@@ -1,0 +1,50 @@
+---
+source: CONCERN-1859
+timestamp: '2026-07-31T15:52:13.284665+00:00'
+title: Demo CI never runs on push to main
+type: learning
+---
+
+## Concern
+
+`demo-integration.yml` triggers only on `pull_request` (to `main`) and
+`workflow_dispatch`; its `invariant-harness` job runs `needs: demo` and is
+therefore also PR-only. The only workflow that fires on `push: main` —
+`demo-image-cache-warm.yml` — builds the demo Docker images but never runs the
+demo or the invariant harness (it only populates the cache). As a result there
+was no post-merge demo/invariant signal on `main`: a PR could be green and
+merge, yet the demos on `main` could be broken with nothing to detect it.
+
+**Underlying problem:** PR CI validates the *merge commit* (PR head merged onto
+current `main` at test time), not the actual merged result of PRs that land
+concurrently. Two PRs each green in isolation can interact to break `main`, and
+nothing re-ran the demos/invariants against the real merged `main` HEAD — the
+default branch had no demo/invariant baseline at all. The path-filtered PR
+trigger only re-checks the demos when a *later* PR happens to touch a filtered
+path, so a broken `main` could persist untested until then.
+
+## Resolution
+
+**Resolved**: 2026-07-31 — implementation tracked in #1862; merge-queue
+follow-up deferred to Idea #1863.
+
+Planning decisions (grill-me):
+
+- Add a `push: main` trigger (same path filter) to `demo-integration.yml` so
+  the full demo + invariant matrix runs against the merged `main` HEAD per
+  qualifying merge. Cron rejected (blind window, range-level attribution);
+  GitHub has no native "once per N hours" throttle for `push`. Cost bounded by
+  path filter + concurrency group.
+- DEMOCI-02-011 (`concurrency` group) was authored as SHOULD but never
+  implemented on either workflow. Promoted to MUST and wired on both triggers
+  via `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` — PR bursts
+  collapse to newest; on-main runs always complete for per-commit attribution.
+- The on-main run exports the `demo-integration-main` cache scope, making
+  `demo-image-cache-warm.yml` redundant — it is removed.
+- Merge queue (closes the concurrent-merge *interaction* gap) deferred to Idea
+  #1863.
+- No ADR — refines existing DEMOCI requirements (spec + notes only).
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1861>.
+Spec: `specs/demo-ci.yaml` (DEMOCI-02-002/003/011, new group DEMOCI-05).
+Notes: `notes/demo-ci-invariants.md` § "Post-Merge Validation on main".

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -6,7 +6,7 @@ description: >-
   when the demo fails — closing the gap where tests pass while the demo produces
   silent failures. Includes requirements for the invariant harness to run as an
   independent CI gate so failures are visible even when the demo itself also fails.
-version: 1.3.0
+version: 1.4.0
 scope:
   - prototype
   - production
@@ -116,19 +116,28 @@ groups:
         kind: project
         statement: >-
           The demo workflow MUST trigger on pull_request events targeting the
-          main branch and on workflow_dispatch events.
+          main branch, on push events to the main branch (see DEMOCI-05), and
+          on workflow_dispatch events.
+        rationale: >-
+          The pull_request trigger validates the ephemeral merge commit before
+          a PR lands. The push-to-main trigger validates the actual merged
+          main HEAD after a PR lands, closing the "green PRs, red main" gap
+          where two individually-green PRs interact to break main with no
+          post-merge signal (see DEMOCI-05).
 
       - id: DEMOCI-02-003
         priority: MUST
         kind: project
         statement: >-
-          The pull_request trigger MUST include a paths filter covering:
-          vultron/**, docker/**, integration_tests/**, pyproject.toml, and
-          uv.lock.
+          Both the pull_request and push triggers MUST include the same paths
+          filter, covering: vultron/**, docker/**, integration_tests/**,
+          test/ci/**, pyproject.toml, and uv.lock.
         rationale: >-
-          These are the files whose changes can affect demo container behaviour.
-          Filtering avoids running the expensive workflow on pure docs or
-          spec changes.
+          These are the files whose changes can affect demo container behaviour
+          or the invariant assertions that validate it. Filtering avoids running
+          the expensive workflow on pure docs or spec changes. The push and
+          pull_request filters MUST match so that any change validated pre-merge
+          is also validated post-merge on main.
 
       - id: DEMOCI-02-004
         priority: MUST
@@ -200,25 +209,29 @@ groups:
           accumulate stale Docker state if teardown is skipped.
 
       - id: DEMOCI-02-011
-        priority: SHOULD
+        priority: MUST
         kind: project
         statement: >-
-          Both demo workflows (demo-integration.yml and
-          demo-image-cache-warm.yml) SHOULD define a `concurrency` group keyed
-          on `${{ github.workflow }}-${{ github.ref }}`. The demo-integration
-          workflow (pull_request-triggered) MUST set `cancel-in-progress: true`
-          so a newer push to a PR branch cancels superseded in-progress and
-          queued runs. The demo-image-cache-warm workflow (push-to-main
-          triggered) MUST set `cancel-in-progress: false` so main-branch cache
-          warms always run to completion.
+          The demo-integration.yml workflow MUST define a `concurrency` group
+          keyed on `${{ github.workflow }}-${{ github.ref }}`. On
+          pull_request-triggered runs it MUST set `cancel-in-progress: true` so
+          a newer push to a PR branch cancels superseded in-progress and queued
+          runs. On push-to-main-triggered runs it MUST set
+          `cancel-in-progress: false` so main-branch runs always run to
+          completion (see DEMOCI-05-002). Because a single workflow file serves
+          both triggers, `cancel-in-progress` MUST be expressed as an expression
+          that evaluates to `false` on the default branch and `true` otherwise,
+          e.g. `${{ github.ref != 'refs/heads/main' }}`.
         rationale: >-
           When commits land quickly during iterative work, queued demo runs
           pile up and waste CI minutes while delaying feedback; a newer commit
           renders earlier PR-branch runs pointless. Cancelling superseded PR
-          runs reclaims those minutes. Cache-warm runs on main are never
-          cancelled because each successful warm protects the fallback cache
-          scope that new PR branches read from (see the workflow header and
-          DEMOCI-02-007).
+          runs reclaims those minutes. On-main runs are never cancelled because
+          each run both validates the merged main HEAD (DEMOCI-05-001) and
+          protects the fallback cache scope that new PR branches read from (see
+          DEMOCI-02-007 and DEMOCI-05-003). Keyed on the ref, a burst of merges
+          to main still runs each qualifying commit to completion rather than
+          collapsing to the newest, preserving per-commit failure attribution.
 
   - id: DEMOCI-03
     title: Extensibility for Additional Demo Scenarios
@@ -382,3 +395,88 @@ groups:
             spec_id: DEMOCI-04-002
           - rel_type: refines
             spec_id: DEMOCI-02-004
+
+  - id: DEMOCI-05
+    title: Post-Merge Validation on the Default Branch
+    specs:
+      - id: DEMOCI-05-001
+        priority: MUST
+        kind: project
+        statement: >-
+          The demo workflow MUST run the full demo + invariant-harness matrix
+          against the main branch HEAD on push events to main (path-filtered
+          per DEMOCI-02-003), producing a commit status on the merged result.
+        rationale: >-
+          The pull_request trigger validates only the ephemeral merge commit
+          (PR head merged onto main at test time), not the actual merged result
+          of PRs that land concurrently. Two PRs each green in isolation can
+          interact to break main, and without an on-main run nothing re-validates
+          the demos or invariants against the real merged main HEAD. The
+          path-filtered pull_request trigger only re-checks the demos when a
+          later PR happens to touch a filtered path, so a broken main can persist
+          untested until then. A push-to-main run gives the default branch its
+          own per-commit demo/invariant baseline.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-02-002
+
+      - id: DEMOCI-05-002
+        priority: MUST
+        kind: project
+        statement: >-
+          On-main demo runs MUST NOT be cancelled by the concurrency group
+          (cancel-in-progress: false on push-to-main runs, per DEMOCI-02-011),
+          so that every qualifying merge to main runs to completion and retains
+          an independent per-commit pass/fail signal for bisection.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-05-001
+          - rel_type: refines
+            spec_id: DEMOCI-02-011
+
+      - id: DEMOCI-05-003
+        priority: MUST
+        kind: project
+        statement: >-
+          The on-main run of demo-integration.yml MUST export its Docker image
+          layers to the `demo-integration-main` GitHub Actions cache scope so
+          that new PR branches read a warm fallback cache (per DEMOCI-02-007).
+          The dedicated demo-image-cache-warm.yml workflow, whose sole purpose
+          was to warm this cache on main, MUST be removed once the on-main demo
+          run performs the same cache export, to avoid a redundant second image
+          build on every qualifying push to main.
+        rationale: >-
+          Before this change, demo-integration.yml ran only on pull_request, so
+          a separate demo-image-cache-warm.yml existed purely to build the demo
+          images on main and populate the demo-integration-main cache scope for
+          new PR branches. Once demo-integration.yml itself runs on push to main
+          and writes that scope, a second cache-only build is pure waste. Folding
+          the cache export into the on-main run gives one build that both
+          validates the demo and warms the cache.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-05-001
+          - rel_type: refines
+            spec_id: DEMOCI-02-007
+
+      - id: DEMOCI-05-004
+        priority: MUST
+        kind: project
+        statement: >-
+          The push-to-main trigger MUST carry the same Dependabot exclusion
+          semantics as the pull_request trigger where applicable. Because
+          push events to main do not originate from `dependabot/` head refs,
+          the guard need not be duplicated on the push path, but the workflow
+          MUST NOT gate the on-main run behind `github.head_ref`-based
+          conditions (which are empty on push events) in a way that would
+          skip the on-main run entirely.
+        rationale: >-
+          The existing `!startsWith(github.head_ref, 'dependabot/')` guards
+          (DEMOCI-02-004, DEMOCI-04-005) evaluate against the PR head ref, which
+          is empty on push events. A naive reuse of that condition as a job-level
+          `if:` would still pass on push (empty string does not start with
+          'dependabot/'), but authors MUST verify the on-main run is not
+          inadvertently skipped when consolidating the guard expressions.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-05-001


### PR DESCRIPTION
- Closes #1859

## Summary

Plans CONCERN-1859: `demo-integration.yml` triggers only on `pull_request`, so
the demo + invariant harness validate only the ephemeral merge commit — never
the merged `main` HEAD. The only push-to-main workflow
(`demo-image-cache-warm.yml`) just warms the Docker cache. Result: two
individually-green PRs can interact to break `main` with no post-merge signal
(the "green PRs, red main" failure mode).

This docs PR amends the DEMOCI spec and design notes to define the fix; the
workflow change itself is tracked in the implementation issue below.

## Decisions (from grill-me)

- **Mechanism**: add a `push: main` trigger (same path filter) so the full
  demo + invariant matrix runs against the merged `main` HEAD per qualifying
  merge — per-commit signal, no blind window. Cron rejected (blind window +
  range-level attribution); GitHub has no native "once per N hours" throttle
  for `push`. Cost is bounded by the path filter and the concurrency group.
- **Concurrency**: DEMOCI-02-011 was authored as SHOULD but never implemented
  (neither workflow has a `concurrency` block). Promoted to MUST and wired on
  both triggers via an expression — `cancel-in-progress: true` off `main`
  (PR bursts collapse), `false` on `main` (each merge runs to completion).
- **Cache-warm fold-in**: the on-main run exports the `demo-integration-main`
  cache scope, making `demo-image-cache-warm.yml` redundant — it is removed.
- **Merge queue**: out of scope; filed as a follow-up Idea.
- **ADR**: none — this refines existing DEMOCI requirements (spec + notes).

## Changes

- `specs/demo-ci.yaml` (1.3.0 → 1.4.0):
  - DEMOCI-02-002: add `push: main` to required triggers.
  - DEMOCI-02-003: require matched path filters on both triggers (adds
    `test/ci/**`).
  - DEMOCI-02-011: SHOULD → MUST; single-file concurrency expression.
  - New group **DEMOCI-05** (Post-Merge Validation on the Default Branch):
    05-001 on-main matrix run, 05-002 no-cancel on main, 05-003 cache-warm
    fold-in + removal, 05-004 Dependabot guard semantics for `push`.
- `notes/demo-ci-invariants.md`: new "Post-Merge Validation on `main`" section
  (why push over cron, concurrency expression, cache-warm removal, merge-queue
  out-of-scope).

## Implementation Issues

- #1862 — add push:main trigger + concurrency; remove cache-warm workflow

## Deferred (follow-up Idea)

- #1863 — evaluate GitHub merge queue (concurrent-merge interaction gap)