### PR TITLE
feat: wire PreCloseAction and rename close-case trigger path

### DIFF
--- a/notes/bt-fuzzer-rm-closure.md
+++ b/notes/bt-fuzzer-rm-closure.md
@@ -47,7 +47,7 @@ complete (or otherwise concluded).
   (`other_close_criteria_factory` param; DETERMINISTIC default = `AlwaysFail`).
   This tree is a seam-only stub — it is **not invoked autonomously**. Case
   closure is always Case Owner-triggered via
-  `create_close_report_trigger_tree`. The `OtherCloseCriteriaMet` Evaluator
+  `create_close_case_trigger_tree`. The `OtherCloseCriteriaMet` Evaluator
   seam is the injection point for a future Close Readiness Monitoring Sentinel
   (see epic #1147 / #1143 Sentinel agent type) that observes protocol state
   and posts an observational note to the Case Owner when objective closure
@@ -70,13 +70,14 @@ complete (or otherwise concluded).
 - **Automation potential**: **Medium** — archiving and standard notification steps can be automated; QA review and final approvals typically require human involvement.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.close_report.PreCloseAction`
 - **Call-out point shape**: Actuator — fires integration hooks before case closure; invokes QA pipeline checks, final notification APIs, and case-archiving services. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
-- **Factory-fn placement**: Belongs in `create_close_report_trigger_tree`
-  (issue T1 from IDEA-1253 planning) — wired as an Actuator node between
-  `CheckReportNotClosed` (or equivalent guard) and `TransitionRMtoClosed`.
-  The DETERMINISTIC default is `AlwaysSucceed` (pre-close hooks are
-  optional infrastructure; absence of a real implementation must not block
-  closure). Not placed in `create_close_report_tree` — that tree is a
-  seam-only stub for autonomous monitoring, not the trigger path.
+- **Factory-fn placement**: Wired in `create_close_case_trigger_tree`
+  (issue T1 from IDEA-1253 planning, completed in #1854) — wired as an
+  Actuator node between `CheckReportNotClosed` (or equivalent guard) and
+  `TransitionRMtoClosed`. The DETERMINISTIC default is `AlwaysSucceed`
+  (pre-close hooks are optional infrastructure; absence of a real
+  implementation must not block closure). Not placed in
+  `create_close_report_tree` — that tree is a seam-only stub for autonomous
+  monitoring, not the trigger path.
 
 ---
 
@@ -112,8 +113,8 @@ Close Readiness Monitoring Sentinel (see **Close Readiness Monitoring** below).
 ### `PreCloseAction` belongs in the trigger tree
 
 `PreCloseAction` (Actuator) fires *after* the Case Owner has decided to close
-— it belongs in `create_close_report_trigger_tree`, wired between the
-not-already-closed guard and `TransitionRMtoClosed`. It is a pre-close hook
+— it is wired in `create_close_case_trigger_tree` (completed in #1854),
+between the not-already-closed guard and `TransitionRMtoClosed`. It is a pre-close hook
 for QA pipelines, archiving, and final notification. The DETERMINISTIC default
 is `AlwaysSucceed`; pre-close hooks must not block closure when no real
 backend is injected.
@@ -146,7 +147,7 @@ is:
 This pattern avoids inventing a new `Question` → `Answer` message exchange.
 The Sentinel fires into `OtherCloseCriteriaMet` seam in
 `create_close_report_tree`; the Case Owner's subsequent `Leave` flows through
-`create_close_report_trigger_tree` as usual.
+`create_close_case_trigger_tree` as usual.
 
 Track under epic #1147 (Coordination Agents), linked to #1143 (Sentinel
 agent type).

--- a/plan/history/2607/implementation/ISSUE-1854.md
+++ b/plan/history/2607/implementation/ISSUE-1854.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1854
+timestamp: '2026-07-31T16:25:28.850047+00:00'
+title: wire PreCloseAction and rename close-case trigger path
+type: implementation
+---
+
+## Issue #1854 — wire PreCloseAction and rename close-case trigger path
+
+Implemented all 3 acceptance criteria:
+
+1. **CheckCaseOwner guard** added as first node in `create_close_case_trigger_tree`; only CASE_OWNER may close
+2. **PreCloseAction** Actuator call-out wired between CheckCaseOwner and CheckReportNotClosed; DETERMINISTIC default = AlwaysSucceed
+3. **Rename**: `create_close_report_trigger_tree` → `create_close_case_trigger_tree`; `SvcCloseReportUseCase` → `SvcCloseCaseUseCase`; all callers updated (service.py, TriggerServicePort, FastAPI router, MCP adapter, 5 test files); backward-compat aliases kept
+
+PR: <https://github.com/CERTCC/Vultron/pull/1869>

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -171,15 +171,41 @@ def invalid_report(report):
     return report
 
 
+def _seed_owner_case(dl, actor_id, report_id):
+    """Seed a VulnerabilityCase where *actor_id* is CASE_OWNER with a CASE_MANAGER for routing."""
+    from vultron.core.models.case import VulnerabilityCase
+    from vultron.core.models.case_participant import CaseParticipant
+
+    owner_p = CaseParticipant(
+        attributed_to=actor_id,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    manager_actor = as_Service(name="Case Manager")
+    manager_p = CaseParticipant(
+        attributed_to=manager_actor.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    case = VulnerabilityCase(name="Owner Case for Close")
+    case.vulnerability_reports.append(report_id)
+    case.actor_participant_index[actor_id] = owner_p.id_
+    case.actor_participant_index[manager_actor.id_] = manager_p.id_
+    dl.create(manager_actor)
+    dl.create(owner_p)
+    dl.create(manager_p)
+    dl.create(case)
+
+
 @pytest.fixture
-def accepted_report(report):
-    """Report in an acceptable state for close-report (no CLOSED record)."""
+def accepted_report(dl, report, actor):
+    """Report in an acceptable state for close-case (actor is CASE_OWNER in linked case)."""
+    _seed_owner_case(dl, actor.id_, report.id_)
     return report
 
 
 @pytest.fixture
 def closed_report(dl, report, actor):
-    """Put the report into RM.CLOSED state (triggers 409 on close-report)."""
+    """Put the report into RM.CLOSED state (triggers 409 on close-report); actor is CASE_OWNER."""
+    _seed_owner_case(dl, actor.id_, report.id_)
     status = ParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.CLOSED.value),
         context=report.id_,

--- a/test/core/behaviors/report/test_trigger_report_trees.py
+++ b/test/core/behaviors/report/test_trigger_report_trees.py
@@ -13,12 +13,12 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Tests for the report trigger BT factories (issue #849 AC-4).
+"""Tests for the report trigger BT factories (issue #849 AC-4, #1854 AC-1/AC-2).
 
 Covers SUCCESS and FAILURE paths for:
   - ``InvalidateReportTriggerBT`` (create_invalidate_report_trigger_tree)
   - ``RejectReportTriggerBT``     (create_reject_report_trigger_tree)
-  - ``CloseReportTriggerBT``      (create_close_report_trigger_tree)
+  - ``CloseCaseTriggerBT``        (create_close_case_trigger_tree)
 """
 
 import pytest
@@ -26,24 +26,25 @@ from py_trees.common import Status
 
 from test.core.behaviors.bt_harness import BTTestScenario
 from vultron.core.behaviors.report.trigger_report_trees import (
-    create_close_report_trigger_tree,
+    create_close_case_trigger_tree,
     create_invalidate_report_trigger_tree,
     create_reject_report_trigger_tree,
 )
 from vultron.core.models.activity import VultronOffer
 from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 from vultron.core.states.rm import RM
 from vultron.core.models._helpers import _report_phase_status_id
+from vultron.enums.roles import CVDRole
 from vultron.errors import VultronInvalidStateTransitionError
-
-# noqa: F401 — vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
     as_VulnerabilityCase,
 )
+from vultron.core.models.case import VulnerabilityCase
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -51,6 +52,7 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
 
 ACTOR_ID = "https://example.org/actors/vendor"
 REPORTER_ID = "https://example.org/actors/reporter"
+CASE_MANAGER_ID = "https://example.org/actors/case-manager"
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +108,56 @@ def closed_status(
     )
     scenario.dl.create(status)
     return status
+
+
+@pytest.fixture
+def case_with_owner(
+    scenario: BTTestScenario, report: VultronReport
+) -> VulnerabilityCase:
+    """Create a VulnerabilityCase where ACTOR_ID is CASE_OWNER and a separate CASE_MANAGER exists for routing."""
+    owner_participant = CaseParticipant(
+        attributed_to=ACTOR_ID,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    manager_actor = VultronCaseActor(id_=CASE_MANAGER_ID, name="Case Manager")
+    manager_participant = CaseParticipant(
+        attributed_to=CASE_MANAGER_ID,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    case = VulnerabilityCase(name="Test Case")
+    case.vulnerability_reports.append(report.id_)
+    case.actor_participant_index[ACTOR_ID] = owner_participant.id_
+    case.actor_participant_index[CASE_MANAGER_ID] = manager_participant.id_
+    scenario.dl.create(manager_actor)
+    scenario.dl.create(owner_participant)
+    scenario.dl.create(manager_participant)
+    scenario.dl.create(case)
+    return case
+
+
+@pytest.fixture
+def case_with_non_owner(
+    scenario: BTTestScenario, report: VultronReport
+) -> VulnerabilityCase:
+    """Create a VulnerabilityCase where ACTOR_ID is VENDOR (not CASE_OWNER) with a CASE_MANAGER for routing."""
+    vendor_participant = CaseParticipant(
+        attributed_to=ACTOR_ID,
+        case_roles=[CVDRole.VENDOR],
+    )
+    manager_actor = VultronCaseActor(id_=CASE_MANAGER_ID, name="Case Manager")
+    manager_participant = CaseParticipant(
+        attributed_to=CASE_MANAGER_ID,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    case = VulnerabilityCase(name="Test Case Non-Owner")
+    case.vulnerability_reports.append(report.id_)
+    case.actor_participant_index[ACTOR_ID] = vendor_participant.id_
+    case.actor_participant_index[CASE_MANAGER_ID] = manager_participant.id_
+    scenario.dl.create(manager_actor)
+    scenario.dl.create(vendor_participant)
+    scenario.dl.create(manager_participant)
+    scenario.dl.create(case)
+    return case
 
 
 # ---------------------------------------------------------------------------
@@ -232,36 +284,74 @@ class TestRejectReportTriggerTree:
 
 
 # ---------------------------------------------------------------------------
-# CloseReportTriggerBT tests
+# CloseCaseTriggerBT tests
 # ---------------------------------------------------------------------------
 
 
-class TestCloseReportTriggerTree:
+class TestCloseCaseTriggerTree:
     def test_success_emits_activity_and_sets_rm_closed(
-        self, scenario: BTTestScenario, actor, report, offer
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        case_with_owner: VulnerabilityCase,
     ):
         """SUCCESS: emits activity and persists RM.CLOSED ParticipantStatus."""
         result_out: dict = {}
-        tree = create_close_report_trigger_tree(
-            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        tree = create_close_case_trigger_tree(
+            actor_id=ACTOR_ID,
+            case_id=case_with_owner.id_,
+            offer_id=offer.id_,
+            report_id=report.id_,
+            result_out=result_out,
         )
-        result = scenario.run(tree)
+        result = scenario.run(tree, case_id=case_with_owner.id_)
         scenario.assert_success(result)
         scenario.assert_rm_state(report.id_, RM.CLOSED)
         assert "error" not in result_out
 
     def test_success_adds_to_outbox(
-        self, scenario: BTTestScenario, actor, report, offer
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        case_with_owner: VulnerabilityCase,
     ):
         """SUCCESS: activity is added to the actor's outbox."""
         before = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
         result_out: dict = {}
-        tree = create_close_report_trigger_tree(
-            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        tree = create_close_case_trigger_tree(
+            actor_id=ACTOR_ID,
+            case_id=case_with_owner.id_,
+            offer_id=offer.id_,
+            report_id=report.id_,
+            result_out=result_out,
         )
-        scenario.run(tree)
+        scenario.run(tree, case_id=case_with_owner.id_)
         after = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
         assert len(after - before) >= 1
+
+    def test_failure_non_case_owner_blocked(
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        case_with_non_owner: VulnerabilityCase,
+    ):
+        """FAILURE: actor is not CASE_OWNER — CheckCaseOwner guard blocks tree."""
+        result_out: dict = {}
+        tree = create_close_case_trigger_tree(
+            actor_id=ACTOR_ID,
+            case_id=case_with_non_owner.id_,
+            offer_id=offer.id_,
+            report_id=report.id_,
+            result_out=result_out,
+        )
+        result = scenario.run(tree, case_id=case_with_non_owner.id_)
+        scenario.assert_failure(result)
 
     def test_failure_already_closed_writes_error(
         self,
@@ -269,14 +359,19 @@ class TestCloseReportTriggerTree:
         actor,
         report,
         offer,
+        case_with_owner: VulnerabilityCase,
         closed_status: ParticipantStatus,
     ):
         """FAILURE: already-closed report writes VultronInvalidStateTransitionError."""
         result_out: dict = {}
-        tree = create_close_report_trigger_tree(
-            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        tree = create_close_case_trigger_tree(
+            actor_id=ACTOR_ID,
+            case_id=case_with_owner.id_,
+            offer_id=offer.id_,
+            report_id=report.id_,
+            result_out=result_out,
         )
-        result = scenario.run(tree)
+        result = scenario.run(tree, case_id=case_with_owner.id_)
         scenario.assert_failure(result)
         assert "error" in result_out
         assert isinstance(
@@ -289,20 +384,30 @@ class TestCloseReportTriggerTree:
         actor,
         report,
         offer,
+        case_with_owner: VulnerabilityCase,
         closed_status: ParticipantStatus,
     ):
         """The error message references the report ID."""
         result_out: dict = {}
-        tree = create_close_report_trigger_tree(
-            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        tree = create_close_case_trigger_tree(
+            actor_id=ACTOR_ID,
+            case_id=case_with_owner.id_,
+            offer_id=offer.id_,
+            report_id=report.id_,
+            result_out=result_out,
         )
-        scenario.run(tree)
+        scenario.run(tree, case_id=case_with_owner.id_)
         error = result_out.get("error")
         assert error is not None
         assert report.id_ in str(error)
 
     def test_failure_no_trigger_activity_factory(
-        self, scenario: BTTestScenario, actor, report, offer
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        case_with_owner: VulnerabilityCase,
     ):
         """FAILURE: no TriggerActivityPort on the blackboard → tree fails."""
         import py_trees
@@ -311,9 +416,15 @@ class TestCloseReportTriggerTree:
 
         bridge_no_factory = BTBridge(datalayer=scenario.dl)
         result_out: dict = {}
-        tree = create_close_report_trigger_tree(
-            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        tree = create_close_case_trigger_tree(
+            actor_id=ACTOR_ID,
+            case_id=case_with_owner.id_,
+            offer_id=offer.id_,
+            report_id=report.id_,
+            result_out=result_out,
         )
         py_trees.blackboard.Blackboard.storage.clear()
-        result = bridge_no_factory.execute_with_setup(tree, actor_id=ACTOR_ID)
+        result = bridge_no_factory.execute_with_setup(
+            tree, actor_id=ACTOR_ID, case_id=case_with_owner.id_
+        )
         assert result.status == Status.FAILURE

--- a/test/core/behaviors/report/test_trigger_report_trees.py
+++ b/test/core/behaviors/report/test_trigger_report_trees.py
@@ -21,10 +21,12 @@ Covers SUCCESS and FAILURE paths for:
   - ``CloseCaseTriggerBT``        (create_close_case_trigger_tree)
 """
 
+import py_trees
 import pytest
 from py_trees.common import Status
 
 from test.core.behaviors.bt_harness import BTTestScenario
+from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
 from vultron.core.behaviors.report.trigger_report_trees import (
     create_close_case_trigger_tree,
     create_invalidate_report_trigger_tree,
@@ -428,3 +430,41 @@ class TestCloseCaseTriggerTree:
             tree, actor_id=ACTOR_ID, case_id=case_with_owner.id_
         )
         assert result.status == Status.FAILURE
+
+    def test_custom_call_out_factory_is_used(
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        case_with_owner: VulnerabilityCase,
+    ):
+        """SUCCESS: a custom call_out bundle's pre_close_action_factory is invoked."""
+        from vultron.core.behaviors.call_out.bundles.close_report import (
+            CloseReportCallOutBundle,
+        )
+
+        invoked: list[str] = []
+
+        def tracking_factory(name: str) -> py_trees.behaviour.Behaviour:
+            invoked.append(name)
+            return AlwaysSucceed(name)
+
+        custom_bundle = CloseReportCallOutBundle(
+            pre_close_action_factory=tracking_factory  # type: ignore[arg-type]
+        )
+
+        result_out: dict = {}
+        tree = create_close_case_trigger_tree(
+            actor_id=ACTOR_ID,
+            case_id=case_with_owner.id_,
+            offer_id=offer.id_,
+            report_id=report.id_,
+            result_out=result_out,
+            call_out=custom_bundle,
+        )
+        result = scenario.run(tree, case_id=case_with_owner.id_)
+        scenario.assert_success(result)
+        assert invoked == [
+            "PreCloseAction"
+        ], "Custom pre_close_action_factory was not called"

--- a/test/core/use_cases/triggers/test_close_case_trigger.py
+++ b/test/core/use_cases/triggers/test_close_case_trigger.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Dedicated execute()-path tests for SvcCloseCaseUseCase.
+
+Per notes/triggers-test-coverage.md: each test exercises the use case's
+execute() path against a real in-memory DataLayer and asserts:
+  1. the RM state mutation (RM → CLOSED via BT);
+  2. the outbox effect (activity queued, addressed correctly per PCR-08-001);
+  3. the documented failure modes the use case is documented to raise
+     (VultronNotFoundError when no linked VulnerabilityCase).
+
+SvcCloseCaseUseCase enforces that only the Case Owner may close the case:
+CheckCaseOwnerNode in the BT tree returns FAILURE when the actor is not
+CASE_OWNER, causing execute() to raise VultronBTError.
+"""
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import (
+    SqliteDataLayer,
+    reset_datalayer,
+)
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.offer_record import VultronOfferRecord
+from vultron.core.use_cases.triggers.report import (
+    SvcCloseCaseUseCase,
+    SvcCloseReportUseCase,
+)
+from vultron.core.use_cases.triggers.requests import CloseReportTriggerRequest
+from vultron.enums.roles import CVDRole
+from vultron.errors import VultronNotFoundError
+from vultron.wire.as2.factories import rm_submit_report_activity
+from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
+from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    as_VulnerabilityReport,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_actor_dl(name: str) -> tuple[as_Service, SqliteDataLayer]:
+    actor = as_Service(name=name)
+    reset_datalayer(actor.id_)
+    dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor.id_)
+    dl.clear_all()
+    dl.create(actor)
+    return actor, dl
+
+
+def _make_offer(
+    dl: SqliteDataLayer,
+    report: as_VulnerabilityReport,
+    recipient_id: str,
+    actor_id: str,
+) -> as_Offer:
+    offer = rm_submit_report_activity(report, recipient_id, actor=actor_id)
+    dl.create(offer)
+    dl.create(
+        VultronOfferRecord(
+            offer_id=offer.id_,
+            report_id=report.id_,
+            offer_actor_id=actor_id,
+            offer_to=[recipient_id],
+        )
+    )
+    return offer
+
+
+def _make_case_with_owner(
+    dl: SqliteDataLayer,
+    owner_id: str,
+    report_id: str,
+    manager_id: str | None = None,
+) -> VulnerabilityCase:
+    owner_p = CaseParticipant(
+        attributed_to=owner_id,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    case = VulnerabilityCase(name="Owner Case")
+    case.vulnerability_reports.append(report_id)
+    case.actor_participant_index[owner_id] = owner_p.id_
+    dl.create(owner_p)
+    if manager_id is not None:
+        mgr_p = CaseParticipant(
+            attributed_to=manager_id,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        case.actor_participant_index[manager_id] = mgr_p.id_
+        dl.create(mgr_p)
+    dl.create(case)
+    return case
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSvcCloseCaseUseCase:
+    """execute()-path tests for SvcCloseCaseUseCase.
+
+    The vendor actor is seeded as CASE_OWNER so CheckCaseOwner passes.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.vendor, self.dl = _make_actor_dl("Vendor Co")
+        self.finder, self.finder_dl = _make_actor_dl("Finder Co")
+        self.case_actor, self.case_actor_dl = _make_actor_dl("Case Actor")
+
+        self.report = as_VulnerabilityReport(
+            name="CVE-TEST",
+            content="Vulnerability report content",
+            attributed_to=self.finder.id_,
+        )
+        self.dl.create(self.report)
+
+        self.offer = _make_offer(
+            self.dl,
+            self.report,
+            self.vendor.id_,
+            actor_id=self.finder.id_,
+        )
+
+        # vendor is CASE_OWNER; case_actor is CASE_MANAGER for routing
+        self.owner_case = _make_case_with_owner(
+            self.dl,
+            owner_id=self.vendor.id_,
+            manager_id=self.case_actor.id_,
+            report_id=self.report.id_,
+        )
+
+        yield
+
+        self.dl.clear_all()
+        self.dl.close()
+        self.finder_dl.clear_all()
+        self.finder_dl.close()
+        self.case_actor_dl.clear_all()
+        self.case_actor_dl.close()
+        reset_datalayer(self.vendor.id_)
+        reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
+
+    def test_close_case_returns_activity_dict(self):
+        """execute() returns result['activity'] as Reject(Offer) dict (DL-06-001)."""
+        request = CloseReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        result = SvcCloseCaseUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+        assert result.get("activity") is not None
+        assert result["activity"].get("type") == "Reject"
+
+    def test_close_case_queues_activity_in_outbox(self):
+        """execute() enqueues at least one activity in the actor's outbox."""
+        request = CloseReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        before = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        SvcCloseCaseUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+        after = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        assert len(after - before) >= 1
+
+    def test_backward_compat_alias_works(self):
+        """SvcCloseReportUseCase alias delegates to SvcCloseCaseUseCase."""
+        assert SvcCloseReportUseCase is SvcCloseCaseUseCase
+
+    def test_close_case_raises_when_no_linked_case(self):
+        """VultronNotFoundError raised when report has no linked VulnerabilityCase."""
+        vendor2, dl2 = _make_actor_dl("Vendor2 Co")
+        try:
+            report2 = as_VulnerabilityReport(
+                name="Unlinked",
+                content="No case",
+                attributed_to=vendor2.id_,
+            )
+            dl2.create(report2)
+            offer2 = _make_offer(
+                dl2, report2, vendor2.id_, actor_id=vendor2.id_
+            )
+            request = CloseReportTriggerRequest(
+                actor_id=vendor2.id_,
+                offer_id=offer2.id_,
+            )
+            with pytest.raises(VultronNotFoundError):
+                SvcCloseCaseUseCase(
+                    dl2,
+                    request,
+                    trigger_activity=TriggerActivityAdapter(dl2),
+                ).execute()
+        finally:
+            dl2.clear_all()
+            dl2.close()
+            reset_datalayer(vendor2.id_)

--- a/test/core/use_cases/triggers/test_report_triggers.py
+++ b/test/core/use_cases/triggers/test_report_triggers.py
@@ -24,6 +24,8 @@ execute() path against a real in-memory DataLayer and asserts:
   3. the documented failure modes the use case is documented to raise.
 """
 
+from typing import Any
+
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import (
@@ -41,6 +43,7 @@ from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.core.models._helpers import _report_phase_status_id
 from vultron.core.use_cases.triggers.report import (
+    SvcCloseCaseUseCase,
     SvcCloseReportUseCase,
     SvcInvalidateReportUseCase,
     SvcRejectReportUseCase,
@@ -529,16 +532,94 @@ class TestSvcRejectReportUseCase(_ReportTriggerBase):
         assert len(after - before) >= 1
 
 
-class TestSvcCloseReportUseCase(_ReportTriggerBase):
-    """execute() path tests for SvcCloseReportUseCase."""
+def _make_case_with_case_owner(
+    dl: SqliteDataLayer,
+    owner_id: str,
+    report_id: str,
+    manager_id: str | None = None,
+) -> "Any":
+    """Build a VulnerabilityCase where *owner_id* holds CVDRole.CASE_OWNER.
 
-    def test_close_report_returns_activity_dict(self):
+    If *manager_id* is provided, also seed a CASE_MANAGER participant so that
+    ``EmitCloseReportActivity`` can route the outbound activity.
+    """
+    from vultron.core.models.case_participant import CaseParticipant
+    from vultron.core.models.case import VulnerabilityCase
+
+    owner_participant = CaseParticipant(
+        attributed_to=owner_id,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    case = VulnerabilityCase(name="Owner Case")
+    case.vulnerability_reports.append(report_id)
+    case.actor_participant_index[owner_id] = owner_participant.id_
+    dl.create(owner_participant)
+
+    if manager_id is not None:
+        manager_participant = CaseParticipant(
+            attributed_to=manager_id,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        case.actor_participant_index[manager_id] = manager_participant.id_
+        dl.create(manager_participant)
+
+    dl.create(case)
+    return case
+
+
+class TestSvcCloseCaseUseCase(_ReportTriggerBase):
+    """execute() path tests for SvcCloseCaseUseCase (primary rename).
+
+    The vendor actor is seeded as CASE_OWNER so CheckCaseOwner passes.
+    SvcCloseReportUseCase is also imported to verify the backward-compat alias.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.vendor, self.dl = _make_actor_dl("Vendor Co")
+        self.finder, self.finder_dl = _make_actor_dl("Finder Co")
+        self.case_actor, self.case_actor_dl = _make_actor_dl("Case Actor")
+
+        self.report = as_VulnerabilityReport(
+            name="CVE-TEST",
+            content="Vulnerability report content",
+            attributed_to=self.finder.id_,
+        )
+        self.dl.create(self.report)
+
+        self.offer = _make_offer(
+            self.dl,
+            self.report,
+            self.vendor.id_,
+            actor_id=self.finder.id_,
+        )
+
+        # vendor is CASE_OWNER; case_actor is CASE_MANAGER for routing
+        self.owner_case = _make_case_with_case_owner(
+            self.dl,
+            owner_id=self.vendor.id_,
+            manager_id=self.case_actor.id_,
+            report_id=self.report.id_,
+        )
+
+        yield
+        self.dl.clear_all()
+        self.dl.close()
+        self.finder_dl.clear_all()
+        self.finder_dl.close()
+        self.case_actor_dl.clear_all()
+        self.case_actor_dl.close()
+        reset_datalayer(self.vendor.id_)
+        reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
+
+    def test_close_case_returns_activity_dict(self):
         """execute() returns result['activity'] as Reject(Offer) dict (DL-06-001)."""
         request = CloseReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
         )
-        result = SvcCloseReportUseCase(
+        result = SvcCloseCaseUseCase(
             self.dl,
             request,
             trigger_activity=TriggerActivityAdapter(self.dl),
@@ -547,20 +628,52 @@ class TestSvcCloseReportUseCase(_ReportTriggerBase):
         assert result.get("activity") is not None
         assert result["activity"].get("type") == "Reject"
 
-    def test_close_report_queues_activity_in_outbox(self):
+    def test_close_case_queues_activity_in_outbox(self):
         """execute() enqueues at least one activity in the actor's outbox."""
         request = CloseReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
         )
         before = set(self.dl.outbox_list_for_actor(self.vendor.id_))
-        SvcCloseReportUseCase(
+        SvcCloseCaseUseCase(
             self.dl,
             request,
             trigger_activity=TriggerActivityAdapter(self.dl),
         ).execute()
         after = set(self.dl.outbox_list_for_actor(self.vendor.id_))
         assert len(after - before) >= 1
+
+    def test_backward_compat_alias_works(self):
+        """SvcCloseReportUseCase alias delegates to SvcCloseCaseUseCase."""
+        assert SvcCloseReportUseCase is SvcCloseCaseUseCase
+
+    def test_close_case_raises_when_no_linked_case(self):
+        """VultronNotFoundError raised when report has no linked VulnerabilityCase."""
+        vendor2, dl2 = _make_actor_dl("Vendor2 Co")
+        try:
+            report2 = as_VulnerabilityReport(
+                name="Unlinked",
+                content="No case",
+                attributed_to=vendor2.id_,
+            )
+            dl2.create(report2)
+            offer2 = _make_offer(
+                dl2, report2, vendor2.id_, actor_id=vendor2.id_
+            )
+            request = CloseReportTriggerRequest(
+                actor_id=vendor2.id_,
+                offer_id=offer2.id_,
+            )
+            with pytest.raises(VultronNotFoundError):
+                SvcCloseCaseUseCase(
+                    dl2,
+                    request,
+                    trigger_activity=TriggerActivityAdapter(dl2),
+                ).execute()
+        finally:
+            dl2.clear_all()
+            dl2.close()
+            reset_datalayer(vendor2.id_)
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/use_cases/triggers/test_report_triggers.py
+++ b/test/core/use_cases/triggers/test_report_triggers.py
@@ -24,8 +24,6 @@ execute() path against a real in-memory DataLayer and asserts:
   3. the documented failure modes the use case is documented to raise.
 """
 
-from typing import Any
-
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import (
@@ -43,15 +41,12 @@ from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.core.models._helpers import _report_phase_status_id
 from vultron.core.use_cases.triggers.report import (
-    SvcCloseCaseUseCase,
-    SvcCloseReportUseCase,
     SvcInvalidateReportUseCase,
     SvcRejectReportUseCase,
     SvcSubmitReportUseCase,
     SvcValidateReportUseCase,
 )
 from vultron.core.use_cases.triggers.requests import (
-    CloseReportTriggerRequest,
     InvalidateReportTriggerRequest,
     RejectReportTriggerRequest,
     SubmitReportTriggerRequest,
@@ -418,7 +413,7 @@ class TestSvcValidateReportUseCase:
 
 
 # ---------------------------------------------------------------------------
-# SvcInvalidateReportUseCase / SvcRejectReportUseCase / SvcCloseReportUseCase
+# SvcInvalidateReportUseCase / SvcRejectReportUseCase
 # ---------------------------------------------------------------------------
 
 
@@ -530,150 +525,6 @@ class TestSvcRejectReportUseCase(_ReportTriggerBase):
         ).execute()
         after = set(self.dl.outbox_list_for_actor(self.vendor.id_))
         assert len(after - before) >= 1
-
-
-def _make_case_with_case_owner(
-    dl: SqliteDataLayer,
-    owner_id: str,
-    report_id: str,
-    manager_id: str | None = None,
-) -> "Any":
-    """Build a VulnerabilityCase where *owner_id* holds CVDRole.CASE_OWNER.
-
-    If *manager_id* is provided, also seed a CASE_MANAGER participant so that
-    ``EmitCloseReportActivity`` can route the outbound activity.
-    """
-    from vultron.core.models.case_participant import CaseParticipant
-    from vultron.core.models.case import VulnerabilityCase
-
-    owner_participant = CaseParticipant(
-        attributed_to=owner_id,
-        case_roles=[CVDRole.CASE_OWNER],
-    )
-    case = VulnerabilityCase(name="Owner Case")
-    case.vulnerability_reports.append(report_id)
-    case.actor_participant_index[owner_id] = owner_participant.id_
-    dl.create(owner_participant)
-
-    if manager_id is not None:
-        manager_participant = CaseParticipant(
-            attributed_to=manager_id,
-            case_roles=[CVDRole.CASE_MANAGER],
-        )
-        case.actor_participant_index[manager_id] = manager_participant.id_
-        dl.create(manager_participant)
-
-    dl.create(case)
-    return case
-
-
-class TestSvcCloseCaseUseCase(_ReportTriggerBase):
-    """execute() path tests for SvcCloseCaseUseCase (primary rename).
-
-    The vendor actor is seeded as CASE_OWNER so CheckCaseOwner passes.
-    SvcCloseReportUseCase is also imported to verify the backward-compat alias.
-    """
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.vendor, self.dl = _make_actor_dl("Vendor Co")
-        self.finder, self.finder_dl = _make_actor_dl("Finder Co")
-        self.case_actor, self.case_actor_dl = _make_actor_dl("Case Actor")
-
-        self.report = as_VulnerabilityReport(
-            name="CVE-TEST",
-            content="Vulnerability report content",
-            attributed_to=self.finder.id_,
-        )
-        self.dl.create(self.report)
-
-        self.offer = _make_offer(
-            self.dl,
-            self.report,
-            self.vendor.id_,
-            actor_id=self.finder.id_,
-        )
-
-        # vendor is CASE_OWNER; case_actor is CASE_MANAGER for routing
-        self.owner_case = _make_case_with_case_owner(
-            self.dl,
-            owner_id=self.vendor.id_,
-            manager_id=self.case_actor.id_,
-            report_id=self.report.id_,
-        )
-
-        yield
-        self.dl.clear_all()
-        self.dl.close()
-        self.finder_dl.clear_all()
-        self.finder_dl.close()
-        self.case_actor_dl.clear_all()
-        self.case_actor_dl.close()
-        reset_datalayer(self.vendor.id_)
-        reset_datalayer(self.finder.id_)
-        reset_datalayer(self.case_actor.id_)
-
-    def test_close_case_returns_activity_dict(self):
-        """execute() returns result['activity'] as Reject(Offer) dict (DL-06-001)."""
-        request = CloseReportTriggerRequest(
-            actor_id=self.vendor.id_,
-            offer_id=self.offer.id_,
-        )
-        result = SvcCloseCaseUseCase(
-            self.dl,
-            request,
-            trigger_activity=TriggerActivityAdapter(self.dl),
-        ).execute()
-
-        assert result.get("activity") is not None
-        assert result["activity"].get("type") == "Reject"
-
-    def test_close_case_queues_activity_in_outbox(self):
-        """execute() enqueues at least one activity in the actor's outbox."""
-        request = CloseReportTriggerRequest(
-            actor_id=self.vendor.id_,
-            offer_id=self.offer.id_,
-        )
-        before = set(self.dl.outbox_list_for_actor(self.vendor.id_))
-        SvcCloseCaseUseCase(
-            self.dl,
-            request,
-            trigger_activity=TriggerActivityAdapter(self.dl),
-        ).execute()
-        after = set(self.dl.outbox_list_for_actor(self.vendor.id_))
-        assert len(after - before) >= 1
-
-    def test_backward_compat_alias_works(self):
-        """SvcCloseReportUseCase alias delegates to SvcCloseCaseUseCase."""
-        assert SvcCloseReportUseCase is SvcCloseCaseUseCase
-
-    def test_close_case_raises_when_no_linked_case(self):
-        """VultronNotFoundError raised when report has no linked VulnerabilityCase."""
-        vendor2, dl2 = _make_actor_dl("Vendor2 Co")
-        try:
-            report2 = as_VulnerabilityReport(
-                name="Unlinked",
-                content="No case",
-                attributed_to=vendor2.id_,
-            )
-            dl2.create(report2)
-            offer2 = _make_offer(
-                dl2, report2, vendor2.id_, actor_id=vendor2.id_
-            )
-            request = CloseReportTriggerRequest(
-                actor_id=vendor2.id_,
-                offer_id=offer2.id_,
-            )
-            with pytest.raises(VultronNotFoundError):
-                SvcCloseCaseUseCase(
-                    dl2,
-                    request,
-                    trigger_activity=TriggerActivityAdapter(dl2),
-                ).execute()
-        finally:
-            dl2.clear_all()
-            dl2.close()
-            reset_datalayer(vendor2.id_)
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -171,12 +171,39 @@ def received_report(dl, actor, report):
 
 
 @pytest.fixture
-def accepted_report(report):
+def accepted_report(dl, report, actor):
+    """Seed the report as ready for close: actor holds CASE_OWNER in linked case."""
+    from vultron.core.models.case import VulnerabilityCase
+    from vultron.core.models.case_participant import CaseParticipant
+
+    owner_p = CaseParticipant(
+        attributed_to=actor.id_,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    case_obj = VulnerabilityCase(name="Owner Case for Close")
+    case_obj.vulnerability_reports.append(report.id_)
+    case_obj.actor_participant_index[actor.id_] = owner_p.id_
+    dl.create(owner_p)
+    _add_case_manager(case_obj, dl)
     return report
 
 
 @pytest.fixture
 def closed_report(dl, report, actor):
+    """Seed report as CLOSED (duplicate-close guard test); also needs a linked case."""
+    from vultron.core.models.case import VulnerabilityCase
+    from vultron.core.models.case_participant import CaseParticipant
+
+    owner_p = CaseParticipant(
+        attributed_to=actor.id_,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    case_obj = VulnerabilityCase(name="Owner Case for Closed")
+    case_obj.vulnerability_reports.append(report.id_)
+    case_obj.actor_participant_index[actor.id_] = owner_p.id_
+    dl.create(owner_p)
+    _add_case_manager(case_obj, dl)
+
     status = ParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.CLOSED.value),
         context=report.id_,
@@ -463,7 +490,7 @@ def test_close_report_trigger_returns_activity_dict(
     """close_report_trigger returns dict with non-None 'activity'."""
     result = TriggerService(
         dl, trigger_activity=TriggerActivityAdapter(dl)
-    ).close_report(actor.id_, offer.id_, None)
+    ).close_case(actor.id_, offer.id_, None)
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
@@ -475,7 +502,7 @@ def test_close_report_trigger_already_closed_raises_409(
     with pytest.raises(VultronInvalidStateTransitionError):
         TriggerService(
             dl, trigger_activity=TriggerActivityAdapter(dl)
-        ).close_report(actor.id_, offer.id_, None)
+        ).close_case(actor.id_, offer.id_, None)
 
 
 def test_close_report_trigger_unknown_actor_raises_404(dl, offer):

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -20,6 +20,8 @@ Tests for D5-7-TRIGNOTIFY-1: verify that trigger use cases populate the
 Spec: specs/outbox.yaml OX-03-001; specs/case-management.yaml CM-06.
 """
 
+from typing import Any
+
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import (
@@ -508,6 +510,39 @@ class TestEmbargoTriggerToField:
         assert self.vendor.id_ not in recipients
 
 
+def _make_case_with_case_owner_and_manager(
+    dl: SqliteDataLayer,
+    owner_id: str,
+    finder_id: str,
+    manager_id: str,
+) -> "Any":
+    """Create a VulnerabilityCase where *owner_id* is CASE_OWNER and *manager_id* is CASE_MANAGER."""
+    from vultron.core.models.case import VulnerabilityCase
+    from vultron.core.models.case_participant import CaseParticipant
+
+    owner_p = CaseParticipant(
+        attributed_to=owner_id,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    finder_p = CaseParticipant(
+        attributed_to=finder_id,
+        case_roles=[CVDRole.FINDER],
+    )
+    manager_p = CaseParticipant(
+        attributed_to=manager_id,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    case = VulnerabilityCase(name="Owner+Manager Case")
+    case.actor_participant_index[owner_id] = owner_p.id_
+    case.actor_participant_index[finder_id] = finder_p.id_
+    case.actor_participant_index[manager_id] = manager_p.id_
+    dl.create(owner_p)
+    dl.create(finder_p)
+    dl.create(manager_p)
+    dl.create(case)
+    return case
+
+
 # ---------------------------------------------------------------------------
 # Report trigger use cases
 # ---------------------------------------------------------------------------
@@ -552,21 +587,24 @@ class TestReportTriggerToField:
         reset_datalayer(self.vendor.id_)
 
     def test_close_report_to_field_falls_back_to_offer_actor(self):
-        """SvcCloseReportUseCase uses offer actor as to when no case exists."""
+        """SvcCloseReportUseCase raises VultronNotFoundError when no linked case.
+
+        Per issue #1854 AC-1: close-case requires a linked VulnerabilityCase;
+        without one, _prepare raises VultronNotFoundError rather than falling
+        back to the offer actor.
+        """
+        from vultron.errors import VultronNotFoundError
+
         request = CloseReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
         )
-        result = SvcCloseReportUseCase(
-            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
-        ).execute()
-
-        _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
-        recipients = _to_field(act_obj)
-
-        assert recipients is not None
-        assert self.finder.id_ in recipients
-        assert self.vendor.id_ not in recipients
+        with pytest.raises(VultronNotFoundError):
+            SvcCloseReportUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()
 
     def test_invalidate_report_to_field_falls_back_to_offer_actor(self):
         """SvcInvalidateReportUseCase uses offer actor as to when no case exists."""
@@ -605,12 +643,15 @@ class TestReportTriggerToField:
     def test_close_report_to_field_uses_case_actor_when_case_exists(
         self,
     ):
-        """SvcCloseReportUseCase routes case-scoped close to the Case Actor."""
-        case = _make_case_with_case_manager(
+        """SvcCloseReportUseCase routes case-scoped close to the Case Actor.
+
+        Per issue #1854 AC-1: vendor must be CASE_OWNER; case actor is CASE_MANAGER.
+        """
+        case = _make_case_with_case_owner_and_manager(
             self.dl,
-            self.vendor.id_,
-            self.finder.id_,
-            self.case_actor.id_,
+            owner_id=self.vendor.id_,
+            finder_id=self.finder.id_,
+            manager_id=self.case_actor.id_,
         )
         case.vulnerability_reports.append(self.report.id_)
         self.dl.save(case)
@@ -687,10 +728,30 @@ class TestReportTriggerToField:
         assert self.vendor.id_ not in recipients
 
     def test_close_report_raises_when_case_exists_without_case_manager(self):
-        """Case-scoped close fails fast when no CASE_MANAGER is resolvable."""
-        case = _make_two_actor_case(self.dl, self.vendor.id_, self.finder.id_)
+        """Case-scoped close fails when actor is CASE_OWNER but no CASE_MANAGER exists.
+
+        Per issue #1854 AC-2: CheckCaseOwner passes (vendor IS CASE_OWNER),
+        but EmitCloseReportActivity cannot route to a CASE_MANAGER → raises
+        VultronValidationError (routing failure).
+        """
+        from vultron.core.models.case import VulnerabilityCase
+        from vultron.core.models.case_participant import CaseParticipant
+
+        owner_p = CaseParticipant(
+            attributed_to=self.vendor.id_,
+            case_roles=[CVDRole.CASE_OWNER],
+        )
+        finder_p = CaseParticipant(
+            attributed_to=self.finder.id_,
+            case_roles=[CVDRole.FINDER],
+        )
+        case = VulnerabilityCase(name="No Manager Case")
         case.vulnerability_reports.append(self.report.id_)
-        self.dl.save(case)
+        case.actor_participant_index[self.vendor.id_] = owner_p.id_
+        case.actor_participant_index[self.finder.id_] = finder_p.id_
+        self.dl.create(owner_p)
+        self.dl.create(finder_p)
+        self.dl.create(case)
 
         request = CloseReportTriggerRequest(
             actor_id=self.vendor.id_,

--- a/vultron/adapters/driving/fastapi/routers/trigger_report.py
+++ b/vultron/adapters/driving/fastapi/routers/trigger_report.py
@@ -176,7 +176,7 @@ def trigger_close_report(
         TB-03-003, TB-04-001, TB-06-001, TB-06-002, TB-07-001
     """
     with domain_error_translation():
-        result = svc.close_report(actor_id, body.offer_id, body.note)
+        result = svc.close_case(actor_id, body.offer_id, body.note)
     background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
     return result
 

--- a/vultron/adapters/driving/mcp_server.py
+++ b/vultron/adapters/driving/mcp_server.py
@@ -35,7 +35,7 @@ from vultron.core.use_cases.triggers.embargo import (
     SvcTerminateEmbargoUseCase,
 )
 from vultron.core.use_cases.triggers.report import (
-    SvcCloseReportUseCase,
+    SvcCloseCaseUseCase,
     SvcInvalidateReportUseCase,
     SvcRejectReportUseCase,
     SvcValidateReportUseCase,
@@ -101,7 +101,7 @@ def mcp_close_report(
     request = CloseReportTriggerRequest(
         actor_id=actor_id, offer_id=offer_id, note=note
     )
-    return SvcCloseReportUseCase(dl, request, trigger_activity).execute()
+    return SvcCloseCaseUseCase(dl, request, trigger_activity).execute()
 
 
 def mcp_engage_case(actor_id: str, case_id: str) -> dict[str, Any]:

--- a/vultron/core/behaviors/report/close_report_tree.py
+++ b/vultron/core/behaviors/report/close_report_tree.py
@@ -22,7 +22,7 @@ type).
 
 Case closure in Vultron is always Case Owner-triggered: the Case Owner (or
 Case Manager acting on their behalf) issues a ``Leave(VulnerabilityCase)``
-activity, which flows through :func:`create_close_report_trigger_tree`.
+activity, which flows through :func:`create_close_case_trigger_tree`.
 There is no autonomous close path because:
 
 - Standard simulator closure criteria (CS.DEPLOYED, RM.DEFERRED, RM.INVALID)
@@ -36,9 +36,9 @@ Its intended future use is: a Sentinel backend injected via
 objective close conditions are met, and posts an observational note to the
 Case Owner.  The Case Owner then issues the ``Leave`` voluntarily.
 
-``PreCloseAction`` (the pre-close Actuator) belongs in
-:func:`create_close_report_trigger_tree`, wired between the
-``CheckReportNotClosed`` guard and ``TransitionRMtoClosed`` (issue #1253 T1).
+``PreCloseAction`` (the pre-close Actuator) is wired in
+:func:`create_close_case_trigger_tree` (completed in #1854), between the
+``CheckReportNotClosed`` guard and ``TransitionRMtoClosed``.
 
 Nodes hosted here
 -----------------
@@ -76,11 +76,11 @@ def create_close_report_tree(
     injection seam for a future Close Readiness Monitoring Sentinel.  The
     DETERMINISTIC default (``AlwaysFail``) is correct: this tree should not
     fire unless a real Sentinel backend is injected — case closure is always
-    Case Owner-triggered via :func:`create_close_report_trigger_tree`.
+    Case Owner-triggered via :func:`create_close_case_trigger_tree`.
 
     The ``pre_close_action_factory`` bundle field is not wired here;
-    ``PreCloseAction`` belongs in :func:`create_close_report_trigger_tree`
-    (see IDEA-1253 T1 and ``notes/bt-fuzzer-rm-closure.md``).
+    ``PreCloseAction`` is wired in :func:`create_close_case_trigger_tree`
+    (completed in #1854 — see ``notes/bt-fuzzer-rm-closure.md``).
 
     Args:
         case_id: ID of VulnerabilityCase being processed.

--- a/vultron/core/behaviors/report/trigger_report_trees.py
+++ b/vultron/core/behaviors/report/trigger_report_trees.py
@@ -184,8 +184,8 @@ def create_close_case_trigger_tree(
 
         CloseCaseTriggerBT (Sequence)
         ├─ CheckCaseOwner           # guard: FAILURE if actor is not CASE_OWNER
-        ├─ PreCloseAction           # Actuator call-out; default = AlwaysSucceed
         ├─ CheckReportNotClosed     # guard: FAILURE + error if already CLOSED
+        ├─ PreCloseAction           # Actuator call-out; default = AlwaysSucceed
         ├─ EmitCloseReportActivity  # emit activity + queue in outbox
         └─ TransitionRMtoClosed     # persist report-phase RM.CLOSED
 
@@ -229,11 +229,11 @@ def create_close_case_trigger_tree(
                 case_id=case_id,
                 name="CheckCaseOwner",
             ),
-            pre_close_node,
             CheckReportNotClosed(
                 report_id=report_id,
                 result_out=result_out,
             ),
+            pre_close_node,
             EmitCloseReportActivity(
                 offer_id=offer_id,
                 report_id=report_id,
@@ -246,8 +246,7 @@ def create_close_case_trigger_tree(
         ],
     )
     logger.debug(
-        "Created CloseCaseTriggerBT for actor=%s case=%s offer=%s report=%s",
-        actor_id,
+        "Created CloseCaseTriggerBT for case=%s offer=%s report=%s",
         case_id,
         offer_id,
         report_id,

--- a/vultron/core/behaviors/report/trigger_report_trees.py
+++ b/vultron/core/behaviors/report/trigger_report_trees.py
@@ -21,19 +21,27 @@ operations:
 
 - ``InvalidateReport`` — emit TentativeReject activity + transition RM → INVALID
 - ``RejectReport``     — emit CloseReport activity + transition RM → CLOSED
-- ``CloseReport``      — guard (not already closed) + emit CloseReport + RM → CLOSED
+- ``CloseCase``        — Case Owner guard + PreCloseAction hook +
+                         guard (not already closed) + emit CloseReport + RM → CLOSED
 
 Trees are run via ``BTBridge.execute_with_setup()`` in the corresponding
 trigger use case.
 
 Per issue #849 AC-1 through AC-3 and specs/behavior-tree-integration.yaml
 BT-15-001, BT-15-002.
+Per issue #1854 AC-1 through AC-5: CheckCaseOwner guard, PreCloseAction
+call-out point, and rename to ``create_close_case_trigger_tree`` /
+``SvcCloseCaseUseCase``.
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import py_trees
 
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckIsCaseOwnerNode,
+)
 from vultron.core.behaviors.report.nodes.conditions import CheckReportNotClosed
 from vultron.core.behaviors.report.nodes.emit import (
     EmitCloseReportActivity,
@@ -44,6 +52,11 @@ from vultron.core.behaviors.report.nodes.rm_transitions import (
     TransitionRMtoClosed,
     TransitionRMtoInvalid,
 )
+
+if TYPE_CHECKING:
+    from vultron.core.behaviors.call_out.bundles.close_report import (
+        CloseReportCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -146,32 +159,43 @@ def create_reject_report_trigger_tree(
     return root
 
 
-def create_close_report_trigger_tree(
+def create_close_case_trigger_tree(
+    actor_id: str,
+    case_id: str,
     offer_id: str,
     report_id: str,
     result_out: dict,
     captured: dict | None = None,
+    call_out: "CloseReportCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
-    """Create the BT for the close-report trigger workflow.
+    """Create the BT for the close-case trigger workflow.
 
-    Guards against duplicate-close, emits ``RmCloseReportActivity``, and
-    records the actor's RM state as CLOSED.  On a duplicate-close attempt
-    ``CheckReportNotClosed`` writes a
+    Guards that only the Case Owner may close the case, runs the
+    ``PreCloseAction`` Actuator call-out hook, guards against
+    duplicate-close, emits ``RmCloseReportActivity``, and records the
+    actor's RM state as CLOSED.
+
+    On a duplicate-close attempt ``CheckReportNotClosed`` writes a
     :class:`~vultron.errors.VultronInvalidStateTransitionError` into
     ``result_out["error"]`` so the calling use case can re-raise the domain
     exception.
 
     Structure::
 
-        CloseReportTriggerBT (Sequence)
+        CloseCaseTriggerBT (Sequence)
+        ├─ CheckCaseOwner           # guard: FAILURE if actor is not CASE_OWNER
+        ├─ PreCloseAction           # Actuator call-out; default = AlwaysSucceed
         ├─ CheckReportNotClosed     # guard: FAILURE + error if already CLOSED
         ├─ EmitCloseReportActivity  # emit activity + queue in outbox
         └─ TransitionRMtoClosed     # persist report-phase RM.CLOSED
 
     Per issue #849 AC-3: the duplicate-close guard is a BT condition node, not
     a procedural ``raise`` in ``execute()``.
+    Per issue #1854 AC-1/AC-2: CheckCaseOwner guard and PreCloseAction wired.
 
     Args:
+        actor_id: ID of the actor attempting to close the case.
+        case_id: ID of the VulnerabilityCase to close.
         offer_id: ID of the Offer being closed.
         report_id: ID of the VulnerabilityReport.
         result_out: Mutable dict for surfacing domain errors back to the caller.
@@ -180,9 +204,73 @@ def create_close_report_trigger_tree(
             closed.
         captured: Optional dict; ``captured["activity"]`` is set to the
             serialised activity dict on success (DL-06-001, AC-1).
+        call_out: Optional :class:`~vultron.core.behaviors.call_out.bundles
+            .close_report.CloseReportCallOutBundle` supplying a custom
+            ``pre_close_action_factory``.  Defaults to
+            :data:`~vultron.core.behaviors.call_out.bundles.close_report
+            .CLOSE_REPORT_DETERMINISTIC` (``AlwaysSucceed``).
 
     Returns:
-        Root node of the ``CloseReportTriggerBT`` Sequence.
+        Root node of the ``CloseCaseTriggerBT`` Sequence.
+    """
+    from vultron.core.behaviors.call_out.bundles.close_report import (
+        CLOSE_REPORT_DETERMINISTIC,
+    )
+
+    bundle = call_out if call_out is not None else CLOSE_REPORT_DETERMINISTIC
+    pre_close_node = bundle.pre_close_action_factory("PreCloseAction")
+
+    root = py_trees.composites.Sequence(
+        name="CloseCaseTriggerBT",
+        memory=False,
+        children=[
+            CheckIsCaseOwnerNode(
+                sender_actor_id=actor_id,
+                case_id=case_id,
+                name="CheckCaseOwner",
+            ),
+            pre_close_node,
+            CheckReportNotClosed(
+                report_id=report_id,
+                result_out=result_out,
+            ),
+            EmitCloseReportActivity(
+                offer_id=offer_id,
+                report_id=report_id,
+                captured=captured,
+            ),
+            TransitionRMtoClosed(
+                report_id=report_id,
+                offer_id=offer_id,
+            ),
+        ],
+    )
+    logger.debug(
+        "Created CloseCaseTriggerBT for actor=%s case=%s offer=%s report=%s",
+        actor_id,
+        case_id,
+        offer_id,
+        report_id,
+    )
+    return root
+
+
+def create_close_report_trigger_tree(
+    offer_id: str,
+    report_id: str,
+    result_out: dict,
+    captured: dict | None = None,
+) -> py_trees.behaviour.Behaviour:
+    """Deprecated alias for :func:`create_close_case_trigger_tree`.
+
+    .. deprecated::
+        Use :func:`create_close_case_trigger_tree` directly.  This shim
+        exists only for callers that have not yet been updated; it omits the
+        ``actor_id`` / ``case_id`` / ``call_out`` parameters and therefore
+        bypasses the ``CheckCaseOwner`` guard and ``PreCloseAction`` hook.
+
+    Returns:
+        Root node of the ``CloseReportTriggerBT`` Sequence (legacy structure).
     """
     root = py_trees.composites.Sequence(
         name="CloseReportTriggerBT",
@@ -204,7 +292,7 @@ def create_close_report_trigger_tree(
         ],
     )
     logger.debug(
-        "Created CloseReportTriggerBT for offer=%s report=%s",
+        "Created CloseReportTriggerBT (legacy) for offer=%s report=%s",
         offer_id,
         report_id,
     )

--- a/vultron/core/ports/trigger_service.py
+++ b/vultron/core/ports/trigger_service.py
@@ -77,6 +77,13 @@ class TriggerServicePort(Protocol):
         note: str | None = None,
     ) -> dict[str, Any]: ...
 
+    def close_case(
+        self,
+        actor_id: str,
+        offer_id: str,
+        note: str | None = None,
+    ) -> dict[str, Any]: ...
+
     def close_report(
         self,
         actor_id: str,

--- a/vultron/core/use_cases/triggers/report.py
+++ b/vultron/core/use_cases/triggers/report.py
@@ -30,7 +30,7 @@ from typing import Any, cast
 import py_trees.behaviour
 
 from vultron.core.behaviors.report.trigger_report_trees import (
-    create_close_report_trigger_tree,
+    create_close_case_trigger_tree,
     create_invalidate_report_trigger_tree,
     create_reject_report_trigger_tree,
     submit_report_trigger_bt,
@@ -175,8 +175,14 @@ class SvcRejectReportUseCase(SvcBTTriggerBase):
         )
 
 
-class SvcCloseReportUseCase(SvcBTTriggerBase):
-    """Close a report via the RM lifecycle (RM → C transition)."""
+class SvcCloseCaseUseCase(SvcBTTriggerBase):
+    """Close a VulnerabilityCase via the RM lifecycle (RM → C transition).
+
+    Only the Case Owner may close the case.  The ``case_id`` is resolved
+    from the ``VulnerabilityCase`` linked to the report at ``_prepare`` time
+    and injected into the BT via ``_extra_execute_kwargs`` so that
+    ``CheckIsCaseOwnerNode`` can validate the CASE_OWNER role.
+    """
 
     def _prepare(self) -> None:
         request = cast(CloseReportTriggerRequest, self._request)
@@ -185,25 +191,40 @@ class SvcCloseReportUseCase(SvcBTTriggerBase):
         self._offer, self._report = _resolve_offer_and_report(
             request.offer_id, self._dl
         )
+        case = self._dl.find_case_by_report_id(self._report.id_)
+        if case is None:
+            raise VultronNotFoundError(
+                "VulnerabilityCase", f"linked to report {self._report.id_}"
+            )
+        self._case_id: str = case.id_
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
-        return create_close_report_trigger_tree(
+        return create_close_case_trigger_tree(
+            actor_id=self._actor_id,
+            case_id=self._case_id,
             offer_id=self._offer.offer_id,
             report_id=self._report.id_,
             result_out=self._result_out,
             captured=self._captured,
         )
 
+    def _extra_execute_kwargs(self) -> dict:
+        return {"case_id": self._case_id}
+
     def _handle_result(self) -> None:
         request = cast(CloseReportTriggerRequest, self._request)
         logger.info(
-            "Actor '%s' closed offer '%s' (report '%s') via RM lifecycle;"
-            " note: %s",
+            "Actor '%s' closed case '%s' (offer '%s', report '%s')"
+            " via RM lifecycle; note: %s",
             self._actor_id,
+            self._case_id,
             self._offer.offer_id,
             self._report.id_,
             request.note,
         )
+
+
+SvcCloseReportUseCase = SvcCloseCaseUseCase
 
 
 class SvcSubmitReportUseCase(SvcBTTriggerBase):

--- a/vultron/core/use_cases/triggers/service.py
+++ b/vultron/core/use_cases/triggers/service.py
@@ -65,7 +65,7 @@ from vultron.core.use_cases.triggers.embargo import (
 )
 from vultron.core.use_cases.triggers.note import SvcAddNoteToCaseUseCase
 from vultron.core.use_cases.triggers.report import (
-    SvcCloseReportUseCase,
+    SvcCloseCaseUseCase,
     SvcInvalidateReportUseCase,
     SvcRejectReportUseCase,
     SvcSubmitReportUseCase,
@@ -194,19 +194,28 @@ class TriggerService:
             self._dl, req, trigger_activity=self._trigger_activity
         ).execute()
 
+    def close_case(
+        self,
+        actor_id: str,
+        offer_id: str,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Close a VulnerabilityCase via the RM lifecycle (Case Owner only)."""
+        req = CloseReportTriggerRequest(
+            actor_id=actor_id, offer_id=offer_id, note=note
+        )
+        return SvcCloseCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
+
     def close_report(
         self,
         actor_id: str,
         offer_id: str,
         note: str | None = None,
     ) -> dict[str, Any]:
-        """Close a report that has progressed through the RM lifecycle."""
-        req = CloseReportTriggerRequest(
-            actor_id=actor_id, offer_id=offer_id, note=note
-        )
-        return SvcCloseReportUseCase(
-            self._dl, req, trigger_activity=self._trigger_activity
-        ).execute()
+        """Deprecated alias for :meth:`close_case`."""
+        return self.close_case(actor_id, offer_id, note)
 
     # -----------------------------------------------------------------------
     # Case triggers


### PR DESCRIPTION
- Closes #1854

## Summary

- Wires `PreCloseAction` Actuator call-out point and `CheckCaseOwner` guard into the close-case trigger BT
- Renames `create_close_report_trigger_tree` → `create_close_case_trigger_tree` and `SvcCloseReportUseCase` → `SvcCloseCaseUseCase`; backward-compat aliases kept
- Updates all callers: service.py, TriggerServicePort, FastAPI router, MCP adapter, and test suite

## Changes

**`trigger_report_trees.py`** — new `create_close_case_trigger_tree` with 5-node Sequence:
`CheckCaseOwner → CheckReportNotClosed → PreCloseAction → EmitCloseReportActivity → TransitionRMtoClosed`

**`use_cases/triggers/report.py`** — `SvcCloseCaseUseCase` with `_prepare` resolving `case_id` via `find_case_by_report_id` (raises `VultronNotFoundError` if none); `_extra_execute_kwargs` injects `case_id` into BTBridge blackboard

**`use_cases/triggers/service.py`** — `close_case` as primary method; `close_report` delegates as deprecated alias

**`ports/trigger_service.py`** — `close_case` added to `TriggerServicePort` Protocol

**Adapters** — FastAPI router and MCP server call `close_case` / `SvcCloseCaseUseCase`

**Tests** — full coverage: CASE_OWNER success, non-CASE_OWNER failure, already-closed 409, no-trigger-activity failure, no-linked-case VultronNotFoundError, custom call_out bundle injection

## Verification

- `uv run pytest` — 5942 passed, 265 skipped, 2 xfailed
- `uv run mypy` — no issues in 1129 source files
- `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)