### PR TITLE
docs: plan issue #1255 — do-work-tree factory is obsolete

### DIFF
--- a/notes/do-work-behaviors.md
+++ b/notes/do-work-behaviors.md
@@ -113,6 +113,48 @@ non-implemented sub-behaviors as named placeholder nodes in the BTs.
 
 ---
 
+## Do-Work as Triggerable Use Cases (Design Direction)
+
+The simulation's `RMDoWorkBt` Fallback (see
+`vultron/bt/report_management/_behaviors/do_work.py`) composed eight
+sub-behaviors into a single BT subtree: `AcquireExploit`, `AssignVulID`,
+`Deployment`, `DevelopFix`, `MonitorThreats`, `Publication`,
+`MaybeReportToOthers`, and `OtherWork`.
+
+As the reference implementation has matured, this structure has proven to be
+an artifact of the simulation layer rather than a model to replicate in
+`vultron/core/`. The individual sub-behaviors have migrated in two directions:
+
+1. **Triggerable use cases** — behaviors such as deploy-fix, develop-fix,
+   publication, and report-to-others are better expressed as discrete use
+   cases (each with its own core factory function) that an external actor,
+   API call, or sentinel agent can trigger when preconditions are met.
+
+2. **Sentinel / event-detection touchpoints** — behaviors like
+   `MonitorThreats` cannot be automated inside Vultron; they require an
+   external sentinel agent that observes the environment and calls back into
+   the system when it detects a relevant event (e.g., a public exploit,
+   an attack in the wild).
+
+**Consequence**: A `create_do_work_tree` factory function that replicates
+the `RMDoWorkBt` compositor is **not needed** in the reference implementation.
+The role of the old compositor is replaced by:
+
+- Individual factory functions in `vultron/core/behaviors/report/` for each
+  triggerable sub-behavior (most already exist).
+- Specialized sentinel agents (outside `vultron/core/`) that recognize when
+  a case-relevant event has occurred and trigger the appropriate use case.
+
+The `OtherWork` placeholder node (an extensibility hook for unmodeled
+activities) similarly has no direct core equivalent: anything that was
+`OtherWork` in the simulation is either a future triggerable use case or a
+future sentinel agent touchpoint. No `AlwaysSucceed` placeholder is needed
+in the core layer.
+
+**See also**: `specs/triggerable-behaviors.yaml`, `notes/agentic-workflow.md`.
+
+---
+
 ## Partially Implementable Behaviors
 
 The following behaviors can be partially supported by the application:

--- a/plan/history/2607/idea/IDEA-1255.md
+++ b/plan/history/2607/idea/IDEA-1255.md
@@ -1,0 +1,22 @@
+---
+source: IDEA-1255
+timestamp: '2026-07-31T18:41:13.545928+00:00'
+title: create_do_work_tree — do-work-tree factory is obsolete
+type: idea
+---
+
+After reviewing the current state of `vultron/core/behaviors/report/`, the
+proposed `create_do_work_tree` factory was found to be obsolete. The
+simulation's `RMDoWorkBt` compositor (eight-child Fallback) was an artifact
+of the simulator layer. Its sub-behaviors have migrated to two patterns in
+the reference implementation: (1) individual triggerable use-case factory
+functions (most already exist in `vultron/core/behaviors/report/`), and (2)
+sentinel agent touchpoints for behaviors Vultron cannot automate internally
+(e.g., MonitorThreats). The `OtherWork` extensibility stub similarly has no
+direct core equivalent. `notes/do-work-behaviors.md` was updated to document
+this design direction.
+
+No implementation issues were created — the idea is fully resolved by the
+design decision recorded in the notes.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1881>


### PR DESCRIPTION
## Summary

Plans and closes #1255 (`[Idea] create_do_work_tree: factory function for other-work BT`).

After reviewing the current state of the reference implementation, the proposed `create_do_work_tree` factory is **obsolete**. The simulation's `RMDoWorkBt` compositor was an artifact of the simulator layer; its sub-behaviors have migrated in two directions:

- **Triggerable use cases** — individual factory functions in `vultron/core/behaviors/report/` (most already exist)
- **Sentinel / event-detection touchpoints** — external agents that observe the environment and call back into the system

The `OtherWork` extensibility hook similarly has no direct core equivalent: any unmodeled work is either a future triggerable use case or a future sentinel agent touchpoint. No `AlwaysSucceed` placeholder is needed in the core layer.

## Changes

- `notes/do-work-behaviors.md` — added "Do-Work as Triggerable Use Cases" section documenting the design direction and the reasons `create_do_work_tree` is not needed

## No implementation issues created

The idea is obsolete; no impl issues are warranted.

Closes #1255