### PR TITLE
docs: July 2026 project report

### DIFF
--- a/.agents/skills/project-report/REFERENCE.md
+++ b/.agents/skills/project-report/REFERENCE.md
@@ -55,6 +55,53 @@ codebase. They care about:
 - Use unexplained acronyms (BT, EM, RM, AS2, etc.) without a brief gloss
 - Claim something is fully functional if issues were found post-close
 - Include every commit; focus on the 5–10 most significant changes
+- Use internal shorthand for numbered work items without describing what they are
+  (e.g., "Production Collapse 3", "FUZZ-08e", "ADR-0042" all need a plain-language
+  gloss or should be replaced with a description of the actual change)
+
+---
+
+## Jargon Glossary and Rewrite Guide
+
+When any of the following terms appear in a draft without an inline explanation,
+either add the gloss shown or rewrite using the plain-language alternative.
+
+| Term | First-use gloss or plain-language rewrite |
+|---|---|
+| BT / behavior tree | "behavior tree — a decision-automation technique borrowed from game AI and robotics" |
+| PEC | "PEC (per-participant embargo-consent state machine)" — or just "embargo-consent state machine" |
+| EM / embargo management | "embargo management — tracking the active embargo agreement" |
+| RM / report management | "report management — the state machine governing a vulnerability report's lifecycle" |
+| CS / case status | "case status — the aggregate fix/deploy/disclosure state of the case" |
+| VFD state flags | "VFD fix-state flags (Vendor fix-ready / Fix-deployed / Disclosed)" — or describe the specific transition in plain terms |
+| f→F / d→D transitions | describe the meaning: "marking a fix as developed" / "marking a fix as deployed" |
+| ADR / ADR-NNNN | "architectural decision record (ADR-NNNN)" on first use; subsequent mentions can use the abbreviation |
+| call-out seam / call-out point | "injectable call-out point — a hook where a custom backend can be plugged in" |
+| DataLayer | "the internal data layer — which separates wire-format messages from domain objects" |
+| wire vocab / wire format | "wire-format messages (ActivityStreams 2.0, a standard social-web protocol)" |
+| blackboard | "shared blackboard — the in-memory store behavior tree nodes read from and write to" |
+| ledger | explain on first use: "case ledger — the append-only log of all events for a case" |
+| FUZZ-08x | do not use; describe what changed (e.g., "the exploit-strategy evaluation fuzzer nodes were converted to call-out point abstractions") |
+| Production Collapse N | do not use; describe what changed (e.g., "the notification loop was collapsed from a stub into a full call-out abstraction") |
+| ASGIEmitter | "the in-process delivery shim (ASGIEmitter)" — or just describe what it did |
+| CaseActor | "the CaseActor service — a dedicated container that owns the canonical case record" |
+| DEMOMA-NN | do not use alone; describe the scenario by its actors and workflow |
+| ECA format | "ECA (Event–Condition–Action) spec format" |
+| ratchet test | "architecture ratchet test — an automated check that prevents a design boundary from eroding" |
+
+### Bad/good rewrite examples
+
+❌ "PEC state machine transitions from NO_EMBARGO were fixed."
+✅ "The embargo-consent state machine was corrected: participants can now accept or decline an embargo offer even when they are not currently party to one."
+
+❌ "Production Collapses 1, 3, and 4 were completed."
+✅ "Three fuzzer subsystems — the exploit-strategy evaluator, the suggest-actor notification loop, and the publication leaf — were converted from simplified simulation placeholders to full call-out abstractions ready for production backend wiring."
+
+❌ "VFD role guards were added for f→F and d→D."
+✅ "Role guards now ensure that only a vendor actor can mark a fix as developed, and only a deployer actor can mark it as deployed — previously these checks were absent."
+
+❌ "FUZZ-08e retriever call-out points were implemented."
+✅ "The actor-retrieval step in the multi-actor suggestion workflow was refactored to expose an injectable call-out point for custom retrieval backends."
 
 ---
 

