### PR TITLE
fix(case-init): seed reporter as embargo SIGNATORY (CM-14-005)

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1868.md
+++ b/plan/history/2608/implementation/ISSUE-1868.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1868
+timestamp: '2026-08-03T18:58:54.212289+00:00'
+title: seed reporter as embargo SIGNATORY (CM-14-005)
+type: implementation
+---
+
+## Issue #1868 — fix(case-init): seed reporter as embargo SIGNATORY (CM-14-005)
+
+Implemented CM-14-005: reporter participant is now seeded as SIGNATORY on any active embargo during case initialization. Added _SeedReporterSignatoryNode BT node to case_proposal_received_tree.py, inserted after _SeedVendorOwnerSignatoryNode and before_CommitNativeLedgerEntriesNode. Uses apply_pec_transition(PEC_Trigger.ACCEPT) — the authoritative consent-write path per CM-18-005, CM-18-006, ADR-0048. Six tests added covering all 5 ACs plus graceful-degradation. PR: <https://github.com/CERTCC/Vultron/pull/1938>

--- a/test/core/behaviors/case/test_case_proposal_received_tree.py
+++ b/test/core/behaviors/case/test_case_proposal_received_tree.py
@@ -813,6 +813,212 @@ class TestADR0041EmbargoInit:
         ), "Active embargo id must be recorded in vendor's accepted list"
 
 
