### PR TITLE
docs: plan issue #1910 — DEMOMA-07-001 RM closure path contradiction

### DIFF
--- a/docs/adr/0050-leave-vul-case-canonical-rm-closure.md
+++ b/docs/adr/0050-leave-vul-case-canonical-rm-closure.md
@@ -81,8 +81,11 @@ Chosen option: **`Leave(VulnerabilityCase)` only**, because:
   is the implementation of the `Leave` receive path.
 - `create_close_case_received_tree` in
   `vultron/core/behaviors/case/receive_close_case_tree.py` is the BT factory.
-- Tests verifying RM.CLOSED is reached only after the ledger round-trip:
-  `test/core/use_cases/test_leave_case_round_trip.py`.
+- Tests for the `Leave` receive path:
+  `test/core/use_cases/received/test_close_case_routing.py` and
+  `test/core/use_cases/triggers/test_close_case_trigger.py`.
+  A dedicated ledger round-trip test is planned in the sidecar
+  implementation issues (#1916, #1917).
 - After #1901 lands: no `AutoCloseSequence` in `add_participant_status_tree`
   (regression test AC on the cleanup issue from #1910).
 

--- a/docs/adr/0050-leave-vuln-case-canonical-rm-closure.md
+++ b/docs/adr/0050-leave-vuln-case-canonical-rm-closure.md
@@ -1,0 +1,113 @@
+---
+status: accepted
+date: 2026-08-03
+deciders: Allen D. Householder
+consulted: []
+informed: []
+---
+
+# Leave(VulnerabilityCase) Is the Canonical RM Case Closure Mechanism
+
+## Context and Problem Statement
+
+`DEMOMA-07-001` originally stated that RM case closure MUST be driven through
+`Add(ParticipantStatus, rm_state=RM.CLOSED)` sent to the Case Actor inbox —
+the same path as CS transitions (fix-ready, fix-deployed, published).
+
+PR #1909 (issue #1858) changed RM case closure to flow through
+`Leave(VulnerabilityCase)` → Case Actor commits a `close_case`
+`CaseLedgerEntry` → broadcast → each replica advances the leaving participant's
+RM state to `RM.CLOSED` on receipt. The three CS transitions were left
+unchanged.
+
+This created a contradiction: `DEMOMA-07-001` said closure must use
+`Add(ParticipantStatus)`, but the implementation used `Leave`. The question is:
+which mechanism is canonical?
+
+## Decision Drivers
+
+- The Case Actor should be the authority for RM closure, not individual
+  participants asserting their own terminal state.
+- A lost `Add(ParticipantStatus, rm_state=RM.CLOSED)` message would allow a
+  participant to ghost a case: their local state becomes `RM.CLOSED` but peers
+  never learn about it.
+- The `Leave` round-trip makes closure observable to all replicas via the
+  canonical ledger rather than as a direct state assertion from the departing
+  participant.
+- The existing `CloseCaseReceivedUseCase` and `create_close_case_received_tree`
+  already implement the `Leave` path as of #1909.
+
+## Considered Options
+
+- **`Leave(VulnerabilityCase)` only** — canonical closure path; `Add(ParticipantStatus,
+  rm_state=RM.CLOSED)` is not a valid closure trigger.
+- **`Add(ParticipantStatus, rm_state=RM.CLOSED)` only** — revert to original
+  `DEMOMA-07-001` intent; roll back #1909.
+- **Either path is valid** — both `Add(ParticipantStatus)` and `Leave` are
+  acceptable closure triggers.
+
+## Decision Outcome
+
+Chosen option: **`Leave(VulnerabilityCase)` only**, because:
+
+- It makes the Case Actor the single authority for RM closure, consistent with
+  the log-centric single-writer regime (ADR-0019, ADR-0021).
+- It prevents ghost-departures: a participant cannot silently reach `RM.CLOSED`
+  on peers without the Case Actor having committed and broadcast a ledger entry.
+- It is already implemented by #1909; rolling back would reintroduce the
+  ghost-departure hazard.
+- `Add(ParticipantStatus)` is semantically a status announcement, not a
+  closure command; conflating the two overloads the message type.
+
+### Consequences
+
+- Good, because RM closure is observable on all replicas via the canonical
+  ledger chain, not inferred from direct status assertions.
+- Good, because the Case Actor can enforce closure sequencing (e.g., embargo
+  teardown must precede closure) via the `Leave` receive path.
+- Good, because `AutoCloseSequence` in `add_participant_status_tree` becomes
+  correctly identified as dead code and can be removed (issue from #1910).
+- Neutral, because `DEMOMA-07-001` must be amended to scope its clause to
+  CS transitions only; this is a spec clarification, not a behavior change.
+- Bad, because `AllParticipantsRMClosedConditionNode` (formerly step 5 of
+  `add_participant_status_tree`) evaluated the all-closed condition only when
+  `Add(ParticipantStatus)` arrived — which always precedes any `Leave`.
+  Step 5's auto-close semantics are therefore moved to the `Leave` receive
+  path (see ADR-0051, CM-23-002).
+
+## Validation
+
+- `CloseCaseReceivedUseCase` in `vultron/core/use_cases/received/case/lifecycle.py`
+  is the implementation of the `Leave` receive path.
+- `create_close_case_received_tree` in
+  `vultron/core/behaviors/case/receive_close_case_tree.py` is the BT factory.
+- Tests verifying RM.CLOSED is reached only after the ledger round-trip:
+  `test/core/use_cases/test_leave_case_round_trip.py`.
+- After #1901 lands: no `AutoCloseSequence` in `add_participant_status_tree`
+  (regression test AC on the cleanup issue from #1910).
+
+## Pros and Cons of the Options
+
+### `Leave(VulnerabilityCase)` only
+
+- Good, because Case Actor is the single authority for closure (ADR-0019).
+- Good, because prevents ghost-departures (lost `Add(ParticipantStatus)` message).
+- Good, because closure is a ledger-observable event, not a state inference.
+- Neutral, because `DEMOMA-07-001` requires amendment.
+
+### `Add(ParticipantStatus, rm_state=RM.CLOSED)` only
+
+- Good, because consistent with DEMOMA-07-001 as originally written.
+- Bad, because participant asserts its own terminal state; peers must accept it.
+- Bad, because a lost message allows ghost-departure.
+- Bad, because rolling back #1909 reintroduces the ghost-departure hazard.
+
+### Either path is valid
+
+- Good, because backward compatible.
+- Bad, because two closure paths create ambiguity about which event is canonical.
+- Bad, because `add_participant_status_tree` would need to handle
+  `rm_state=RM.CLOSED` as a closure trigger, re-introducing the hazard.
+
+Generated spec requirements: `case-management.yaml` CM-23-001 through CM-23-004;
+`multi-actor-demo.yaml` DEMOMA-07-001 (amended).

--- a/docs/adr/0051-caseactor-rm-lifecycle.md
+++ b/docs/adr/0051-caseactor-rm-lifecycle.md
@@ -1,0 +1,111 @@
+---
+status: accepted
+date: 2026-08-03
+deciders: Allen D. Householder
+consulted: []
+informed: []
+---
+
+# CaseActor Has Its Own RM Lifecycle Tracked via CaseParticipant
+
+## Context and Problem Statement
+
+The CaseActor registers itself as a `CaseParticipant` with
+`CVDRole.COORDINATOR + CVDRole.CASE_MANAGER` during case initialization
+(ADR-0041, CM-22-001). However, this `CaseParticipant` record has historically
+had no `ParticipantStatus` entries and therefore no RM state.
+
+With `Leave(VulnerabilityCase)` as the canonical RM closure path (ADR-0050),
+owner `Leave` must advance the Case Actor's own RM state to `RM.CLOSED` as
+the penultimate step before emitting the final `case_fully_closed`
+`CaseLedgerEntry` (CM-23-002). This requires the Case Actor to have a valid
+RM lifecycle starting from `RM.RECEIVED`.
+
+The question is: should the Case Actor have an RM lifecycle at all, and if so,
+what do the RM states mean for a coordinator?
+
+## Decision Drivers
+
+- Owner `Leave` processing (CM-23-002) requires the Case Actor to advance to
+  `RM.CLOSED`; this requires a prior RM state to transition from.
+- Uniform RM lifecycle tracking across all participants, including the
+  coordinator, keeps the case-level RM model consistent and avoids
+  special-casing the Case Actor in ledger consumers.
+- Each RM transition should be a `CaseLedgerEntry` (CM-02-009) so the
+  Case Actor's role in case initialization is part of the traceable ledger
+  history.
+- The RM state machine transitions are already meaningful for the coordinator
+  if the states are reinterpreted in terms of case-level events rather than
+  report-validation events.
+
+## Considered Options
+
+- **Case Actor has full RM lifecycle** — add `ParticipantStatus` entries at
+  `RM.RECEIVED`, `RM.VALID`, `RM.ACCEPTED` during bootstrap; advance to
+  `RM.CLOSED` on owner Leave. Each is a `CaseLedgerEntry`.
+- **Bootstrap directly at RM.ACCEPTED** — skip `RECEIVED`/`VALID`; start at
+  `ACCEPTED`. Simpler but bypasses the state machine.
+- **No RM lifecycle for Case Actor** — Case Actor's `CaseParticipant` never
+  has `RM` state; case closure is a distinct mechanism that does not involve
+  the RM machine.
+
+## Decision Outcome
+
+Chosen option: **Case Actor has full RM lifecycle**, because:
+
+- It avoids introducing a `START → ACCEPTED` shortcut that would break the
+  RM state machine invariants for all participants.
+- The RM transitions map cleanly to case-level events for the coordinator
+  (see CM-23-006 for the mapping).
+- Each transition as a `CaseLedgerEntry` gives the ledger a complete
+  protocol-significant history of case initialization.
+- Owner `Leave` can then cleanly advance the Case Actor to `RM.CLOSED` as
+  the penultimate ledger step.
+
+### Consequences
+
+- Good, because case initialization is fully traceable in the ledger with
+  timestamped CaseActor RM transitions.
+- Good, because `RM.CLOSED` for the Case Actor is a clean terminal signal
+  that the case is fully closed.
+- Good, because ledger consumers need no special-casing for the Case Actor
+  participant.
+- Neutral, because `AllParticipantsRMClosedConditionNode` currently skips
+  `CVDRole.CASE_MANAGER` participants. After the sidecar impl issue lands,
+  this skip can be removed so the Case Actor's `RM.CLOSED` participates in
+  the all-closed check.
+- Bad, because `RegisterCaseActorAsParticipantNode` in
+  `case_proposal_received_tree.py` must be updated to emit three
+  `ParticipantStatus` records at bootstrap instead of none.
+- Bad, because three new `CaseLedgerEntry` records are emitted per case
+  initialization (minor overhead; acceptable for audit completeness).
+
+## Case Actor RM State Meanings
+
+The RM state machine labels map to the following case-level events for the
+Case Actor:
+
+| RM State | Meaning for Case Actor |
+|---|---|
+| `RM.RECEIVED` | A `CaseProposal` has been received and is being evaluated |
+| `RM.VALID` | The `CaseProposal` is correctly formatted and actionable; case creation has begun |
+| `RM.ACCEPTED` | The `VulnerabilityCase` has been successfully created and is being coordinated |
+| `RM.CLOSED` | The Case Owner has sent `Leave(VulnerabilityCase)`; the case is fully closed |
+
+`RM.DEFERRED` and `RM.INVALID` are not used in the Case Actor's lifecycle
+(a `CaseProposal` that is not valid is rejected, not deferred).
+
+## Validation
+
+- `RegisterCaseActorAsParticipantNode` (or equivalent) in
+  `case_proposal_received_tree.py` must emit `ParticipantStatus` records for
+  `RM.RECEIVED`, `RM.VALID`, and `RM.ACCEPTED` at bootstrap.
+- Each bootstrap transition must produce a `CaseLedgerEntry` in the canonical
+  ledger.
+- Owner `Leave` processing must advance the Case Actor participant to
+  `RM.CLOSED` before emitting the final `case_fully_closed` entry.
+- `AllParticipantsRMClosedConditionNode` currently skips `CASE_MANAGER`;
+  after the sidecar impl issue lands, this skip SHOULD be removed.
+- Implementation tracked in the sidecar issue from #1910 planning.
+
+Generated spec requirements: `case-management.yaml` CM-23-005 through CM-23-007.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -118,6 +118,8 @@ General information about architectural decision records is available at <https:
 - [ADR-0047 Report-to-Others Party Discovery: Sentinel Over Inline BT Loop](0047-report-to-others-sentinel-over-inline-bt.md)
 - [ADR-0048 PEC `NO_EMBARGO` Means Absence of Embargo, Not Pre-Consent](0048-pec-no-embargo-is-absence-not-pre-consent.md)
 - [ADR-0049 Core Does Not Model Inbound Protocol Error Message Types; No `create_inbound_error_followup_tree`](0049-core-does-not-model-error-message-types.md)
+- [ADR-0050 Leave(VulnerabilityCase) Is the Canonical RM Case Closure Mechanism](0050-leave-vuln-case-canonical-rm-closure.md)
+- [ADR-0051 CaseActor Has Its Own RM Lifecycle Tracked via CaseParticipant](0051-caseactor-rm-lifecycle.md)
 
 ## Proposed ADRs
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -118,7 +118,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0047 Report-to-Others Party Discovery: Sentinel Over Inline BT Loop](0047-report-to-others-sentinel-over-inline-bt.md)
 - [ADR-0048 PEC `NO_EMBARGO` Means Absence of Embargo, Not Pre-Consent](0048-pec-no-embargo-is-absence-not-pre-consent.md)
 - [ADR-0049 Core Does Not Model Inbound Protocol Error Message Types; No `create_inbound_error_followup_tree`](0049-core-does-not-model-error-message-types.md)
-- [ADR-0050 Leave(VulnerabilityCase) Is the Canonical RM Case Closure Mechanism](0050-leave-vuln-case-canonical-rm-closure.md)
+- [ADR-0050 Leave(VulnerabilityCase) Is the Canonical RM Case Closure Mechanism](0050-leave-vul-case-canonical-rm-closure.md)
 - [ADR-0051 CaseActor Has Its Own RM Lifecycle Tracked via CaseParticipant](0051-caseactor-rm-lifecycle.md)
 
 ## Proposed ADRs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -267,7 +267,7 @@ nav:
       - Report-to-Others Party Discovery Sentinel: 'adr/0047-report-to-others-sentinel-over-inline-bt.md'
       - PEC NO_EMBARGO Is Absence Not Pre-Consent: 'adr/0048-pec-no-embargo-is-absence-not-pre-consent.md'
       - No Core Error Message Types or Error-Followup Factory: 'adr/0049-core-does-not-model-error-message-types.md'
-      - Leave(VulnerabilityCase) Is the Canonical RM Closure Mechanism: 'adr/0050-leave-vuln-case-canonical-rm-closure.md'
+      - Leave(VulnerabilityCase) Is the Canonical RM Closure Mechanism: 'adr/0050-leave-vul-case-canonical-rm-closure.md'
       - CaseActor Has Its Own RM Lifecycle via CaseParticipant: 'adr/0051-caseactor-rm-lifecycle.md'
   - About:
     - Contributing: 'about/contributing.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -267,6 +267,8 @@ nav:
       - Report-to-Others Party Discovery Sentinel: 'adr/0047-report-to-others-sentinel-over-inline-bt.md'
       - PEC NO_EMBARGO Is Absence Not Pre-Consent: 'adr/0048-pec-no-embargo-is-absence-not-pre-consent.md'
       - No Core Error Message Types or Error-Followup Factory: 'adr/0049-core-does-not-model-error-message-types.md'
+      - Leave(VulnerabilityCase) Is the Canonical RM Closure Mechanism: 'adr/0050-leave-vuln-case-canonical-rm-closure.md'
+      - CaseActor Has Its Own RM Lifecycle via CaseParticipant: 'adr/0051-caseactor-rm-lifecycle.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/plan/history/2608/learning/CONCERN-1910.md
+++ b/plan/history/2608/learning/CONCERN-1910.md
@@ -1,0 +1,79 @@
+---
+source: CONCERN-1910
+timestamp: '2026-08-03T15:16:03.574942+00:00'
+title: DEMOMA-07-001 RM closure path — Leave(VulnerabilityCase) is canonical
+type: learning
+---
+
+## Concern
+
+`DEMOMA-07-001` mandated that RM case closure flow through
+`Add(ParticipantStatus, rm_state=RM.CLOSED)`. PR #1909 (issue #1858)
+changed RM closure to flow through `Leave(VulnerabilityCase)`, creating
+a direct contradiction. The spec said one thing; the implementation did
+another. Step 5 (`AutoCloseSequence`) in `add_participant_status_tree`
+became dead code as a result — `AllParticipantsRMClosedConditionNode`
+always returns FAILURE because all `Add(ParticipantStatus)` messages arrive
+before any `Leave`.
+
+## Resolution
+
+`Leave(VulnerabilityCase)` is the canonical RM closure mechanism.
+`Add(ParticipantStatus, rm_state=RM.CLOSED)` MUST NOT be used as a closure
+trigger. Rationale: the Case Actor is the single authority for closure
+(log-centric single-writer regime, ADR-0019/ADR-0021); the `Leave`
+round-trip makes closure observable to all replicas via the canonical
+ledger; a lost `Add(ParticipantStatus)` message would allow ghost-departures.
+
+Two new ADRs were authored:
+
+- **ADR-0050**: `Leave(VulnerabilityCase)` is the canonical RM closure
+  mechanism; `Add(ParticipantStatus, rm_state=RM.CLOSED)` is prohibited.
+- **ADR-0051**: CaseActor has a full RM lifecycle tracked via
+  `CaseParticipant` (`RECEIVED → VALID → ACCEPTED` at bootstrap, `CLOSED`
+  on owner `Leave`). Each transition is a `CaseLedgerEntry`. RM state
+  meanings for the coordinator: RECEIVED=CaseProposal received,
+  VALID=proposal validated+case creation begun, ACCEPTED=case created,
+  CLOSED=owner Left.
+
+A new spec group **CM-23** was added to `specs/case-management.yaml`
+(CM-23-001 through CM-23-007), covering:
+
+- Leave-only closure (CM-23-001)
+- Owner Leave sequence: owner→CLOSED, CaseActor→CLOSED, final
+  `case_fully_closed` entry, fan-out (CM-23-002)
+- Non-owner Leave: only that participant→CLOSED (CM-23-003)
+- Fan-out exclusion of RM.CLOSED participants (CM-23-004)
+- CaseActor RM lifecycle bootstrap (CM-23-005 through CM-23-007)
+
+`DEMOMA-07-001` was amended to scope its clause to CS transitions only;
+`DEMOMA-07-003 step 5` and `DEMOMA-07-006` were marked `[SUPERSEDED]`.
+
+## Implementation Issues
+
+- #1916 — Remove `AutoCloseSequence` + conform to CM-23-001 through
+  CM-23-004 (blocked by #1901)
+- #1917 — CaseActor `CaseParticipant` RM lifecycle bootstrap: CM-23-005
+  through CM-23-007 (blocked by #1901)
+- #1918 — Idea: Rejoin semantics for departed case participants (deferred)
+
+## Key Design Notes
+
+- Owner Leave vs non-owner Leave: owner closes the case for all; non-owner
+  removes only that participant.
+- `EmitCloseCaseNode` in the dead `AutoCloseSequence` uses
+  `actor=self.actor_id` — this would have advanced the CaseActor's own
+  participant to `RM.CLOSED` as a departing participant, which is hazardous
+  under the Leave path.
+- `RM.CLOSED` is currently terminal. The rejoin question (whether it should
+  be non-terminal, or whether a new `RM.TERMINATED` state is needed) is
+  deferred to #1918.
+- `AllParticipantsRMClosedConditionNode` currently skips
+  `CVDRole.CASE_MANAGER` participants. After #1917 lands, this skip can be
+  removed.
+- Issue #1858 (blocked by this concern) will need #1916 and #1917 wired as
+  blockers appropriately.
+
+## Docs PR
+
+<https://github.com/CERTCC/Vultron/pull/1915>

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -1235,3 +1235,146 @@ groups:
       spec_id: CP-09-003
     adr:
     - ADR-0041
+
+- id: CM-23
+  title: RM Case Closure via Leave(VulnerabilityCase)
+  description: >-
+    Requirements for the canonical RM case closure path: Leave(VulnerabilityCase)
+    is the sole mechanism for advancing a participant's RM state to CLOSED.
+    Add(ParticipantStatus, rm_state=RM.CLOSED) is not a valid closure trigger.
+    See ADR-0050 (Leave is canonical for RM closure) and ADR-0051
+    (CaseActor RM lifecycle).
+  specs:
+  - id: CM-23-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      RM case closure MUST flow through Leave(VulnerabilityCase) → Case Actor
+      ledger commit → broadcast → each replica advances the leaving participant's
+      RM state to RM.CLOSED on receipt of the Announce(CaseLedgerEntry).
+      Add(ParticipantStatus, rm_state=RM.CLOSED) MUST NOT be used as a closure
+      trigger.
+    rationale: >-
+      The Leave round-trip makes the Case Actor the authority for closure and
+      prevents ghost-departures from lost messages: a participant cannot
+      silently reach RM.CLOSED on peers without the Case Actor having committed
+      and broadcast a ledger entry.  See ADR-0050.
+    adr:
+    - ADR-0050
+  - id: CM-23-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When the Case Actor receives Leave(VulnerabilityCase) from the Case Owner,
+      it MUST execute the following sequence:
+      (1) advance the Case Owner participant to RM.CLOSED,
+      (2) advance the Case Actor's own CaseParticipant to RM.CLOSED,
+      (3) emit a final case_fully_closed CaseLedgerEntry as the last ledger entry
+          for the case,
+      (4) fan-out the final entry to all participants not already at RM.CLOSED.
+    rationale: >-
+      The Case Owner's departure is the authoritative termination event for a
+      case.  Making the Case Actor's own RM.CLOSED the penultimate step and
+      case_fully_closed the final entry gives all replicas an unambiguous
+      terminal anchor in the ledger chain.  See ADR-0050, ADR-0051.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-23-001
+    adr:
+    - ADR-0050
+    - ADR-0051
+  - id: CM-23-003
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When the Case Actor receives Leave(VulnerabilityCase) from a non-owner
+      participant, it MUST advance only that participant's RM state to RM.CLOSED
+      and commit a CaseLedgerEntry recording the departure.  The case MUST remain
+      open for the remaining participants.
+    rationale: >-
+      Non-owner departure is a participant-scoped event, not a case termination
+      event.  Treating a non-owner Leave identically to an owner Leave would
+      prematurely close the case and violate the Case Owner's authority over the
+      case lifecycle.  See ADR-0050.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-23-001
+    adr:
+    - ADR-0050
+  - id: CM-23-004
+    priority: MUST
+    kind: protocol
+    statement: >-
+      Case Actor fan-out of CaseLedgerEntry MUST NOT send entries to participants
+      whose latest ParticipantStatus has rm_state=RM.CLOSED.
+    rationale: >-
+      Once a participant reaches RM.CLOSED they have departed the case and no
+      longer need (or should receive) case updates.  Continuing to send them
+      entries wastes bandwidth and may trigger erroneous processing on stale
+      replicas.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-23-001
+  - id: CM-23-005
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The Case Actor MUST track its own RM lifecycle via a CaseParticipant
+      record with ParticipantStatus entries that advance through
+      RM.RECEIVED, RM.VALID, and RM.ACCEPTED during case initialization,
+      and RM.CLOSED on case termination (owner Leave).  Each transition
+      MUST be recorded as a CaseLedgerEntry.
+    rationale: >-
+      Uniform RM lifecycle tracking across all participants (including the
+      coordinator) enables case-level RM state to be read consistently from
+      the ledger without special-casing the Case Actor.  See ADR-0051.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-23-002
+    adr:
+    - ADR-0051
+  - id: CM-23-006
+    priority: MUST
+    kind: protocol
+    statement: >-
+      For the Case Actor's CaseParticipant, the RM states have the following
+      case-actor-specific meanings:
+      RM.RECEIVED = a CaseProposal has been received and is being evaluated;
+      RM.VALID = the CaseProposal is correctly formatted and actionable by this
+      Case Actor, and case creation has begun;
+      RM.ACCEPTED = the case has been successfully created and is being
+      coordinated;
+      RM.CLOSED = the Case Owner has left the case and the case is fully closed.
+    rationale: >-
+      The RM state machine models a lifecycle that applies to any actor
+      processing a case, but its transition labels (RECEIVED, VALID, ACCEPTED,
+      CLOSED) map to case-level events for the coordinator rather than to
+      report-validation events as for other participants.  See ADR-0051.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-23-005
+    adr:
+    - ADR-0051
+  - id: CM-23-007
+    priority: MUST
+    kind: protocol
+    statement: >-
+      During case initialization (after accepting a CaseProposal), the Case
+      Actor MUST emit CaseLedgerEntry records for each of its own RM transitions:
+      (a) CaseActor→RM.RECEIVED when the CaseProposal arrives,
+      (b) CaseActor→RM.VALID when the proposal is validated and case creation
+          begins,
+      (c) CaseActor→RM.ACCEPTED when the VulnerabilityCase is successfully
+          created and initialized.
+    rationale: >-
+      Ledger entries for the Case Actor's own RM transitions create a traceable,
+      timestamped protocol-significant history of case initialization, consistent
+      with CM-02-009 (CaseActor applies its own timestamp to every state-changing
+      event).  See ADR-0051.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-23-005
+    - rel_type: refines
+      spec_id: CM-02-009
+    adr:
+    - ADR-0051

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -346,10 +346,21 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      CS state transitions (fix-ready, fix-deployed, published) and RM case closure MUST
-      all be driven through participant status updates via
-      Add(ParticipantStatus, target=Case) sent to the Case Actor inbox, not through dedicated
-      low-level state-machine endpoints
+      CS state transitions (fix-ready, fix-deployed, published) MUST be driven through
+      participant status updates via Add(ParticipantStatus, target=Case) sent to the Case
+      Actor inbox, not through dedicated low-level state-machine endpoints.
+      RM case closure is explicitly excluded from this requirement: RM.CLOSED MUST be
+      reached via the Leave(VulnerabilityCase) round-trip (CM-23-001), not via
+      Add(ParticipantStatus, rm_state=RM.CLOSED).
+    rationale: >-
+      PR #1909 (issue #1858) changed RM case closure to flow through
+      Leave(VulnerabilityCase) → Case Actor ledger commit → broadcast, rather than
+      Add(ParticipantStatus, rm_state=RM.CLOSED).  This makes the Case Actor the
+      authority for closure and prevents ghost-departures from lost messages.
+      See ADR-0050.
+    relationships:
+    - rel_type: implements
+      spec_id: CM-23-001
   - id: DEMOMA-07-002
     priority: MUST
     kind: project
@@ -407,14 +418,21 @@ groups:
     - order: 5
       actor: case_actor
       action: >-
-        If all non-CASE_MANAGER participants have RM.CLOSED as their latest status
-        and no Leave(VulnerabilityCase) has already been emitted for this case,
-        emit Leave(VulnerabilityCase) to the Case Actor to close the case
-      expected: close_case activity queued; case closure initiated
+        [SUPERSEDED] This step previously described an all-participants-RM.CLOSED
+        check that emitted Leave(VulnerabilityCase) from the Case Actor to trigger
+        case closure.  This step is retired: RM case closure now flows through each
+        participant's own Leave(VulnerabilityCase) round-trip (CM-23-001).
+        The owner-Leave path (CM-23-002) replaces this step; when the Case Owner
+        sends Leave(VulnerabilityCase), the Case Actor closes the case and
+        advances the CaseActor participant to RM.CLOSED (CM-23-004, ADR-0051).
+        Implementation: see #1901.
+      expected: >-
+        [SUPERSEDED] No AutoCloseSequence fires in add_participant_status_tree.
+        Case closure is triggered by Leave(VulnerabilityCase) from the Case Owner.
     postconditions:
     - description: >-
         Participant record updated; CaseLedgerEntry committed and broadcast;
-        embargo teardown triggered if CS.P+CASE_OWNER; case closed if all RM.CLOSED
+        embargo teardown triggered if CS.P+CASE_OWNER.
     relationships:
     - rel_type: refines
       spec_id: SYNC-02-002
@@ -423,24 +441,22 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The all-participants-RM-CLOSED check (DEMOMA-07-003 step 5) MUST be implemented
-      as a DataLayerCondition BT node (not as procedural logic inside a DataLayerAction
-      node's update() method). The condition node MUST: (a) iterate all
-      actor_participant_index entries, (b) skip participants holding CVDRole.CASE_MANAGER,
-      and (c) return FAILURE if any remaining participant's latest status rm_state is not
-      RM.CLOSED. The emit step that follows MUST also check that no Leave(VulnerabilityCase)
-      has already been written to the outbox for the case (idempotency via DataLayer
-      query, not via a process-level in-memory set).
+      [SUPERSEDED by CM-23-001 and ADR-0050]  The BT node decomposition
+      requirements for DEMOMA-07-003 step 5 (AllParticipantsRMClosedConditionNode,
+      CloseNotYetEmittedConditionNode, EmitCloseCaseNode) are retired from the
+      add_participant_status_tree path.  Those nodes MUST NOT be wired into
+      add_participant_status_tree; they were live dead code after PR #1909 because
+      the AutoCloseSequence evaluated AllParticipantsRMClosedConditionNode only
+      when Add(ParticipantStatus) arrived, which always precedes any Leave and
+      therefore could never observe all participants at RM.CLOSED.
+      The equivalent closure logic belongs in the Leave(VulnerabilityCase) receive
+      path, implemented by #1901 (CM-23-002, CM-23-003, ADR-0051).
     testable: true
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-07-003
       note: >-
-        Mandates BT node decomposition for step 5 close-ready precondition;
-        prohibits god-node pattern (BT-IDM-03)
-    - rel_type: refines
-      spec_id: BT-06-001
-      note: all protocol-significant behavior must be in the BT
+        Step 5 is superseded; AutoCloseSequence removed from add_participant_status_tree
   - id: DEMOMA-07-004
     priority: SHOULD
     kind: project


### PR DESCRIPTION
- Closes #1910

## Summary

Resolves the contradiction between `DEMOMA-07-001` (which mandated `Add(ParticipantStatus, rm_state=RM.CLOSED)` for RM closure) and PR #1909 (which changed RM closure to flow through `Leave(VulnerabilityCase)`). Establishes `Leave` as the canonical mechanism via two new ADRs and a new CM-23 spec group; amends the contradicting DEMOMA-07 spec entries.

## Changes

- **`docs/adr/0050-leave-vuln-case-canonical-rm-closure.md`**: New ADR — `Leave(VulnerabilityCase)` is the canonical RM closure mechanism; `Add(ParticipantStatus, rm_state=RM.CLOSED)` MUST NOT be used as a closure trigger. Rationale: Case Actor is the single authority; `Leave` round-trip prevents ghost-departures; already implemented by #1909.
- **`docs/adr/0051-caseactor-rm-lifecycle.md`**: New ADR — CaseActor has its own full RM lifecycle tracked via `CaseParticipant` (`RECEIVED → VALID → ACCEPTED` at bootstrap, `CLOSED` on owner `Leave`). Each transition is a `CaseLedgerEntry`. Includes RM-state-meaning table for coordinator role.
- **`docs/adr/index.md`**: Regenerated to include ADR-0050 and ADR-0051 in the Accepted list.
- **`mkdocs.yml`**: Added nav entries for ADR-0050 and ADR-0051.
- **`specs/case-management.yaml`**: Added CM-23 group (CM-23-001 through CM-23-007) specifying `Leave`-only RM closure, owner/non-owner Leave semantics, fan-out exclusion of `RM.CLOSED` participants, and CaseActor RM lifecycle bootstrap requirements.
- **`specs/multi-actor-demo.yaml`**: Amended `DEMOMA-07-001` to scope its clause to CS transitions only (RM closure excluded, references CM-23-001 and ADR-0050); marked `DEMOMA-07-003 step 5` and `DEMOMA-07-006` as `[SUPERSEDED]` with `AutoCloseSequence` dead-code explanation and forward references to the Leave receive path in #1901.

## Implementation Issues

- #1916 — Remove `AutoCloseSequence` from `add_participant_status_tree` and conform to CM-23 Leave-closure specs (blocked by #1901)
- #1917 — CaseActor `CaseParticipant` RM lifecycle bootstrap: CM-23-005 through CM-23-007 (blocked by #1901)
- #1918 — Idea: Rejoin semantics for departed case participants (deferred)