### PR TITLE
docs: plan issue #1783 — resolve AdvisoryReviewDecision.approved design question

### DIFF
--- a/docs/adr/0030-publish-leaf-draft-review-submit-pipeline.md
+++ b/docs/adr/0030-publish-leaf-draft-review-submit-pipeline.md
@@ -11,6 +11,15 @@ deciders: [adh]
 > question about participant-comment broadcast in the review phase (AC-4) was
 > **deferred** to a follow-on issue — the pipeline functions without it using
 > the default auto-approve `ReviewAdvisoryDraft` Evaluator.
+>
+> **Deferred design question resolved (issue #1783, 2026-08-03):** The original
+> implementation included an `approved: bool = True` field on `AdvisoryReviewDecision`
+> as informational metadata, with a note that gating submission on `approved=False`
+> was a follow-on design question.  That question is now resolved: the field was
+> **removed** as redundant.  An Evaluator that needs to block submission for any
+> reason (legal hold, compliance failure, editorial rejection) MUST return
+> `Status.FAILURE` from `update()` — that is the universal BT blocking idiom and
+> no separate approval flag is needed.  See spec entry BT-18-007.
 
 ## Context and Problem Statement
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -185,7 +185,7 @@ it cannot revert. This forms a 64-state lattice (2^6 combinations).
 | **CVDRole** | A StrEnum representing individual, atomic CVD roles (FINDER, REPORTER, VENDOR, DEPLOYER, COORDINATOR, OTHER, CASE_OWNER, CASE_MANAGER); participants hold zero or more roles represented as `list[CVDRole]`; preferred representation for new code (replaces legacy bitmask) | Role value, role enum |
 | **Dimension Object** | A small immutable `BaseModel` capturing the state of exactly one state machine (RM, EM, VFD, or PXA) at a point in time; replaces flat fields in `CaseStatus`/`ParticipantStatus` per ADR-0036 | Status sub-object, state fragment |
 | **Advisory** | A public disclosure document summarizing a vulnerability's details, remediation, and affected parties; produced by the publication pipeline via a Draft → Review → Submit sequence | Security advisory, disclosure document, bulletin |
-| **Advisory Review Decision** | A record produced by a **Reviewer** (Evaluator-type **Coordination Agent**) capturing whether an **Advisory** draft needs revision; the `needs_revision` flag gates the BT pipeline; the `approved` field is informational metadata only | Review result, review outcome |
+| **Advisory Review Decision** | A record produced by a **Reviewer** (Evaluator-type **Coordination Agent**) capturing whether an **Advisory** draft needs revision; the `needs_revision` flag gates the BT pipeline; to block submission for any reason, the Evaluator MUST return `Status.FAILURE` (BT-18-007) | Review result, review outcome |
 | **Publication Intent** | A domain object recording a participant's decision about *how* and *when* to disclose a vulnerability (e.g., which advisory platform, embargo exit condition); gates the BT publish pipeline | Disclosure intent, publish intent |
 | **CVDRolesFlag** | Legacy bitmask-based Flag enum using bitwise arithmetic to represent combined roles; retained for backward compatibility with the `vultron.bt` simulator layer only; **do not use in new code** — use `list[CVDRole]` instead | Bitmask roles, legacy roles |
 | **CASE_OWNER** | A **CVDRole** value marking a participant as the human decision-maker who owns and administers the VulnerabilityCase (BTND-05-001); distinct from CASE_MANAGER which is the service actor | Owner role |
@@ -451,23 +451,18 @@ it cannot revert. This forms a 64-state lattice (2^6 combinations).
      - **CVDRolesFlag** is a legacy Flag enum (bitmask) used only by the `vultron.bt` simulator layer; it existed before the migration to list-based roles and is retained for backward compatibility only.
      - **Recommendation**: Always use `list[CVDRole]` in new code; never use **CVDRolesFlag** outside the `vultron.bt` simulator. When discussing roles, say "CVDRole" or "role list," never "CVDRoles" (plural, deprecated name).
 
-16. **"approved" vs. "needs_revision" in Advisory Review Decision**:
-     - `AdvisoryReviewDecision.approved` is metadata the **Evaluator** backend sets to record its stance; the BT pipeline does **not** read it as a gate.
-     - `AdvisoryReviewDecision.needs_revision` is the actual BT gate; `_NeedsRevisionGate` reads this field to decide whether to route back for edits.
-     - **Recommendation**: When describing pipeline gating logic, say "the pipeline checks `needs_revision`." Reserve "approved" for describing the reviewer's recorded decision. Do not say "the advisory was approved" when you mean "the pipeline passed the review gate."
-
-17. **"Call-Out Point" vs. "Fuzzer Node"**:
+16. **"Call-Out Point" vs. "Fuzzer Node"**:
      - A **Call-Out Point** is the abstract concept — a BT location requiring external input.
      - A **Fuzzer Node** is the concrete simulator-layer stub that occupies that location until a real **Coordination Agent** is wired in.
      - **Recommendation**: Use "**Call-Out Point**" when discussing design or integration seams; use "**Fuzzer Node**" only when discussing the simulator implementation.
 
-18. **"Composer" vs. "Actuator"**:
+17. **"Composer" vs. "Actuator"**:
      - A **Composer** reads context, runs a generation process, and writes a content artifact to the blackboard (e.g., advisory draft text).
      - An **Actuator** receives a trigger, calls an external system, and confirms the side effect; no artifact is placed on the blackboard.
      - Misclassification risk: nodes that "do something" to an external system look like Composers if you only notice they dispatch outbound calls. The discriminator is whether a content artifact lands on the blackboard. If not, it is an **Actuator**.
      - **Recommendation**: Before classifying a node as Composer, verify it writes a content artifact to the blackboard. If the only output is a SUCCESS/FAILURE confirming an external side effect, it is an **Actuator**.
 
-19. **"Dimension Object" vs. "status field"**:
+18. **"Dimension Object" vs. "status field"**:
      - A **Dimension Object** (per ADR-0036) is an immutable `BaseModel` containing the state of one machine; it is a first-class structured type, not a flat field.
      - "Status field" is informal language that may mean a flat scalar (`rmState: "ACCEPTED"`) or a **Dimension Object** (`rm: {"state": "ACCEPTED"}`); both appear in real ledger snapshots.
      - **Recommendation**: Say "**Dimension Object**" when referring to the structured sub-model; say "flat legacy field" when referring to the pre-ADR-0036 serialization. When extracting state from JSONL, probe both shapes (see 2026-07-22 learning on three nesting shapes).
@@ -571,12 +566,12 @@ it cannot revert. This forms a 64-state lattice (2^6 combinations).
 > returns SUCCESS or FAILURE probabilistically. In production you wire in a **Coordination Agent** —
 > an **Evaluator** subtype — that reviews the draft and records an **Advisory Review Decision**."
 >
-> **Developer:** "What does the BT read from that decision? The `approved` flag?"
+> **Developer:** "What does the BT read from that decision? Just `needs_revision`?"
 >
-> **Domain Expert:** "No — `approved` is metadata for the reviewer backend to record its intent.
-> The BT reads `needs_revision`. If that's true, the pipeline fails and the draft goes back for
-> revision. If you want to block outright without requesting edits — say, a legal hold — your
-> **Evaluator** returns `FAILURE` directly from `update()`. The BT never reads `approved` as a gate."
+> **Domain Expert:** "Yes. If `needs_revision=True`, the pipeline routes to the revision arm before
+> submit. If you want to block outright without requesting edits — say, a legal hold — your
+> **Evaluator** returns `FAILURE` directly from `update()`. That's the universal BT blocking idiom
+> (BT-18-007)."
 >
 > **Developer:** "And if there's no human reviewer yet, we just leave the **Fuzzer Node** in place?"
 >

--- a/plan/history/2608/idea/IDEA-1783.md
+++ b/plan/history/2608/idea/IDEA-1783.md
@@ -1,0 +1,41 @@
+---
+source: IDEA-1783
+timestamp: '2026-08-03T18:22:49.978375+00:00'
+title: 'Design: should AdvisoryReviewDecision.approved=False gate advisory submission?'
+type: idea
+---
+
+## Background
+
+`AdvisoryReviewDecision` (in `vultron/core/behaviors/report/publish_artifact_tree.py`)
+has an `approved: bool = True` field. The pipeline reads only `needs_revision`;
+`approved` is metadata for the `ReviewAdvisoryDraft` evaluator backend to record
+its decision.
+
+The current design is:
+
+- `approved` is informational metadata — it is never read by the pipeline.
+- A backend that needs to block submission without requesting edits (e.g., legal
+  hold, compliance review failure) MUST return `Status.FAILURE` from `update()`
+  so the Sequence fails.
+- Gating submission on `approved=False` was explicitly deferred.
+
+## Design Question
+
+Should a future revision of the pipeline check `approved=False` explicitly as a
+submission gate? If so:
+
+1. Where should the gate live — a new `CheckAdvisoryApproved` condition node
+   before `SubmitAdvisory`, or inside `_NeedsRevisionGate`?
+2. How does `approved=False` differ semantically from `needs_revision=True`?
+   (`needs_revision=True` requests editorial revision; `approved=False` could
+   mean a broader stop such as a legal hold or compliance block.)
+3. Is returning `Status.FAILURE` from the evaluator's `update()` the better
+   interface for structured refusal, making the `approved` field redundant?
+
+**Processed**: 2026-08-03 — resolved as Option C (remove approved field).
+Decision: approved=False+Status.SUCCESS is incoherent; Status.FAILURE is the
+universal BT blocking idiom; the field is redundant and will be removed.
+Implementation tracked in #1932.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1931>.
+Spec: `specs/behavior-tree-integration.yaml` BT-18-007.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -565,6 +565,28 @@ groups:
       spec_id: BT-18-005
       note: BT-18-005 establishes that shape is determined by the seam-structure decision tree; BT-18-006 resolves the specific
         Sentinel vs. Retriever ambiguity for binary-result external queries.
+  - id: BT-18-007
+    priority: MUST
+    kind: project
+    statement: An Evaluator call-out point that needs to block downstream BT execution — for any reason (editorial rejection,
+      legal hold, compliance failure, or other non-approval decision) — MUST return Status.FAILURE from its update() method.
+      Setting a structured output field to a "rejected" value while returning Status.SUCCESS does not block a Sequence and
+      MUST NOT be used as a blocking mechanism.
+    rationale: >
+      A BT Sequence halts and returns FAILURE as soon as any child returns FAILURE; this is the universal py_trees
+      blocking idiom. Relying on a field value (e.g., approved=False) to signal rejection is ineffective because
+      the Sequence has no gate that reads it — only Status.FAILURE stops execution. This requirement resolves the
+      deferred design question from ADR-0030 / issue #1312 (whether AdvisoryReviewDecision.approved=False should
+      gate submission): the answer is no, because the field was redundant with Status.FAILURE. The approved field
+      was removed from AdvisoryReviewDecision (issue #1783) to eliminate the trap. The principle generalises: any
+      Evaluator whose output record carries a boolean approval flag is a design smell unless that flag is the
+      sole input to a subsequent ProtocolInternal gate node.
+    tracking_issue: '#1783'
+    relationships:
+    - rel_type: refines
+      spec_id: BT-18-002
+      note: BT-18-002 states that SUCCESS MUST accompany all declared output writes; BT-18-007 is the complementary
+        rule — FAILURE is the correct signal when the Evaluator's decision is to block, regardless of output field values.
 - id: BT-19
   title: Routing-Gated State Mutation in Lifecycle BT Sequences
   specs:


### PR DESCRIPTION
- Closes #1783

## Summary

Resolves the deferred design question from ADR-0030 / issue #1312: should
`AdvisoryReviewDecision.approved=False` gate advisory submission?

**Decision: no.** The field is redundant with `Status.FAILURE`, which is the
universal BT blocking idiom. An Evaluator that needs to block submission must
return `Status.FAILURE` from `update()`.

## Changes

- **`specs/behavior-tree-integration.yaml`** — add BT-18-007: Evaluator MUST
  return `Status.FAILURE` to block pipeline execution; setting a field value
  while returning `SUCCESS` does not block a Sequence and MUST NOT be used as
  a blocking mechanism
- **`docs/adr/0030-...`** — revise ADR-0030 in place to record the resolution
  of the deferred `approved` question; references BT-18-007
- **`docs/reference/glossary.md`** — remove disambiguation #16 (approved vs
  needs_revision), update the Advisory Review Decision term definition, revise
  the Call-Out Points example dialogue

## What comes next

A follow-on implementation issue will remove `approved: bool = True` from
`AdvisoryReviewDecision`, update its tests, and remove the stale docstring
references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Implementation Issues

- #1932