### PR TITLE
demo: remove unused actor params from _phase_dump_case_ledgers in fvcv/fccv handoff demos

### DIFF
--- a/test/demo/test_fccv_handoff_demo.py
+++ b/test/demo/test_fccv_handoff_demo.py
@@ -325,3 +325,99 @@ class TestFccvHandoffCliCommand:
         runner = CliRunner()
         result = runner.invoke(main, ["fccv-handoff", "--help"])
         assert "--case-actor-url" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _phase_dump_case_ledgers
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseDumpCaseLedgersFccv:
+    """Tests for the case-ledger dump phase in the FCCV-handoff demo."""
+
+    def test_writes_jsonl_files_for_all_four_actors(
+        self, tmp_path, monkeypatch
+    ):
+        finder_client = MagicMock()
+        c1_client = MagicMock()
+        c2_client = MagicMock()
+        vendor_client = MagicMock()
+        finder_client.get_list.return_value = [{"logIndex": 0}]
+        c1_client.get_list.return_value = [{"logIndex": 0}]
+        c2_client.get_list.return_value = [{"logIndex": 0}]
+        vendor_client.get_list.return_value = [{"logIndex": 0}]
+
+        case = demo.as_VulnerabilityCase(
+            id_="https://example.org/cases/fccv-test-case"
+        )
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        demo._phase_dump_case_ledgers(
+            finder_client=finder_client,
+            c1_client=c1_client,
+            c2_client=c2_client,
+            vendor_client=vendor_client,
+            case=case,
+        )
+
+        case_slug = "https_example.org_cases_fccv-test-case"
+        assert (
+            tmp_path
+            / "fccv-handoff"
+            / "finder"
+            / f"{case_slug}-case-ledger.jsonl"
+        ).exists()
+        assert (
+            tmp_path
+            / "fccv-handoff"
+            / "vendor"
+            / f"{case_slug}-case-ledger.jsonl"
+        ).exists()
+        assert (
+            tmp_path
+            / "fccv-handoff"
+            / "coordinator"
+            / f"{case_slug}-case-ledger.jsonl"
+        ).exists()
+        assert (
+            tmp_path
+            / "fccv-handoff"
+            / "vendor2"
+            / f"{case_slug}-case-ledger.jsonl"
+        ).exists()
+
+    def test_includes_case_actor_when_in_participant_index(
+        self, tmp_path, monkeypatch
+    ):
+        finder_client = MagicMock()
+        c1_client = MagicMock()
+        c2_client = MagicMock()
+        vendor_client = MagicMock()
+        finder_client.get_list.return_value = [{"logIndex": 0}]
+        c1_client.get_list.return_value = [{"logIndex": 0}]
+        c2_client.get_list.return_value = [{"logIndex": 0}]
+        vendor_client.get_list.return_value = [{"logIndex": 0}]
+
+        case = demo.as_VulnerabilityCase(
+            id_="https://example.org/cases/fccv-with-ca",
+            actor_participant_index={
+                "https://example.org/actors/case-actor-fccv": (
+                    "https://example.org/cases/fccv-with-ca/participants/case-actor"
+                )
+            },
+        )
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        demo._phase_dump_case_ledgers(
+            finder_client=finder_client,
+            c1_client=c1_client,
+            c2_client=c2_client,
+            vendor_client=vendor_client,
+            case=case,
+        )
+
+        assert any(
+            "/actors/case-actor-fccv/demo/cases/fccv-with-ca/log"
+            in call.args[0]
+            for call in c1_client.get_list.call_args_list
+        )

