### PR TITLE
feat(#1901): receiver-side role semantics for Leave(VulnerabilityCase)

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1901.md
+++ b/plan/history/2608/implementation/ISSUE-1901.md
@@ -1,0 +1,23 @@
+---
+source: ISSUE-1901
+timestamp: '2026-08-03T17:45:14.552794+00:00'
+title: Leave(VulnerabilityCase) receiver-side role semantics
+type: implementation
+---
+
+## Issue #1901 — feat: receiver-side role semantics for Leave(VulnerabilityCase)
+
+Implemented CM-23-002 (owner Leave) and CM-23-003 (non-owner Leave) in the CaseActor receive path.
+
+Key additions:
+
+- `vultron/core/behaviors/case/nodes/leave.py`: `AdvanceParticipantToRMClosedNode`, `AdvanceCaseActorToRMClosedNode`
+- `vultron/core/behaviors/case/receive_close_case_tree.py`: role-branching BT using `CheckIsCaseOwnerNode` as tree-level condition (BTND-08-001/002)
+- `vultron/core/behaviors/sync/nodes/conditions.py`: `IsCloseCaseEventNode`
+- `vultron/core/behaviors/sync/nodes/effects.py`: `ApplyCloseCaseFromLedgerNode` for fan-out path
+- `vultron/core/behaviors/sync/announce_tree.py`: `CloseCaseEffects` slot
+- Trigger side: `SvcLeaveCaseUseCase`, `LeaveCaseTriggerRequest`, `leave_case()` service method
+- `demo_close_case` now uses canonical `leave_case()` path (ADR-0050) instead of direct `add_participant_status`
+- 8 new tests covering all paths (receive + fan-out, owner + non-owner)
+
+PR: <https://github.com/CERTCC/Vultron/pull/1929>

--- a/test/ci/invariants/common.py
+++ b/test/ci/invariants/common.py
@@ -357,19 +357,38 @@ def check_no_rm_state_oscillation(
 def check_rm_closed_termination(
     replicas: dict[str, list[dict]],
 ) -> list[str]:
-    """The log terminates with every participant in RM=CLOSED (Invariant 7)."""
+    """The log terminates with every participant in RM=CLOSED (Invariant 7).
+
+    Recognises two event types as RM-state carriers:
+
+    - ``add_participant_status_to_participant``: explicit RM state for the
+      participant in the ``payloadSnapshot`` (pre-ADR-0050 CS transitions).
+    - ``close_case``: signals ``RM=CLOSED`` for the departing actor whose ID
+      is in ``payloadSnapshot.actor`` (ADR-0050 canonical closure path via
+      ``Leave(VulnerabilityCase)``).
+    """
     auth = auth_entries(replicas)
     latest_rm: dict[str, str] = {}
     for e in auth:
-        if event_type(e) != "add_participant_status_to_participant":
-            continue
-        p_id, rm_state = participant_status_identity_and_rm(payload(e))
-        if p_id and rm_state:
-            latest_rm[p_id] = rm_state
+        et = event_type(e)
+        snap = payload(e)
+        if et == "add_participant_status_to_participant":
+            p_id, rm_state = participant_status_identity_and_rm(snap)
+            if p_id and rm_state:
+                latest_rm[p_id] = rm_state
+        elif et == "close_case":
+            # close_case entries record the departing actor in payloadSnapshot.actor
+            # (ADR-0050: Leave(VulnerabilityCase) is the canonical RM closure path).
+            actor_val = snap.get("actor")
+            if isinstance(actor_val, dict):
+                actor_val = actor_val.get("id")
+            if isinstance(actor_val, str) and actor_val:
+                latest_rm[actor_val] = "CLOSED"
 
     if not latest_rm:
         return [
-            "No add_participant_status_to_participant entries found in case-actor log"
+            "No add_participant_status_to_participant or close_case entries"
+            " found in case-actor log"
         ]
 
     return [

--- a/test/core/use_cases/received/test_close_case_role_semantics.py
+++ b/test/core/use_cases/received/test_close_case_role_semantics.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Receiver-side role semantics tests for Leave(VulnerabilityCase).
+
+Covers CM-23-002 (owner Leave) and CM-23-003 (non-owner Leave) across:
+
+1. The Case Actor's direct receive path (``create_close_case_received_tree``).
+2. The fan-out replica path (``ApplyCloseCaseFromLedgerNode`` via announce tree).
+"""
+
+from __future__ import annotations
+
+import pytest
+import py_trees
+
+from unittest.mock import MagicMock
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.sync.announce_tree import (
+    create_announce_log_entry_tree,
+)
+from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
+from vultron.core.models.activity import VultronActivity
+from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.case_ledger import HashChainLedgerRecord
+from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
+from vultron.core.models.events.base import MessageSemantics
+from vultron.core.models.events.case import CloseCaseReceivedEvent
+from vultron.core.models.events.sync import AnnounceLogEntryReceivedEvent
+from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.states.rm import RM
+from vultron.core.use_cases.received.case.lifecycle import (
+    CloseCaseReceivedUseCase,
+)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.enums.roles import CVDRole
+from vultron.semantic_registry import extract_event
+from vultron.wire.as2.factories import announce_log_entry_activity
+from vultron.wire.as2.vocab.objects.case_ledger_entry import (
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
+)
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CASE_ACTOR_ID = "https://example.org/actors/case-actor-roles"
+OWNER_ID = "https://example.org/actors/owner-roles"
+VENDOR_ID = "https://example.org/actors/vendor-roles"
+CASE_ID = "https://example.org/cases/c-role-test"
+
+_ZERO_HASH = "0" * 64
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+def _make_dl() -> SqliteDataLayer:
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+def _make_full_dl(
+    owner_id: str = OWNER_ID,
+    extra_participant_id: str | None = VENDOR_ID,
+) -> SqliteDataLayer:
+    """DataLayer as seen by the CaseActor, with all participants set up.
+
+    Participants:
+    - CaseActor: CASE_MANAGER role
+    - owner_id: CASE_OWNER role
+    - extra_participant_id (optional): VENDOR role
+    """
+    dl = _make_dl()
+
+    ca_svc = VultronCaseActor(id_=CASE_ACTOR_ID, context=CASE_ID)
+    dl.save(ca_svc)
+
+    case = as_VulnerabilityCase(
+        id_=CASE_ID,
+        name="Role Semantics Test",
+        attributed_to=CASE_ACTOR_ID,
+    )
+
+    cm_participant = as_CaseParticipant(
+        attributed_to=CASE_ACTOR_ID,
+        context=CASE_ID,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    dl.create(cm_participant)
+    case.case_participants.append(cm_participant.id_)
+    case.actor_participant_index[CASE_ACTOR_ID] = cm_participant.id_
+
+    owner_participant = as_CaseParticipant(
+        attributed_to=owner_id,
+        context=CASE_ID,
+        case_roles=[CVDRole.CASE_OWNER, CVDRole.FINDER],
+    )
+    dl.create(owner_participant)
+    case.case_participants.append(owner_participant.id_)
+    case.actor_participant_index[owner_id] = owner_participant.id_
+
+    if extra_participant_id is not None:
+        vendor_participant = as_CaseParticipant(
+            attributed_to=extra_participant_id,
+            context=CASE_ID,
+            case_roles=[CVDRole.VENDOR],
+        )
+        dl.create(vendor_participant)
+        case.case_participants.append(vendor_participant.id_)
+        case.actor_participant_index[extra_participant_id] = (
+            vendor_participant.id_
+        )
+
+    dl.save(case)
+    return dl
+
+
+def _make_close_case_event(
+    sender_actor_id: str,
+    receiving_actor_id: str = CASE_ACTOR_ID,
+) -> CloseCaseReceivedEvent:
+    case_obj = as_VulnerabilityCase(id_=CASE_ID)
+    activity = VultronActivity(
+        id_="https://example.org/activities/leave-role-test",
+        type_="Leave",
+        actor=sender_actor_id,
+        object_=case_obj,
+    )
+    return CloseCaseReceivedEvent(
+        semantic_type=MessageSemantics.CLOSE_CASE,
+        activity_id=activity.id_,
+        actor_id=sender_actor_id,
+        object_=case_obj,
+        activity=activity,
+        receiving_actor_id=receiving_actor_id,
+    )
+
+
+def _participant_rm_states(dl: SqliteDataLayer, actor_id: str) -> list[RM]:
+    """Return list of RM states from participant_statuses for actor_id in CASE_ID."""
+    case = dl.read(CASE_ID)
+    if not isinstance(case, VulnerabilityCase):
+        return []
+    participant_id = case.actor_participant_index.get(actor_id)
+    if participant_id is None:
+        return []
+    participant = dl.read(participant_id)
+    if not isinstance(participant, CaseParticipant):
+        return []
+    return [
+        ps.rm.state
+        for ps in participant.participant_statuses
+        if hasattr(ps, "rm") and ps.rm is not None
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Case Actor receive path (create_close_case_received_tree)
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerLeaveReceivePath:
+    """CM-23-002: Owner Leave advances leaving participant + CaseActor to RM.CLOSED."""
+
+    def test_owner_leave_advances_owner_to_rm_closed(self):
+        """Owner Leave: the leaving owner actor is advanced to RM.CLOSED."""
+        dl = _make_full_dl()
+        CloseCaseReceivedUseCase(
+            dl=dl,
+            request=_make_close_case_event(sender_actor_id=OWNER_ID),
+            sync_port=SyncActivityAdapter(dl),
+        ).execute()
+
+        rm_states = _participant_rm_states(dl, OWNER_ID)
+        assert RM.CLOSED in rm_states, (
+            f"Owner participant must be at RM.CLOSED after owner Leave;"
+            f" rm_states={rm_states}"
+        )
+
+    def test_owner_leave_advances_case_actor_to_rm_closed(self):
+        """Owner Leave: the CaseActor is also advanced to RM.CLOSED (CM-23-002 step 2)."""
+        dl = _make_full_dl()
+        CloseCaseReceivedUseCase(
+            dl=dl,
+            request=_make_close_case_event(sender_actor_id=OWNER_ID),
+            sync_port=SyncActivityAdapter(dl),
+        ).execute()
+
+        rm_states = _participant_rm_states(dl, CASE_ACTOR_ID)
+        assert RM.CLOSED in rm_states, (
+            f"CaseActor must be at RM.CLOSED after owner Leave (CM-23-002);"
+            f" rm_states={rm_states}"
+        )
+
+    def test_owner_leave_does_not_close_non_departed_participants(self):
+        """Owner Leave: the remaining non-leaving vendor participant is NOT changed.
+
+        The Case Actor only closes the owner + itself in the receive path.
+        Non-leaving participants learn via Announce(CaseLedgerEntry) fan-out.
+        """
+        dl = _make_full_dl()
+        CloseCaseReceivedUseCase(
+            dl=dl,
+            request=_make_close_case_event(sender_actor_id=OWNER_ID),
+            sync_port=SyncActivityAdapter(dl),
+        ).execute()
+
+        rm_states = _participant_rm_states(dl, VENDOR_ID)
+        assert RM.CLOSED not in rm_states, (
+            f"Vendor participant must NOT be at RM.CLOSED after owner Leave"
+            f" — fan-out handles that; rm_states={rm_states}"
+        )
+
+
+class TestNonOwnerLeaveReceivePath:
+    """CM-23-003: Non-owner Leave advances only the leaving participant."""
+
+    def test_non_owner_leave_advances_only_leaving_participant(self):
+        """Non-owner Leave: the leaving vendor actor is advanced to RM.CLOSED."""
+        dl = _make_full_dl()
+        CloseCaseReceivedUseCase(
+            dl=dl,
+            request=_make_close_case_event(sender_actor_id=VENDOR_ID),
+            sync_port=SyncActivityAdapter(dl),
+        ).execute()
+
+        rm_states = _participant_rm_states(dl, VENDOR_ID)
+        assert RM.CLOSED in rm_states, (
+            f"Non-owner leaving participant must be at RM.CLOSED (CM-23-003);"
+            f" rm_states={rm_states}"
+        )
+
+    def test_non_owner_leave_does_not_close_owner(self):
+        """Non-owner Leave: the case owner remains open (CM-23-003)."""
+        dl = _make_full_dl()
+        CloseCaseReceivedUseCase(
+            dl=dl,
+            request=_make_close_case_event(sender_actor_id=VENDOR_ID),
+            sync_port=SyncActivityAdapter(dl),
+        ).execute()
+
+        rm_states = _participant_rm_states(dl, OWNER_ID)
+        assert RM.CLOSED not in rm_states, (
+            f"Owner participant must NOT be at RM.CLOSED after non-owner Leave;"
+            f" rm_states={rm_states}"
+        )
+
+    def test_non_owner_leave_does_not_close_case_actor(self):
+        """Non-owner Leave: the CaseActor remains open (CM-23-003)."""
+        dl = _make_full_dl()
+        CloseCaseReceivedUseCase(
+            dl=dl,
+            request=_make_close_case_event(sender_actor_id=VENDOR_ID),
+            sync_port=SyncActivityAdapter(dl),
+        ).execute()
+
+        rm_states = _participant_rm_states(dl, CASE_ACTOR_ID)
+        assert RM.CLOSED not in rm_states, (
+            f"CaseActor must NOT be at RM.CLOSED after non-owner Leave;"
+            f" rm_states={rm_states}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fan-out path (ApplyCloseCaseFromLedgerNode via announce tree)
+# ---------------------------------------------------------------------------
+
+
+def _make_close_case_ledger_entry(
+    dl: SqliteDataLayer,
+    departing_actor_id: str,
+) -> VultronCaseLedgerEntry:
+    """Build a close_case CaseLedgerEntry with the correct genesis hash.
+
+    Uses the case's ``genesis_hash`` as ``prev_log_hash`` so that
+    ``ReconstructChainTailNode`` accepts it as the first entry in a fresh chain.
+    """
+    case = dl.read(CASE_ID)
+    genesis_hash = getattr(case, "genesis_hash", _ZERO_HASH) or _ZERO_HASH
+    return _to_persistable_entry(
+        HashChainLedgerRecord(
+            case_id=CASE_ID,
+            log_index=0,
+            object_id="https://example.org/activities/leave-for-fanout",
+            event_type="close_case",
+            payload_snapshot={"actor": departing_actor_id},
+            prev_log_hash=genesis_hash,
+        )
+    )
+
+
+def _make_announce_event(
+    entry: VultronCaseLedgerEntry,
+    sender_actor_id: str,
+) -> AnnounceLogEntryReceivedEvent:
+    from typing import cast
+
+    wire_entry = WireCaseLedgerEntry.model_validate(
+        entry.model_dump(mode="json")
+    )
+    activity = announce_log_entry_activity(
+        entry=wire_entry, actor=sender_actor_id
+    )
+    return cast(AnnounceLogEntryReceivedEvent, extract_event(activity))
+
+
+class TestCloseCaseFanOut:
+    """Fan-out: ApplyCloseCaseFromLedgerNode advances departing participant on replicas."""
+
+    def test_fan_out_advances_departing_participant_to_rm_closed(self):
+        """Announce(close_case entry) advances the departing participant on a non-CaseActor replica.
+
+        This simulates the VENDOR actor's local DataLayer receiving the
+        ``Announce(CaseLedgerEntry)`` that the Case Actor broadcast after
+        processing the owner's Leave.  The vendor replica must advance the
+        OWNER participant to RM.CLOSED (CM-23-003).
+
+        The entry is NOT pre-stored: ``CheckLedgerEntryAlreadyStoredNode`` in
+        the announce tree short-circuits with SUCCESS (skips effects) when the
+        entry is already present.  The fan-out scenario is: entry arrives fresh.
+        """
+        dl = _make_full_dl()
+        entry = _make_close_case_ledger_entry(dl, departing_actor_id=OWNER_ID)
+
+        event = _make_announce_event(
+            entry=entry, sender_actor_id=CASE_ACTOR_ID
+        )
+
+        tree = create_announce_log_entry_tree()
+        BTBridge(datalayer=dl).execute_with_setup(
+            tree=tree,
+            actor_id=VENDOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        rm_states = _participant_rm_states(dl, OWNER_ID)
+        assert RM.CLOSED in rm_states, (
+            f"Announce(close_case) fan-out must advance departing participant"
+            f" to RM.CLOSED on vendor replica (CM-23-003);"
+            f" rm_states={rm_states}"
+        )
+
+    def test_fan_out_does_not_advance_non_departing_participant(self):
+        """Announce(close_case entry for OWNER) must not advance VENDOR to RM.CLOSED."""
+        dl = _make_full_dl()
+        entry = _make_close_case_ledger_entry(dl, departing_actor_id=OWNER_ID)
+
+        event = _make_announce_event(
+            entry=entry, sender_actor_id=CASE_ACTOR_ID
+        )
+
+        tree = create_announce_log_entry_tree()
+        BTBridge(datalayer=dl).execute_with_setup(
+            tree=tree,
+            actor_id=VENDOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        rm_states = _participant_rm_states(dl, VENDOR_ID)
+        assert RM.CLOSED not in rm_states, (
+            f"Announce(close_case for OWNER) must NOT advance VENDOR to RM.CLOSED;"
+            f" rm_states={rm_states}"
+        )

--- a/test/core/use_cases/triggers/case/test_leave.py
+++ b/test/core/use_cases/triggers/case/test_leave.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import (
+    SqliteDataLayer,
+    reset_datalayer,
+)
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
+from vultron.core.states.rm import RM
+from vultron.core.use_cases.triggers.case import (
+    LeaveCaseTriggerRequest,
+    SvcLeaveCaseUseCase,
+)
+from vultron.enums.roles import CVDRole
+from vultron.errors import VultronNotFoundError, VultronValidationError
+from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import (
+    as_CaseParticipant,
+    FinderParticipant,
+)
+from vultron.wire.as2.vocab.objects.case_status import (
+    as_ParticipantStatus as WireParticipantStatus,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
+
+
+def _make_actor(name: str) -> as_Service:
+    return as_Service(
+        name=name, url=f"https://example.org/{name.lower().replace(' ', '-')}"
+    )
+
+
+def _make_actor_dl(name: str) -> tuple[as_Service, SqliteDataLayer]:
+    actor = _make_actor(name)
+    dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor.id_)
+    dl.clear_all()
+    dl.create(actor)
+    return actor, dl
+
+
+def _make_case_with_case_manager(
+    dl: SqliteDataLayer,
+    actor_id: str,
+    finder_id: str,
+    case_actor_id: str,
+) -> tuple[as_VulnerabilityCase, as_CaseParticipant]:
+    case = as_VulnerabilityCase(name="Test Case")
+
+    actor_participant = as_CaseParticipant(
+        attributed_to=actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.VENDOR],
+    )
+    actor_participant.participant_statuses.append(
+        WireParticipantStatus(context=case.id_, rm_state=RM.RECEIVED)
+    )
+    actor_participant.participant_statuses.append(
+        WireParticipantStatus(context=case.id_, rm_state=RM.VALID)
+    )
+
+    finder_participant = FinderParticipant(
+        attributed_to=finder_id,
+        context=case.id_,
+    )
+    case_manager_participant = as_CaseParticipant(
+        attributed_to=case_actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+
+    case.actor_participant_index[actor_id] = actor_participant.id_
+    case.actor_participant_index[finder_id] = finder_participant.id_
+    case.actor_participant_index[case_actor_id] = case_manager_participant.id_
+
+    case.case_participants.append(actor_participant.id_)
+    case.case_participants.append(finder_participant.id_)
+    case.case_participants.append(case_manager_participant.id_)
+
+    dl.create(case)
+    dl.create(actor_participant)
+    dl.create(finder_participant)
+    dl.create(case_manager_participant)
+    return case, actor_participant
+
+
+class TestLeaveCaseTriggersOutboxActivity:
+    """AC-1: execute() queues a Leave(VulnerabilityCase) activity in the outbox.
+
+    Covers: outbox effect (PCR-08-001 routing), and failure modes.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.vendor, self.dl = _make_actor_dl("Vendor Co")
+        self.finder, _ = _make_actor_dl("Finder Co")
+        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.case, self.vendor_participant = _make_case_with_case_manager(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
+        )
+        yield
+        self.dl.clear_all()
+        reset_datalayer(self.vendor.id_)
+        reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
+
+    def test_leave_case_queues_activity_in_outbox(self):
+        request = LeaveCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+        )
+        before = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        SvcLeaveCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+        after = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        assert len(after - before) >= 1
+
+    def test_leave_case_outbox_activity_addressed_to_case_actor(self):
+        """Activity is routed exclusively to the Case Actor (PCR-08-001)."""
+        request = LeaveCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+        )
+        before = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        SvcLeaveCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+        after = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        new_ids = after - before
+        assert new_ids, "No new outbox item was queued"
+
+        activity_id = next(iter(new_ids))
+        activity = self.dl.read(activity_id)
+        assert activity is not None
+        to = getattr(activity, "to", None)
+        to_ids = (
+            [
+                (
+                    item
+                    if isinstance(item, str)
+                    else getattr(item, "id_", str(item))
+                )
+                for item in to
+            ]
+            if isinstance(to, list)
+            else ([to] if isinstance(to, str) else [])
+        )
+        assert self.case_actor.id_ in to_ids
+        assert self.vendor.id_ not in to_ids
+        assert self.finder.id_ not in to_ids
+        assert len(to_ids) == 1, f"Expected exactly 1 recipient, got {to_ids}"
+
+    def test_leave_case_actor_not_found_raises_error(self):
+        request = LeaveCaseTriggerRequest(
+            actor_id="urn:uuid:no-such-actor",
+            case_id=self.case.id_,
+        )
+        with pytest.raises(VultronNotFoundError):
+            SvcLeaveCaseUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()
+
+    def test_leave_case_not_found_raises_error(self):
+        request = LeaveCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id="urn:uuid:no-such-case",
+        )
+        with pytest.raises(VultronNotFoundError):
+            SvcLeaveCaseUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()
+
+    def test_leave_case_no_case_manager_raises_validation_error(self):
+        """VultronValidationError raised when case has no CASE_MANAGER."""
+        case_solo = as_VulnerabilityCase(name="Solo Case")
+        vendor_participant = as_CaseParticipant(
+            attributed_to=self.vendor.id_,
+            context=case_solo.id_,
+            case_roles=[CVDRole.VENDOR],
+        )
+        vendor_participant.participant_statuses.append(
+            WireParticipantStatus(context=case_solo.id_, rm_state=RM.RECEIVED)
+        )
+        vendor_participant.participant_statuses.append(
+            WireParticipantStatus(context=case_solo.id_, rm_state=RM.VALID)
+        )
+        case_solo.actor_participant_index[self.vendor.id_] = (
+            vendor_participant.id_
+        )
+        case_solo.case_participants.append(vendor_participant.id_)
+        self.dl.create(case_solo)
+        self.dl.create(vendor_participant)
+
+        request = LeaveCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=case_solo.id_,
+        )
+        with pytest.raises(VultronValidationError):
+            SvcLeaveCaseUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -1045,16 +1045,18 @@ class TestWaitForAllParticipantsRmClosed:
         )
         assert result is True
 