--- a/.agents/skills/project-report/SKILL.md
+++ b/.agents/skills/project-report/SKILL.md
@@ -102,12 +102,24 @@ Write the full report following the structure and tone guidelines in
 - **Footer line**: `*Report covers: <start> through <end> | Repository:
   [CERTCC/Vultron](https://github.com/CERTCC/Vultron)*`
 
+**Before holding the draft**, do a mandatory jargon scan: read every sentence
+and ask "would a work sponsor who has never read the source code understand
+this?" For each insider term found, either add a brief inline gloss the first
+time it appears, or rewrite the sentence in plain language. See
+[REFERENCE.md](REFERENCE.md) for the known-jargon list and rewrite examples.
+
 Hold the draft in memory — do not write to the output path yet.
 
 ### Phase 5 — Review with user
 
-Use `ask_user` to present the draft. Offer:
-`["Looks good — write it out", "I have feedback"]`
+Use `ask_user` to present the draft. Frame the review question explicitly for
+a non-developer audience:
+
+> "Does this draft read clearly for a work sponsor who doesn't know the Vultron
+> codebase? Please flag any terms or passages that need plain-language rewrites,
+> or select 'Looks good' to write the file."
+
+Offer: `["Looks good — write it out", "I have feedback"]`
 
 If the user selects "I have feedback", incorporate the feedback and ask again.
 

