### PR TITLE
docs: plan issue #1256 — create_terminate_active_embargo_tree design

### DIFF
--- a/notes/bt-fuzzer-nodes-embargo.md
+++ b/notes/bt-fuzzer-nodes-embargo.md
@@ -167,6 +167,53 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
   `_ConsiderTerminatingActiveEmbargo` Sequence, after the condition Selector
   succeeds and before `terminate_embargo_trigger_bt`
 
+### `EmbargoExitPolicyGuard`
+
+- **Node name**: `EmbargoExitPolicyGuard`
+- **btz type**: `AlwaysSucceed` (p=1.00)
+- **Source file**: `vultron/demo/fuzzer/embargo.py` (to be added)
+- **Parent tree**: `_AuthorizeEmbargoExit` (within
+  `create_terminate_active_embargo_tree`)
+- **Semantic function**: Condition — check whether site policy permits the
+  actor to proceed with voluntary embargo termination after a reason has been
+  selected (e.g., no active revision negotiation, no pending approvals)
+- **Input dependency**: Automated policy evaluation; integration with
+  case-management or approval-workflow systems
+- **Notes**: Always succeeds in simulation (happy path assumes policy permits);
+  in production may invoke an approval queue or rule engine
+- **Automation potential**: **High** — rule-based checks (pending revision,
+  approval status) are fully automatable via case-management API calls.
+- **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.EmbargoExitPolicyGuard`
+- **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
+  (issue #1256) — first arm of the authorization Selector, after the reason
+  Selector succeeds and before OnEmbargoExit
+
+### `EmbargoExitOverride`
+
+- **Node name**: `EmbargoExitOverride`
+- **btz type**: `AlwaysFail` (p=0.00)
+- **Source file**: `vultron/demo/fuzzer/embargo.py` (to be added)
+- **Parent tree**: `_AuthorizeEmbargoExit` (within
+  `create_terminate_active_embargo_tree`)
+- **Semantic function**: Condition — actor explicitly accepts responsibility
+  for overriding a policy veto and proceeding with voluntary embargo
+  termination; produces a distinct audit-trail entry for the override
+- **Input dependency**: Explicit actor acknowledgment; may invoke an
+  escalation endpoint or confirmation dialog
+- **Notes**: Always fails in simulation (override is not active by default);
+  in production an integrator wires this to an escalation acknowledgment
+  mechanism; the override is logged separately from the normal policy path
+- **Automation potential**: **Low** — override requires explicit actor
+  acknowledgment for accountability; should not be auto-approved.
+- **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.EmbargoExitOverride`
+- **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
+  (issue #1256) — second (fallback) arm of the authorization Selector;
+  reached only when EmbargoExitPolicyGuard returns FAILURE
+
 ### `StopProposingEmbargo`
 
 - **Node name**: `StopProposingEmbargo`

--- a/notes/bt-fuzzer-nodes-embargo.md
+++ b/notes/bt-fuzzer-nodes-embargo.md
@@ -71,9 +71,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
   (`exit_embargo_when_deployed_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
-  (issue #1256) — condition guard in the TerminateEmbargo Selector, checked
-  before delegating to `terminate_embargo_trigger_bt`
+  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
+  (issue #1256) — condition guard in the Reason Selector, checked
+  before delegating to `terminate_embargo_bt`
 
 ### `ExitEmbargoWhenFixReady`
 
@@ -93,9 +93,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
   (`exit_embargo_when_fix_ready_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
-  (issue #1256) — condition guard in the TerminateEmbargo Selector, checked
-  before delegating to `terminate_embargo_trigger_bt`
+  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
+  (issue #1256) — condition guard in the Reason Selector, checked
+  before delegating to `terminate_embargo_bt`
 
 ### `ExitEmbargoForOtherReason`
 
@@ -115,8 +115,8 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
   (`exit_embargo_for_other_reason_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
-  (issue #1256) — rare fallback condition guard in the TerminateEmbargo
+  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
+  (issue #1256) — rare fallback condition guard in the Reason
   Selector for extraordinary circumstances
 
 ### `EmbargoTimerExpired`
@@ -140,7 +140,7 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
   independently or fire a trigger endpoint. A timestamp comparison is the simplest kind of
   structured fact (ADR-0024 BT-18-006: binary on-demand queries are Retrievers, not Sentinels).
 - **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
+  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
   (issue #1256) — Retriever condition guard early in the
   `_SufficientCauseToTerminateActiveEmbargo` Sequence; reads embargo expiry
   timestamp from DataLayer and compares to system clock
@@ -162,10 +162,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoExit`
 - **Call-out point shape**: Actuator — fires integration hooks on embargo exit; invokes notification APIs, case-management state-write calls, and downstream trigger endpoints. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
 - **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
+  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
   (issue #1256) — Actuator effect node in
   `_ConsiderTerminatingActiveEmbargo` Sequence, after the condition Selector
-  succeeds and before `terminate_embargo_trigger_bt`
+  succeeds and before `terminate_embargo_bt`
 
 ### `EmbargoExitPolicyGuard`
 

--- a/plan/history/2607/idea/IDEA-1256.md
+++ b/plan/history/2607/idea/IDEA-1256.md
@@ -1,0 +1,33 @@
+---
+source: IDEA-1256
+timestamp: '2026-07-31T20:09:37.591665+00:00'
+title: 'create_terminate_active_embargo_tree: production design for actor-voluntary
+  embargo exit'
+type: idea
+---
+
+Planned the production design for `create_terminate_active_embargo_tree`.
+Original issue framed this as a direct port of the simulation's
+`TerminateEmbargoBt`, but codebase analysis revealed that CS-triggered
+auto-exits (p→P, x→X, a→A) are already handled by
+`ThreatTerminationBranchNode` / `PublicDisclosureBranchNode`, making the
+scope much narrower than described.
+
+Key design decisions reached through conversation:
+
+- Production model follows "actor chooses reason, system executes" — not a
+  simulation BT translation
+- Tree: reason Selector (ExitEmbargoWhenDeployed / ExitEmbargoWhenFixReady /
+  ExitEmbargoForOtherReason) → authorization Selector (EmbargoExitPolicyGuard
+  | EmbargoExitOverride) → OnEmbargoExit actuator → terminate_embargo_bt
+- EmbargoExitPolicyGuard and EmbargoExitOverride are new call-out points added
+  to EmbargoCallOutBundle; the override carries an independent audit trail
+- StopProposingEmbargo: simulator-only, dropped
+- EmbargoTimerExpired: Sentinel/Retriever shape, tracked under epic #1147
+- Abandon proposed embargo: different cascade (ER not ET), separate idea needed
+
+Outputs: EMB-14-001 through EMB-14-003 in `specs/em-behavior.yaml`,
+two new fuzzer node catalog entries, two new `EmbargoCallOutBundle` fields.
+Implementation tracked in #1891 (FUZZ-08a-ter).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1890>

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -1153,3 +1153,123 @@ groups:
     - rel_type: satisfies
       spec_id: VP-14-003
       note: Once Attacks observed, new embargoes SHALL NOT be sought
+
+- id: EMB-14
+  title: Actor-Voluntary Embargo Termination (Trigger Side)
+  trigger:
+    type: state_entered
+    value: EM.ACTIVE
+  specs:
+  - id: EMB-14-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The create_terminate_active_embargo_tree factory MUST require the actor
+      to supply a termination reason before delegating to terminate_embargo_bt.
+      Valid reasons are: fix-deployed, fix-ready, or other. The reason is
+      recorded via the matching Evaluator call-out point (ExitEmbargoWhenDeployed,
+      ExitEmbargoWhenFixReady, or ExitEmbargoForOtherReason).
+    rationale: >-
+      Voluntary termination requires an auditable reason. Structuring reason
+      selection as a Selector of Evaluator call-out points gives actors a
+      clear interface (three buttons) while preserving the audit trail and
+      allowing policy-rule backends to be injected per ADR-0025.
+    testable: true
+    preconditions:
+    - em_state:
+        - ACTIVE
+        - REVISE
+      description: EM state is Active or Revise
+    steps:
+    - order: 1
+      actor: actor
+      action: Select termination reason (ExitEmbargoWhenDeployed,
+        ExitEmbargoWhenFixReady, or ExitEmbargoForOtherReason)
+      expected: Matching Evaluator call-out point returns SUCCESS; reason recorded
+    - order: 2
+      actor: system
+      action: Run EmbargoExitPolicyGuard or EmbargoExitOverride
+      expected: Policy check passes or actor override accepted
+    - order: 3
+      actor: system
+      action: Run OnEmbargoExit actuator
+      expected: Site-specific integration hooks execute
+    - order: 4
+      actor: system
+      action: Delegate to terminate_embargo_bt
+      expected: ET emitted; EM transitions to EXITED
+    postconditions:
+    - description: EM state is EXITED; ET queued; termination reason recorded
+    relationships:
+    - rel_type: refines
+      spec_id: EMB-07-001
+      note: Voluntary actor termination is a sub-case of active-embargo termination
+
+  - id: EMB-14-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The create_terminate_active_embargo_tree factory MUST include an
+      EmbargoExitPolicyGuard Evaluator call-out point that runs after the
+      reason Selector and before OnEmbargoExit. The guard MAY veto termination
+      regardless of the chosen reason.
+    rationale: >-
+      Separating the reason selection (actor intent) from the policy check
+      (system authorization) allows external policy engines to block termination
+      on grounds orthogonal to the stated reason (e.g., active revision
+      negotiation, pending approvals) without coupling the guard logic to the
+      reason semantics.
+    testable: true
+    preconditions:
+    - em_state:
+        - ACTIVE
+        - REVISE
+      description: EM state is Active or Revise; reason Selector has succeeded
+    steps:
+    - order: 1
+      actor: system
+      action: Run EmbargoExitPolicyGuard call-out point
+      expected: Returns SUCCESS (policy permits) or FAILURE (policy vetoes)
+    postconditions:
+    - description: >-
+        SUCCESS: pipeline continues to OnEmbargoExit and terminate_embargo_bt.
+        FAILURE: termination blocked; actor may retry with override.
+    relationships:
+    - rel_type: refines
+      spec_id: EMB-14-001
+
+  - id: EMB-14-003
+    priority: SHOULD
+    kind: protocol
+    statement: >-
+      The create_terminate_active_embargo_tree factory SHOULD include an
+      EmbargoExitOverride Evaluator call-out point in a Selector alongside
+      EmbargoExitPolicyGuard. When the actor explicitly accepts responsibility
+      for overriding policy, EmbargoExitOverride SHOULD return SUCCESS so that
+      termination proceeds despite a policy veto.
+    rationale: >-
+      Providing an override seam lets actors exercise their authority to exit
+      in exceptional circumstances without requiring code changes. The override
+      is a distinct call-out point so that integrators can log, gate, or audit
+      it separately from the normal policy path.
+    testable: true
+    preconditions:
+    - em_state:
+        - ACTIVE
+        - REVISE
+      description: >-
+        EM state is Active or Revise; reason Selector succeeded;
+        EmbargoExitPolicyGuard returned FAILURE
+    steps:
+    - order: 1
+      actor: actor
+      action: Invoke EmbargoExitOverride call-out point
+      expected: Override accepted; pipeline continues to OnEmbargoExit
+    postconditions:
+    - description: Override recorded; termination proceeds; audit trail reflects override
+    lint_suppress:
+    - testable_without_steps
+    relationships:
+    - rel_type: refines
+      spec_id: EMB-14-002
+      note: Override is the fallback arm of the policy authorization Selector

--- a/vultron/core/behaviors/call_out/bundles/embargo.py
+++ b/vultron/core/behaviors/call_out/bundles/embargo.py
@@ -33,6 +33,8 @@ Ceiling/floor mapping (BT-23-002):
 - ``on_embargo_exit_factory``                  — OnEmbargoExit                 (p=1.0) → AlwaysSucceed
 - ``on_embargo_accept_factory``                — OnEmbargoAccept               (p=1.0) → AlwaysSucceed
 - ``on_embargo_reject_factory``                — OnEmbargoReject               (p=1.0) → AlwaysSucceed
+- ``embargo_exit_policy_guard_factory``        — EmbargoExitPolicyGuard        (p=1.0) → AlwaysSucceed
+- ``embargo_exit_override_factory``            — EmbargoExitOverride           (p=0.0) → AlwaysFail
 """
 
 from __future__ import annotations
@@ -58,7 +60,9 @@ class EmbargoCallOutBundle:
     """Call-out backend bundle for the embargo management domain (BT-23-003).
 
     Fields map to the corresponding factory parameters on
-    :func:`~vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`.
+    :func:`~vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+    and (for termination-specific fields) the future
+    ``create_terminate_active_embargo_tree`` factory (issue #1256).
     """
 
     exit_embargo_when_deployed_factory: CallOutBackendFactory = field(
@@ -99,6 +103,12 @@ class EmbargoCallOutBundle:
     )
     on_embargo_reject_factory: CallOutBackendFactory = field(
         default=_always_succeed  # type: ignore[assignment]
+    )
+    embargo_exit_policy_guard_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    embargo_exit_override_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
     )
 
 


### PR DESCRIPTION
- Closes #1256

## Summary

Plans the production design for `create_terminate_active_embargo_tree`: an
actor-voluntary active embargo termination BT subtree. This replaces the
original issue framing (direct simulation port) with a production-oriented
design developed through a conversation about process joints and the
"actor chooses, system executes" model.

## Changes

- **`specs/em-behavior.yaml`** — adds EMB-14-001 through EMB-14-003 specifying
  the actor-voluntary termination tree structure:
  - EMB-14-001: Reason Selector (ExitEmbargoWhenDeployed / ExitEmbargoWhenFixReady /
    ExitEmbargoForOtherReason) records actor intent before delegating to
    `terminate_embargo_bt`
  - EMB-14-002: EmbargoExitPolicyGuard Evaluator call-out point authorizes or
    vetoes termination after reason selection
  - EMB-14-003: EmbargoExitOverride Evaluator call-out point as fallback arm of
    the authorization Selector for exceptional actor-overrides with audit trail

- **`notes/bt-fuzzer-nodes-embargo.md`** — adds two new fuzzer node catalog
  entries: `EmbargoExitPolicyGuard` (Evaluator, AlwaysSucceed default,
  High automation potential) and `EmbargoExitOverride` (Evaluator, AlwaysFail
  default, Low automation potential), both with factory-fn placement pointing to
  the `create_terminate_active_embargo_tree` factory in issue #1256

- **`vultron/core/behaviors/call_out/bundles/embargo.py`** — adds
  `embargo_exit_policy_guard_factory` (AlwaysSucceed default) and
  `embargo_exit_override_factory` (AlwaysFail default) fields to
  `EmbargoCallOutBundle`

## Key design decisions captured

- CS-triggered auto-exits (p→P, x→X, a→A) are **already handled** by
  `ThreatTerminationBranchNode` and `PublicDisclosureBranchNode` — not in scope
- `StopProposingEmbargo` is simulator-only, dropped from scope
- `EmbargoTimerExpired` is a Sentinel/Retriever shape — tracked separately under
  epic #1147
- "Abandon proposed embargo" has a different cascade (ER not ET) — separate issue
- The new tree delegates to the existing `terminate_embargo_bt` for the actual
  ET emission

## Implementation Issues

- #1891