### PR TITLE
fix(pec): allow ACCEPT/DECLINE directly from NO_EMBARGO (ADR-0048)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1865.md
+++ b/plan/history/2607/implementation/ISSUE-1865.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1865
+timestamp: '2026-07-31T18:41:56.330560+00:00'
+title: 'fix(pec): allow ACCEPT/DECLINE directly from NO_EMBARGO'
+type: implementation
+---
+
+## Issue #1865 — fix(pec): allow ACCEPT/DECLINE directly from NO_EMBARGO (ADR-0048)
+
+Added `ACCEPT: NO_EMBARGO → SIGNATORY` and `DECLINE: NO_EMBARGO → DECLINED`
+to the PEC FSM. Fixed `_SignEmbargoConsentLeafNode` which hardcoded `PEC.NO_EMBARGO`
+instead of using `participant.embargo_consent_state`, causing a silent CM-10-001
+violation. Added regression tests covering all starting states (NO_EMBARGO,
+INVITED, LAPSED, SIGNATORY).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1882>

--- a/test/core/behaviors/case/test_accept_invite_tree.py
+++ b/test/core/behaviors/case/test_accept_invite_tree.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Regression tests for _SignEmbargoConsentLeafNode (ADR-0048, CM-10-001).
+
+AC-4: The invitee MUST reach PEC.SIGNATORY after signing embargo consent.
+This test MUST fail on main before the fix and pass after.
+"""
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.case.accept_invite_tree import (
+    _SignEmbargoConsentLeafNode,
+)
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.states.participant_embargo_consent import PEC
+from test.core.behaviors.bt_harness import BTTestScenario
+
+_ACTOR_ID = "https://example.org/actors/invitee"
+_EMBARGO_ID = "https://example.org/embargoes/embargo-001"
+
+
+def _run_sign_node(
+    bt_scenario: BTTestScenario,
+    starting_pec: PEC,
+) -> tuple[Status, CaseParticipant]:
+    """Create a CaseParticipant at ``starting_pec``, run the sign node, return result."""
+    participant = CaseParticipant(
+        id_=_ACTOR_ID,
+        attributed_to=_ACTOR_ID,
+        embargo_consent_state=starting_pec,
+    )
+
+    node = _SignEmbargoConsentLeafNode(invitee_id=_ACTOR_ID)
+
+    result = bt_scenario.run(
+        node,
+        actor_id=_ACTOR_ID,
+        new_invite_participant=participant,
+        active_embargo_id=_EMBARGO_ID,
+    )
+    return result.status, participant
+
+
+class TestSignEmbargoConsentLeafNode:
+    """_SignEmbargoConsentLeafNode must set invitee to SIGNATORY (CM-10-001)."""
+
+    def test_invitee_reaches_signatory_from_no_embargo(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Regression: invitee starting at NO_EMBARGO must reach SIGNATORY.
+
+        Before the ADR-0048 fix, apply_pec_trigger(NO_EMBARGO, ACCEPT)
+        returned NO_EMBARGO unchanged and the node logged success while
+        leaving consent unrecorded — CM-10-001 violated.
+        """
+        status, participant = _run_sign_node(
+            bt_scenario, starting_pec=PEC.NO_EMBARGO
+        )
+        assert status == Status.SUCCESS
+        assert participant.embargo_consent_state == PEC.SIGNATORY
+
+    def test_invitee_reaches_signatory_from_invited(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Invitee who was formally INVITED also reaches SIGNATORY."""
+        status, participant = _run_sign_node(
+            bt_scenario, starting_pec=PEC.INVITED
+        )
+        assert status == Status.SUCCESS
+        assert participant.embargo_consent_state == PEC.SIGNATORY
+
+    def test_invitee_reaches_signatory_from_lapsed(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Invitee who LAPSED (embargo revised) can re-consent without a new invite."""
+        status, participant = _run_sign_node(
+            bt_scenario, starting_pec=PEC.LAPSED
+        )
+        assert status == Status.SUCCESS
+        assert participant.embargo_consent_state == PEC.SIGNATORY
+
+    def test_already_signatory_is_no_op(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Participant already SIGNATORY: ACCEPT is invalid, state unchanged."""
+        status, participant = _run_sign_node(
+            bt_scenario, starting_pec=PEC.SIGNATORY
+        )
+        # apply_pec_trigger returns the state unchanged on an invalid trigger
+        assert status == Status.SUCCESS
+        assert participant.embargo_consent_state == PEC.SIGNATORY
+
+    def test_embargo_id_recorded_on_participant(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """The active embargo ID is appended to accepted_embargo_ids."""
+        _, participant = _run_sign_node(
+            bt_scenario, starting_pec=PEC.NO_EMBARGO
+        )
+        assert _EMBARGO_ID in participant.accepted_embargo_ids
+
+    def test_failure_when_participant_missing(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """FAILURE returned when new_invite_participant is absent."""
+        node = _SignEmbargoConsentLeafNode(invitee_id=_ACTOR_ID)
+        result = bt_scenario.run(
+            node,
+            actor_id=_ACTOR_ID,
+            active_embargo_id=_EMBARGO_ID,
+        )
+        assert result.status == Status.FAILURE
+
+    def test_failure_when_embargo_id_missing(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """FAILURE returned when active_embargo_id is absent."""
+        participant = CaseParticipant(
+            id_=_ACTOR_ID,
+            attributed_to=_ACTOR_ID,
+            embargo_consent_state=PEC.NO_EMBARGO,
+        )
+        node = _SignEmbargoConsentLeafNode(invitee_id=_ACTOR_ID)
+        result = bt_scenario.run(
+            node,
+            actor_id=_ACTOR_ID,
+            new_invite_participant=participant,
+        )
+        assert result.status == Status.FAILURE

--- a/test/core/models/test_dimensions.py
+++ b/test/core/models/test_dimensions.py
@@ -186,9 +186,10 @@ class TestPecDimension:
         assert d2.state == PEC.INVITED
 
     def test_transition_invalid_raises(self):
-        d = PecDimension(state=PEC.NO_EMBARGO)
+        # CM-18-004: SIGNATORY → INVITED is still invalid (ADR-0048)
+        d = PecDimension(state=PEC.SIGNATORY)
         with pytest.raises(VultronInvalidStateTransitionError):
-            d.transition(PEC_Trigger.ACCEPT)
+            d.transition(PEC_Trigger.INVITE)
 
     def test_is_signatory(self):
         assert PecDimension(state=PEC.SIGNATORY).is_signatory()

--- a/test/core/states/test_participant_embargo_consent.py
+++ b/test/core/states/test_participant_embargo_consent.py
@@ -86,22 +86,28 @@ class TestApplyPecTrigger:
         result = apply_pec_trigger(state, PEC_Trigger.RESET)
         assert result == PEC.NO_EMBARGO
 
-    # --- Invalid transitions return current state (no raise) ---
+    # --- ADR-0048: ACCEPT and DECLINE directly from NO_EMBARGO ---
+    def test_accept_from_no_embargo(self) -> None:
+        result = apply_pec_trigger(PEC.NO_EMBARGO, PEC_Trigger.ACCEPT)
+        assert result == PEC.SIGNATORY
+
+    def test_decline_from_no_embargo(self) -> None:
+        result = apply_pec_trigger(PEC.NO_EMBARGO, PEC_Trigger.DECLINE)
+        assert result == PEC.DECLINED
+
+    # --- CM-18-004: SIGNATORY → INVITED must remain invalid ---
     def test_invite_from_signatory_is_invalid(self) -> None:
         result = apply_pec_trigger(PEC.SIGNATORY, PEC_Trigger.INVITE)
         assert result == PEC.SIGNATORY  # unchanged
 
-    def test_accept_from_no_embargo_is_invalid(self) -> None:
-        result = apply_pec_trigger(PEC.NO_EMBARGO, PEC_Trigger.ACCEPT)
-        assert result == PEC.NO_EMBARGO  # unchanged
-
+    # --- Other invalid transitions return current state (no raise) ---
     def test_accept_from_declined_is_invalid(self) -> None:
         result = apply_pec_trigger(PEC.DECLINED, PEC_Trigger.ACCEPT)
         assert result == PEC.DECLINED  # unchanged
 
-    def test_decline_from_no_embargo_is_invalid(self) -> None:
-        result = apply_pec_trigger(PEC.NO_EMBARGO, PEC_Trigger.DECLINE)
-        assert result == PEC.NO_EMBARGO  # unchanged
+    def test_decline_from_declined_is_invalid(self) -> None:
+        result = apply_pec_trigger(PEC.DECLINED, PEC_Trigger.DECLINE)
+        assert result == PEC.DECLINED  # unchanged
 
     def test_revise_from_invited_is_invalid(self) -> None:
         result = apply_pec_trigger(PEC.INVITED, PEC_Trigger.REVISE)

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -59,7 +59,6 @@ from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import (
-    PEC,
     PEC_Trigger,
     apply_pec_trigger,
 )
@@ -492,7 +491,7 @@ class _SignEmbargoConsentLeafNode(DataLayerAction):
 
         participant.accepted_embargo_ids.append(active_embargo_id)
         participant.embargo_consent_state = apply_pec_trigger(
-            PEC.NO_EMBARGO, PEC_Trigger.ACCEPT
+            participant.embargo_consent_state, PEC_Trigger.ACCEPT
         )
         self.logger.info(
             "%s: signed embargo consent for invitee '%s' (EM.ACTIVE,"

--- a/vultron/core/states/participant_embargo_consent.py
+++ b/vultron/core/states/participant_embargo_consent.py
@@ -18,10 +18,14 @@ DECLINED    – Participant explicitly declined (current invite or lapsed terms)
 Transitions
 -----------
 INVITE  : NO_EMBARGO | LAPSED | DECLINED → INVITED
-ACCEPT  : INVITED | LAPSED → SIGNATORY
-DECLINE : INVITED | LAPSED → DECLINED
+ACCEPT  : NO_EMBARGO | INVITED | LAPSED → SIGNATORY
+DECLINE : NO_EMBARGO | INVITED | LAPSED → DECLINED
 REVISE  : SIGNATORY → LAPSED
 RESET   : * → NO_EMBARGO  (embargo terminated or removed)
+
+``NO_EMBARGO`` means *no embargo is in scope* (ADR-0048), not *pre-consent*.
+``ACCEPT`` and ``DECLINE`` are therefore valid directly from ``NO_EMBARGO``
+for self-determined embargoes and implicit-consent cases (CM-14-005).
 """
 
 #  Copyright (c) 2026 Carnegie Mellon University and Contributors.
@@ -86,14 +90,20 @@ _transitions: list[dict] = [
     PECTransition(
         trigger=PEC_Trigger.INVITE, source=PEC.DECLINED, dest=PEC.INVITED
     ).model_dump(),
-    # ACCEPT transitions
+    # ACCEPT transitions (ADR-0048: NO_EMBARGO is absence-of-embargo, not pre-consent)
+    PECTransition(
+        trigger=PEC_Trigger.ACCEPT, source=PEC.NO_EMBARGO, dest=PEC.SIGNATORY
+    ).model_dump(),
     PECTransition(
         trigger=PEC_Trigger.ACCEPT, source=PEC.INVITED, dest=PEC.SIGNATORY
     ).model_dump(),
     PECTransition(
         trigger=PEC_Trigger.ACCEPT, source=PEC.LAPSED, dest=PEC.SIGNATORY
     ).model_dump(),
-    # DECLINE transitions
+    # DECLINE transitions (ADR-0048: symmetric with ACCEPT from NO_EMBARGO)
+    PECTransition(
+        trigger=PEC_Trigger.DECLINE, source=PEC.NO_EMBARGO, dest=PEC.DECLINED
+    ).model_dump(),
     PECTransition(
         trigger=PEC_Trigger.DECLINE, source=PEC.INVITED, dest=PEC.DECLINED
     ).model_dump(),


### PR DESCRIPTION
- Closes #1865

## What changed

Per ADR-0048, `NO_EMBARGO` means *absence of embargo*, not *pre-consent*.
The PEC FSM previously blocked `ACCEPT` and `DECLINE` from `NO_EMBARGO`,
which caused a silent MUST-level failure in production code
(`_SignEmbargoConsentLeafNode` passed `PEC.NO_EMBARGO` to
`apply_pec_trigger(PEC.NO_EMBARGO, ACCEPT)`, which returned `NO_EMBARGO`
unchanged, while the node logged success — CM-10-001 violated).

### `vultron/core/states/participant_embargo_consent.py`

- Added `ACCEPT: NO_EMBARGO → SIGNATORY` (AC-1)
- Added `DECLINE: NO_EMBARGO → DECLINED` (AC-1, symmetric with ACCEPT)
- Updated module docstring transition table (AC-2)

### `vultron/core/behaviors/case/accept_invite_tree.py`

- Fixed `_SignEmbargoConsentLeafNode` to pass `participant.embargo_consent_state`
  (the actual current state) instead of hardcoded `PEC.NO_EMBARGO` to
  `apply_pec_trigger`. Removed now-unused `PEC` import.

### Tests

- `test_participant_embargo_consent.py`: replaced two stale "invalid"
  tests with tests asserting both new transitions succeed (AC-3).
  Added `test_decline_from_declined_is_invalid` in place of the removed
  `test_decline_from_no_embargo_is_invalid`.
- `test_dimensions.py`: updated `test_transition_invalid_raises` to use
  `SIGNATORY → INVITED` (CM-18-004 still enforced) instead of the now-valid
  `NO_EMBARGO → ACCEPT` (AC-5).
- `test_accept_invite_tree.py` (new): regression tests for
  `_SignEmbargoConsentLeafNode` covering NO_EMBARGO, INVITED, LAPSED,
  SIGNATORY starting states and missing-blackboard-key failure paths (AC-4).

## Audit (AC-6)

The 9 remaining consent-write sites noted in ADR-0048 (3 direct-assignment
sites + 5 `apply_pec_trigger` sites in `EmbargoLifecycle` + 1 in
`_helpers.py`) still do not persist the resulting `ParticipantStatus`.
None relied on "consent implies a prior invitation" being unreachable;
they are tracked under issue #538 (EmbargoLifecycle) and are out of scope
for this PR.

## Test plan

- `uv run pytest test/core/states/test_participant_embargo_consent.py` (25 pass)
- `uv run pytest test/core/models/test_dimensions.py::TestPecDimension` (10 pass)
- `uv run pytest test/core/behaviors/case/test_accept_invite_tree.py` (7 pass)
- `uv run pytest --tb=short` (5968 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)