+class TestCM14005ReporterSignatory:
+    """CM-14-005: reporter seeded as embargo SIGNATORY at case initialization."""
+
+    def _get_reporter_participant(self, dl):
+        from vultron.core.models.case import VulnerabilityCase
+        from vultron.core.models.case_participant import CaseParticipant
+
+        cases = list(dl.list_objects("VulnerabilityCase"))
+        assert cases
+        case = cases[0]
+        assert isinstance(case, VulnerabilityCase)
+        participant_id = case.actor_participant_index.get(_REPORTER_URI)
+        if participant_id is None:
+            return None, case
+        participant = dl.read(participant_id)
+        assert isinstance(participant, CaseParticipant)
+        return participant, case
+
+    def test_reporter_seeded_as_signatory(self, make_payload):
+        """AC-1: reporter is SIGNATORY after initialization."""
+        from vultron.core.states.participant_embargo_consent import PEC
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _seed_report(dl)
+        _run_full_bt(make_payload, dl)
+
+        participant, case = self._get_reporter_participant(dl)
+        assert participant is not None, "Reporter participant must exist"
+        assert participant.embargo_consent_state == PEC.SIGNATORY, (
+            "Reporter must be seeded SIGNATORY on the active embargo"
+            f" at case initialization (CM-14-005), got"
+            f" {participant.embargo_consent_state!r}"
+        )
+
+    def test_reporter_accepted_embargo_ids_populated(self, make_payload):
+        """AC-2: reporter's accepted_embargo_ids includes the active embargo."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _seed_report(dl)
+        _run_full_bt(make_payload, dl)
+
+        participant, case = self._get_reporter_participant(dl)
+        assert participant is not None, "Reporter participant must exist"
+        assert case.active_embargo is not None
+        assert case.active_embargo in participant.accepted_embargo_ids, (
+            "Reporter's accepted_embargo_ids must include the active embargo"
+            " (CM-14-005 AC-2)"
+        )
+
+    def test_no_active_embargo_reporter_remains_no_embargo(self):
+        """AC-3: _SeedReporterSignatoryNode no-ops gracefully when no active embargo."""
+        from vultron.core.behaviors.case.case_proposal_received_tree import (
+            _SeedReporterSignatoryNode,
+        )
+        from vultron.core.models.case import VulnerabilityCase
+        from vultron.core.models.case_participant import CaseParticipant
+        from vultron.core.models.report import VulnerabilityReport
+        from vultron.core.states.participant_embargo_consent import PEC
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        # Build a minimal case with no active embargo and a reporter participant
+        case = VulnerabilityCase(id_=_CASE_URI)
+        reporter_participant = CaseParticipant(
+            id_="https://example.org/participants/reporter",
+            attributed_to=_REPORTER_URI,
+            context=_CASE_URI,
+        )
+        dl.save(reporter_participant)
+        case.actor_participant_index[_REPORTER_URI] = reporter_participant.id_
+        case.case_participants.append(reporter_participant.id_)
+        dl.save(case)
+        report = VulnerabilityReport(
+            id_=_REPORT_URI, attributed_to=_REPORTER_URI
+        )
+        dl.save(report)
+
+        node = _SeedReporterSignatoryNode(report_id=_REPORT_URI)
+        tree = py_trees.composites.Sequence(
+            name="TestSeq", memory=False, children=[node]
+        )
+        client = py_trees.blackboard.Client(name="TestSetupAC3")
+        client.register_key(key="case_id", access=py_trees.common.Access.WRITE)
+        client.case_id = _CASE_URI
+
+        from vultron.core.behaviors.bridge import BTBridge
+
+        result = BTBridge(datalayer=dl).execute_with_setup(
+            tree=tree, actor_id=_CASE_ACTOR_URI
+        )
+        assert result.status == py_trees.common.Status.SUCCESS, (
+            "_SeedReporterSignatoryNode must return SUCCESS when no active"
+            " embargo (AC-3, best-effort)"
+        )
+        stored_participant = dl.read(reporter_participant.id_)
+        assert isinstance(stored_participant, CaseParticipant)
+        assert stored_participant.embargo_consent_state == PEC.NO_EMBARGO, (
+            "Reporter must remain NO_EMBARGO when no active embargo exists"
+            " (CM-14-005 AC-3)"
+        )
+
+    def test_reporter_signatory_ledger_snapshot_consistent(self, make_payload):
+        """AC-4: ledger snapshot for reporter shows SIGNATORY consent.
+
+        The ``_CommitNativeLedgerEntriesNode`` runs *after*
+        ``_SeedReporterSignatoryNode``, so the participant status it snapshots
+        must already carry ``emConsentState=SIGNATORY`` and
+        ``embargoAdherence=True`` — no contradictory pair.
+        """
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _seed_report(dl)
+        _run_full_bt(make_payload, dl)
+
+        participant, case = self._get_reporter_participant(dl)
+        assert participant is not None
+
+        entries = list(dl.list_objects("CaseLedgerEntry"))
+        reporter_status_entries = [
+            e
+            for e in entries
+            if getattr(e, "event_type", None)
+            == "add_participant_status_to_participant"
+            and getattr(e, "case_id", None) == case.id_
+        ]
+        assert (
+            reporter_status_entries
+        ), "add_participant_status_to_participant entries must be present"
+
+        # The snapshot structure is:
+        # { "type": "Add", "actor": CaseActor, "object": {ParticipantStatus...},
+        #   "target": {CaseParticipant...}, "context": case_id }
+        # The reporter's entry has object["attributedTo"] == _REPORTER_URI.
+        reporter_entries = [
+            e
+            for e in reporter_status_entries
+            if _REPORTER_URI
+            in str(
+                (getattr(e, "payload_snapshot", {}).get("object") or {}).get(
+                    "attributedTo", ""
+                )
+            )
+        ]
+        assert reporter_entries, (
+            "At least one ledger entry's object.attributedTo must be the"
+            " reporter URI"
+        )
+        for entry in reporter_entries:
+            snap = getattr(entry, "payload_snapshot", {})
+            obj = snap.get("object", {})
+            em_consent = obj.get("emConsentState") or obj.get(
+                "em_consent_state"
+            )
+            embargo_adherence = obj.get("embargoAdherence") or obj.get(
+                "embargo_adherence"
+            )
+            if em_consent is not None:
+                assert em_consent in ("SIGNATORY", "signatory"), (
+                    f"Ledger snapshot emConsentState must be SIGNATORY for"
+                    f" reporter, got {em_consent!r} (CM-14-005 AC-4)"
+                )
+            if embargo_adherence is not None:
+                assert embargo_adherence is True, (
+                    f"Ledger snapshot embargoAdherence must be True for"
+                    f" reporter, got {embargo_adherence!r} (CM-14-005 AC-4)"
+                )
+
+    def test_reporter_embargo_adherence_true(self, make_payload):
+        """AC-5: embargo_adherence is True in reporter's latest ParticipantStatus."""
+        from vultron.core.states.participant_embargo_consent import PEC
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _seed_report(dl)
+        _run_full_bt(make_payload, dl)
+
+        participant, _case = self._get_reporter_participant(dl)
+        assert participant is not None
+        assert participant.embargo_consent_state == PEC.SIGNATORY
+
+        # embargo_adherence lives on ParticipantStatus, not on CaseParticipant.
+        # The latest status is exposed via participant.participant_status.
+        latest_status = participant.participant_status
+        assert (
+            latest_status is not None
+        ), "Reporter must have at least one ParticipantStatus"
+        assert latest_status.embargo_adherence is True, (
+            "reporter ParticipantStatus.embargo_adherence must be True after"
+            f" initialization (CM-14-005 AC-5),"
+            f" got {latest_status.embargo_adherence!r}"
+        )
+
+    def test_no_report_reporter_seeding_does_not_fail_sequence(
+        self, make_payload
+    ):
+        """Reporter seeding skips gracefully when report is absent."""
+        from vultron.core.models.case import VulnerabilityCase
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        # Deliberately NOT seeding the report
+        _run_full_bt(make_payload, dl)
+
+        cases = list(dl.list_objects("VulnerabilityCase"))
+        assert cases, "Case must still be created even without a seeded report"
+        case = cases[0]
+        assert isinstance(case, VulnerabilityCase)
+        # Vendor participant must still be present
+        assert _VENDOR_URI in case.actor_participant_index
+
+
 class TestADR0041LedgerEntries:
     """ADR-0041 AC-4: canonical ledger entries committed natively."""
 

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -22,10 +22,10 @@ ADR-0041 before emitting outbound activities:
   5. Seed vendor (CASE_OWNER) as embargo SIGNATORY (CM-13)
   6. Seed reporter as embargo SIGNATORY (CM-14-005)
   7. Commit canonical ledger entries natively (AC-4)
