### PR TITLE
docs: plan issue #1217 — FCVCV 5-party scenario

### DIFF
--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -63,6 +63,7 @@ DEMOMA-16-008 are the normative source; the test constants implement them.
 | FVCV-handoff | same | invite_actor_to_case, accept_invite_actor_to_case |
 | FCCV-handoff | same | invite_actor_to_case, accept_invite_actor_to_case |
 | FCV | same | invite_actor_to_case |
+| FCVCV | same | invite_actor_to_case (≥3), offer_case_participant (≥1), accept_invite_actor_to_case (≥3) |
 
 ### Relationship to scenario-specific test functions
 

--- a/plan/history/2608/idea/IDEA-1217.md
+++ b/plan/history/2608/idea/IDEA-1217.md
@@ -1,0 +1,44 @@
+---
+source: IDEA-1217
+timestamp: '2026-08-03T17:45:44.881890+00:00'
+title: FCVCV 5-party CVD demo scenario plan
+type: idea
+---
+
+Planned the FCVCV 5-party CVD demo scenario (Finder + Coordinator1 + Vendor1 +
+Coordinator2 + Vendor2, issue #1217). Research into prior scenario PRs
+(#1234, #1215, #1216) surfaced two stale spec entries that were corrected in this PR.
+
+## Spec corrections
+
+**DEMOMA-07-003 step 4** — The spec stated embargo teardown fires only when the
+Case Owner's CaseStatus reaches CS.P/X/A. Code inspection of
+ThreatTerminationBranchNode (RSH-03-002) shows it fires for any participant's
+CS.P/X/A; there is no sender-role gate. The spec step was rewritten to describe
+the actual implementation and to document the SideEffectsGuard call-out seam
+(RSH-02-001), which defaults to AlwaysSucceed but is designed to accommodate a
+future "ask CASE_OWNER to confirm" policy.
+
+**DEMOMA-15-001** — The spec listed CVDRole.VENDOR as the required role for both
+verify_fix_ready and verify_fix_deployed. This was overfitted to scenarios where
+Vendor and Deployer were always the same actor. The d→D BT transition is gated
+on CVDRole.DEPLOYER (CheckDeployerRoleNode), not VENDOR. The spec was split and
+the code fix (_assert_deployer_or_vendor_role) was applied to
+vultron/demo/helpers/milestones.py.
+
+## New spec entries
+
+- DEMOMA-16-009: FCVCV expected event types (invite_actor_to_case ≥3,
+  offer_case_participant ≥1, accept_invite_actor_to_case ≥3)
+- DEMOMA-19 (9 entries): container topology (actor6), seed_containers_fcvcv,
+  fcvcv_demo.py phases, V1 VENDOR-only VFd path vs V2 VENDOR+DEPLOYER VFD path,
+  embargo teardown ordering (V1 publishes first), fcvcv CLI command, CI matrix
+  entry + devlog naming, invariant harness, ADR-0026 suggest-actor flow for V2
+
+## Outcome
+
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/1922> (Closes #1217)
+- Implementation issues: #1923 (actor6 topology), #1924 (seed_containers_fcvcv),
+  #1925 (fcvcv_demo.py + CLI), #1926 (CI + invariant harness), #1927 (milestones tests)
+- Container rename Idea: #1928 ([Idea] Rename docker-compose containers to
+  generic names actor1–actor6) filed under Epic #1083

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -411,10 +411,18 @@ groups:
     - order: 4
       actor: case_actor
       action: >-
-        If the new ParticipantStatus indicates CS.P (public awareness) and the
-        sender holds CASE_OWNER role and an active embargo exists,
-        emit ET (Embargo Termination) to initiate teardown
-      expected: Embargo teardown triggered; EM transitions to EXITED
+        If the new CaseStatus (derived from the participant status update) indicates
+        at least one of CS.P, CS.X, or CS.A and an active embargo exists, trigger
+        embargo teardown automatically via ThreatTerminationBranchNode (RSH-03-001).
+        A SideEffectsGuard call-out seam (RSH-02-001) precedes the teardown node;
+        it defaults to AlwaysSucceed (auto-approve) but is designed to accommodate
+        a future "ask CASE_OWNER to confirm" policy. The CASE_OWNER gate previously
+        stated here is incorrect — the code fires teardown for any participant's
+        CS.P/X/A, not only the Case Owner's. See ThreatTerminationBranchNode
+        (RSH-03-002: no sender-role gate) and ADR-0046.
+      expected: >-
+        Embargo teardown triggered (EM.EXITED) when any participant's CaseStatus
+        carries CS.P, CS.X, or CS.A and an active embargo is present
     - order: 5
       actor: case_actor
       action: >-
@@ -432,7 +440,8 @@ groups:
     postconditions:
     - description: >-
         Participant record updated; CaseLedgerEntry committed and broadcast;
-        embargo teardown triggered if CS.P+CASE_OWNER.
+        embargo teardown triggered when any participant's CaseStatus carries
+        CS.P, CS.X, or CS.A and an active embargo exists.
     relationships:
     - rel_type: refines
       spec_id: SYNC-02-002
@@ -1776,24 +1785,26 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The `receiver_actor_id` argument passed to `verify_fix_ready` and
-      `verify_fix_deployed` in `vultron/demo/helpers/milestones.py` MUST be the
-      full URI of an actor that holds `CVDRole.VENDOR` in the case's participant
-      index. Passing the ID of an actor that does not hold `CVDRole.VENDOR` (e.g.,
-      a COORDINATOR or CASE_OWNER) is a caller error. Both helpers MUST enforce
-      this precondition at runtime by fetching the participant record and asserting
-      `CVDRole.VENDOR in participant.case_roles`, raising `AssertionError` with the
-      actor ID and its actual roles if the assertion fails.
+      `verify_fix_ready` in `vultron/demo/helpers/milestones.py` MUST accept only
+      actor IDs holding `CVDRole.VENDOR` in the case's participant index; the f→F
+      (fix-ready) transition is gated on VENDOR by `CheckVendorRoleNode`.
+      `verify_fix_deployed` MUST accept actor IDs holding `CVDRole.VENDOR` OR
+      `CVDRole.DEPLOYER`; the d→D (fix-deployed) transition is gated on DEPLOYER
+      by `CheckDeployerRoleNode`. Passing any other actor (e.g. COORDINATOR or
+      CASE_OWNER) to either helper is a caller error. Each helper MUST enforce its
+      precondition at runtime, raising `AssertionError` with the actor ID and its
+      actual roles if the assertion fails.
     rationale: >-
-      Only actors holding `CVDRole.VENDOR` participate in the VFD fix lifecycle
-      (vfd → Vfd → VFd → VFD). Actors holding only `CVDRole.COORDINATOR` or
-      `CVDRole.CASE_OWNER` have no fix path and their `vfd_state` will never
-      advance beyond `vfd`. Without the precondition guard, a caller that
-      accidentally passes a Coordinator actor ID will observe `vfd_state=vfd` and
-      receive a misleading failure that reports an unexpected state rather than
-      identifying the wrong actor as the root cause. This was the root cause of
-      the M4/M5 CI failures in PR #1623 (issue #1593), where `fcv_demo.py`
-      passed `coordinator.id_` instead of `vendor.id_`.
+      The f→F (fix-ready) transition requires CVDRole.VENDOR; coordinators have no
+      vendor fix path. The d→D (fix-deployed) transition requires CVDRole.DEPLOYER;
+      a vendor who is not a deployer stops at VFd. An actor may hold both roles
+      (e.g. [vendor, deployer]) and passes both checks. The original spec listed
+      VENDOR for both helpers, which was an overfit to single-vendor scenarios
+      where Vendor and Deployer were always the same actor. The FCVCV scenario
+      introduced a distinct Vendor-Deployer actor (V2) that makes the distinction
+      observable. This was the root cause of the M4/M5 CI failures in PR #1623
+      (issue #1593), where `fcv_demo.py` passed `coordinator.id_` instead of
+      `vendor.id_`.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-06-002
@@ -1934,6 +1945,32 @@ groups:
     - rel_type: refines
       spec_id: DEMOCI-04-004
 
+  - id: DEMOMA-16-009
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCVCV scenario expected-event-types list MUST include
+      `invite_actor_to_case`, `offer_case_participant`, and
+      `accept_invite_actor_to_case` in addition to the four universal types
+      (DEMOMA-16-001). `invite_actor_to_case` appears at least three times
+      (C1 invites V1, C1 invites C2, and CaseActor invites V2 via the
+      ADR-0026 path); `offer_case_participant` appears at least once (C2
+      suggests V2 to C1 via the ADR-0026 suggest-actor flow);
+      `accept_invite_actor_to_case` appears at least three times (V1, C2,
+      and V2 each accept their respective invitations).
+    rationale: >-
+      FCVCV is the first scenario with two independent coordinators and two
+      independent vendor actors. C1 directly invites V1 and C2; C2 suggests
+      V2 via ADR-0026 (offer_case_participant → CaseActor invite → V2
+      accept); all three vendor/coordinator invitees issue explicit accepts.
+      Verifying these event types confirms the full ADR-0026 suggest-actor
+      path and the multi-vendor invitation chain are exercised end-to-end.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+    - rel_type: refines
+      spec_id: DEMOMA-19-001
+
 - id: DEMOMA-18
   title: In-Process Fuzz Simulation Scenario
   specs:
@@ -2071,3 +2108,247 @@ groups:
     - rel_type: refines
       spec_id: DEMOMA-03-001
       note: acceptance test scenario files are also subject to this rule
+
+- id: DEMOMA-19
+  title: FCVCV 5-Party Scenario (Finder + Coordinator1 + Vendor1 + Coordinator2 + Vendor2)
+  description: >-
+    Specifies the FCVCV multi-actor demo scenario: a 5-party CVD case with
+    Finder (F), Coordinator1 (C1), Vendor1 (V1), Coordinator2 (C2), and
+    Vendor2 (V2). C1 receives the report and creates the case. C1 invites V1
+    and C2. C2 suggests V2 to C1 via the ADR-0026 suggest-actor flow; C1
+    approves; CaseActor invites V2. V1 holds only CVDRole.VENDOR (reaches VFd,
+    fix-ready, but has no deploy path). V2 holds both CVDRole.VENDOR and
+    CVDRole.DEPLOYER (full VFD path). V1 triggers CS.P first, causing
+    CaseActor to initiate embargo teardown via ThreatTerminationBranchNode.
+    This scenario is the first to exercise: (a) two independent coordinators,
+    (b) two vendor actors with different role sets, (c) embargo teardown
+    triggered by a non-CASE_OWNER vendor participant's publication.
+  specs:
+  - id: DEMOMA-19-001
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCVCV scenario MUST add an `actor6` service to
+      `docker/docker-compose-multi-actor.yml`, configured identically to
+      the existing `actor5` service (same `*actor-service` anchor, port
+      pattern, data volume) with `VULTRON_SERVER__BASE_URL=http://actor6:7999/api/v2/`,
+      `VULTRON_ACTOR_ID=http://actor6:7999/api/v2/actors/vendor-deployer`,
+      `VULTRON_ACTOR__DEFAULT_CASE_ROLES=["vendor","deployer"]`, and
+      `VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-actor6.yaml`. A
+      corresponding `seed-actor6.yaml` seed config MUST be created in
+      `docker/seed-configs/` with `local_actor.id=http://actor6:7999/api/v2/actors/vendor-deployer`,
+      `local_actor.name=VendorDeployer`, and a peers list covering the five
+      other actors (finder, vendor, coordinator, actor5, case-actor). The
+      `demo-runner` service MUST add `actor6` to its `depends_on` list and
+      expose `VULTRON_VENDOR_DEPLOYER_BASE_URL=http://actor6:7999/api/v2` in
+      its environment block.
+    rationale: >-
+      The FCVCV scenario requires five independent actor containers — one per
+      CVD-role actor — to force all inter-actor communication over the network
+      wire protocol (DEMOMA-01-001). The existing four non-CaseActor containers
+      are insufficient; a sixth container (`actor6`) carries V2 (VendorDeployer).
+      Keeping one actor per container preserves the architectural isolation
+      invariant that prevents intra-container data-layer shortcuts (ADR-0042).
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+    - rel_type: refines
+      spec_id: DEMOMA-02-001
+
+  - id: DEMOMA-19-002
+    priority: MUST
+    kind: project
+    statement: >-
+      A `seed_containers_fcvcv` function MUST be added to
+      `vultron/demo/helpers/seeding.py` accepting five `DataLayerClient`
+      arguments (finder_client, c1_client, v1_client, c2_client, v2_client)
+      and five optional deterministic actor ID arguments. It MUST create
+      five local actors: Finder (Person), Coordinator1 (Organization), Vendor1
+      (Organization), Coordinator2 (Organization), VendorDeployer (Organization).
+      It MUST then register every actor as a known peer on each of the other
+      four containers (N×(N-1) = 20 cross-registrations total, following the
+      same Phase 1 / Phase 2 pattern as `seed_containers_fccv`).
+    rationale: >-
+      The 5-actor cross-registration ensures that every actor can locate and
+      deliver activities to every other actor without runtime DNS surprises.
+      The N×(N-1) pattern is established by all existing multi-actor seed
+      functions (seed_containers_fvv, seed_containers_fvcv, seed_containers_fccv).
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-19-001
+    - rel_type: refines
+      spec_id: DEMOMA-02-002
+
+  - id: DEMOMA-19-003
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCVCV scenario file MUST be implemented at
+      `vultron/demo/scenario/fcvcv_demo.py`. It MUST be structured with the
+      following phases executed in order: (1) report_submission — F submits
+      report to C1, C1 validates, C1 creates case, C1 invites V1 and C2;
+      (2) c2_suggests_v2 — C2 sends suggest-actor-to-case for V2 to
+      CaseActor, C1 approves the CaseParticipant Offer, CaseActor sends
+      Invite to V2, V2 accepts; (3) sync_verification — M1 milestone check
+      (all five containers hold the case replica); (4) notes_exchange — each
+      of the five actors posts a note; (5) fix_lifecycle — V1 advances to
+      VFd (fix-ready; no deploy step); V2 advances to VFD (fix-ready then
+      fix-deployed); (6) publication — V1 publishes first (triggering CS.P
+      and embargo teardown via CaseActor), then V2 publishes; (7) case_closure
+      — all participants close; (8) dump_case_ledgers — devlog output.
+    rationale: >-
+      The phased structure mirrors the FCCV-extension scenario (the closest
+      prior template) while adding V1's vendor-only VFd path and V2's full
+      VFD path. Having V1 publish first exercises the
+      ThreatTerminationBranchNode on a non-CASE_OWNER vendor participant, a
+      path not covered by any prior scenario (DEMOMA-07-003 correction).
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+    - rel_type: refines
+      spec_id: DEMOMA-03-002
+    - rel_type: refines
+      spec_id: DEMOMA-17-001
+
+  - id: DEMOMA-19-004
+    priority: MUST
+    kind: project
+    statement: >-
+      In the FCVCV scenario, V1 MUST be assigned `CVDRole.VENDOR` only (no
+      DEPLOYER role) and V2 MUST be assigned both `CVDRole.VENDOR` and
+      `CVDRole.DEPLOYER`. The fix lifecycle phase MUST call `verify_fix_ready`
+      for both V1 and V2 after they each advance to VFd. It MUST then call
+      `verify_fix_deployed` for V2 only after V2 advances to VFD.
+      `verify_fix_ready` MUST NOT be called with a DEPLOYER-only actor ID;
+      `verify_fix_deployed` MUST NOT be called with a VENDOR-only (no DEPLOYER)
+      actor ID such as V1.
+    rationale: >-
+      V1's vendor-only role set (stops at VFd) and V2's vendor-deployer role
+      set (reaches VFD) are the key differentiators of this scenario. The
+      distinction verifies DEMOMA-15-001's corrected precondition guards:
+      `verify_fix_ready` requires VENDOR; `verify_fix_deployed` requires
+      VENDOR or DEPLOYER. Using V1 in a `verify_fix_deployed` call would
+      exercise the wrong path and mask a future regression where the d→D BT
+      gate is weakened.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-15-001
+    - rel_type: refines
+      spec_id: DEMOMA-19-003
+
+  - id: DEMOMA-19-005
+    priority: MUST
+    kind: project
+    statement: >-
+      In the FCVCV scenario, V1 MUST publish before V2. After V1 sends its
+      participant status update indicating CS.P, the scenario MUST wait for
+      CaseActor to process that update and emit the embargo teardown
+      (EM.EXITED) before V2 publishes. The `verify_publicly_disclosed`
+      check MUST be called after both V1 and V2 have published.
+    rationale: >-
+      Having V1 publish first exercises the ThreatTerminationBranchNode code
+      path where a VENDOR participant (not the CASE_OWNER) triggers embargo
+      teardown — the scenario path corrected in DEMOMA-07-003. Waiting for
+      EM.EXITED before V2 publishes avoids a timing race where the
+      teardown-triggered publication arrives concurrently with V2's
+      publication and produces a non-deterministic ledger order.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-07-003
+    - rel_type: refines
+      spec_id: DEMOMA-19-003
+
+  - id: DEMOMA-19-006
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCVCV scenario MUST be registered as the `fcvcv` sub-command in
+      `vultron/demo/cli.py`, consistent with the naming convention of existing
+      scenario commands (fv, fvv, fcv, fvcv, fccv).
+    rationale: >-
+      The CLI is the single entry point for all demo scenarios (DC-01-001).
+      Omitting the sub-command leaves the scenario unreachable from
+      `vultron demo fcvcv` and from the CI matrix DEMO variable override.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+
+  - id: DEMOMA-19-007
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCVCV scenario MUST be added to the CI demo-integration matrix in
+      `.github/workflows/demo-integration.yml` with `DEMO=fcvcv`, and
+      `actor6` MUST be listed as a service dependency alongside the existing
+      five services. The CI devlogs directory for the FCVCV run MUST use the
+      scenario-role naming convention: `finder`, `c1`, `v1`, `c2`, `v2`,
+      `case-actor` (not docker service names).
+    rationale: >-
+      CI coverage of all demo scenarios is required by DEMOCI-04-001. The
+      FCVCV scenario introduces the actor6 container, which must be listed as
+      a service dependency so CI spins it up. Scenario-role names in devlogs
+      match the names used in scenario code, making log archaeology easier.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-04-001
+    - rel_type: refines
+      spec_id: DEMOMA-19-001
+
+  - id: DEMOMA-19-008
+    priority: MUST
+    kind: project
+    statement: >-
+      An invariant harness file MUST be created at
+      `test/ci/invariants/test_fcvcv_invariants.py`. It MUST define
+      `_FCVCV_EXPECTED_EVENT_TYPES` per DEMOMA-16-009, a `_CHAIN_ACTORS`
+      list of scenario-role actor names (finder, c1, v1, c2, v2, case-actor),
+      and the universal invariant tests (Invariants 1–5) plus at minimum the
+      following scenario-specific invariant tests: (a)
+      `invite_actor_to_case` appears at least three times (C1→V1, C1→C2,
+      CaseActor→V2); (b) `offer_case_participant` appears at least once (C2
+      suggests V2 via ADR-0026); (c) `accept_invite_actor_to_case` appears
+      at least three times (V1, C2, V2 each accept). The harness MUST be
+      added to `test/ci/invariants/conftest.py` under the `fcvcv` scenario
+      key.
+    rationale: >-
+      The invariant harness is the CI-level acceptance test for the scenario.
+      The three scenario-specific count checks verify that the multi-party
+      invitation and suggest-actor flows were exercised end-to-end. The
+      per-actor chain checks confirm ledger contiguity for all five actor
+      devlogs. Derived from the FCCV-extension invariant harness as the
+      closest prior template.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-04-001
+    - rel_type: refines
+      spec_id: DEMOMA-16-009
+    - rel_type: refines
+      spec_id: DEMOMA-19-003
+
+  - id: DEMOMA-19-009
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCVCV scenario MUST exercise the ADR-0026 suggest-actor flow for
+      V2's onboarding. The flow sequence is: (1) C2 posts `suggest-actor-to-case`
+      trigger (Offer(Actor, Case) sent to CaseActor); (2) CaseActor stores the
+      offer and forwards an `Offer(CaseParticipant)` to the CASE_OWNER (C1);
+      (3) C1 posts `accept-actor-recommendation` trigger providing the
+      CaseParticipant offer ID; (4) CaseActor sends `Invite` to V2; (5) V2
+      receives the `Invite` and posts `accept-case-invite`. The scenario MUST
+      use polling helpers (not `post_to_inbox_and_wait`) to deliver the invite
+      to V2's inbox, consistent with the no-mail-carrying rule (DEMOMA-03-003).
+    rationale: >-
+      The ADR-0026 flow is the accepted pattern for coordinator-to-case actor
+      suggestion (ADR-0026). The FCVCV scenario is the first to exercise C2
+      (a non-CASE_OWNER coordinator) suggesting a vendor; prior scenarios
+      (FCCV-extension) exercised C2 suggesting an existing vendor, but FCVCV
+      adds V2 as a new participant. The no-mail-carrying rule (DEMOMA-03-003)
+      requires that the demo orchestrator never post directly to another
+      actor's inbox; the invite must arrive via the normal routing path and
+      be detected by polling.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-03-003
+    - rel_type: refines
+      spec_id: DEMOMA-19-003

--- a/vultron/demo/helpers/milestones.py
+++ b/vultron/demo/helpers/milestones.py
@@ -211,6 +211,45 @@ def verify_fix_ready(
     logger.info("✓ fix ready: both replicas show CS includes F (fix ready)")
 
 
+def _assert_deployer_or_vendor_role(
+    client: DataLayerClient,
+    case_id: str,
+    actor_id: str,
+    label: str,
+) -> None:
+    """Assert that *actor_id* holds ``CVDRole.DEPLOYER`` or ``CVDRole.VENDOR``.
+
+    The d→D (fix-deployed) transition is gated on ``CVDRole.DEPLOYER`` by
+    ``CheckDeployerRoleNode``; an actor that holds only ``CVDRole.VENDOR`` but
+    not ``CVDRole.DEPLOYER`` stops at VFd and cannot reach VFD.  An actor may
+    hold both roles and passes this check.
+
+    Spec: DEMOMA-15-001.
+
+    Args:
+        client: DataLayerClient for the target container.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
+        actor_id: Full URI of the actor to check.
+        label: Human-readable label for the ``AssertionError`` message.
+
+    Raises:
+        AssertionError: If the participant is not found or holds neither
+            ``CVDRole.DEPLOYER`` nor ``CVDRole.VENDOR``.
+    """
+    participant = _fetch_participant(client, case_id, actor_id)
+    if participant is None:
+        raise AssertionError(
+            f"{label}: actor {actor_id!r} not found as a participant in case"
+            f" {case_id!r}"
+        )
+    vfd_roles = {CVDRole.VENDOR, CVDRole.DEPLOYER}
+    if not (vfd_roles & set(participant.case_roles or [])):
+        raise AssertionError(
+            f"{label}: actor {actor_id!r} holds neither CVDRole.VENDOR nor"
+            f" CVDRole.DEPLOYER; actual roles: {participant.case_roles!r}"
+        )
+
+
 def verify_fix_deployed(
     receiver_client: DataLayerClient,
     reporter_client: DataLayerClient,
@@ -220,9 +259,11 @@ def verify_fix_deployed(
     """Verify that both replicas show CS includes D (fix deployed).
 
     The ``receiver_actor_id`` MUST be the full URI of an actor holding
-    ``CVDRole.VENDOR`` in the case.  Passing any other actor (e.g. a
-    Coordinator) is a caller error and will raise ``AssertionError`` before
-    the state check runs.
+    ``CVDRole.DEPLOYER`` or ``CVDRole.VENDOR`` in the case.  The d→D
+    transition is gated on ``CVDRole.DEPLOYER``; an actor with only
+    ``CVDRole.VENDOR`` and no deployer role cannot advance beyond VFd.
+    Passing any other actor (e.g. a Coordinator) is a caller error and will
+    raise ``AssertionError`` before the state check runs.
 
     Specs: DEMOMA-06-002, DEMOMA-15-001.
 
@@ -234,11 +275,11 @@ def verify_fix_deployed(
             participant vfd_state to check.
 
     Raises:
-        AssertionError: If ``receiver_actor_id`` does not hold
-            ``CVDRole.VENDOR``, or if either replica does not reflect
-            fix-deployed state.
+        AssertionError: If ``receiver_actor_id`` holds neither
+            ``CVDRole.DEPLOYER`` nor ``CVDRole.VENDOR``, or if either
+            replica does not reflect fix-deployed state.
     """
-    _assert_vendor_role(
+    _assert_deployer_or_vendor_role(
         receiver_client, case_id, receiver_actor_id, "verify_fix_deployed"
     )
     deployed_state = {CS_vfd.VFD}


### PR DESCRIPTION
- Closes #1217

## Summary

Plans the FCVCV 5-party CVD demo scenario (Finder + Coordinator1 + Vendor1 +
Coordinator2 + Vendor2, issue #1217), corrects two stale spec entries
discovered during implementation research, and adds the full DEMOMA-19 spec
group that will drive implementation.

## Changes

### Spec corrections (bugs found during research)

**DEMOMA-07-003 step 4 — embargo teardown gate was wrong**

The previous spec stated that embargo teardown was triggered only when the
*Case Owner's* CaseStatus reached CS.P/X/A.  Code inspection of
`ThreatTerminationBranchNode` (RSH-03-002) shows it fires for *any*
participant's CS.P/X/A; there is no sender-role gate.  The spec step has been
rewritten to describe the actual implementation and to document the
`SideEffectsGuard` call-out seam (RSH-02-001), which defaults to
`AlwaysSucceed` but is designed to accommodate a future "ask CASE_OWNER to
confirm" policy.

**DEMOMA-15-001 — `verify_fix_deployed` role guard was overfitted**

The previous spec listed `CVDRole.VENDOR` as the required role for both
`verify_fix_ready` and `verify_fix_deployed`.  This was an overfit to
scenarios where the Vendor and Deployer were always the same actor.  The d→D
BT transition is gated on `CVDRole.DEPLOYER` (via `CheckDeployerRoleNode`),
not VENDOR.  DEMOMA-15-001 has been split:

- `verify_fix_ready` → requires `CVDRole.VENDOR` (f→F gate, unchanged)
- `verify_fix_deployed` → requires `CVDRole.VENDOR` **or** `CVDRole.DEPLOYER`

The code fix adds `_assert_deployer_or_vendor_role` in
`vultron/demo/helpers/milestones.py` and updates `verify_fix_deployed` to
call it.  A VENDOR-only actor (V1 in FCVCV) correctly stops at VFd; a
VENDOR+DEPLOYER actor (V2) passes the new guard and can advance to VFD.

### New spec entries

- **DEMOMA-16-009** — FCVCV expected event types for the invariant harness
  (`invite_actor_to_case` ≥3, `offer_case_participant` ≥1,
  `accept_invite_actor_to_case` ≥3)
- **DEMOMA-19** (9 entries) — full FCVCV scenario specification:
  - DEMOMA-19-001: `actor6` service + `seed-actor6.yaml` container topology
  - DEMOMA-19-002: `seed_containers_fcvcv` (5-actor, N×(N-1) cross-reg)
  - DEMOMA-19-003: `fcvcv_demo.py` phase structure (8 phases)
  - DEMOMA-19-004: V1 (VENDOR only, stops at VFd) vs V2 (VENDOR+DEPLOYER, VFD)
  - DEMOMA-19-005: V1 publishes first → embargo teardown; V2 publishes after
  - DEMOMA-19-006: `fcvcv` CLI sub-command
  - DEMOMA-19-007: CI matrix entry + `actor6` service dependency + devlog naming
  - DEMOMA-19-008: invariant harness at `test/ci/invariants/test_fcvcv_invariants.py`
  - DEMOMA-19-009: ADR-0026 suggest-actor flow for V2 onboarding (no mail-carrying)

## Test plan

- [ ] `uv run spec-dump` parses the updated YAML without errors (validated locally)
- [ ] `markdownlint-cli2` reports 0 issues (validated locally)
- [ ] `black` passes on `vultron/demo/helpers/milestones.py` (validated via pre-commit)
- [ ] `flake8` passes (validated via pre-commit)
- [ ] Implementation issues created (see below) will carry the per-AC test plans

## Implementation Issues

- #1923 — Add `actor6` service + `seed-actor6.yaml` (DEMOMA-19-001)
- #1924 — `seed_containers_fcvcv` in seeding.py (DEMOMA-19-002)
- #1925 — `fcvcv_demo.py` scenario script + `fcvcv` CLI command (DEMOMA-19-003–006, 19-009)
- #1926 — CI matrix entry, invariant harness, devlog naming (DEMOMA-16-009, 19-007–008)
- #1927 — Unit tests for `verify_fix_deployed` VENDOR-or-DEPLOYER guard (DEMOMA-15-001)
- #1928 — [Idea] Rename docker-compose containers to generic names (actor1–actor6)