### PR TITLE
test(#1858): add leave-case round-trip, announce-tree, and demo endpoint tests

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1858.md
+++ b/plan/history/2608/implementation/ISSUE-1858.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1858
+timestamp: '2026-08-05T14:51:26.881653+00:00'
+title: Leave-case round-trip, announce-tree, and demo endpoint tests
+type: implementation
+---
+
+## Issue #1858 — test(#1858): add leave-case round-trip, announce-tree, and demo endpoint tests
+
+Added 11 new tests across three files to complete coverage for the SvcLeaveCaseUseCase / Leave(VulnerabilityCase) closure path. The core implementation was already fully present at HEAD via PRs #1901, #1965, and #1966.
+
+New files/additions:
+
+- test/core/use_cases/test_leave_case_round_trip.py (new): AC-5 end-to-end round-trip across two SqliteDataLayer replicas
+- test/core/behaviors/sync/test_announce_tree.py: TestAnnounceLogEntryAppliesCloseCase + failure-blocks-persist test
+- test/adapters/driving/fastapi/routers/test_demo_triggers.py: TestDemoCloseCase (4 tests)
+
+PR: <https://github.com/CERTCC/Vultron/pull/1909>

--- a/plan/incoming/learnings/20260805-issue-already-implemented-before-session.md
+++ b/plan/incoming/learnings/20260805-issue-already-implemented-before-session.md
@@ -1,0 +1,25 @@
+---
+title: Issue already fully implemented before session began (ISSUE-1858)
+type: learning
+timestamp: 2026-08-05
+source: ISSUE-1858
+signal: process-issue
+---
+
+When the build session for ISSUE-1858 began, the core implementation
+(SvcLeaveCaseUseCase, receive_close_case_tree role discriminator, announce-tree
+CloseCaseEffects slot, demo_close_case rewire) was already fully present at
+HEAD, landed via PRs #1901, #1965, and #1966 during the period the original PR
+PR 1909 was set aside.
+
+The issue remained OPEN with an OPEN PR (#1909) despite the implementation
+being complete, because the gap was in *test coverage* (AC-5 round-trip,
+announce-tree close-case tests, demo endpoint tests) — not in code. The issue
+comment history on #1858 documented the upstream impacts but did not explicitly
+note that the core work was done.
+
+Going forward: when picking up a previously-set-aside issue, the first step
+after orient+deepen should include an explicit diff of what the issue requires
+vs. what is already at HEAD — not just what the stale PR branch contains.
+The `claim-issue.sh` guard (branch already exists) is a signal that prior
+work may have landed via other paths.

--- a/test/adapters/driving/fastapi/routers/test_demo_triggers.py
+++ b/test/adapters/driving/fastapi/routers/test_demo_triggers.py
@@ -516,7 +516,7 @@ class TestDemoCloseCase:
     def test_leave_activity_in_response(
         self, client_demo: TestClient, actor, case_with_actor
     ):
-        """Response body contains a Leave activity addressed to the Case Actor (DEMOMA-07-001)."""
+        """Response body contains a Leave activity with correct type and actor fields."""
         response = client_demo.post(
             f"/actors/{actor.id_}/demo/close-case",
             json={"case_id": case_with_actor.id_},
@@ -547,18 +547,23 @@ class TestDemoCloseCase:
         case = dl.read(case_with_actor.id_)
         assert isinstance(case, VulnerabilityCase)
         participant_id = case.actor_participant_index.get(actor.id_)
-        if participant_id is not None:
-            participant = dl.read(participant_id)
-            if isinstance(participant, CaseParticipant):
-                rm_states = [
-                    ps.rm.state
-                    for ps in participant.participant_statuses
-                    if hasattr(ps, "rm") and ps.rm is not None
-                ]
-                assert RM.CLOSED not in rm_states, (
-                    "RM.CLOSED must not be set at send time (AC-2);"
-                    f" rm_states={rm_states}"
-                )
+        assert (
+            participant_id is not None
+        ), "actor must have a participant entry in actor_participant_index"
+        participant = dl.read(participant_id)
+        assert isinstance(participant, CaseParticipant), (
+            f"dl.read({participant_id!r}) must return CaseParticipant;"
+            f" got {type(participant)}"
+        )
+        rm_states = [
+            ps.rm.state
+            for ps in participant.participant_statuses
+            if hasattr(ps, "rm") and ps.rm is not None
+        ]
+        assert RM.CLOSED not in rm_states, (
+            "RM.CLOSED must not be set at send time (AC-2);"
+            f" rm_states={rm_states}"
+        )
 
     def test_unknown_case_returns_404(self, client_demo: TestClient, actor):
         """Request for a non-existent case must return 404."""

--- a/test/adapters/driving/fastapi/routers/test_demo_triggers.py
+++ b/test/adapters/driving/fastapi/routers/test_demo_triggers.py
@@ -493,3 +493,77 @@ class TestDemoGetCaseLedgerEntry:
         assert "caseId" in data
         assert "log_object_id" not in data
         assert "event_type" not in data
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /actors/{actor_id}/demo/close-case  (TRIG-09-001, DEMOMA-07-001)
+# ---------------------------------------------------------------------------
+
+
+class TestDemoCloseCase:
+    """Tests for the demo close-case endpoint."""
+
+    def test_returns_202_on_success(
+        self, client_demo: TestClient, actor, case_with_actor
+    ):
+        """Successful close-case returns 202 Accepted."""
+        response = client_demo.post(
+            f"/actors/{actor.id_}/demo/close-case",
+            json={"case_id": case_with_actor.id_},
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+
+    def test_leave_activity_in_response(
+        self, client_demo: TestClient, actor, case_with_actor
+    ):
+        """Response body contains a Leave activity addressed to the Case Actor (DEMOMA-07-001)."""
+        response = client_demo.post(
+            f"/actors/{actor.id_}/demo/close-case",
+            json={"case_id": case_with_actor.id_},
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        data = response.json()
+        assert "activity" in data, "Response must contain 'activity' key"
+        activity = data["activity"]
+        assert (
+            activity.get("type") == "Leave"
+        ), f"Activity type must be 'Leave'; got {activity.get('type')}"
+        assert (
+            activity.get("actor") == actor.id_
+        ), f"Activity actor must be actor.id_; got {activity.get('actor')}"
+
+    def test_rm_not_closed_at_send_time(
+        self, client_demo: TestClient, actor, case_with_actor, dl
+    ):
+        """RM.CLOSED must NOT appear at send time — only after ledger round-trip (AC-2)."""
+        from vultron.core.models.case import VulnerabilityCase
+        from vultron.core.models.case_participant import CaseParticipant
+        from vultron.core.states.rm import RM
+
+        client_demo.post(
+            f"/actors/{actor.id_}/demo/close-case",
+            json={"case_id": case_with_actor.id_},
+        )
+        case = dl.read(case_with_actor.id_)
+        assert isinstance(case, VulnerabilityCase)
+        participant_id = case.actor_participant_index.get(actor.id_)
+        if participant_id is not None:
+            participant = dl.read(participant_id)
+            if isinstance(participant, CaseParticipant):
+                rm_states = [
+                    ps.rm.state
+                    for ps in participant.participant_statuses
+                    if hasattr(ps, "rm") and ps.rm is not None
+                ]
+                assert RM.CLOSED not in rm_states, (
+                    "RM.CLOSED must not be set at send time (AC-2);"
+                    f" rm_states={rm_states}"
+                )
+
+    def test_unknown_case_returns_404(self, client_demo: TestClient, actor):
+        """Request for a non-existent case must return 404."""
+        response = client_demo.post(
+            f"/actors/{actor.id_}/demo/close-case",
+            json={"case_id": "urn:uuid:no-such-case"},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/test/core/behaviors/sync/test_announce_tree.py
+++ b/test/core/behaviors/sync/test_announce_tree.py
@@ -20,6 +20,7 @@ from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.events.sync import AnnounceLogEntryReceivedEvent
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.states.em import EM
+from vultron.core.states.rm import RM
 from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import announce_log_entry_activity
@@ -678,3 +679,165 @@ class TestEffectsFailureBlocksPersist:
 
         assert result.status == Status.FAILURE
         assert datalayer.read(entry.id_) is None
+
+    def test_apply_close_case_failure_blocks_persist(
+        self, bridge, datalayer, case_actor, case_obj
+    ):
+        """PersistReceivedLogEntry must NOT run when ApplyCloseCaseFromLedger returns FAILURE."""
+        entry = _make_close_case_entry(0, case_obj.genesis_hash)
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        tree = create_announce_log_entry_tree()
+        apply_node = _find_node_by_name(tree, "ApplyCloseCaseFromLedger")
+        assert apply_node is not None
+        apply_node.update = lambda: Status.FAILURE  # type: ignore[method-assign]
+
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert result.status == Status.FAILURE
+        assert datalayer.read(entry.id_) is None
+
+
+# ---------------------------------------------------------------------------
+# Announce tree applies close_case ledger entry (CloseCaseEffects slot)
+# ---------------------------------------------------------------------------
+
+DEPARTING_ACTOR_ID = "https://example.org/actors/departing"
+DEPARTING_PARTICIPANT_ID = "https://example.org/participants/departing"
+
+
+def _make_close_case_entry(
+    log_index: int, prev_hash: str = _ZERO_HASH
+) -> VultronCaseLedgerEntry:
+    """Build a close_case ledger entry with payload_snapshot carrying actor."""
+    return _to_persistable_entry(
+        HashChainLedgerRecord(
+            case_id=CASE_ID,
+            log_index=log_index,
+            object_id=f"https://example.org/activities/leave-{log_index}",
+            event_type="close_case",
+            payload_snapshot={"actor": DEPARTING_ACTOR_ID},
+            prev_log_hash=prev_hash,
+        )
+    )
+
+
+def _make_case_with_departing_participant(
+    datalayer: SqliteDataLayer,
+) -> as_VulnerabilityCase:
+    """Seed CASE_ID with a departing participant so the apply node can find them."""
+    case = as_VulnerabilityCase(id_=CASE_ID, attributed_to=OWNER_ACTOR_ID)
+    participant = CaseParticipant(
+        id_=DEPARTING_PARTICIPANT_ID,
+        attributed_to=DEPARTING_ACTOR_ID,
+        context=CASE_ID,
+    )
+    datalayer.create(participant)
+    case.actor_participant_index[DEPARTING_ACTOR_ID] = DEPARTING_PARTICIPANT_ID
+    datalayer.save(case)
+    return case
+
+
+class TestAnnounceLogEntryAppliesCloseCase:
+    """Participant receiving close_case ledger entry must advance departing actor to RM.CLOSED."""
+
+    def test_participant_advances_departing_actor_to_rm_closed(
+        self, bridge, datalayer, case_actor
+    ):
+        """BT advances the departing actor to RM.CLOSED on close_case entry (CM-23-003, CM-23-004)."""
+        case_obj = _make_case_with_departing_participant(datalayer)
+        entry = _make_close_case_entry(0, case_obj.genesis_hash)
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert result.status == Status.SUCCESS
+        updated = datalayer.read(DEPARTING_PARTICIPANT_ID)
+        assert updated is not None
+        rm_states = [
+            ps.rm.state
+            for ps in updated.participant_statuses
+            if hasattr(ps, "rm") and ps.rm is not None
+        ]
+        assert RM.CLOSED in rm_states, (
+            f"Departing actor must reach RM.CLOSED after close_case announce;"
+            f" rm_states={rm_states}"
+        )
+
+    def test_close_case_not_applied_for_other_event_types(
+        self, bridge, datalayer, case_actor, case_obj
+    ):
+        """CloseCaseEffects Selector short-circuits for unrelated event_types."""
+        _make_case_with_departing_participant(datalayer)
+        entry = _make_entry(
+            0, case_obj.genesis_hash
+        )  # event_type="test_event"
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert result.status == Status.SUCCESS
+        updated = datalayer.read(DEPARTING_PARTICIPANT_ID)
+        assert updated is not None
+        rm_states = [
+            ps.rm.state
+            for ps in updated.participant_statuses
+            if hasattr(ps, "rm") and ps.rm is not None
+        ]
+        assert RM.CLOSED not in rm_states, (
+            f"Non-close-case entry must NOT advance departing actor to RM.CLOSED;"
+            f" rm_states={rm_states}"
+        )
+
+    def test_close_case_apply_is_idempotent(self, datalayer):
+        """ApplyCloseCaseFromLedgerNode called twice must not create duplicate RM.CLOSED entries.
+
+        Calls the apply node directly (bypassing CheckLogEntryAlreadyStored)
+        so we verify the node's own idempotency guard, not the tree-level guard.
+        """
+        from vultron.core.behaviors.case.nodes.leave import (
+            AdvanceParticipantToRMClosedNode,
+        )
+
+        _make_case_with_departing_participant(datalayer)
+
+        def _run_advance() -> None:
+            node = AdvanceParticipantToRMClosedNode(
+                leaving_actor_id=DEPARTING_ACTOR_ID,
+                case_id=CASE_ID,
+            )
+            node.datalayer = datalayer
+            node.setup()
+            node.update()
+
+        _run_advance()
+        _run_advance()
+
+        updated = datalayer.read(DEPARTING_PARTICIPANT_ID)
+        assert updated is not None
+        closed_count = sum(
+            1
+            for ps in updated.participant_statuses
+            if hasattr(ps, "rm")
+            and ps.rm is not None
+            and ps.rm.state == RM.CLOSED
+        )
+        assert closed_count == 1, (
+            f"Expected exactly 1 RM.CLOSED ParticipantStatus;"
+            f" found {closed_count}"
+        )

--- a/test/core/use_cases/test_leave_case_round_trip.py
+++ b/test/core/use_cases/test_leave_case_round_trip.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""AC-5 end-to-end round-trip tests for Leave(VulnerabilityCase).
+
+Tests the full path:
+  Leave emitted (SvcLeaveCaseUseCase)
+  → ledger entry committed (CloseCaseReceivedUseCase on Case Actor)
+  → RM.CLOSED applied on each replica
+
+Two SqliteDataLayer replicas are used: the leaving actor's local DL and
+the Case Actor's local DL.  The test drives the BT directly via
+CloseCaseReceivedUseCase rather than HTTP delivery, which gives a
+deterministic round-trip without network noise.
+
+Per specs/case-management.yaml CM-23-002, CM-23-003, ADR-0050.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
+from vultron.core.models.activity import VultronActivity
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.events.base import MessageSemantics
+from vultron.core.models.events.case import CloseCaseReceivedEvent
+from vultron.core.states.rm import RM
+from vultron.core.use_cases.received.case.lifecycle import (
+    CloseCaseReceivedUseCase,
+)
+from vultron.core.use_cases.triggers.case import (
+    LeaveCaseTriggerRequest,
+    SvcLeaveCaseUseCase,
+)
+from vultron.enums.roles import CVDRole
+from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import (
+    as_ParticipantStatus as WireParticipantStatus,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CASE_ACTOR_URL = "https://example.org/actors/case-actor-rt"
+VENDOR_URL = "https://example.org/actors/vendor-rt"
+FINDER_URL = "https://example.org/actors/finder-rt"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_actor_dl(url: str) -> tuple[as_Service, SqliteDataLayer]:
+    actor = as_Service(name=url.split("/")[-1], url=url)
+    dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor.id_)
+    dl.clear_all()
+    dl.create(actor)
+    return actor, dl
+
+
+def _seed_case(
+    dl: SqliteDataLayer,
+    case_id: str,
+    actor_id: str,
+    role: CVDRole,
+    case_actor_id: str,
+) -> tuple[as_VulnerabilityCase, as_CaseParticipant]:
+    """Seed a VulnerabilityCase with one participant + a CASE_MANAGER.
+
+    Returns the case and the seeded participant for ``actor_id``.
+    """
+    case = as_VulnerabilityCase(
+        id_=case_id, name="Round-Trip Test Case", attributed_to=case_actor_id
+    )
+
+    participant = as_CaseParticipant(
+        attributed_to=actor_id,
+        context=case_id,
+        case_roles=[role],
+    )
+    participant.participant_statuses.append(
+        WireParticipantStatus(context=case_id, rm_state=RM.RECEIVED)
+    )
+    participant.participant_statuses.append(
+        WireParticipantStatus(context=case_id, rm_state=RM.VALID)
+    )
+    participant.participant_statuses.append(
+        WireParticipantStatus(context=case_id, rm_state=RM.ACCEPTED)
+    )
+    dl.create(participant)
+    case.actor_participant_index[actor_id] = participant.id_
+    case.case_participants.append(participant.id_)
+
+    cm_participant = as_CaseParticipant(
+        attributed_to=case_actor_id,
+        context=case_id,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    # Bootstrap CaseActor with 3 statuses + RM.CLOSED so AllParticipantsRMClosed
+    # can succeed after owner Leave (ADR-0051, CM-23-005).
+    for state in [RM.RECEIVED, RM.VALID, RM.ACCEPTED, RM.CLOSED]:
+        cm_participant.participant_statuses.append(
+            WireParticipantStatus(context=case_id, rm_state=state)
+        )
+    dl.create(cm_participant)
+    case.actor_participant_index[case_actor_id] = cm_participant.id_
+    case.case_participants.append(cm_participant.id_)
+
+    dl.save(case)
+    return case, participant
+
+
+def _participant_rm_states(
+    dl: SqliteDataLayer, case_id: str, actor_id: str
+) -> list[RM]:
+    case = dl.read(case_id)
+    if not isinstance(case, VulnerabilityCase):
+        return []
+    pid = case.actor_participant_index.get(actor_id)
+    if pid is None:
+        return []
+    participant = dl.read(pid)
+    if not isinstance(participant, CaseParticipant):
+        return []
+    return [
+        ps.rm.state
+        for ps in participant.participant_statuses
+        if hasattr(ps, "rm") and ps.rm is not None
+    ]
+
+
+def _make_close_case_event(
+    activity_id: str,
+    sender_actor_id: str,
+    case_id: str,
+    receiving_actor_id: str,
+) -> CloseCaseReceivedEvent:
+    activity = VultronActivity(
+        id_=activity_id,
+        type_="Leave",
+        actor=sender_actor_id,
+        object_=as_VulnerabilityCase(id_=case_id),
+    )
+    return CloseCaseReceivedEvent(
+        semantic_type=MessageSemantics.CLOSE_CASE,
+        activity_id=activity.id_,
+        actor_id=sender_actor_id,
+        object_=activity.object_,
+        activity=activity,
+        receiving_actor_id=receiving_actor_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vendor_and_dl():
+    actor, dl = _make_actor_dl(VENDOR_URL)
+    yield actor, dl
+    dl.close()
+
+
+@pytest.fixture
+def case_actor_and_dl():
+    actor, dl = _make_actor_dl(CASE_ACTOR_URL)
+    yield actor, dl
+    dl.close()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestLeaveCaseRoundTrip:
+    """AC-5: end-to-end Leave → ledger → RM.CLOSED across two replicas."""
+
+    def test_non_owner_leave_emitted_then_received_sets_rm_closed(
+        self,
+        vendor_and_dl: tuple[as_Service, SqliteDataLayer],
+        case_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+    ):
+        """Non-owner Leave round-trip: RM.CLOSED applied after ledger receipt (CM-23-003).
+
+        Step 1: SvcLeaveCaseUseCase queues Leave in the vendor's outbox.
+        Step 2: CloseCaseReceivedUseCase processes it on the Case Actor's DL.
+        Step 3: vendor's RM state on the Case Actor's DL is RM.CLOSED.
+        """
+        vendor, vendor_dl = vendor_and_dl
+        case_actor, ca_dl = case_actor_and_dl
+
+        case, _ = _seed_case(
+            vendor_dl,
+            case_id="https://example.org/cases/rt-non-owner",
+            actor_id=vendor.id_,
+            role=CVDRole.VENDOR,
+            case_actor_id=case_actor.id_,
+        )
+        # Mirror case on Case Actor's DL
+        _seed_case(
+            ca_dl,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            role=CVDRole.VENDOR,
+            case_actor_id=case_actor.id_,
+        )
+
+        # Step 1: vendor triggers Leave
+        request = LeaveCaseTriggerRequest(
+            actor_id=vendor.id_,
+            case_id=case.id_,
+        )
+        before = set(vendor_dl.outbox_list_for_actor(vendor.id_))
+        SvcLeaveCaseUseCase(
+            vendor_dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(vendor_dl),
+        ).execute()
+        after = set(vendor_dl.outbox_list_for_actor(vendor.id_))
+        assert after - before, "Leave must be queued in vendor outbox"
+
+        # AC-2: vendor RM is NOT closed immediately at send time
+        assert RM.CLOSED not in _participant_rm_states(
+            vendor_dl, case.id_, vendor.id_
+        ), "RM.CLOSED must not be set at send time (AC-2)"
+
+        # Step 2: Case Actor receives the Leave
+        event = _make_close_case_event(
+            activity_id="https://example.org/activities/leave-rt-non-owner",
+            sender_actor_id=vendor.id_,
+            case_id=case.id_,
+            receiving_actor_id=case_actor.id_,
+        )
+        CloseCaseReceivedUseCase(
+            dl=ca_dl,
+            request=event,
+            sync_port=SyncActivityAdapter(ca_dl),
+        ).execute()
+
+        # Step 3: vendor is RM.CLOSED on Case Actor replica (CM-23-003)
+        rm_states = _participant_rm_states(ca_dl, case.id_, vendor.id_)
+        assert RM.CLOSED in rm_states, (
+            f"Non-owner Leave must advance vendor to RM.CLOSED on Case Actor replica;"
+            f" rm_states={rm_states}"
+        )
+
+    def test_ghost_protection_leave_emitted_but_never_delivered(
+        self,
+        vendor_and_dl: tuple[as_Service, SqliteDataLayer],
+        case_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+    ):
+        """Lost Leave must NOT result in RM.CLOSED — ghosting protection (AC-2).
+
+        The vendor emits Leave, but the message never reaches the Case Actor.
+        Both replicas must remain at RM.ACCEPTED, not RM.CLOSED.
+        """
+        vendor, vendor_dl = vendor_and_dl
+        case_actor, ca_dl = case_actor_and_dl
+
+        case, _ = _seed_case(
+            vendor_dl,
+            case_id="https://example.org/cases/rt-ghost",
+            actor_id=vendor.id_,
+            role=CVDRole.VENDOR,
+            case_actor_id=case_actor.id_,
+        )
+        _seed_case(
+            ca_dl,
+            case_id=case.id_,
+            actor_id=vendor.id_,
+            role=CVDRole.VENDOR,
+            case_actor_id=case_actor.id_,
+        )
+
+        # Vendor emits Leave — message is lost, never delivered
+        request = LeaveCaseTriggerRequest(
+            actor_id=vendor.id_,
+            case_id=case.id_,
+        )
+        SvcLeaveCaseUseCase(
+            vendor_dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(vendor_dl),
+        ).execute()
+
+        # Neither replica must be at RM.CLOSED
+        vendor_rm = _participant_rm_states(vendor_dl, case.id_, vendor.id_)
+        assert RM.CLOSED not in vendor_rm, (
+            f"Lost Leave must NOT set RM.CLOSED on vendor replica;"
+            f" rm_states={vendor_rm}"
+        )
+        ca_rm = _participant_rm_states(ca_dl, case.id_, vendor.id_)
+        assert RM.CLOSED not in ca_rm, (
+            f"Lost Leave must NOT set RM.CLOSED on Case Actor replica;"
+            f" rm_states={ca_rm}"
+        )
+
+    def test_owner_leave_closes_case_actor_rm(
+        self,
+        vendor_and_dl: tuple[as_Service, SqliteDataLayer],
+        case_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+    ):
+        """Owner Leave round-trip: CaseActor advances to RM.CLOSED (CM-23-002 step 2)."""
+        vendor, vendor_dl = vendor_and_dl
+        case_actor, ca_dl = case_actor_and_dl
+        case_id = "https://example.org/cases/rt-owner"
+
+        case, _ = _seed_case(
+            vendor_dl,
+            case_id=case_id,
+            actor_id=vendor.id_,
+            role=CVDRole.CASE_OWNER,
+            case_actor_id=case_actor.id_,
+        )
+        _seed_case(
+            ca_dl,
+            case_id=case_id,
+            actor_id=vendor.id_,
+            role=CVDRole.CASE_OWNER,
+            case_actor_id=case_actor.id_,
+        )
+
+        event = _make_close_case_event(
+            activity_id="https://example.org/activities/owner-leave-rt",
+            sender_actor_id=vendor.id_,
+            case_id=case_id,
+            receiving_actor_id=case_actor.id_,
+        )
+        CloseCaseReceivedUseCase(
+            dl=ca_dl,
+            request=event,
+            sync_port=SyncActivityAdapter(ca_dl),
+        ).execute()
+
+        owner_rm = _participant_rm_states(ca_dl, case_id, vendor.id_)
+        assert RM.CLOSED in owner_rm, (
+            f"Owner Leave must advance owner to RM.CLOSED (CM-23-002);"
+            f" rm_states={owner_rm}"
+        )
+        ca_rm = _participant_rm_states(ca_dl, case_id, case_actor.id_)
+        assert RM.CLOSED in ca_rm, (
+            f"Owner Leave must advance CaseActor to RM.CLOSED (CM-23-002 step 2);"
+            f" rm_states={ca_rm}"
+        )

--- a/test/core/use_cases/test_leave_case_round_trip.py
+++ b/test/core/use_cases/test_leave_case_round_trip.py
@@ -120,9 +120,10 @@ def _seed_case(
         context=case_id,
         case_roles=[CVDRole.CASE_MANAGER],
     )
-    # Bootstrap CaseActor with 3 statuses + RM.CLOSED so AllParticipantsRMClosed
-    # can succeed after owner Leave (ADR-0051, CM-23-005).
-    for state in [RM.RECEIVED, RM.VALID, RM.ACCEPTED, RM.CLOSED]:
+    # Bootstrap CaseActor with RM lifecycle up to ACCEPTED only.
+    # RM.CLOSED is intentionally absent — AdvanceCaseActorToRMClosedNode must
+    # add it during owner Leave; pre-seeding would make the assertion vacuous.
+    for state in [RM.RECEIVED, RM.VALID, RM.ACCEPTED]:
         cm_participant.participant_statuses.append(
             WireParticipantStatus(context=case_id, rm_state=state)
         )
@@ -316,9 +317,18 @@ class TestLeaveCaseRoundTrip:
             f"Lost Leave must NOT set RM.CLOSED on vendor replica;"
             f" rm_states={vendor_rm}"
         )
+        # CA replica check: _participant_rm_states on an untouched DL verifies
+        # the seeding itself did not create RM.CLOSED (sanity guard) AND that
+        # SvcLeaveCaseUseCase did not bypass protocol and write to a foreign DL.
         ca_rm = _participant_rm_states(ca_dl, case.id_, vendor.id_)
         assert RM.CLOSED not in ca_rm, (
             f"Lost Leave must NOT set RM.CLOSED on Case Actor replica;"
+            f" rm_states={ca_rm}"
+        )
+        # Explicit: seeding ends at RM.ACCEPTED, so RM.CLOSED absence confirms
+        # neither SvcLeaveCaseUseCase nor the seeding wrote it.
+        assert RM.ACCEPTED in ca_rm, (
+            "CA replica must still be at RM.ACCEPTED (never advanced);"
             f" rm_states={ca_rm}"
         )
 
@@ -327,7 +337,13 @@ class TestLeaveCaseRoundTrip:
         vendor_and_dl: tuple[as_Service, SqliteDataLayer],
         case_actor_and_dl: tuple[as_Service, SqliteDataLayer],
     ):
-        """Owner Leave round-trip: CaseActor advances to RM.CLOSED (CM-23-002 step 2)."""
+        """Owner Leave round-trip: RM.CLOSED after ledger delivery (CM-23-002 step 2).
+
+        Step 1: SvcLeaveCaseUseCase queues Leave in the vendor's outbox.
+        Step 2: RM.CLOSED must NOT be set at send time (AC-2).
+        Step 3: CloseCaseReceivedUseCase processes Leave on the Case Actor's DL.
+        Step 4: Both owner and CaseActor are at RM.CLOSED on the CA replica.
+        """
         vendor, vendor_dl = vendor_and_dl
         case_actor, ca_dl = case_actor_and_dl
         case_id = "https://example.org/cases/rt-owner"
@@ -347,6 +363,29 @@ class TestLeaveCaseRoundTrip:
             case_actor_id=case_actor.id_,
         )
 
+        # Step 1: vendor (Case Owner) triggers Leave
+        request = LeaveCaseTriggerRequest(
+            actor_id=vendor.id_,
+            case_id=case.id_,
+        )
+        before = set(vendor_dl.outbox_list_for_actor(vendor.id_))
+        SvcLeaveCaseUseCase(
+            vendor_dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(vendor_dl),
+        ).execute()
+        after = set(vendor_dl.outbox_list_for_actor(vendor.id_))
+        assert after - before, "Owner Leave must be queued in vendor outbox"
+
+        # Step 2: AC-2 — RM.CLOSED must NOT be set at send time
+        assert RM.CLOSED not in _participant_rm_states(
+            vendor_dl, case.id_, vendor.id_
+        ), "RM.CLOSED must not be set at send time on owner path (AC-2)"
+        assert RM.CLOSED not in _participant_rm_states(
+            ca_dl, case_id, case_actor.id_
+        ), "CaseActor RM.CLOSED must not be pre-set before ledger delivery"
+
+        # Step 3: Case Actor receives the Leave
         event = _make_close_case_event(
             activity_id="https://example.org/activities/owner-leave-rt",
             sender_actor_id=vendor.id_,
@@ -359,6 +398,7 @@ class TestLeaveCaseRoundTrip:
             sync_port=SyncActivityAdapter(ca_dl),
         ).execute()
 
+        # Step 4: owner and CaseActor are both RM.CLOSED on the CA replica
         owner_rm = _participant_rm_states(ca_dl, case_id, vendor.id_)
         assert RM.CLOSED in owner_rm, (
             f"Owner Leave must advance owner to RM.CLOSED (CM-23-002);"


### PR DESCRIPTION
- Closes #1858

## Summary

Adds the missing test coverage for Issue #1858 (`SvcLeaveCaseUseCase` and
Leave(VulnerabilityCase) closure path). The core implementation landed in PRs
#1901, #1965, and #1966; this PR adds the three test groups that were not yet
present at HEAD.

## Changes

**`test/core/use_cases/test_leave_case_round_trip.py`** (new, 3 tests)
AC-5 end-to-end round-trip across two `SqliteDataLayer` replicas:
- Non-owner Leave emitted → `CloseCaseReceivedUseCase` on Case Actor DL → vendor participant reaches `RM.CLOSED` (CM-23-003)
- Ghost-protection: Leave emitted but never delivered leaves both replicas at `RM.ACCEPTED`, not `RM.CLOSED` (AC-2)
- Owner Leave: `CloseCaseReceivedUseCase` advances both owner and CaseActor to `RM.CLOSED` (CM-23-002 step 2)

**`test/core/behaviors/sync/test_announce_tree.py`** (3 new tests + 1 in `TestEffectsFailureBlocksPersist`)
`TestAnnounceLogEntryAppliesCloseCase` — the `CloseCaseEffects` Selector slot in `AnnounceLogEntryReceivedBT`:
- `close_case` entry advances departing actor to `RM.CLOSED` on replica
- Unrelated event types do not advance departing actor (guard short-circuits)
- `AdvanceParticipantToRMClosedNode` called twice produces exactly one `RM.CLOSED` ParticipantStatus (node-level idempotency, bypasses tree guard)
- `ApplyCloseCaseFromLedger` FAILURE blocks `PersistReceivedLogEntry` (SYNC-12-001)

**`test/adapters/driving/fastapi/routers/test_demo_triggers.py`** (4 new tests in `TestDemoCloseCase`)
Demo endpoint `POST /{actor_id}/demo/close-case`:
- Returns 202
- Response body contains a `Leave` activity with the correct `actor`
- `RM.CLOSED` is not set at send time (AC-2)
- Unknown case returns 404

## Verification

- 6100 tests pass (11 new), 0 failures
- Black, flake8, mypy, pyright clean

## Deviations / notes

The core implementation was already fully present at HEAD via PRs #1901, #1965, and #1966 — this PR adds tests only. The branch was rebased clean onto `origin/main`; old implementation commits from the draft phase are gone.

Pre-existing Pyright INFORMATION warnings at lines 145 and 448 of `test_announce_tree.py` (`case_actor` fixture unused in two original test helpers) are not introduced by this PR.