-  7. Emit ``Accept(as_CaseProposal)``
-  8. Write durable retry marker (CP-05-005)
-  9. Emit ``Create(VulnerabilityCase)`` with inline participants (AC-5)
-  10. Clear retry marker on success
+  8. Emit ``Accept(as_CaseProposal)``
+  9. Write durable retry marker (CP-05-005)
+  10. Emit ``Create(VulnerabilityCase)`` with inline participants (AC-5)
+  11. Clear retry marker on success
 
 Idempotency (CP-05-006):
 
@@ -99,7 +99,10 @@ from vultron.core.models.pending_create_case_activity import (
 )
 from vultron.core.models.report import VulnerabilityReport
 from vultron.core.models.vultron_types import VultronParticipant
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.ports.case_persistence import (
+    CaseOutboxPersistence,
+    CasePersistence,
+)
 from vultron.core.states.participant_embargo_consent import PEC, PEC_Trigger
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
@@ -772,6 +775,36 @@ class _CommitNativeLedgerEntriesNode(DataLayerAction):
         return Status.SUCCESS
 
 
+def _seed_participant_as_signatory(
+    datalayer: CasePersistence,
+    stored_case: VulnerabilityCase,
+    participant: CaseParticipant,
+    log_label: str,
+    spec_ref: str,
+) -> None:
+    """Seed *participant* as embargo SIGNATORY on *stored_case*'s active embargo.
+
+    Shared by ``_SeedVendorOwnerSignatoryNode`` (CM-13) and
+    ``_SeedReporterSignatoryNode`` (CM-14-005). Uses
+    ``apply_pec_transition(PEC_Trigger.ACCEPT)`` — the authoritative
+    consent-write path (CM-18-005, ADR-0048) — to update both the PEC state
+    machine and ``ParticipantStatus.consent`` atomically. The idempotency
+    guard (``!= PEC.SIGNATORY``) prevents double-transitions on retries.
+    """
+    embargo_id = stored_case.active_embargo
+    if participant.embargo_consent_state != PEC.SIGNATORY:
+        participant.apply_pec_transition(PEC_Trigger.ACCEPT)
+    if embargo_id and embargo_id not in participant.accepted_embargo_ids:
+        participant.accepted_embargo_ids.append(embargo_id)
+    datalayer.save(participant)
+    logger.info(
+        "Seeded %s as embargo SIGNATORY in case '%s' (%s)",
+        log_label,
+        stored_case.id_,
+        spec_ref,
+    )
+
+
 class _SeedVendorOwnerSignatoryNode(DataLayerAction):
     """Seed the vendor (CASE_OWNER) participant as embargo SIGNATORY (CM-13).
 
@@ -878,19 +911,13 @@ class _SeedVendorOwnerSignatoryNode(DataLayerAction):
         stored_case: VulnerabilityCase,
         participant: CaseParticipant,
     ) -> None:
-        embargo_id = stored_case.active_embargo
-        if participant.embargo_consent_state != PEC.SIGNATORY:
-            participant.apply_pec_transition(PEC_Trigger.ACCEPT)
-        if embargo_id and embargo_id not in participant.accepted_embargo_ids:
-            participant.accepted_embargo_ids.append(embargo_id)
         assert self.datalayer is not None
-        self.datalayer.save(participant)
-        logger.info(
-            "%s: Seeded vendor '%s' as embargo SIGNATORY in case '%s'"
-            " (CM-13)",
-            self.name,
-            self._vendor_uri,
-            stored_case.id_,
+        _seed_participant_as_signatory(
+            self.datalayer,
+            stored_case,
+            participant,
+            log_label=f"vendor '{self._vendor_uri}'",
+            spec_ref="CM-13",
         )
 
 
@@ -1038,18 +1065,13 @@ class _SeedReporterSignatoryNode(DataLayerAction):
         stored_case: VulnerabilityCase,
         participant: CaseParticipant,
     ) -> None:
-        embargo_id = stored_case.active_embargo
-        if participant.embargo_consent_state != PEC.SIGNATORY:
-            participant.apply_pec_transition(PEC_Trigger.ACCEPT)
-        if embargo_id and embargo_id not in participant.accepted_embargo_ids:
-            participant.accepted_embargo_ids.append(embargo_id)
         assert self.datalayer is not None
-        self.datalayer.save(participant)
-        logger.info(
-            "%s: Seeded reporter as embargo SIGNATORY in case '%s'"
-            " (CM-14-005)",
-            self.name,
-            stored_case.id_,
+        _seed_participant_as_signatory(
+            self.datalayer,
+            stored_case,
+            participant,
+            log_label="reporter",
+            spec_ref="CM-14-005",
         )
 
 

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -20,7 +20,8 @@ ADR-0041 before emitting outbound activities:
   3. Add reporter as participant at RM.ACCEPTED (AC-2)
   4. Initialize the default embargo (AC-3)
   5. Seed vendor (CASE_OWNER) as embargo SIGNATORY (CM-13)
-  6. Commit canonical ledger entries natively (AC-4)
+  6. Seed reporter as embargo SIGNATORY (CM-14-005)
+  7. Commit canonical ledger entries natively (AC-4)
   7. Emit ``Accept(as_CaseProposal)``
   8. Write durable retry marker (CP-05-005)
   9. Emit ``Create(VulnerabilityCase)`` with inline participants (AC-5)
@@ -893,6 +894,165 @@ class _SeedVendorOwnerSignatoryNode(DataLayerAction):
         )
 
 
+class _SeedReporterSignatoryNode(DataLayerAction):
+    """Seed the reporter participant as embargo SIGNATORY (CM-14-005).
+
+    CM-14-005 requires: "When the reporter is added as a participant during
+    case initialization, they MUST be seeded as SIGNATORY on any active
+    embargo."  The reporter's consent is *implicit* in submitting the report
+    (ADR-0048) — no invitation round-trip is needed.
+
+    This node runs after ``InitializeDefaultEmbargoNode`` (so the embargo is
+    already ACTIVE) and after ``_AddReporterParticipantNode`` (so the
+    participant record exists).  It resolves the reporter URI from the report
+    in the DataLayer, looks up the participant, and calls
+    ``apply_pec_transition(PEC_Trigger.ACCEPT)`` via the shared helper so that
+    both the PEC state machine and the ``ParticipantStatus.consent`` dimension
+    are updated atomically (CM-18-005, CM-18-006, ADR-0048).
+
+    Best-effort: if the report, reporter URI, or participant cannot be
+    resolved, or if there is no active embargo, the node logs a warning and
+    returns SUCCESS so the enclosing Sequence is not blocked.
+
+    Reads ``case_id`` from the blackboard.
+    """
+
+    def __init__(
+        self,
+        report_id: str | None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._report_id = report_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+
+    def _resolve_reporter_uri(self, report_id: str) -> str | None:
+        assert self.datalayer is not None
+        raw_report = self.datalayer.read(report_id)
+        if not isinstance(raw_report, VulnerabilityReport):
+            logger.warning(
+                "%s: report '%s' not found — skipping reporter SIGNATORY"
+                " seed (best-effort)",
+                self.name,
+                report_id,
+            )
+            return None
+        reporter_uri = getattr(raw_report, "attributed_to", None)
+        if not isinstance(reporter_uri, str) or not reporter_uri:
+            logger.warning(
+                "%s: report '%s' has no attributed_to — skipping reporter"
+                " SIGNATORY seed (best-effort)",
+                self.name,
+                report_id,
+            )
+            return None
+        return reporter_uri
+
+    def _resolve_participant(
+        self, case_id: str, reporter_uri: str
+    ) -> tuple[VulnerabilityCase | None, CaseParticipant | None]:
+        """Return (case, participant) for *reporter_uri*, or (None, None) on miss."""
+        assert self.datalayer is not None
+        stored_case = self.datalayer.read(case_id, raise_on_missing=False)
+        if not isinstance(stored_case, VulnerabilityCase):
+            logger.warning(
+                "%s: case '%s' not found — cannot seed reporter SIGNATORY"
+                " (best-effort)",
+                self.name,
+                case_id,
+            )
+            return None, None
+        if stored_case.active_embargo is None:
+            logger.debug(
+                "%s: no active embargo on case '%s' — nothing to seed for"
+                " reporter",
+                self.name,
+                case_id,
+            )
+            return None, None
+        participant_id = stored_case.actor_participant_index.get(reporter_uri)
+        if not participant_id:
+            logger.warning(
+                "%s: reporter '%s' has no participant in case '%s' —"
+                " cannot seed SIGNATORY (best-effort)",
+                self.name,
+                reporter_uri,
+                case_id,
+            )
+            return None, None
+        participant = self.datalayer.read(
+            participant_id, raise_on_missing=False
+        )
+        if not isinstance(participant, CaseParticipant):
+            logger.warning(
+                "%s: reporter participant '%s' not found in case '%s' —"
+                " cannot seed SIGNATORY (best-effort)",
+                self.name,
+                participant_id,
+                case_id,
+            )
+            return None, None
+        return stored_case, participant
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        if self._report_id is None:
+            logger.debug(
+                "%s: no report_id — skipping reporter SIGNATORY seed",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        try:
+            case_id = self.blackboard.get("case_id")
+        except KeyError:
+            self.feedback_message = "case_id not found in blackboard"
+            return Status.FAILURE
+        if not isinstance(case_id, str):
+            self.feedback_message = "case_id is not a string"
+            return Status.FAILURE
+
+        reporter_uri = self._resolve_reporter_uri(self._report_id)
+        if reporter_uri is None:
+            return Status.SUCCESS
+
+        stored_case, participant = self._resolve_participant(
+            case_id, reporter_uri
+        )
+        if stored_case is None or participant is None:
+            return Status.SUCCESS
+
+        self._seed_signatory(stored_case, participant)
+        return Status.SUCCESS
+
+    def _seed_signatory(
+        self,
+        stored_case: VulnerabilityCase,
+        participant: CaseParticipant,
+    ) -> None:
+        embargo_id = stored_case.active_embargo
+        if participant.embargo_consent_state != PEC.SIGNATORY:
+            participant.apply_pec_transition(PEC_Trigger.ACCEPT)
+        if embargo_id and embargo_id not in participant.accepted_embargo_ids:
+            participant.accepted_embargo_ids.append(embargo_id)
+        assert self.datalayer is not None
+        self.datalayer.save(participant)
+        logger.info(
+            "%s: Seeded reporter as embargo SIGNATORY in case '%s'"
+            " (CM-14-005)",
+            self.name,
+            stored_case.id_,
+        )
+
+
 class _EmitAcceptCaseProposalNode(DataLayerAction):
     """Build Accept(CaseProposal), store it, and queue it to the outbox.
 