--- a/test/demo/test_fvcv_handoff_demo.py
+++ b/test/demo/test_fvcv_handoff_demo.py
@@ -1,0 +1,188 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for the FVCV-handoff five-actor CVD demo (DEMOMA-15).
+
+True multi-container isolation is validated by the acceptance test runnable via:
+    DEMO=fvcv-handoff docker compose -f docker/docker-compose-multi-actor.yml up --abort-on-container-exit
+"""
+
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+import vultron.demo.scenario.fvcv_handoff_demo as demo
+from test.demo._helpers import make_testclient_call
+from vultron.demo.cli import main
+
+
+@pytest.fixture(scope="module")
+def base(client: TestClient) -> str:
+    return str(client.base_url).rstrip("/") + "/api/v2"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def patch_datalayer_call(client: TestClient, base: str):
+    mp = MonkeyPatch()
+    try:
+        mp.setattr(
+            demo.DataLayerClient, "call", make_testclient_call(client, base)
+        )
+        yield
+    finally:
+        mp.undo()
+        importlib.reload(demo)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _phase_dump_case_ledgers
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseDumpCaseLedgersFvcv:
+    """Tests for the case-ledger dump phase in the FVCV-handoff demo."""
+
+    def test_writes_jsonl_files_for_all_four_actors(
+        self, tmp_path, monkeypatch
+    ):
+        finder_client = MagicMock()
+        vendor_client = MagicMock()
+        coordinator_client = MagicMock()
+        vendor2_client = MagicMock()
+        finder_client.get_list.return_value = [{"logIndex": 0}]
+        vendor_client.get_list.return_value = [{"logIndex": 0}]
+        coordinator_client.get_list.return_value = [{"logIndex": 0}]
+        vendor2_client.get_list.return_value = [{"logIndex": 0}]
+
+        case = demo.as_VulnerabilityCase(
+            id_="https://example.org/cases/fvcv-test-case"
+        )
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        demo._phase_dump_case_ledgers(
+            finder_client=finder_client,
+            vendor_client=vendor_client,
+            coordinator_client=coordinator_client,
+            vendor2_client=vendor2_client,
+            case=case,
+        )
+
+        case_slug = "https_example.org_cases_fvcv-test-case"
+        assert (
+            tmp_path
+            / "fvcv-handoff"
+            / "finder"
+            / f"{case_slug}-case-ledger.jsonl"
+        ).exists()
+        assert (
+            tmp_path
+            / "fvcv-handoff"
+            / "vendor"
+            / f"{case_slug}-case-ledger.jsonl"
+        ).exists()
+        assert (
+            tmp_path
+            / "fvcv-handoff"
+            / "coordinator"
+            / f"{case_slug}-case-ledger.jsonl"
+        ).exists()
+        assert (
+            tmp_path
+            / "fvcv-handoff"
+            / "vendor2"
+            / f"{case_slug}-case-ledger.jsonl"
+        ).exists()
+
+    def test_includes_case_actor_when_in_participant_index(
+        self, tmp_path, monkeypatch
+    ):
+        finder_client = MagicMock()
+        vendor_client = MagicMock()
+        coordinator_client = MagicMock()
+        vendor2_client = MagicMock()
+        finder_client.get_list.return_value = [{"logIndex": 0}]
+        vendor_client.get_list.return_value = [{"logIndex": 0}]
+        coordinator_client.get_list.return_value = [{"logIndex": 0}]
+        vendor2_client.get_list.return_value = [{"logIndex": 0}]
+
+        case = demo.as_VulnerabilityCase(
+            id_="https://example.org/cases/fvcv-with-ca",
+            actor_participant_index={
+                "https://example.org/actors/case-actor-fvcv": (
+                    "https://example.org/cases/fvcv-with-ca/participants/case-actor"
+                )
+            },
+        )
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        demo._phase_dump_case_ledgers(
+            finder_client=finder_client,
+            vendor_client=vendor_client,
+            coordinator_client=coordinator_client,
+            vendor2_client=vendor2_client,
+            case=case,
+        )
+
+        assert any(
+            "/actors/case-actor-fvcv/demo/cases/fvcv-with-ca/log"
+            in call.args[0]
+            for call in vendor_client.get_list.call_args_list
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestFvcvHandoffCliCommand:
+    """Test that the 'fvcv-handoff' CLI sub-command is registered and reachable."""
+
+    def test_fvcv_handoff_command_exists(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["fvcv-handoff", "--help"])
+        assert result.exit_code == 0, result.output
+
+    def test_fvcv_handoff_command_finder_url_option(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["fvcv-handoff", "--help"])
+        assert "--finder-url" in result.output
+
+    def test_fvcv_handoff_command_vendor_url_option(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["fvcv-handoff", "--help"])
+        assert "--vendor-url" in result.output
+
+    def test_fvcv_handoff_command_coordinator_url_option(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["fvcv-handoff", "--help"])
+        assert "--coordinator-url" in result.output
+
+    def test_fvcv_handoff_command_vendor2_url_option(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["fvcv-handoff", "--help"])
+        assert "--vendor2-url" in result.output
+
+    def test_fvcv_handoff_command_case_actor_url_option(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["fvcv-handoff", "--help"])
+        assert "--case-actor-url" in result.output
+
+    def test_fvcv_handoff_command_skip_health_check_option(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["fvcv-handoff", "--help"])
+        assert "--skip-health-check" in result.output

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -932,10 +932,6 @@ def _phase_dump_case_ledgers(
     c1_client: DataLayerClient,
     c2_client: DataLayerClient,
     vendor_client: DataLayerClient,
-    finder: as_Actor,
-    c1: as_Actor,
-    c2: as_Actor,
-    vendor: as_Actor,
     case: as_VulnerabilityCase,
     demo_name: str = "fccv-handoff",
 ) -> None:
@@ -1164,10 +1160,6 @@ def run_fccv_handoff_demo(
         c1_client=c1_client,
         c2_client=c2_client,
         vendor_client=vendor_client,
-        finder=finder,
-        c1=c1,
-        c2=c2,
-        vendor=vendor_in_vendor,
         case=case,
     )
 

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -972,10 +972,6 @@ def _phase_dump_case_ledgers(
     vendor_client: DataLayerClient,
     coordinator_client: DataLayerClient,
     vendor2_client: DataLayerClient,
-    finder: as_Actor,
-    vendor: as_Actor,
-    coordinator: as_Actor,
-    vendor2: as_Actor,
     case: as_VulnerabilityCase,
     demo_name: str = "fvcv-handoff",
 ) -> None:
@@ -1208,10 +1204,6 @@ def run_fvcv_handoff_demo(
         vendor_client=vendor_client,
         coordinator_client=coordinator_client,
         vendor2_client=vendor2_client,
-        finder=finder,
-        vendor=vendor,
-        coordinator=coordinator,
-        vendor2=vendor2_in_vendor2,
         case=case,
     )
 


### PR DESCRIPTION
- Closes #1626

## Summary

`_phase_dump_case_ledgers` in `fvcv_handoff_demo.py` and `fccv_handoff_demo.py` accepted `as_Actor` parameters for finder, vendor, coordinator, and vendor2 that were never read — ledger dump paths are hardcoded strings derived solely from the DataLayer URL.

## Changes

- **`vultron/demo/scenario/fvcv_handoff_demo.py`**: removed 4 dead `as_Actor` parameters (`finder`, `vendor`, `coordinator`, `vendor2`) from `_phase_dump_case_ledgers`; updated call site in `run_fvcv_handoff_demo`
- **`vultron/demo/scenario/fccv_handoff_demo.py`**: same removal for `finder`, `c1`, `c2`, `vendor`; updated call site in `run_fccv_handoff_demo`
- **`test/demo/test_fvcv_handoff_demo.py`** (new): tests for `_phase_dump_case_ledgers` and CLI option coverage for the `fvcv-handoff` command
- **`test/demo/test_fccv_handoff_demo.py`**: added `TestPhaseDumpCaseLedgersFccv` covering the new signature

## Verification

- All 29 targeted tests pass (`uv run pytest test/demo/test_fvcv_handoff_demo.py test/demo/test_fccv_handoff_demo.py -m "" --tb=short`) — 11 new
- Full suite clean (5982 passed)
- Black + flake8 + mypy + pyright — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)