--- a/plan/history/2607/report/project-report-20260701-20260731.md
+++ b/plan/history/2607/report/project-report-20260701-20260731.md
@@ -1,0 +1,110 @@
+---
+title: "July 2026 Project Report"
+type: report
+period_start: "2026-07-01"
+period_end: "2026-07-31"
+timestamp: "2026-08-03T00:00:00+00:00"
+---
+
+# Vultron Project — July 2026 Work Sponsor Report
+
+## Executive Summary
+
+July 2026 was the most productive single month in the project's history: 197 pull requests merged. Work spanned five new multi-actor CVD (coordinated vulnerability disclosure) demo scenarios, completion of three core protocol automation factories, significant protocol correctness fixes, and a major architectural cleanup of the data layer. Key deliverables include handoff-and-extension demo scenarios exercising real coordinator-to-vendor ownership-transfer workflows, full automation of the fix-development, fix-deployment, and CVE ID assignment decision sequences, a corrected embargo-consent state machine, and a tightened boundary between the wire-message format and the internal domain model. Several items begun in July — notably a migration to a more type-safe node design pattern, a close-case seam redesign, and a post-merge demo CI gate — carry into August.
+
+---
+
+## New Multi-Actor CVD Demo Scenarios
+
+Vultron models the real-world process by which a vulnerability finder, vendors, and coordinators collaborate to fix and disclose a security issue. Each participant runs their own instance of the software and communicates over the network. This month added five new end-to-end coordination demo scenarios demonstrating realistic multi-party handoff workflows.
+
+- **FCV three-actor scenario** (Finder → Coordinator → Vendor): a complete workflow in which a finder submits a report to a coordinator, who then brings in the affected vendor ([PR #1623](https://github.com/CERTCC/Vultron/pull/1623)).
+- **FVCV-handoff demo**: Vendor 1 transfers case ownership to Coordinator, who then invites Vendor 2 ([PR #1590](https://github.com/CERTCC/Vultron/pull/1590)).
+- **FCCV-handoff demo**: Coordinator 1 transfers case ownership to Coordinator 2, who invites the Vendor ([PR #1628](https://github.com/CERTCC/Vultron/pull/1628)).
+- **FVCV-extension and FCCV-extension** scenarios: a coordinator suggests adding a second vendor or coordinator to an already-running case via the actor-recommendation protocol ([PR #1540](https://github.com/CERTCC/Vultron/pull/1540), [PR #1743](https://github.com/CERTCC/Vultron/pull/1743)).
+
+Supporting the new scenarios, the demo CI (continuous integration) pipeline was converted to a matrix strategy ([PR #1638](https://github.com/CERTCC/Vultron/pull/1638)) so that all scenarios run in parallel rather than sequentially. An artificial testing shortcut — demo scripts that bypassed the network layer to hand messages directly between containers — was removed in favor of real inter-container HTTP delivery ([PR #1730](https://github.com/CERTCC/Vultron/pull/1730)). An intermittent race condition causing incorrect fix-status broadcasts across containers was also corrected ([PR #1725](https://github.com/CERTCC/Vultron/pull/1725)).
+
+The case-timeline report tool, which summarizes a completed CVD case from its ledger log, was substantially enriched: it now shows elapsed time between events, per-participant embargo-consent state, human-readable actor names (resolved from wire-format URIs), and a per-case total time range ([PRs #1704](https://github.com/CERTCC/Vultron/pull/1704), [#1712](https://github.com/CERTCC/Vultron/pull/1712), [#1708](https://github.com/CERTCC/Vultron/pull/1708), [#1764](https://github.com/CERTCC/Vultron/pull/1764)).
+
+---
+
+## Protocol Automation: Behavior Tree Factories
+
+Vultron uses behavior trees — a well-known technique from game AI and robotics — to automate the protocol decisions each CVD participant must make, such as "should I assign a CVE ID now?" or "is this fix ready to deploy?". Each decision sequence is expressed as a tree of conditions and actions. This month completed three major production-ready factory functions that build those trees.
+
+**Fix-development tree** ([PR #1818](https://github.com/CERTCC/Vultron/pull/1818)): automates the sequence of checks a vendor must pass before a fix is marked ready for acceptance — confirming the actor has the correct role, checking the current fix state, and emitting the appropriate state transition. The tree exposes injectable "call-out" seams so that custom backends (for example, a real ticket system) can be plugged in without changing the tree structure.
+
+**Fix-deployment tree** ([PR #1838](https://github.com/CERTCC/Vultron/pull/1838)): replaces a prior placeholder stub with a four-arm decision tree handling the full deployment lifecycle — an early-exit if the fix is already deployed, a deferred-wait arm, a deploy-if-ready arm, and a monitoring arm. Role guards ensure that only an actor with the appropriate vendor or deployer role can trigger the relevant state transitions; these guards were absent from the previous stub.
+
+**CVE ID assignment tree** ([PR #1835](https://github.com/CERTCC/Vultron/pull/1835)): a 21-node tree grounded in the CNA (CVE Numbering Authority) Operational Rules v4.1.0, with 14 injectable call-out points covering authority checking, ID assignment, and public-disclosure logic.
+
+**Publication tree bug fix**: The tree controlling whether and when a vulnerability is disclosed publicly had a defect in its default configuration that caused all publication arms to be silently skipped — the system appeared to succeed while publishing nothing. This is now corrected ([PR #1846](https://github.com/CERTCC/Vultron/pull/1846)).
+
+Several other protocol automation trees were also advanced: the exploit-strategy evaluation subtree, the suggest-actor notification loop, and the vulnerability-publication leaf were each converted from simplified simulation placeholders into full call-out point abstractions ready for production backend wiring. The auto-close branch — which decides when a case can be closed — was decomposed from a monolithic node into a cleaner precondition-check + routing + emit sequence ([PR #1724](https://github.com/CERTCC/Vultron/pull/1724)).
+
+As a foundation for future work, a more type-safe node design pattern (using py-trees "typed Ports") was introduced and piloted on four nodes ([PR #1827](https://github.com/CERTCC/Vultron/pull/1827)); migration of the full node inventory continues in August.
+
+---
+
+## Protocol Correctness and State Machine Fixes
+
+Several protocol-level bugs and design gaps were identified and resolved this month.
+
+**Embargo-consent state machine**: In Vultron's multi-party model, each participant independently tracks their consent to an active embargo — an agreement among parties to delay public disclosure until a fix is ready. The consent state machine had an incorrect design: the initial "no embargo" state was being treated as a preliminary gating state, blocking participants from accepting or declining an embargo offer when one arrived. Per a new architectural decision (ADR-0048), "no embargo" simply means the participant is not yet party to any embargo, and they should be free to accept or decline one when invited ([PR #1882](https://github.com/CERTCC/Vultron/pull/1882)).
+
+**Case ownership and initialization (ADR-0041)**: Under the current architecture, a dedicated CaseActor service owns the canonical case record and is authoritative for case creation. A back-fill mechanism that had been writing speculative ledger entries from the reporter's side before the CaseActor container was ready was removed ([PR #1851](https://github.com/CERTCC/Vultron/pull/1851)), and initialization is now correctly owned by the CaseActor ([PR #1791](https://github.com/CERTCC/Vultron/pull/1791)). A concurrent-isolation smoke test guards this path against regressions ([PR #1860](https://github.com/CERTCC/Vultron/pull/1860)).
+
+**Role guards for fix state transitions**: The CVD protocol distinguishes who is allowed to change which fix-state flags. A bug allowed an actor with the "deployer" role to advance the fix-developed flag (which should only be set by a vendor) and vice versa. Guards now enforce the correct mapping ([PR #1765](https://github.com/CERTCC/Vultron/pull/1765)).
+
+**Out-of-order ledger announcements**: When case-closure messages arrive before ledger-entry announcements — a timing issue in multi-container communication — the system previously failed silently. These messages are now buffered until the correct ordering can be established ([PR #1564](https://github.com/CERTCC/Vultron/pull/1564)). A related fix ensures that when a referenced case record is missing, the system sends an explicit rejection message rather than silently dropping the announcement ([PR #1889](https://github.com/CERTCC/Vultron/pull/1889)).
+
+**Concurrent inbox handling**: When multiple messages arrived simultaneously at a participant's HTTP inbox, the internal ledger could receive entries out of order. A per-actor concurrency lock now serializes inbox processing ([PR #1533](https://github.com/CERTCC/Vultron/pull/1533)).
+
+---
+
+## Data Layer Architecture Cleanup
+
+Vultron separates the wire-message format (ActivityStreams 2.0, a standard social-web protocol) from its internal domain objects. Keeping this boundary clean is important for correctness, testability, and future protocol evolution. This month the boundary was substantially tightened.
+
+The internal read path was refactored so that it returns typed domain objects rather than raw wire-format messages ([PR #1512](https://github.com/CERTCC/Vultron/pull/1512)). An automated architecture test was added to prevent the boundary from eroding in future changes ([PR #1531](https://github.com/CERTCC/Vultron/pull/1531)). Five categories of redundant re-reads — where code fetched the same wire object multiple times to extract identical data — were eliminated, reducing latency and code duplication ([PRs #1534](https://github.com/CERTCC/Vultron/pull/1534), [#1541](https://github.com/CERTCC/Vultron/pull/1541), [#1553](https://github.com/CERTCC/Vultron/pull/1553)).
+
+Lifecycle-staged domain types were introduced — a vulnerability report advances through `IncomingReport → VulnerabilityCase → EmbargoedCase` — so the type system reflects the object's actual lifecycle phase rather than relying on runtime checks ([PR #1473](https://github.com/CERTCC/Vultron/pull/1473)).
+
+An in-process delivery shim that sent messages to other containers by calling them directly in memory, bypassing real network transport, was retired. Real inter-container HTTP delivery is now the only delivery path ([PR #1874](https://github.com/CERTCC/Vultron/pull/1874)).
+
+---
+
+## Specification Infrastructure
+
+Vultron maintains a corpus of machine-readable specifications that describe required protocol behavior and test-case acceptance criteria. This month the corpus was significantly reorganized and expanded.
+
+The previous six-category taxonomy for specification items was replaced with a four-tier portability hierarchy that more clearly distinguishes protocol-portable requirements from implementation-specific ones ([PR #1578](https://github.com/CERTCC/Vultron/pull/1578)). Behavioral conformance specifications for the three core state machines — report management, embargo management, and case status — were authored and populated ([PRs #1439](https://github.com/CERTCC/Vultron/pull/1439), [#1444](https://github.com/CERTCC/Vultron/pull/1444)), and behavior-logic documentation was cross-referenced with specification IDs to enable traceability ([PR #1494](https://github.com/CERTCC/Vultron/pull/1494)).
+
+All 65 specification YAML files were tagged with searchable category labels ([PR #1501](https://github.com/CERTCC/Vultron/pull/1501)), and the documentation site now generates browsable specification pages directly from the YAML source ([PR #1485](https://github.com/CERTCC/Vultron/pull/1485)). A CI linter enforces a consistent structure for demo scenario specifications ([PR #1664](https://github.com/CERTCC/Vultron/pull/1664)).
+
+---
+
+## Developer Tooling and Agentic Workflows
+
+Several new automated skills — AI-agent workflow scripts that assist the development team — were added to the project toolchain.
+
+- **create-pr skill** ([PR #1468](https://github.com/CERTCC/Vultron/pull/1468)): handles branch-freshening, linting, and pull-request creation as a shared step reused across the build, plan, bugfix, and learn workflows.
+- **pr-ship pipeline** ([PR #1654](https://github.com/CERTCC/Vultron/pull/1654)): an end-to-end pull-request review pipeline (triage → review → verification) with resume support if interrupted mid-run.
+- **velocity-report skill** ([PR #1770](https://github.com/CERTCC/Vultron/pull/1770)): generates issue throughput and cycle-time metrics from project history.
+- **requirements-retrospective skill** ([PR #1781](https://github.com/CERTCC/Vultron/pull/1781)): audits completed work against specification requirements to surface gaps.
+- **decision-audit skill** ([PR #1797](https://github.com/CERTCC/Vultron/pull/1797)): scores architectural decision records for confidence-signal completeness and flags decisions lacking adequate rationale or test coverage; extended to score specification groups as well ([PR #1804](https://github.com/CERTCC/Vultron/pull/1804)).
+- **Call-out bundle configuration** ([PR #1658](https://github.com/CERTCC/Vultron/pull/1658)): production, stochastic-simulation, and deterministic-test backends for each behavior tree can now be selected via a single configuration parameter rather than manual wiring.
+
+A completeness doctrine was documented and applied to all workflow skills ([PR #1403](https://github.com/CERTCC/Vultron/pull/1403)), ensuring each workflow closes all open loops before reporting completion. A signal taxonomy was also added so that concerns and learning discoveries surfaced during development are routed to the correct intake track ([PR #1610](https://github.com/CERTCC/Vultron/pull/1610)).
+
+---
+
+## Dependencies
+
+Approximately 20 automated dependency bumps were merged cleanly during July, including updates to `fastapi`, `httpx2`, `uvicorn`, `mypy`, `py-trees`, `pandas`, `pre-commit`, and GitHub Actions runners.
+
+---
+
+*Report covers: 2026-07-01 through 2026-07-31 |
+Repository: [CERTCC/Vultron](https://github.com/CERTCC/Vultron)*


### PR DESCRIPTION
## Summary

- Adds the July 2026 work sponsor project report covering 197 PRs merged during the period
- Updates the `project-report` skill to prevent insider-jargon from reaching future reports without explanation

## Changes

- `plan/history/2607/report/project-report-20260701-20260731.md` — July 2026 report, written for a non-developer sponsor audience with all internal terms explained inline
- `.agents/skills/project-report/SKILL.md` — adds a mandatory jargon-scan pass at the end of Phase 4 and reframes the Phase 5 review question to explicitly invoke the non-developer audience
- `.agents/skills/project-report/REFERENCE.md` — adds a jargon glossary (15 insider terms with plain-language alternatives) and four bad/good rewrite examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)