@@ -1322,20 +1482,22 @@ def create_case_proposal_received_tree(
          (ADR-0041 AC-3)
       7. ``_SeedVendorOwnerSignatoryNode`` — vendor (CASE_OWNER) seeded as
          embargo SIGNATORY (CM-13)
-      8. ``_CommitNativeLedgerEntriesNode`` — canonical ledger entries
+      8. ``_SeedReporterSignatoryNode`` — reporter seeded as embargo
+         SIGNATORY (CM-14-005); implicit consent per ADR-0048
+      9. ``_CommitNativeLedgerEntriesNode`` — canonical ledger entries
          committed (ADR-0041 AC-4)
 
       Then the outbound messaging steps:
 
-      9. ``_EmitAcceptCaseProposalNode`` — emits Accept(as_CaseProposal)
-      10. ``_WriteCreateCaseMarkerNode`` — writes durable retry marker with
+      10. ``_EmitAcceptCaseProposalNode`` — emits Accept(as_CaseProposal)
+      11. ``_WriteCreateCaseMarkerNode`` — writes durable retry marker with
          inline case object (CP-05-005, ADR-0041 AC-5)
-      11. ``_EmitCreateVulnerabilityCaseNode`` — emits
+      12. ``_EmitCreateVulnerabilityCaseNode`` — emits
          Create(VulnerabilityCase) with inline participants
-      12. ``_ClearCreateCaseMarkerNode`` — removes marker on success
+      13. ``_ClearCreateCaseMarkerNode`` — removes marker on success
          (CP-05-005)
 
-    If node 10 fails, the marker written in node 9 remains in the DataLayer so
+    If node 11 fails, the marker written in node 10 remains in the DataLayer so
     that a retry runner (#1139) can complete the ``Create(VulnerabilityCase)``
     delivery independently.
 
@@ -1399,6 +1561,10 @@ def create_case_proposal_received_tree(
             # actor_id (the CaseActor), which is not a participant here, so it
             # no-ops; this node seeds the vendor explicitly.
             _SeedVendorOwnerSignatoryNode(vendor_uri=vendor_uri),
+            # CM-14-005: seed the reporter as embargo SIGNATORY.
+            # Reporter consent is implicit in submitting the report (ADR-0048);
+            # no invitation round-trip is needed or appropriate.
+            _SeedReporterSignatoryNode(report_id=report_id),
             # ADR-0041 AC-4: commit canonical ledger entries natively
             _CommitNativeLedgerEntriesNode(
                 vendor_uri=vendor_uri,


### PR DESCRIPTION
- Closes #1868

## Summary

- Added `_SeedReporterSignatoryNode` BT node to `case_proposal_received_tree.py` that seeds the reporter participant as embargo `SIGNATORY` during case initialization (CM-14-005).
- The node runs after `InitializeDefaultEmbargoNode` and `_SeedVendorOwnerSignatoryNode`, using `apply_pec_transition(PEC_Trigger.ACCEPT)` as the authoritative consent-write path (CM-18-005, CM-18-006, ADR-0048).
- Reporter consent is implicit (ADR-0048) — no invitation round-trip is needed; `ACCEPT` is valid directly from `NO_EMBARGO`.
- `_CommitNativeLedgerEntriesNode` runs after the new node, so the ledger snapshot reflects `SIGNATORY` (no contradictory `embargoAdherence: true` / `emConsentState: NO_EMBARGO` pair).
- Six new tests covering all five ACs from issue #1868 plus a graceful-degradation case.

## Changes

- `vultron/core/behaviors/case/case_proposal_received_tree.py` — added `_SeedReporterSignatoryNode` class and inserted it into the tree between `_SeedVendorOwnerSignatoryNode` and `_CommitNativeLedgerEntriesNode`
- `test/core/behaviors/case/test_case_proposal_received_tree.py` — added `TestCM14005ReporterSignatory` with 6 tests

## Verification

- [x] `test_reporter_seeded_as_signatory` — reporter `embargo_consent_state == PEC.SIGNATORY` after full BT (AC-1)
- [x] `test_reporter_accepted_embargo_ids_populated` — active embargo ID in `accepted_embargo_ids` (AC-2)
- [x] `test_no_active_embargo_reporter_remains_no_embargo` — node no-ops gracefully when no active embargo (AC-3)
- [x] `test_reporter_signatory_ledger_snapshot_consistent` — ledger snapshot `emConsentState=SIGNATORY`, `embargoAdherence=True` (AC-4)
- [x] `test_reporter_embargo_adherence_true` — `ParticipantStatus.embargo_adherence is True` (AC-5)
- [x] `test_no_report_reporter_seeding_does_not_fail_sequence` — missing report: sequence still succeeds
- [x] Full unit suite: 5988 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)