-    def test_url_based_participant_id_handled_gracefully(
+    def test_url_based_actor_keys_handled_gracefully(
         self, client: TestClient, base: str
     ):
-        """URL-based participant IDs (HTTP URLs with slashes) are now fetchable.
+        """URL-based actor IDs in actor_participant_index keys are fetchable.
 
-        Regression test for #610.  The Case Actor's participant ID is an HTTP
-        URL.  After the fix (``/{key:path}`` catch-all route), the DataLayer
-        endpoint correctly decodes the URL key and returns the stored record.
-        ``_all_fetchable_participants_rm_closed`` must also handle URL-based
-        IDs without error.
+        Regression test for #610.  The Case Actor's actor ID (index key) is an
+        HTTP URL; its participant record is stored under a ``urn:uuid:`` ID
+        (index value).  After the fix (``/{key:path}`` catch-all route), both
+        the Service object (HTTP-URL key) and the CaseParticipant (urn:uuid:
+        key) are fetchable via the DataLayer endpoint.
+        ``_all_fetchable_participants_rm_closed`` must also handle this layout
+        without error.
         """
         from urllib.parse import quote
 
@@ -1063,26 +1065,28 @@ class TestWaitForAllParticipantsRmClosed:
         )
         case_data = vendor_client.get(f"/datalayer/{case.id_}")
         fetched_case = as_VulnerabilityCase.model_validate(case_data)
-        url_based_ids = [
-            p_id
-            for p_id in fetched_case.actor_participant_index.values()
-            if p_id.startswith("http")
+
+        # actor_participant_index keys are actor IDs; the CaseActor key is an
+        # HTTP URL while participant IDs (values) are urn:uuid: URNs.
+        url_based_actor_ids = [
+            actor_id
+            for actor_id in fetched_case.actor_participant_index.keys()
+            if actor_id.startswith("http")
         ]
         assert (
-            url_based_ids
-        ), "Expected at least one URL-based participant ID (Case Actor)"
+            url_based_actor_ids
+        ), "Expected at least one URL-based actor ID (Case Actor) in index keys"
 
-        # After fix: URL-based participant IDs must be fetchable via
-        # the DataLayer endpoint with percent-encoded slashes.
-        p_id = url_based_ids[0]
-        encoded = quote(p_id, safe="")
+        # The CaseActor Service object (HTTP-URL key) must be fetchable.
+        actor_id = url_based_actor_ids[0]
+        encoded = quote(actor_id, safe="")
         result = vendor_client.get(f"/datalayer/{encoded}")
         assert (
-            isinstance(result, dict) and result.get("id") == p_id
-        ), f"Expected participant record for URL-format ID {p_id!r}, got {result!r}"
+            isinstance(result, dict) and result.get("id") == actor_id
+        ), f"Expected Service record for URL-format ID {actor_id!r}, got {result!r}"
 
-        # _all_fetchable_participants_rm_closed must also handle URL-based
-        # participant IDs without error.
+        # _all_fetchable_participants_rm_closed must also handle this layout
+        # without error.
         try:
             demo._all_fetchable_participants_rm_closed(
                 vendor_client, fetched_case
@@ -1090,7 +1094,7 @@ class TestWaitForAllParticipantsRmClosed:
         except Exception as exc:
             pytest.fail(
                 f"_all_fetchable_participants_rm_closed crashed on"
-                f" URL-based participant ID {p_id!r}: {exc}"
+                f" URL-based actor ID {actor_id!r}: {exc}"
             )
 
 
@@ -1825,8 +1829,11 @@ class TestCaseLedgerInvariants:
     ) -> None:
         """All tracked participants end in RM=CLOSED at scenario completion.
 
-        Scans add_participant_status entries in the combined case log and
-        checks the final RM state recorded for each participant.
+        Scans add_participant_status and close_case entries in the combined
+        case log to determine the final RM state per participant.
+        ``add_participant_status_to_participant`` entries carry the RM state
+        explicitly; ``close_case`` entries signal RM=CLOSED for the departing
+        actor recorded in ``payloadSnapshot.actor`` (ADR-0050, CM-23-002/003).
         Corresponds to CI invariant 7 (terminal RM state check) from
         test/ci/test_case_ledger_invariants.py.
         Spec: CLP-07.
@@ -1837,18 +1844,24 @@ class TestCaseLedgerInvariants:
         # CI invariant 7 — last RM state per participant must be CLOSED.
         latest_rm: dict[str, str] = {}
         for entry in entries:
-            if (
-                _log_event_type(entry)
-                != "add_participant_status_to_participant"
-            ):
-                continue
-            p_id, rm_state = _participant_id_and_rm(_log_payload(entry))
-            if p_id and rm_state:
-                latest_rm[p_id] = rm_state
+            event_type = _log_event_type(entry)
+            payload = _log_payload(entry)
+            if event_type == "add_participant_status_to_participant":
+                p_id, rm_state = _participant_id_and_rm(payload)
+                if p_id and rm_state:
+                    latest_rm[p_id] = rm_state
+            elif event_type == "close_case":
+                # close_case entries signal RM=CLOSED for the departing actor
+                # (ADR-0050: Leave(VulnerabilityCase) is the canonical closure path).
+                actor_id = payload.get("actor") or payload.get("attributedTo")
+                if isinstance(actor_id, dict):
+                    actor_id = actor_id.get("id")
+                if actor_id:
+                    latest_rm[str(actor_id)] = "CLOSED"
 
         assert latest_rm, (
-            "No add_participant_status_to_participant entries found in"
-            " combined case log; cannot verify terminal RM states."
+            "No add_participant_status_to_participant or close_case entries"
+            " found in combined case log; cannot verify terminal RM states."
         )
 
         not_closed = {

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -238,11 +238,11 @@ def demo_notify_published(
 @router.post(
     "/{actor_id}/demo/close-case",
     status_code=status.HTTP_202_ACCEPTED,
-    summary="[Demo] Report that the actor is closing the case (RM.CLOSED).",
+    summary="[Demo] Actor sends Leave(VulnerabilityCase) to close the case.",
     description=(
         "Demo-only scaffold. "
-        "Self-reports RM state CLOSED "
-        "to the Case Manager via Add(ParticipantStatus, CaseParticipant). "
+        "Triggers Leave(VulnerabilityCase) via the canonical RM closure path "
+        "(ADR-0050). "
         "Only available in ``RunMode.PROTOTYPE``. "
         "Spec: DEMOMA-07-001."
     ),
@@ -256,17 +256,18 @@ def demo_close_case(
     dl: DataLayer = Depends(get_trigger_dl),
     actor_dl: ActorScopedDataLayer = Depends(get_canonical_actor_dl),
 ) -> dict[str, Any]:
-    """Report that the actor is closing the case (demo scaffold).
+    """Trigger Leave(VulnerabilityCase) for the given actor and case.
+
+    Implements the canonical RM case closure path (ADR-0050): emits
+    Leave(VulnerabilityCase) to the Case Actor inbox, which commits a
+    ``close_case`` CaseLedgerEntry and fans it out to all participants.
 
     Implements: DEMOMA-07-001, TRIG-09-001, TB-01-001, TB-06-001.
     """
-    from vultron.core.states.rm import RM
-
     with domain_error_translation():
-        result = svc.add_participant_status(
+        result = svc.leave_case(
             actor_id=actor_id,
             case_id=body.case_id,
-            rm_state=RM.CLOSED,
         )
     background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
     return result

--- a/vultron/core/behaviors/case/nodes/leave.py
+++ b/vultron/core/behaviors/case/nodes/leave.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Receiver-side action nodes for Leave(VulnerabilityCase) processing.
+
+Implements the role-discriminating effects of a received Leave activity:
+
+- :class:`AdvanceParticipantToRMClosedNode`: Advances the leaving actor's
+  :class:`~vultron.core.models.participant_status.ParticipantStatus` to
+  ``RM.CLOSED`` in the local DataLayer.  Used on both the owner and non-owner
+  paths (the departure effect is the same; what differs is whether the whole
+  case also closes).
+
+- :class:`AdvanceCaseActorToRMClosedNode`: Advances the Case Actor's own
+  :class:`~vultron.core.models.participant_status.ParticipantStatus` to
+  ``RM.CLOSED``.  Only reached on the owner Leave path (CM-23-002 step 2).
+
+Per ADR-0050, ADR-0051, and specs/case-management.yaml CM-23-002/CM-23-003.
+"""
+
+import logging
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.case.nodes.participant.status import (
+    CreateParticipantStatusNode,
+)
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.states.rm import RM
+
+logger = logging.getLogger(__name__)
+
+
+class AdvanceParticipantToRMClosedNode(DataLayerAction):
+    """Advance the leaving actor's RM state to ``RM.CLOSED`` in the DataLayer.
+
+    Reads the leaving actor's :class:`~vultron.core.models.case_participant
+    .CaseParticipant` record from the DataLayer and appends a new
+    :class:`~vultron.core.models.participant_status.ParticipantStatus` entry
+    with ``rm_state=RM.CLOSED``.  Idempotent: if the participant is already at
+    ``RM.CLOSED``, the node returns ``SUCCESS`` without creating a duplicate
+    entry.
+
+    Used on both the owner and non-owner Leave receive paths (the participant
+    departure effect is identical; only the downstream case-closure steps differ).
+
+    Per CM-23-002 (owner path step 1), CM-23-003 (non-owner path step 1).
+    """
+
+    def __init__(
+        self,
+        leaving_actor_id: str,
+        case_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._leaving_actor_id = leaving_actor_id
+        self._case_id = case_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.logger.warning(
+                "%s: case '%s' not found or wrong type",
+                self.name,
+                self._case_id,
+            )
+            return Status.FAILURE
+
+        participant_id = case.actor_participant_index.get(
+            self._leaving_actor_id
+        )
+        if participant_id is None:
+            self.logger.debug(
+                "%s: leaving actor '%s' not in actor_participant_index"
+                " for case '%s' — skipping (non-fatal)",
+                self.name,
+                self._leaving_actor_id,
+                self._case_id,
+            )
+            return Status.SUCCESS
+
+        participant = self.datalayer.read(participant_id)
+        if not isinstance(participant, CaseParticipant):
+            self.logger.warning(
+                "%s: participant '%s' not found or wrong type",
+                self.name,
+                participant_id,
+            )
+            return Status.FAILURE
+
+        # Idempotency: skip if already at RM.CLOSED
+        for ps in participant.participant_statuses:
+            rm_dim = getattr(ps, "rm", None)
+            rm_state = getattr(rm_dim, "state", None) if rm_dim else None
+            if rm_state == RM.CLOSED:
+                self.logger.debug(
+                    "%s: participant '%s' already at RM.CLOSED — no-op",
+                    self.name,
+                    participant_id,
+                )
+                return Status.SUCCESS
+
+        result_out: dict = {}
+        node = CreateParticipantStatusNode(
+            case_id=self._case_id,
+            actor_id=self._leaving_actor_id,
+            rm_state=RM.CLOSED,
+            vfd_state=None,
+            pxa_state=None,
+            result_out=result_out,
+            name=f"{self.name}.CreateParticipantStatus",
+        )
+        node.datalayer = self.datalayer
+        node.actor_id = self._leaving_actor_id
+        result = node.update()
+        if result != Status.SUCCESS:
+            self.logger.warning(
+                "%s: failed to create RM.CLOSED ParticipantStatus for"
+                " actor '%s' in case '%s'",
+                self.name,
+                self._leaving_actor_id,
+                self._case_id,
+            )
+            return Status.FAILURE
+
+        self.logger.info(
+            "%s: advanced actor '%s' to RM.CLOSED in case '%s'"
+            " (CM-23-002/CM-23-003)",
+            self.name,
+            self._leaving_actor_id,
+            self._case_id,
+        )
+        return Status.SUCCESS
+
+
+class AdvanceCaseActorToRMClosedNode(DataLayerAction):
+    """Advance the Case Actor's own RM state to ``RM.CLOSED``.
+
+    Reads the Case Actor's :class:`~vultron.core.models.case_participant
+    .CaseParticipant` record from the DataLayer and appends a new
+    :class:`~vultron.core.models.participant_status.ParticipantStatus` entry
+    with ``rm_state=RM.CLOSED``.  Only executed on the owner Leave path, as
+    the penultimate step before emitting the ``case_fully_closed`` ledger entry
+    (CM-23-002 step 2; ADR-0051).
+
+    Idempotent: returns ``SUCCESS`` without modification if the Case Actor is
+    already at ``RM.CLOSED``.
+    """
+
+    def __init__(
+        self,
+        case_actor_id: str,
+        case_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_actor_id = case_actor_id
+        self._case_id = case_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.logger.warning(
+                "%s: case '%s' not found or wrong type",
+                self.name,
+                self._case_id,
+            )
+            return Status.FAILURE
+
+        participant_id = case.actor_participant_index.get(self._case_actor_id)
+        if participant_id is None:
+            self.logger.warning(
+                "%s: case actor '%s' not in actor_participant_index"
+                " for case '%s'",
+                self.name,
+                self._case_actor_id,
+                self._case_id,
+            )
+            return Status.FAILURE
+
+        participant = self.datalayer.read(participant_id)
+        if not isinstance(participant, CaseParticipant):
+            self.logger.warning(
+                "%s: participant '%s' for case actor not found or wrong type",
+                self.name,
+                participant_id,
+            )
+            return Status.FAILURE
+
+        # Idempotency: skip if already at RM.CLOSED
+        for ps in participant.participant_statuses:
+            rm_dim = getattr(ps, "rm", None)
+            rm_state = getattr(rm_dim, "state", None) if rm_dim else None
+            if rm_state == RM.CLOSED:
+                self.logger.debug(
+                    "%s: case actor '%s' already at RM.CLOSED — no-op",
+                    self.name,
+                    self._case_actor_id,
+                )
+                return Status.SUCCESS
+
+        result_out: dict = {}
+        node = CreateParticipantStatusNode(
+            case_id=self._case_id,
+            actor_id=self._case_actor_id,
+            rm_state=RM.CLOSED,
+            vfd_state=None,
+            pxa_state=None,
+            result_out=result_out,
+            name=f"{self.name}.CreateParticipantStatus",
+        )
+        node.datalayer = self.datalayer
+        node.actor_id = self._case_actor_id
+        result = node.update()
+        if result != Status.SUCCESS:
+            self.logger.warning(
+                "%s: failed to create RM.CLOSED ParticipantStatus for"
+                " case actor '%s' in case '%s'",
+                self.name,
+                self._case_actor_id,
+                self._case_id,
+            )
+            return Status.FAILURE
+
+        self.logger.info(
+            "%s: advanced case actor '%s' to RM.CLOSED in case '%s'"
+            " (CM-23-002 step 2, ADR-0051)",
+            self.name,
+            self._case_actor_id,
+            self._case_id,
+        )
+        return Status.SUCCESS

--- a/vultron/core/behaviors/case/receive_close_case_tree.py
+++ b/vultron/core/behaviors/case/receive_close_case_tree.py
@@ -13,15 +13,42 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Received-side BT factory for the close-case workflow (ADR-0022)."""
+"""Received-side BT factory for the close-case workflow (ADR-0022).
+
+Implements receiver-side role semantics for Leave(VulnerabilityCase):
+
+- **Owner Leave** (sender holds ``CVDRole.CASE_OWNER``): advances the leaving
+  participant to ``RM.CLOSED``, then advances the CaseActor to ``RM.CLOSED``,
+  completing the full case closure sequence on the Case Actor replica
+  (CM-23-002).
+- **Non-owner Leave**: advances only the leaving participant to ``RM.CLOSED``;
+  the case remains open for remaining participants (CM-23-003).
+
+The role check is performed by :class:`~vultron.core.behaviors.case.nodes
+.vfd_role_guards.CheckIsCaseOwnerNode` as a tree-level condition node, per
+BTND-08-001/BTND-08-002 (role checks MUST be in the tree, not in action node
+``update()`` logic).
+
+Fan-out to non-CaseActor replicas is handled by
+:class:`~vultron.core.behaviors.sync.nodes.effects.ApplyCloseCaseFromLedgerNode`
+in the announce tree, which mirrors the participant departure effect on every
+other replica.
+"""
 
 import logging
 from typing import Any
 
 import py_trees
 
+from vultron.core.behaviors.case.nodes.leave import (
+    AdvanceCaseActorToRMClosedNode,
+    AdvanceParticipantToRMClosedNode,
+)
 from vultron.core.behaviors.case.nodes.lifecycle import (
     create_receive_activity_tree,
+)
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckIsCaseOwnerNode,
 )
 from vultron.core.behaviors.report.nodes.storage import StoreActivityNode
 
@@ -32,18 +59,38 @@ def create_close_case_received_tree(
     case_id: str,
     activity_id: str,
     activity_obj: Any,
+    sender_actor_id: str | None = None,
+    receiving_actor_id: str | None = None,
 ) -> py_trees.composites.Sequence:
     """Single-BT received-side tree for CloseCaseReceived (ADR-0022).
 
-    Structure::
+    When ``sender_actor_id`` is provided, the tree branches on the sender's
+    ``CVDRole.CASE_OWNER`` role (CM-23-002/CM-23-003):
+
+    - Owner Leave → advance leaving participant to ``RM.CLOSED``, then
+      advance the CaseActor to ``RM.CLOSED`` (owner path, CM-23-002).
+    - Non-owner Leave → advance only the leaving participant to ``RM.CLOSED``;
+      case remains open (non-owner path, CM-23-003).
+
+    When ``sender_actor_id`` is ``None`` (e.g., in legacy paths or tests that
+    do not supply it), the tree falls back to the pre-#1901 behaviour:
+    ``StoreActivityNode`` only, no participant state mutation.
+
+    Structure (with role semantics)::
 
         CloseCaseBT (Sequence)
         ├── GuardedCommitOrSkip (Selector)             # Record receipt (CLP-10-006)
-        │   ├── Sequence
-        │   │   ├── CheckIsCaseManagerNode
-        │   │   └── CommitCaseLedgerEntryNode
-        │   └── Success("CommitSkippedNotCaseManager")
-        └── StoreActivityNode("Leave")                 # Persist inbound Leave activity
+        │   ├── Sequence(SkipIfNotCaseManager)
+        │   │   └── Inverter(CheckIsCaseManagerNode)
+        │   └── CommitCaseLedgerEntryNode
+        ├── OwnerOrNonOwnerEffects (Selector)           # Role discriminator
+        │   ├── OwnerLeaveSeq (Sequence)                # Owner path
+        │   │   ├── CheckIsCaseOwnerNode                # guard: sender IS CASE_OWNER
+        │   │   ├── AdvanceParticipantToRMClosedNode    # step 1: owner → RM.CLOSED
+        │   │   └── AdvanceCaseActorToRMClosedNode      # step 2: CaseActor → RM.CLOSED
+        │   └── NonOwnerLeaveFallbackSeq (Sequence)     # Non-owner path (fallback)
+        │       └── AdvanceParticipantToRMClosedNode    # departing participant → RM.CLOSED
+        └── StoreActivityNode("Leave")                  # Persist inbound Leave activity
 
     Running under ``actor_id=receiving_actor_id`` means
     ``CheckIsCaseManagerNode`` naturally gates the commit to the actor that
@@ -53,19 +100,81 @@ def create_close_case_received_tree(
         case_id: ID of the VulnerabilityCase being closed.
         activity_id: ID of the inbound Leave activity to store idempotently.
         activity_obj: The wire activity object to persist.
+        sender_actor_id: Actor URI of the Leave sender (resolved from the
+            inbound Leave activity's ``actor`` field).  When provided, the tree
+            applies role-discriminating RM closure effects (CM-23-002/003).
+            When ``None``, only ``StoreActivityNode`` runs as a fallback.
+        receiving_actor_id: Actor URI of the receiving actor.  Used as the
+            ``case_actor_id`` argument of :class:`AdvanceCaseActorToRMClosedNode`
+            so that the CaseActor's own RM state is advanced on owner Leave.
 
     Returns:
         Root ``CloseCaseBT`` Sequence node.
     """
+    store_node = StoreActivityNode(
+        activity_id=activity_id,
+        activity_obj=activity_obj,
+        label="Leave",
+    )
+
+    if sender_actor_id is None:
+        return create_receive_activity_tree(
+            name="CloseCaseBT",
+            case_id=case_id,
+            precondition_guards=[],
+            effect_nodes=[store_node],
+        )
+
+    advance_leaving_participant = AdvanceParticipantToRMClosedNode(
+        leaving_actor_id=sender_actor_id,
+        case_id=case_id,
+        name="AdvanceLeavingParticipantToRMClosed",
+    )
+
+    owner_leave_children: list[py_trees.behaviour.Behaviour] = [
+        CheckIsCaseOwnerNode(
+            sender_actor_id=sender_actor_id,
+            case_id=case_id,
+            name="CheckIsCaseOwnerForLeave",
+        ),
+        AdvanceParticipantToRMClosedNode(
+            leaving_actor_id=sender_actor_id,
+            case_id=case_id,
+            name="AdvanceOwnerToRMClosed",
+        ),
+    ]
+    if receiving_actor_id is not None:
+        owner_leave_children.append(
+            AdvanceCaseActorToRMClosedNode(
+                case_actor_id=receiving_actor_id,
+                case_id=case_id,
+                name="AdvanceCaseActorToRMClosed",
+            )
+        )
+
+    owner_or_non_owner_effects = py_trees.composites.Selector(
+        name="OwnerOrNonOwnerEffects",
+        memory=False,
+        children=[
+            py_trees.composites.Sequence(
+                name="OwnerLeaveSeq",
+                memory=False,
+                children=owner_leave_children,
+            ),
+            py_trees.composites.Sequence(
+                name="NonOwnerLeaveFallbackSeq",
+                memory=False,
+                children=[advance_leaving_participant],
+            ),
+        ],
+    )
+
     return create_receive_activity_tree(
         name="CloseCaseBT",
         case_id=case_id,
         precondition_guards=[],
         effect_nodes=[
-            StoreActivityNode(
-                activity_id=activity_id,
-                activity_obj=activity_obj,
-                label="Leave",
-            ),
+            owner_or_non_owner_effects,
+            store_node,
         ],
     )

--- a/vultron/core/behaviors/sync/announce_tree.py
+++ b/vultron/core/behaviors/sync/announce_tree.py
@@ -5,6 +5,7 @@ import py_trees
 
 from vultron.core.behaviors.embargo.nodes import ApplyEmbargoTeardownNode
 from vultron.core.behaviors.sync.nodes import (
+    ApplyCloseCaseFromLedgerNode,
     ApplyInviteAcceptFromLedgerNode,
     ApplyNoteFromLedgerNode,
     ApplyParticipantStatusFromLedgerNode,
@@ -13,6 +14,7 @@ from vultron.core.behaviors.sync.nodes import (
     CheckIsNotOwnCaseActorNode,
     CheckLedgerEntryAlreadyStoredNode,
     IsAddNoteEventNode,
+    IsCloseCaseEventNode,
     IsInviteAcceptEventNode,
     IsParticipantStatusEventNode,
     IsRemoveEmbargoEventNode,
@@ -133,6 +135,28 @@ def create_announce_log_entry_tree() -> py_trees.behaviour.Behaviour:
                         name="SkipIfNotInviteAcceptEvent",
                         child=IsInviteAcceptEventNode(
                             name="CheckNotInviteAcceptEvent"
+                        ),
+                    ),
+                ],
+            ),
+            py_trees.composites.Selector(
+                name="CloseCaseEffects",
+                memory=False,
+                children=[
+                    py_trees.composites.Sequence(
+                        name="ApplyCloseCaseEffectsSeq",
+                        memory=False,
+                        children=[
+                            IsCloseCaseEventNode(name="IsCloseCaseEvent"),
+                            ApplyCloseCaseFromLedgerNode(
+                                name="ApplyCloseCaseFromLedger"
+                            ),
+                        ],
+                    ),
+                    py_trees.decorators.Inverter(
+                        name="SkipIfNotCloseCaseEvent",
+                        child=IsCloseCaseEventNode(
+                            name="CheckNotCloseCaseEvent"
                         ),
                     ),
                 ],

--- a/vultron/core/behaviors/sync/nodes/__init__.py
+++ b/vultron/core/behaviors/sync/nodes/__init__.py
@@ -40,6 +40,7 @@ from vultron.core.behaviors.sync.nodes.conditions import (
     CheckLedgerEntryAlreadyStoredNode,
     CheckLedgerFreshnessNode,
     IsAddNoteEventNode,
+    IsCloseCaseEventNode,
     IsInviteAcceptEventNode,
     IsParticipantStatusEventNode,
     IsRemoveEmbargoEventNode,
@@ -57,6 +58,7 @@ from vultron.core.behaviors.sync.nodes.receive import (
     SendRejectLogEntryNode,
 )
 from vultron.core.behaviors.sync.nodes.effects import (
+    ApplyCloseCaseFromLedgerNode,
     ApplyInviteAcceptFromLedgerNode,
     ApplyNoteFromLedgerNode,
     ApplyParticipantStatusFromLedgerNode,
@@ -84,10 +86,12 @@ __all__ = [
     "IsParticipantStatusEventNode",
     "IsAddNoteEventNode",
     "IsInviteAcceptEventNode",
+    "IsCloseCaseEventNode",
     # effects
     "ApplyParticipantStatusFromLedgerNode",
     "ApplyNoteFromLedgerNode",
     "ApplyInviteAcceptFromLedgerNode",
+    "ApplyCloseCaseFromLedgerNode",
     # receive
     "LogDeliveryConfirmationNode",
     "PersistReceivedLogEntryNode",

--- a/vultron/core/behaviors/sync/nodes/conditions.py
+++ b/vultron/core/behaviors/sync/nodes/conditions.py
@@ -181,6 +181,7 @@ _REMOVE_EMBARGO_EVENT = "remove_embargo_event_from_case"
 _ADD_PARTICIPANT_STATUS_EVENT = "add_participant_status_to_participant"
 _ADD_NOTE_TO_CASE_EVENT = "add_note_to_case"
 _ACCEPT_INVITE_ACTOR_TO_CASE_EVENT = "accept_invite_actor_to_case"
+_CLOSE_CASE_EVENT = "close_case"
 
 
 class IsRemoveEmbargoEventNode(DataLayerCondition):
@@ -311,6 +312,39 @@ class IsInviteAcceptEventNode(DataLayerCondition):
     def update(self) -> Status:
         entry = _require_log_entry(self.blackboard.activity, self.name)
         if entry.event_type == _ACCEPT_INVITE_ACTOR_TO_CASE_EVENT:
+            return Status.SUCCESS
+        return Status.FAILURE
+
+
+class IsCloseCaseEventNode(DataLayerCondition):
+    """Precondition: return SUCCESS when this log entry IS a close-case event.
+
+    Used as the precondition in the ``CloseCaseEffects`` Selector's inner
+    Sequence in ``AnnounceLogEntryReceivedBT``::
+
+        Selector(CloseCaseEffects)
+          Sequence
+            IsCloseCaseEventNode   ← SUCCESS iff event_type matches
+            ApplyCloseCaseFromLedgerNode
+          Inverter(IsCloseCaseEventNode)  ← SUCCESS iff wrong event type
+
+    The Inverter fires SUCCESS only when the condition does NOT match (routing
+    no-op for the wrong event type).  When the condition matches but
+    ApplyCloseCaseFromLedgerNode fails, both branches of the Selector fail and
+    the FAILURE propagates to block PersistReceivedLogEntry (SYNC-12-001).
+
+    Per BTND-08-001, BTND-08-002, CM-23-003, SYNC-12-001.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        if entry.event_type == _CLOSE_CASE_EVENT:
             return Status.SUCCESS
         return Status.FAILURE
 

--- a/vultron/core/behaviors/sync/nodes/effects.py
+++ b/vultron/core/behaviors/sync/nodes/effects.py
@@ -27,8 +27,13 @@ Currently implemented effects:
 - :class:`ApplyInviteAcceptFromLedgerNode`: applies an
   ``accept_invite_actor_to_case`` event to the local case replica by creating
   a stub ``CaseParticipant`` for the new invitee and calling ``add_participant``.
+- :class:`ApplyCloseCaseFromLedgerNode`: applies a ``close_case`` event to
+  the local case replica by advancing the departing actor's
+  :class:`~vultron.core.models.participant_status.ParticipantStatus` to
+  ``RM.CLOSED`` (CM-23-003, ADR-0050).
 
-Per specs/multi-actor-demo.yaml DEMOMA-07-003 step 3 and
+Per specs/multi-actor-demo.yaml DEMOMA-07-003 step 3,
+specs/case-management.yaml CM-23-003, and
 specs/sync-ledger-replication.yaml SYNC-02-002.
 """
 
@@ -361,6 +366,128 @@ class ApplyInviteAcceptFromLedgerNode(DataLayerAction):
             " (SYNC-02-002, DEMOMA-07-003)",
             self.name,
             invitee_id,
+            case_id,
+        )
+        return Status.SUCCESS
+
+
+class ApplyCloseCaseFromLedgerNode(DataLayerAction):
+    """Apply a ``close_case`` ledger entry to the local case replica.
+
+    When a non-CaseActor participant receives ``Announce(CaseLedgerEntry)``
+    and the entry's ``event_type`` is ``close_case``, this node extracts the
+    departing actor ID from ``payload_snapshot["actor"]`` and advances that
+    actor's :class:`~vultron.core.models.participant_status.ParticipantStatus`
+    to ``RM.CLOSED`` on the local DataLayer replica.
+
+    This is the fan-out counterpart of the CaseActor's ``receive_close_case_tree``
+    effect: both paths MUST produce the same end state on every replica
+    (CM-23-003, CM-23-004, ADR-0050).
+
+    Lenient on missing data: if the case replica is absent, the departing actor
+    ID is not extractable, or the participant record is missing, the node
+    returns SUCCESS to avoid blocking the ``Announce`` processing flow.
+
+    Per specs/case-management.yaml CM-23-003, CM-23-004,
+    specs/sync-ledger-replication.yaml SYNC-02-002.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        from vultron.core.behaviors.sync.nodes.conditions import (
+            _require_log_entry,
+        )
+        from vultron.core.behaviors.case.nodes.participant.status import (
+            CreateParticipantStatusNode,
+        )
+        from vultron.core.states.rm import RM
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        snapshot = entry.payload_snapshot
+        case_id = entry.case_id
+
+        departing_actor_id = _extract_id_from_field(snapshot.get("actor"))
+        if not departing_actor_id or not case_id:
+            self.logger.debug(
+                "%s: payload_snapshot missing 'actor' id or case_id"
+                " — skipping close-case apply (non-fatal)",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        case = self.datalayer.read(case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.logger.debug(
+                "%s: case '%s' not found in local DataLayer"
+                " — skipping (non-fatal, partial case view)",
+                self.name,
+                case_id,
+            )
+            return Status.SUCCESS
+
+        if departing_actor_id not in case.actor_participant_index:
+            self.logger.debug(
+                "%s: departing actor '%s' not in actor_participant_index"
+                " for case '%s' — skipping (non-fatal)",
+                self.name,
+                departing_actor_id,
+                case_id,
+            )
+            return Status.SUCCESS
+
+        # Idempotency: skip if already at RM.CLOSED
+        participant_id = case.actor_participant_index[departing_actor_id]
+        participant = self.datalayer.read(participant_id)
+        if isinstance(participant, CaseParticipant):
+            for ps in participant.participant_statuses:
+                rm_dim = getattr(ps, "rm", None)
+                if getattr(rm_dim, "state", None) == RM.CLOSED:
+                    self.logger.debug(
+                        "%s: departing actor '%s' already at RM.CLOSED — no-op",
+                        self.name,
+                        departing_actor_id,
+                    )
+                    return Status.SUCCESS
+
+        # Advance the departing actor to RM.CLOSED using CreateParticipantStatusNode
+        # logic directly (avoids re-entering the BT machinery).
+        result_out: dict = {}
+        node = CreateParticipantStatusNode(
+            case_id=case_id,
+            actor_id=departing_actor_id,
+            rm_state=RM.CLOSED,
+            vfd_state=None,
+            pxa_state=None,
+            result_out=result_out,
+            name=f"{self.name}.CreateParticipantStatus",
+        )
+        node.datalayer = self.datalayer
+        node.actor_id = departing_actor_id
+        result = node.update()
+        if result != Status.SUCCESS:
+            self.logger.warning(
+                "%s: failed to advance departing actor '%s' to RM.CLOSED"
+                " in case '%s'",
+                self.name,
+                departing_actor_id,
+                case_id,
+            )
+            return Status.FAILURE
+
+        self.logger.info(
+            "%s: applied ledger close-case for departing actor '%s'"
+            " in case '%s' (CM-23-003, SYNC-02-002)",
+            self.name,
+            departing_actor_id,
             case_id,
         )
         return Status.SUCCESS

--- a/vultron/core/ports/trigger_service.py
+++ b/vultron/core/ports/trigger_service.py
@@ -118,6 +118,12 @@ class TriggerServicePort(Protocol):
         case_id: str,
     ) -> dict[str, Any]: ...
 
+    def leave_case(
+        self,
+        actor_id: str,
+        case_id: str,
+    ) -> dict[str, Any]: ...
+
     def add_object_to_case(
         self,
         actor_id: str,

--- a/vultron/core/use_cases/received/case/lifecycle.py
+++ b/vultron/core/use_cases/received/case/lifecycle.py
@@ -96,6 +96,8 @@ class CloseCaseReceivedUseCase:
             case_id=case_id,
             activity_id=request.activity_id,
             activity_obj=request.activity,
+            sender_actor_id=request.actor_id,
+            receiving_actor_id=receiving_actor_id,
         )
         result = BTBridge(datalayer=self._dl).execute_with_setup(
             tree=tree,

--- a/vultron/core/use_cases/triggers/case/__init__.py
+++ b/vultron/core/use_cases/triggers/case/__init__.py
@@ -28,6 +28,7 @@ from vultron.core.use_cases.triggers.requests import (
     CreateCaseTriggerRequest,
     DeferCaseTriggerRequest,
     EngageCaseTriggerRequest,
+    LeaveCaseTriggerRequest,
 )
 
 from .add_object import SvcAddObjectToCaseUseCase
@@ -36,6 +37,7 @@ from .add_report import SvcAddReportToCaseUseCase
 from .create import SvcCreateCaseUseCase
 from .defer import SvcDeferCaseUseCase
 from .engage import SvcEngageCaseUseCase
+from .leave import SvcLeaveCaseUseCase
 
 __all__ = [
     "AddObjectToCaseTriggerRequest",
@@ -44,10 +46,12 @@ __all__ = [
     "CreateCaseTriggerRequest",
     "DeferCaseTriggerRequest",
     "EngageCaseTriggerRequest",
+    "LeaveCaseTriggerRequest",
     "SvcAddObjectToCaseUseCase",
     "SvcAddParticipantStatusUseCase",
     "SvcAddReportToCaseUseCase",
     "SvcCreateCaseUseCase",
     "SvcDeferCaseUseCase",
     "SvcEngageCaseUseCase",
+    "SvcLeaveCaseUseCase",
 ]

--- a/vultron/core/use_cases/triggers/case/leave.py
+++ b/vultron/core/use_cases/triggers/case/leave.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Trigger use case for Leave(VulnerabilityCase).
+
+Emits ``Leave(VulnerabilityCase)`` to the Case Actor inbox.  The Case Actor
+commits a ``close_case`` :class:`~vultron.core.models.case_ledger_entry
+.VultronCaseLedgerEntry` and broadcasts it; each replica then advances the
+departing actor's RM state to ``RM.CLOSED`` via
+:class:`~vultron.core.behaviors.sync.nodes.effects.ApplyCloseCaseFromLedgerNode`
+(ADR-0050, CM-23-002/CM-23-003).
+
+Per specs/case-management.yaml DEMOMA-07-001, CM-23-002, CM-23-003.
+"""
+
+import logging
+from typing import cast
+
+import py_trees.behaviour
+
+from vultron.core.behaviors.sender.send_tree import sender_side_bt
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
+from vultron.core.use_cases.triggers._helpers import (
+    resolve_actor,
+    resolve_case,
+)
+from vultron.core.use_cases.triggers.requests import LeaveCaseTriggerRequest
+
+logger = logging.getLogger(__name__)
+
+
+class SvcLeaveCaseUseCase(SvcBTTriggerBase):
+    """Send Leave(VulnerabilityCase) to the Case Actor (ADR-0050, CM-23-002/003).
+
+    Routes ``Leave(VulnerabilityCase)`` to the Case Actor inbox so the Case
+    Actor can commit a ``close_case`` ledger entry and broadcast it.  The
+    receiver-side role semantics (owner closes all, non-owner departs only)
+    are applied in :func:`~vultron.core.behaviors.case.receive_close_case_tree
+    .create_close_case_received_tree` on the Case Actor, and fanned out to all
+    replicas via :class:`~vultron.core.behaviors.sync.nodes.effects
+    .ApplyCloseCaseFromLedgerNode`.
+
+    The sender does NOT update their own RM state here — RM.CLOSED is applied
+    on every replica when each replica receives the ``close_case`` ledger entry
+    via ``Announce(CaseLedgerEntry)`` (ADR-0050).
+    """
+
+    def _prepare(self) -> None:
+        request = cast(LeaveCaseTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case_id = resolve_case(request.case_id, self._dl).id_
+
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        def _build_activities(case_manager_id: str) -> list[str]:
+            activity_id, activity_dict = self._factory.close_case(
+                case_id=self._case_id,
+                actor=self._actor_id,
+                to=[case_manager_id],
+            )
+            self._captured["activity"] = activity_dict
+            return [activity_id]
+
+        return sender_side_bt(
+            case_id=self._case_id,
+            activity_builder=_build_activities,
+        )
+
+    def _handle_result(self) -> None:
+        logger.info(
+            "Actor '%s' sent Leave(VulnerabilityCase) for case '%s'"
+            " (ADR-0050, DEMOMA-07-001)",
+            self._actor_id,
+            self._case_id,
+        )

--- a/vultron/core/use_cases/triggers/requests.py
+++ b/vultron/core/use_cases/triggers/requests.py
@@ -92,6 +92,17 @@ class DeferCaseTriggerRequest(CaseTriggerRequest):
     pass
 
 
+class LeaveCaseTriggerRequest(CaseTriggerRequest):
+    """Trigger request for an actor to send Leave(VulnerabilityCase).
+
+    Routes ``Leave(VulnerabilityCase)`` to the Case Actor inbox so the
+    Case Actor can commit a ``close_case`` ledger entry and broadcast it
+    to all participants (ADR-0050).
+    """
+
+    pass
+
+
 class ProposeEmbargoTriggerRequest(CaseTriggerRequest):
     end_time: datetime  # pyright: ignore[reportGeneralTypeIssues]
 

--- a/vultron/core/use_cases/triggers/service.py
+++ b/vultron/core/use_cases/triggers/service.py
@@ -57,6 +57,7 @@ from vultron.core.use_cases.triggers.case import (
     SvcCreateCaseUseCase,
     SvcDeferCaseUseCase,
     SvcEngageCaseUseCase,
+    SvcLeaveCaseUseCase,
 )
 from vultron.core.use_cases.triggers.embargo import (
     SvcAcceptEmbargoUseCase,
@@ -86,6 +87,7 @@ from vultron.core.use_cases.triggers.requests import (
     CreateCaseTriggerRequest,
     DeferCaseTriggerRequest,
     EngageCaseTriggerRequest,
+    LeaveCaseTriggerRequest,
     InvalidateReportTriggerRequest,
     InviteActorToCaseTriggerRequest,
     OfferCaseManagerRoleTriggerRequest,
@@ -263,6 +265,23 @@ class TriggerService:
         """Defer a case, transitioning RM state to DEFERRED."""
         req = DeferCaseTriggerRequest(actor_id=actor_id, case_id=case_id)
         return SvcDeferCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
+
+    def leave_case(
+        self,
+        actor_id: str,
+        case_id: str,
+    ) -> dict[str, Any]:
+        """Send Leave(VulnerabilityCase) to the Case Actor (ADR-0050).
+
+        Routes ``Leave(VulnerabilityCase)`` to the Case Actor inbox so the
+        Case Actor can commit a ``close_case`` ledger entry and broadcast it
+        to all participants.  The receiver-side role semantics (owner closes
+        all, non-owner departs only) are applied on the Case Actor replica.
+        """
+        req = LeaveCaseTriggerRequest(actor_id=actor_id, case_id=case_id)
+        return SvcLeaveCaseUseCase(
             self._dl, req, trigger_activity=self._trigger_activity
         ).execute()
 

--- a/vultron/demo/helpers/actions.py
+++ b/vultron/demo/helpers/actions.py
@@ -145,20 +145,23 @@ def actor_closes_case(
     actor: as_Actor,
     case_id: str,
 ) -> dict:
-    """Self-report case closed (RM.CLOSED) via the demo trigger endpoint.
+    """Send Leave(VulnerabilityCase) via the demo trigger endpoint (ADR-0050).
 
-    When all participants report RM.CLOSED, the Case Actor automatically
-    closes the case (DEMOMA-07-003 step 5).
+    Triggers the canonical RM case closure path: the actor sends
+    ``Leave(VulnerabilityCase)`` to the Case Actor, which commits a
+    ``close_case`` ``CaseLedgerEntry`` and broadcasts it to all participants.
+    Each replica then advances the departing actor's RM state to ``RM.CLOSED``
+    via ``ApplyCloseCaseFromLedgerNode`` (CM-23-002/CM-23-003).
 
     Args:
         client: DataLayerClient connected to the actor's container.
-        actor: The actor closing the case.
+        actor: The actor sending Leave.
         case_id: Full URI of the ``VulnerabilityCase``.
 
     Returns:
         Response dict from the trigger endpoint.
 
-    Spec: DEMOMA-07-001.
+    Spec: DEMOMA-07-001, CM-23-002, CM-23-003.
     """
     with demo_step(f"Actor {ref_id(actor)} closes case"):
         return post_to_trigger(

--- a/vultron/demo/helpers/seeding.py
+++ b/vultron/demo/helpers/seeding.py
@@ -792,8 +792,11 @@ def _seed_reporter_participant(
 
 
 def _seed_case_actor_participant(case_obj, report_id: str | None, dl) -> None:
+    import uuid as _uuid
+
     from vultron.config.app import get_config
     from vultron.core.behaviors.case.nodes.conditions import _derive_case_slug
+    from vultron.core.models.case_actor import CaseActor
     from vultron.core.models.case_participant import CaseParticipant
     from vultron.enums.roles import CVDRole
 
@@ -808,8 +811,29 @@ def _seed_case_actor_participant(case_obj, report_id: str | None, dl) -> None:
     case_actor_id = f"{base_url}/actors/case-actor-{case_slug}"
     if case_actor_id in case_obj.actor_participant_index:
         return
-    manager_p = CaseParticipant(
+
+    # Create the CaseActor Service object so that inbox delivery to the
+    # CaseActor succeeds in single-container test environments (the inbox
+    # endpoint resolves actors by short ID, which requires a Service row).
+    actor_obj = CaseActor(
         id_=case_actor_id,
+        name=f"CaseActor for {case_id}",
+        attributed_to=case_actor_id,
+        context=case_id,
+    )
+    try:
+        dl.create(actor_obj)
+    except ValueError:
+        pass
+
+    # CaseParticipant needs a distinct ID from the Service object —
+    # matching production where RegisterCaseActorParticipantNode creates
+    # the participant with a separate UUID attributed to case_actor_id.
+    participant_id = (
+        f"urn:uuid:{_uuid.uuid5(_uuid.NAMESPACE_URL, case_actor_id)}"
+    )
+    manager_p = CaseParticipant(
+        id_=participant_id,
         attributed_to=case_actor_id,
         context=case_id,
         name=f"CaseActor participant for {case_id}",


### PR DESCRIPTION
- Closes #1901

## Summary

Implements receiver-side role differentiation in the `Leave(VulnerabilityCase)` receive path per specs/case-management.yaml CM-23-002 and CM-23-003:

- **Owner Leave** (CM-23-002): the Case Actor advances the leaving owner to `RM.CLOSED` and then closes itself (`AdvanceCaseActorToRMClosedNode`).
- **Non-owner Leave** (CM-23-003): only the departing participant is advanced to `RM.CLOSED`; the case remains open.
- **Fan-out replicas**: `ApplyCloseCaseFromLedgerNode` in `announce_tree.py` mirrors the departure effect on every non-CaseActor replica that receives the `Announce(CaseLedgerEntry)`.

Also replaces the direct `add_participant_status(rm_state=RM.CLOSED)` call in `demo_close_case` with the canonical `leave_case()` service path (ADR-0050).

## Changes

- `vultron/core/behaviors/case/receive_close_case_tree.py` — new tree with `CheckIsCaseOwnerNode` gate; owner path closes CaseActor, non-owner path departs only
- `vultron/core/behaviors/sync/nodes/effects.py` — `ApplyCloseCaseFromLedgerNode` fans out RM.CLOSED to departing participant on every replica
- `vultron/core/use_cases/triggers/case/leave.py` — new `SvcLeaveCaseUseCase` + `LeaveCaseTriggerRequest`
- `vultron/core/use_cases/triggers/requests.py` — adds `LeaveCaseTriggerRequest`
- `demo/` — replaces direct `add_participant_status(rm_state=RM.CLOSED)` with canonical `leave_case()` service call (ADR-0050)
- `test/core/behaviors/case/test_close_case_role_semantics.py` — 8 new tests covering owner/non-owner receive paths and fan-out
- `test/core/use_cases/triggers/case/test_leave.py` — 5 unit tests for `SvcLeaveCaseUseCase` trigger path

## Test plan

- [x] `TestOwnerLeaveReceivePath`: 3 tests — owner → RM.CLOSED, CaseActor → RM.CLOSED, non-departed vendor NOT → RM.CLOSED
- [x] `TestNonOwnerLeaveReceivePath`: 3 tests — leaving vendor → RM.CLOSED, owner unchanged, CaseActor unchanged
- [x] `TestCloseCaseFanOut`: 2 tests — fan-out advances departing participant, fan-out does NOT advance non-departing participant
- [x] `TestLeaveCaseTriggersOutboxActivity`: 5 tests — outbox effect, PCR-08-001 routing, failure modes
- [x] All 5982 existing tests pass
- [x] `mypy`, `pyright`, `flake8` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)