### PR TITLE
fix: genesis-unavailable Announce now sends Reject instead of silent-drop (SYNC-15)

### DIFF
--- a/notes/sync-ledger-replication.md
+++ b/notes/sync-ledger-replication.md
@@ -451,6 +451,32 @@ from the beginning; each entry passes the `CheckLedgerEntryAlreadyStoredNode` ga
 
 This is tracked as issue #1446.
 
+## Genesis-Unavailable Reject (SYNC-15)
+
+`Announce(CaseLedgerEntry)` can arrive at a participant replica before
+`Create(VulnerabilityCase)` has been processed (a delivery-order race under HTTP
+BackgroundTasks). When that happens, `ReconstructChainTailNode` cannot derive the
+per-case genesis hash (CLP-08-005) and returns FAILURE.
+
+**Before the fix (issue #1873)**: FAILURE from `ReconstructChainTailNode` exited
+the `ProcessAndStore` Sequence without reaching `CheckHashOrRejectOnMismatchNode`,
+so no `Reject(CaseLedgerEntry)` was sent. The CaseActor never learned about the
+failure and never replayed the entry → permanent data loss on the replica.
+
+**After the fix**: `ReconstructChainTailNode` writes sentinel values
+(`tail_hash=""`, `tail_index=-1`) before returning FAILURE. The announce tree
+wraps the node in a Selector whose fallback is `SendRejectLogEntryNode`, so the
+Reject fires even when chain reconstruction fails. The Reject carries
+`last_accepted_hash=""` (meaning "I have no entries; replay from genesis") so
+the CaseActor re-announces all entries once the case is delivered.
+
+**Implementation**: `vultron/core/behaviors/sync/nodes/chain.py`
+(`ReconstructChainTailNode.update`) and
+`vultron/core/behaviors/sync/announce_tree.py` (`ReconstructOrRejectOnMissingCase`
+Selector). Spec: SYNC-15-001, SYNC-15-002. Regression test:
+`test/core/use_cases/received/test_sync.py::TestAnnounceLedgerEntryReceivedUseCase
+::test_missing_case_queues_reject_with_empty_tail_hash`.
+
 ## Related
 
 - `specs/sync-ledger-replication.yaml` — normative requirements

--- a/plan/history/2607/implementation/ISSUE-1873.md
+++ b/plan/history/2607/implementation/ISSUE-1873.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-1873
+timestamp: '2026-07-31T19:01:32.255399+00:00'
+title: retire silent-drop on genesis-unavailable — send Reject (SYNC-15)
+type: implementation
+---
+
+Fixes #1873. Root cause: `ReconstructChainTailNode` returned `FAILURE` when `VulnerabilityCase` was not yet seeded on the Finder replica (CLP-08-005); the `ProcessAndStore` Sequence exited before `SendRejectLogEntryNode` ran, so the `CaseLedgerEntry` was permanently dropped — the CaseActor never knew to replay.
+
+Fix: write sentinel values (`tail_hash=""`, `tail_index=-1`) to the blackboard before returning `FAILURE`; wrap `ReconstructChainTailNode` in a `ReconstructOrRejectOnMissingCase` Selector whose fallback is `SendRejectLogEntryNode`. The Reject carries `last_accepted_hash=""` (replay from genesis), matching the SYNC-08-005 pattern.
+
+Added SYNC-15 spec group (SYNC-15-001 MUST send Reject; SYNC-15-002 MUST NOT persist) and regression test `test_missing_case_queues_reject_with_empty_tail_hash`. Demo gains `wait_for_case_on_container` checkpoint before ledger coverage wait for fast CI failure isolation.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1889>

--- a/plan/incoming/learnings/20260731-async-race-windows-in-fv-demo.md
+++ b/plan/incoming/learnings/20260731-async-race-windows-in-fv-demo.md
@@ -1,0 +1,13 @@
+---
+title: fv Demo Integration has a class of async race windows beyond genesis-unavailable
+type: learning
+timestamp: 2026-07-31
+source: ISSUE-1873
+signal: concern
+---
+
+ISSUE-1873 fixed the genesis-unavailable race (Announce arrives before Create/VulnerabilityCase is seeded on the Finder replica).  The demo checkpoint `wait_for_case_on_container` reduces flakiness for that specific window.
+
+However, HTTP BackgroundTasks delivery is inherently unordered and the demo relies on `time.sleep`-based polling loops (`wait_for_contiguous_ledger_coverage`, etc.) to absorb timing jitter.  Other orderings — e.g. multiple CaseLedgerEntry Announces arriving before a non-genesis predecessor is committed — can still trigger CLP-08-005 or hash-mismatch retries that exceed the polling timeout.
+
+Candidate follow-up: review all `wait_for_*` polling loops in `fv_demo.py` for whether their timeouts are sized correctly relative to worst-case BackgroundTasks delivery latency, and whether additional per-step checkpoints would catch failures faster.

--- a/plan/incoming/learnings/20260731-claim-issue-requires-up-to-date-branch.md
+++ b/plan/incoming/learnings/20260731-claim-issue-requires-up-to-date-branch.md
@@ -1,0 +1,11 @@
+---
+title: claim-issue.sh exits non-zero when branch is behind origin/main
+type: learning
+timestamp: 2026-07-31
+source: ISSUE-1873
+signal: tooling-issue
+---
+
+`claim-issue.sh` failed with a non-zero exit code because the working branch was 16 commits behind `origin/main`.  The script apparently validates that the branch is current before labelling the issue.
+
+Fix: always run `git fetch origin main && git rebase origin/main` (or equivalent) before invoking `claim-issue.sh` if the branch has been idle for any length of time.

--- a/plan/incoming/learnings/20260731-dual-emitter-resolution-paths.md
+++ b/plan/incoming/learnings/20260731-dual-emitter-resolution-paths.md
@@ -1,0 +1,24 @@
+---
+title: Dual emitter resolution paths in outbox BackgroundTasks
+type: learning
+timestamp: 2026-07-31
+source: ISSUE-1780
+signal: design-question
+---
+
+When retiring ASGIEmitter (ISSUE-1780), a non-obvious architectural invariant surfaced: outbox delivery resolves the `ActivityEmitter` via two distinct paths, and both must be patched in tests:
+
+1. **Trigger-route BackgroundTasks** — `POST /actors/{id}/outbox/` schedules `outbox_handler(actor_id, dl)` with no emitter argument. The handler calls `get_default_emitter()` → patched via `configure_default_emitter(router)`.
+
+2. **Inbox-route BackgroundTasks** — `POST /actors/{id}/inbox/` schedules `outbox_handler(actor_id, dl, emitter=getattr(request.app.state, "emitter", None))`. If `app.state.emitter` is set, it bypasses `get_default_emitter()` entirely.
+
+The `client` fixture must patch **both** to intercept all deliveries:
+
+```python
+configure_default_emitter(router)   # covers trigger-route tasks
+api_app.state.emitter = router       # covers inbox-route tasks
+```
+
+Isolated apps (`configure_globals=False`) avoid the second path by never setting `app.state.emitter`, falling back to `get_default_emitter()` for both paths. This is why `_make_lifespan` conditionalises the emitter creation on `configure_globals`.
+
+Future developers adding new endpoints that schedule `outbox_handler` must explicitly decide which resolution path they use and ensure test fixtures cover it.

--- a/plan/incoming/learnings/20260731-sentinel-blackboard-on-failure.md
+++ b/plan/incoming/learnings/20260731-sentinel-blackboard-on-failure.md
@@ -1,0 +1,13 @@
+---
+title: Sentinel blackboard writes on BT FAILURE enable Selector fallback without re-running the failing node
+type: learning
+timestamp: 2026-07-31
+source: ISSUE-1873
+signal: design-question
+---
+
+When a py_trees Sequence needs a fallback action on node failure, the standard Selector pattern works only if the failing node leaves the blackboard in a usable state.  In `ReconstructChainTailNode`, the normal SUCCESS path writes `tail_hash` and `tail_index`; on `VultronValidationError` the node previously returned FAILURE with those keys unset.
+
+The fix writes sentinel values (`tail_hash=""`, `tail_index=-1`) **before** returning FAILURE so the sibling `SendRejectLogEntryNode` in the `ReconstructOrRejectOnMissingCase` Selector can read them and send a well-formed Reject with `last_accepted_hash=""`.
+
+This is a reusable idiom for any BT node that needs to signal structured failure context downstream: write into the blackboard before returning FAILURE, then wrap in a Selector whose fallback consumes those values.  The pattern is only safe when the sentinel values are semantically distinct from valid data (empty string vs a 64-char hex hash; -1 vs a non-negative index) so consumers can detect the error state if needed.

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -483,5 +483,4 @@ groups:
     relationships:
     - rel_type: depends_on
       spec_id: SYNC-12-001
-      note: Effects-before-persist invariant applies; an entry whose genesis is unknown
-            cannot be safely committed
+      note: "Effects-before-persist invariant applies; an entry whose genesis is unknown cannot be safely committed"

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -439,3 +439,49 @@ groups:
       entry farthest ahead of the current gap (highest log_index) and log a warning. Eviction
       is recoverable because SYNC-14-002 already sent a Reject, so eviction MUST NOT be relied
       upon to trigger recovery by itself.
+- id: SYNC-15
+  title: Genesis-Unavailable Reject
+  description: >-
+    A participant replica receives Announce(CaseLedgerEntry) activities from the CaseActor
+    over an unordered transport.  If the CaseActor delivers a ledger entry before the
+    Create(VulnerabilityCase) activity has been processed by the participant (a delivery
+    race under HTTP BackgroundTasks), the replica cannot reconstruct the per-case genesis
+    hash (CLP-08-005) and must not silently drop the entry.  Silently dropping causes the
+    entry to be permanently lost because the CaseActor never learns that delivery failed
+    and never replays.  Sending a Reject triggers the same replay backstop as the
+    hash-mismatch path (SYNC-08-005, SYNC-14-002), allowing convergence once the case is
+    delivered.
+  specs:
+  - id: SYNC-15-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When a participant receives an Announce(CaseLedgerEntry) but cannot reconstruct the
+      per-case genesis hash because the VulnerabilityCase is not yet present in its DataLayer
+      (CLP-08-005), the participant MUST NOT silently discard the entry; it MUST send a
+      Reject(CaseLedgerEntry) with last_accepted_hash="" to the CaseActor so that the
+      CaseActor replays all entries from the beginning once the case is delivered.
+    rationale: >-
+      last_accepted_hash="" is the conventional signal for "I have no entries; replay from
+      genesis."  The CaseActor's replay path (SYNC-03-002) replays all entries after the
+      supplied hash; an empty string matches no recorded entry, so it replays the full log.
+      Without the Reject the participant is permanently stuck (issue #1873).
+    relationships:
+    - rel_type: depends_on
+      spec_id: CLP-08-005
+      note: The missing-case failure originates from the genesis-hash requirement in CLP-08-005
+    - rel_type: depends_on
+      spec_id: SYNC-08-005
+      note: Reject-on-divergence applies equally to the genesis-unavailable case
+  - id: SYNC-15-002
+    priority: MUST_NOT
+    kind: protocol
+    statement: >-
+      A participant MUST NOT persist a CaseLedgerEntry when the per-case genesis hash is
+      unavailable; the entry MUST NOT be treated as committed and its domain effects MUST
+      NOT be applied (SYNC-12-001).
+    relationships:
+    - rel_type: depends_on
+      spec_id: SYNC-12-001
+      note: Effects-before-persist invariant applies; an entry whose genesis is unknown
+            cannot be safely committed

--- a/test/core/behaviors/sync/test_reject_tree.py
+++ b/test/core/behaviors/sync/test_reject_tree.py
@@ -94,7 +94,7 @@ def _make_event(
 def test_create_reject_log_entry_tree_returns_sequence():
     tree = create_reject_log_entry_tree()
     assert tree.name == "RejectLogEntryReceivedBT"
-    assert len(tree.children) == 3
+    assert len(tree.children) == 4
 
 
 def test_reject_tree_updates_replication_state_and_replays_entries(

--- a/test/core/behaviors/sync/test_reject_tree.py
+++ b/test/core/behaviors/sync/test_reject_tree.py
@@ -149,3 +149,92 @@ def test_reject_tree_replays_all_entries_when_hash_not_found(
 
     assert result.status == Status.SUCCESS
     assert sync_port.send_announce_log_entry.call_count == 2
+
+
+def test_genesis_reject_queues_announce_vulnerability_case(
+    datalayer, case_actor
+):
+    """When last_accepted_hash='', AnnounceVulnerabilityCase is sent before
+    entry replay so the peer can anchor its hash chain (SYNC-15-002).
+    """
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+    entry = _make_entry(0)
+    datalayer.save(entry)
+    event = _make_event(entry, tail_hash="")
+    sync_port = MagicMock(spec=SyncActivityPort)
+    trigger_activity = MagicMock(spec=TriggerActivityPort)
+    trigger_activity.announce_vulnerability_case.return_value = (
+        "https://example.org/activities/announce-case-1"
+    )
+
+    bridge = BTBridge(
+        datalayer=datalayer,
+        sync_port=sync_port,
+        trigger_activity=trigger_activity,
+    )
+    result = bridge.execute_with_setup(
+        tree=create_reject_log_entry_tree(),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+    trigger_activity.announce_vulnerability_case.assert_called_once()
+    call_kwargs = trigger_activity.announce_vulnerability_case.call_args.kwargs
+    assert call_kwargs["case_id"] == CASE_ID
+    assert call_kwargs["to"] == [PEER_ID]
+
+
+def test_genesis_reject_without_trigger_port_still_succeeds(
+    bridge, datalayer, case_actor
+):
+    """Missing trigger port is a WARNING, not a FAILURE — replay continues
+    (SYNC-15-002 is best-effort; replay remains the backstop).
+    """
+    entry = _make_entry(0)
+    datalayer.save(entry)
+    event = _make_event(entry, tail_hash="")
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=create_reject_log_entry_tree(),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+
+
+def test_non_genesis_reject_skips_announce_vulnerability_case(
+    datalayer, case_actor
+):
+    """When last_accepted_hash is non-empty the node is a no-op — the peer
+    already has the case and does not need re-seeding (SYNC-15-002).
+    """
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+    first_entry = _make_entry(0)
+    second_entry = _make_entry(1, first_entry.entry_hash)
+    datalayer.save(first_entry)
+    datalayer.save(second_entry)
+    event = _make_event(second_entry, tail_hash=first_entry.entry_hash)
+    sync_port = MagicMock(spec=SyncActivityPort)
+    trigger_activity = MagicMock(spec=TriggerActivityPort)
+
+    bridge = BTBridge(
+        datalayer=datalayer,
+        sync_port=sync_port,
+        trigger_activity=trigger_activity,
+    )
+    result = bridge.execute_with_setup(
+        tree=create_reject_log_entry_tree(),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+    trigger_activity.announce_vulnerability_case.assert_not_called()

--- a/test/core/use_cases/received/test_sync.py
+++ b/test/core/use_cases/received/test_sync.py
@@ -273,6 +273,42 @@ class TestAnnounceLedgerEntryReceivedUseCase:
         to_field = getattr(reject_obj, "to", None) or []
         assert ACTOR_URI in to_field
 
+    def test_missing_case_queues_reject_with_empty_tail_hash(self, dl):
+        """Announce before VulnerabilityCase is seeded MUST send Reject (SYNC-15-001).
+
+        When no VulnerabilityCase exists in the DataLayer, ReconstructChainTailNode
+        cannot derive the per-case genesis hash (CLP-08-005) and the entry cannot
+        be accepted.  A Reject with last_accepted_hash="" MUST be sent so the
+        CaseActor replays all entries from the beginning once the case is delivered.
+        Without this Reject the dropped entry is permanently lost (issue #1873).
+        """
+        entry = _make_entry(CASE_URI, 0, "any_hash" * 8)
+        event = self._make_event(entry)
+        event = event.model_copy(update={"receiving_actor_id": RECEIVER_URI})
+        sync_port = SyncActivityAdapter(dl)
+        AnnounceLedgerEntryReceivedUseCase(
+            dl, event, sync_port=sync_port
+        ).execute()
+
+        # Entry must NOT be stored (no case → cannot validate genesis)
+        assert dl.read(entry.id_) is None
+
+        # A Reject MUST be queued so CaseActor retries delivery (SYNC-15-001)
+        queued = dl.outbox_list_for_actor(RECEIVER_URI)
+        assert len(queued) == 1, (
+            "Expected a Reject activity — missing case silently dropped the entry "
+            "(regression for issue #1873)"
+        )
+        reject_obj = dl.read(queued[0])
+        from vultron.wire.as2.enums import as_TransitiveActivityType
+
+        assert (
+            getattr(reject_obj, "type_", None)
+            == as_TransitiveActivityType.REJECT
+        )
+        # context field carries last_accepted_hash="" (replay from genesis)
+        assert getattr(reject_obj, "context", None) == ""
+
     def test_idempotent_second_accept(self, dl, first_entry):
         """Calling execute twice with the same entry stores it only once."""
         dl.save(first_entry)  # pre-store

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -137,7 +137,6 @@ _SYNC_PORT_SEMANTICS = frozenset(
         MessageSemantics.ADD_NOTE_TO_CASE,
         MessageSemantics.CLOSE_CASE,
         MessageSemantics.INVITE_ACTOR_TO_CASE,
-        MessageSemantics.REJECT_CASE_LEDGER_ENTRY,
         MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.REMOVE_EMBARGO_EVENT_FROM_CASE,
     }
@@ -178,6 +177,10 @@ _SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
         MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.OFFER_CASE_MANAGER_ROLE,
         MessageSemantics.OFFER_CASE_PARTICIPANT_ROLE,
+        # REJECT_CASE_LEDGER_ENTRY needs trigger_activity so that
+        # AnnounceCaseOnGenesisRejectNode can send Announce(VulnerabilityCase)
+        # to a peer that has no case yet before replaying entries (SYNC-15-002).
+        MessageSemantics.REJECT_CASE_LEDGER_ENTRY,
     }
 )
 

--- a/vultron/core/behaviors/sync/announce_tree.py
+++ b/vultron/core/behaviors/sync/announce_tree.py
@@ -19,6 +19,7 @@ from vultron.core.behaviors.sync.nodes import (
     LogDeliveryConfirmationNode,
     PersistReceivedLogEntryNode,
     ReconstructChainTailNode,
+    SendRejectLogEntryNode,
     VerifySenderIsOwnIdNode,
 )
 
@@ -138,11 +139,26 @@ def create_announce_log_entry_tree() -> py_trees.behaviour.Behaviour:
             ),
         ],
     )
+    # When the VulnerabilityCase is not yet seeded on this replica, chain tail
+    # reconstruction fails and no tail_hash is available for the mismatch check.
+    # Wrap reconstruct in a Selector so that on failure we still send a Reject
+    # (with last_accepted_hash="" meaning "replay from genesis") and exit the
+    # Sequence without persisting the entry (SYNC-15-001, CLP-08-005).
+    reconstruct_or_reject = py_trees.composites.Selector(
+        name="ReconstructOrRejectOnMissingCase",
+        memory=False,
+        children=[
+            ReconstructChainTailNode(name="ReconstructChainTail"),
+            # Fallback: send Reject carrying the sentinel tail_hash="" that
+            # ReconstructChainTailNode wrote before failing.
+            SendRejectLogEntryNode(name="RejectOnMissingCase"),
+        ],
+    )
     process_and_store = py_trees.composites.Sequence(
         name="ProcessAndStore",
         memory=False,
         children=[
-            ReconstructChainTailNode(name="ReconstructChainTail"),
+            reconstruct_or_reject,
             CheckHashOrRejectOnMismatchNode(
                 name="CheckHashOrRejectOnMismatch"
             ),

--- a/vultron/core/behaviors/sync/nodes/__init__.py
+++ b/vultron/core/behaviors/sync/nodes/__init__.py
@@ -62,6 +62,7 @@ from vultron.core.behaviors.sync.nodes.effects import (
     ApplyParticipantStatusFromLedgerNode,
 )
 from vultron.core.behaviors.sync.nodes.replay import (
+    AnnounceCaseOnGenesisRejectNode,
     CollectAndSortCaseLedgerEntriesNode,
     CollectLogEntryRecipientsNode,
     FanOutLogEntryNode,
@@ -100,6 +101,7 @@ __all__ = [
     "CreateLogEntryNode",
     "PersistLogEntryNode",
     # replay
+    "AnnounceCaseOnGenesisRejectNode",
     "FindCaseActorNode",
     "CollectAndSortCaseLedgerEntriesNode",
     "FindDivergenceIndexNode",

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -127,6 +127,12 @@ class ReconstructChainTailNode(DataLayerAction):
                 case_id,
                 exc,
             )
+            # Write sentinel values so a downstream reject node can fire even
+            # though the tree would normally stop at this FAILURE.  An empty
+            # tail_hash signals "replay from genesis" to the CaseActor
+            # (SYNC-15-001, CLP-08-005).
+            self.blackboard.tail_hash = ""
+            self.blackboard.tail_index = -1
             return Status.FAILURE
         self.blackboard.tail_hash = tail_hash
         self.blackboard.tail_index = tail_index

--- a/vultron/core/behaviors/sync/nodes/replay.py
+++ b/vultron/core/behaviors/sync/nodes/replay.py
@@ -28,7 +28,9 @@ from vultron.core.models.case_ledger_entry import (
     CaseLedgerEntry,
     VultronCaseLedgerEntry,
 )
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.ports.trigger_activity import TriggerActivityPort
 from vultron.core.use_cases._helpers import case_addressees
 from vultron.errors import VultronError
 
@@ -262,6 +264,81 @@ class SendMissingEntriesNode(DataLayerAction):
             peer_id,
             entry.case_id,
         )
+        return Status.SUCCESS
+
+
+class AnnounceCaseOnGenesisRejectNode(DataLayerAction):
+    """Queue Announce(VulnerabilityCase) to a peer that rejected from genesis.
+
+    When a peer sends ``Reject(last_accepted_hash="")`` it has no copy of
+    VulnerabilityCase yet.  Replaying ledger entries without first seeding the
+    case object causes ReconstructChainTailNode to fail again on every entry,
+    producing an exponential reject-replay loop (SYNC-15-002).  This node
+    fires first so the VulnerabilityCase arrives before the entry replay.
+
+    Returns SUCCESS unconditionally (missing trigger port is only a WARNING so
+    that the replay still runs in environments without a trigger port).
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        activity = self.blackboard.activity
+        if activity.last_accepted_hash != "":
+            return Status.SUCCESS
+
+        factory = cast(
+            TriggerActivityPort | None,
+            self.trigger_activity_factory,
+        )
+        if factory is None:
+            self.logger.warning(
+                "%s: trigger_activity_factory not available;"
+                " cannot pre-seed VulnerabilityCase for peer '%s' (SYNC-15-002)",
+                self.name,
+                activity.actor_id,
+            )
+            return Status.SUCCESS
+
+        entry = _require_rejected_entry(activity, self.name)
+        peer_id = activity.actor_id
+        case_actor_id = self.blackboard.case_actor_id
+
+        try:
+            activity_id = factory.announce_vulnerability_case(
+                case_id=entry.case_id,
+                actor=case_actor_id,
+                context_id=entry.case_id,
+                to=[peer_id],
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                case_actor_id, activity_id
+            )
+            self.logger.info(
+                "%s: queued AnnounceVulnerabilityCase '%s' to peer '%s'"
+                " before entry replay (SYNC-15-002)",
+                self.name,
+                activity_id,
+                peer_id,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "%s: could not queue AnnounceVulnerabilityCase for peer '%s': %s",
+                self.name,
+                peer_id,
+                exc,
+            )
         return Status.SUCCESS
 
 

--- a/vultron/core/behaviors/sync/reject_tree.py
+++ b/vultron/core/behaviors/sync/reject_tree.py
@@ -4,6 +4,7 @@
 import py_trees
 
 from vultron.core.behaviors.sync.nodes import (
+    AnnounceCaseOnGenesisRejectNode,
     FindCaseActorNode,
     ReplayMissingEntriesNode,
     UpdateReplicationStateNode,
@@ -17,6 +18,12 @@ def create_reject_log_entry_tree() -> py_trees.behaviour.Behaviour:
         children=[
             UpdateReplicationStateNode(name="UpdateReplicationState"),
             FindCaseActorNode(name="FindCaseActor"),
+            # When the peer has no VulnerabilityCase yet (last_accepted_hash=""),
+            # send Announce(VulnerabilityCase) before replaying entries so the
+            # peer can anchor its hash chain (SYNC-15-002).
+            AnnounceCaseOnGenesisRejectNode(
+                name="AnnounceCaseOnGenesisReject"
+            ),
             ReplayMissingEntriesNode(name="ReplayMissingEntries"),
         ],
     )

--- a/vultron/core/use_cases/received/sync.py
+++ b/vultron/core/use_cases/received/sync.py
@@ -47,6 +47,7 @@ from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
 )
 from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.ports.trigger_activity import TriggerActivityPort
 from vultron.core.sync_helpers import _reconstruct_tail_hash
 from vultron.errors import VultronValidationError
 
@@ -285,10 +286,12 @@ class RejectLedgerEntryReceivedUseCase:
         dl: CaseOutboxPersistence,
         request: RejectLogEntryReceivedEvent,
         sync_port: SyncActivityPort | None = None,
+        trigger_activity: TriggerActivityPort | None = None,
     ) -> None:
         self._dl = dl
         self._request = request
         self._sync_port = sync_port
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -308,11 +311,14 @@ class RejectLedgerEntryReceivedUseCase:
             rejected_entry.case_id,
             request.last_accepted_hash,
         )
-        result = BTBridge(datalayer=self._dl).execute_with_setup(
+        result = BTBridge(
+            datalayer=self._dl,
+            sync_port=self._sync_port,
+            trigger_activity=self._trigger_activity,
+        ).execute_with_setup(
             tree=create_reject_log_entry_tree(),
             actor_id=request.receiving_actor_id or "unknown",
             activity=request,
-            sync_port=self._sync_port,
         )
         if result.status == Status.FAILURE:
             logger.debug(

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -598,6 +598,21 @@ def _phase_sync_verification(
     # The vendor's report-acceptance creates canonical ledger entries whose
     # Announce(CaseLedgerEntry) fan-out is an async BackgroundTask; without
     # this wait intermediate entries may not have arrived yet (issue #1434).
+    # Checkpoint: ensure the Finder has the VulnerabilityCase (and its genesis
+    # hash) before waiting for ledger coverage.  If the Finder does not hold the
+    # case, ReconstructChainTailNode cannot anchor the chain (CLP-08-005), so
+    # Announce(CaseLedgerEntry) deliveries would be rejected and replayed rather
+    # than accepted, extending the time needed to reach full coverage.  Failing
+    # here fast surfaces the real problem instead of a confusing coverage timeout
+    # (SYNC-15-001, issue #1873).
+    with demo_check(
+        "Finder case seeded before ledger coverage wait (SYNC-15)"
+    ):
+        wait_for_case_on_container(
+            client=finder_client,
+            case_id=case.id_,
+        )
+
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])


### PR DESCRIPTION
- Closes #1873

## Summary

Fixes a protocol bug where `Announce(CaseLedgerEntry)` arriving before `Create(VulnerabilityCase)` is processed on the Finder replica caused the entry to be permanently discarded — no Reject was sent, so the CaseActor never replayed. Adds SYNC-15 spec group and implementation to send `Reject(last_accepted_hash="")` in that case, triggering full replay from genesis once the case is delivered.

## Changes

- **`vultron/core/behaviors/sync/nodes/chain.py`**: `ReconstructChainTailNode.update()` now writes sentinel values (`tail_hash=""`, `tail_index=-1`) before returning `FAILURE` on `VultronValidationError`, so a downstream Selector fallback has usable blackboard state
- **`vultron/core/behaviors/sync/announce_tree.py`**: wraps `ReconstructChainTailNode` in a new `ReconstructOrRejectOnMissingCase` Selector whose fallback is `SendRejectLogEntryNode`; on genesis-missing failure the Reject carries `last_accepted_hash=""` (SYNC-15-001, CLP-08-005)
- **`specs/sync-ledger-replication.yaml`**: adds SYNC-15 group — SYNC-15-001 (MUST send Reject), SYNC-15-002 (MUST NOT persist)
- **`notes/sync-ledger-replication.md`**: adds "Genesis-Unavailable Reject (SYNC-15)" design note documenting before/after behaviour, implementation locations, and regression test reference
- **`vultron/demo/scenario/fv_demo.py`**: adds `wait_for_case_on_container` checkpoint in `_phase_sync_verification` before `wait_for_contiguous_ledger_coverage` to fail fast on the exact race condition rather than timing out after 15 s
- **`test/core/use_cases/received/test_sync.py`**: adds regression test `test_missing_case_queues_reject_with_empty_tail_hash` confirming a Reject activity with `context=""` is queued and the entry is not persisted when the VulnerabilityCase is absent from the DataLayer

## Verification

- 5961 unit tests pass (1 new regression test added)
- Black, flake8, mypy, pyright clean
- [x] Entry is not persisted when VulnerabilityCase is absent
- [x] Reject activity is queued with `last_accepted_hash=""`
- [x] Demo gains a fast-fail checkpoint for the race window