### PR TITLE
refactor(bt): extract _SendEmbargoActivityBase for factory-dispatch pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,8 +276,9 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **Splits Must Not Produce New God Modules** — submodules ≤500 lines; split
   recursively when they re-accumulate. See CS-18-001 through CS-18-004.
 - **BT Emit Nodes: Inherit Base Classes, Never Reimplement Guard Boilerplate**
-  — use `_EmitCaseActorReportActivityBase`; override only `_call_factory()`.
-  See BTND-07-005.
+  — use `_EmitCaseActorReportActivityBase` (report domain) or
+  `_SendEmbargoActivityBase` (embargo domain); override only `_call_factory()`
+  and the three hook methods. See BTND-07-005.
 - **Peer Broadcast Nodes Must Not Mask Delivery Failure with SUCCESS** —
   see [notes/peer-broadcast-failure-semantics.md](notes/peer-broadcast-failure-semantics.md) BT-14-001.
 - **Negative-Guard Condition Nodes Are a Readability Anti-Pattern** — use

--- a/plan/history/2608/implementation/ISSUE-1707.md
+++ b/plan/history/2608/implementation/ISSUE-1707.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1707
+timestamp: '2026-08-03T19:09:05.650022+00:00'
+title: extract _SendEmbargoActivityBase for embargo emit nodes
+type: implementation
+---
+
+## Issue #1707 — refactor(bt): extract _SendEmbargoActivityBase for factory-dispatch pattern
+
+Created `_SendEmbargoActivityBase` in new `vultron/core/behaviors/embargo/nodes/emit.py`, implementing the shared guard/factory-dispatch/outbox-write skeleton per BTND-07-005. Refactored `SendAnnounceEmbargoEventNode` (best-effort) and `SendTerminateEmbargoActivityNode` (fail-fast BT-14-001) to inherit from the base. Updated architecture ratchet. Added 7 contract tests.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1939>

--- a/test/architecture/test_behaviors_no_use_case_imports.py
+++ b/test/architecture/test_behaviors_no_use_case_imports.py
@@ -100,7 +100,7 @@ KNOWN_VIOLATIONS: frozenset[str] = frozenset(
         "vultron/core/behaviors/case/nodes/conditions.py",
         "vultron/core/behaviors/case/nodes/lifecycle.py",
         "vultron/core/behaviors/case/nodes/participant/owner.py",
-        "vultron/core/behaviors/embargo/nodes/lifecycle.py",
+        "vultron/core/behaviors/embargo/nodes/emit.py",
         "vultron/core/behaviors/embargo/nodes/proposal.py",
         "vultron/core/behaviors/embargo/nodes/teardown.py",
         "vultron/core/behaviors/report/nodes/emit.py",

--- a/test/core/behaviors/embargo/nodes/test_emit.py
+++ b/test/core/behaviors/embargo/nodes/test_emit.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for _SendEmbargoActivityBase in emit.py."""
+
+from unittest.mock import MagicMock, patch
+
+import py_trees
+import pytest
+
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
+from vultron.core.states.em import EM
+
+from test.core.behaviors.embargo.nodes.conftest import (
+    CASE_MANAGER_ACTOR,
+    make_case_with_manager,
+    setup_blackboard,
+)
+
+ACTOR_ID = "https://example.org/actors/vendor"
+CASE_ID = "https://example.org/cases/case_emit1"
+EMBARGO_ID = "https://example.org/cases/case_emit1/embargo_events/e1"
+ACTIVITY_ID = "https://example.org/activities/act1"
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+def _make_concrete(
+    *,
+    factory_missing_returns: Status = Status.FAILURE,
+    resolve_result: "tuple[str, str] | Status" = (
+        EMBARGO_ID,
+        CASE_MANAGER_ACTOR,
+    ),
+    call_result: "tuple[str, dict] | Exception" = (ACTIVITY_ID, {}),
+    outbox_fail_returns: Status = Status.FAILURE,
+) -> "_SendEmbargoActivityBase":
+    """Create a minimal concrete subclass for contract testing."""
+
+    class _ConcreteNode(_SendEmbargoActivityBase):
+        def _on_factory_unavailable(self) -> Status:
+            return factory_missing_returns
+
+        def _resolve_embargo_and_manager(self) -> "tuple[str, str] | Status":
+            return resolve_result
+
+        def _call_factory(
+            self, _actor_id: str, _embargo_id: str, _case_manager_id: str
+        ) -> tuple[str, object]:
+            if isinstance(call_result, Exception):
+                raise call_result
+            return call_result
+
+        def _on_outbox_write_failure(
+            self, _activity_id: str, _exc: Exception
+        ) -> Status:
+            return outbox_fail_returns
+
+    return _ConcreteNode(case_id=CASE_ID, name="_ConcreteNode")
+
+
+def _setup_with_factory(dl: SqliteDataLayer, factory: MagicMock) -> None:
+    py_trees.blackboard.Blackboard.enable_activity_stream()
+    bb = py_trees.blackboard.Client(name="test-emit-setup")
+    for key in ("datalayer", "actor_id", "trigger_activity_factory"):
+        bb.register_key(key=key, access=py_trees.common.Access.WRITE)
+    bb.datalayer = dl
+    bb.actor_id = ACTOR_ID
+    bb.trigger_activity_factory = factory
+
+
+class TestSendEmbargoActivityBaseContract:
+    """Contract tests for _SendEmbargoActivityBase dispatch skeleton."""
+
+    def test_success_path_calls_factory_and_queues(self):
+        """Happy-path: factory called and activity queued to outbox."""
+        _, _, dl = make_case_with_manager("emit1", em_state=EM.ACTIVE)
+        factory = MagicMock()
+        _setup_with_factory(dl, factory)
+
+        node = _make_concrete()
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == Status.SUCCESS
+
+    def test_factory_unavailable_delegates_to_hook(self):
+        """When factory is None, _on_factory_unavailable determines the status."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        setup_blackboard(dl, actor_id=ACTOR_ID)
+
+        for expected in (Status.SUCCESS, Status.FAILURE):
+            py_trees.blackboard.Blackboard.storage.clear()
+            setup_blackboard(dl, actor_id=ACTOR_ID)
+
+            node = _make_concrete(factory_missing_returns=expected)
+            bt = py_trees.trees.BehaviourTree(root=node)
+            bt.setup()
+            bt.tick()
+
+            assert node.status == expected
+
+    def test_resolve_failure_propagated(self):
+        """When _resolve_embargo_and_manager returns FAILURE, update() returns FAILURE."""
+        _, _, dl = make_case_with_manager("emit2", em_state=EM.ACTIVE)
+        factory = MagicMock()
+        _setup_with_factory(dl, factory)
+
+        node = _make_concrete(resolve_result=Status.FAILURE)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == Status.FAILURE
+        factory.assert_not_called()
+
+    def test_resolve_success_skip_propagated(self):
+        """When _resolve_embargo_and_manager returns SUCCESS (graceful skip), no factory call."""
+        _, _, dl = make_case_with_manager("emit3", em_state=EM.ACTIVE)
+        factory = MagicMock()
+        _setup_with_factory(dl, factory)
+
+        node = _make_concrete(resolve_result=Status.SUCCESS)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == Status.SUCCESS
+        factory.assert_not_called()
+
+    def test_factory_exception_returns_failure(self):
+        """When _call_factory raises, update() returns FAILURE."""
+        _, _, dl = make_case_with_manager("emit4", em_state=EM.ACTIVE)
+        factory = MagicMock()
+        _setup_with_factory(dl, factory)
+
+        node = _make_concrete(call_result=RuntimeError("factory boom"))
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == Status.FAILURE
+
+    def test_outbox_write_failure_delegates_to_hook(self):
+        """When outbox write fails, _on_outbox_write_failure determines the status."""
+        _, _, dl = make_case_with_manager("emit5", em_state=EM.ACTIVE)
+        factory = MagicMock()
+        _setup_with_factory(dl, factory)
+
+        patch_target = (
+            "vultron.core.behaviors.embargo.nodes.emit.add_activity_to_outbox"
+        )
+        for expected in (Status.SUCCESS, Status.FAILURE):
+            py_trees.blackboard.Blackboard.storage.clear()
+            _setup_with_factory(dl, factory)
+
+            node = _make_concrete(outbox_fail_returns=expected)
+            bt = py_trees.trees.BehaviourTree(root=node)
+            bt.setup()
+
+            with patch(patch_target, side_effect=RuntimeError("outbox error")):
+                bt.tick()
+
+            assert node.status == expected
+
+    def test_missing_datalayer_returns_failure(self):
+        """FAILURE when blackboard has no datalayer."""
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        bb = py_trees.blackboard.Client(name="test-no-dl")
+        for key in ("datalayer", "actor_id", "trigger_activity_factory"):
+            bb.register_key(key=key, access=py_trees.common.Access.WRITE)
+        bb.datalayer = None
+        bb.actor_id = ACTOR_ID
+        bb.trigger_activity_factory = MagicMock()
+
+        node = _make_concrete()
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == Status.FAILURE

--- a/test/core/behaviors/embargo/nodes/test_teardown.py
+++ b/test/core/behaviors/embargo/nodes/test_teardown.py
@@ -355,7 +355,9 @@ class TestSendAnnounceEmbargoEventNode:
         bt = py_trees.trees.BehaviourTree(root=node)
         bt.setup()
 
-        patch_target = "vultron.core.behaviors.embargo.nodes.teardown.add_activity_to_outbox"
+        patch_target = (
+            "vultron.core.behaviors.embargo.nodes.emit.add_activity_to_outbox"
+        )
         with patch(patch_target, side_effect=RuntimeError("outbox error")):
             bt.tick()
 

--- a/vultron/core/behaviors/embargo/nodes/emit.py
+++ b/vultron/core/behaviors/embargo/nodes/emit.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Shared base class for embargo activity emit nodes (BTND-07-005)."""
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.use_cases._helpers import add_activity_to_outbox
+
+
+class _SendEmbargoActivityBase(DataLayerAction):
+    """Abstract base for embargo activity emit nodes (BTND-07-005).
+
+    Implements the common guard/factory-dispatch/outbox-write skeleton:
+
+    1. Check factory availability → delegate to ``_on_factory_unavailable()``.
+    2. Guard ``datalayer`` and ``actor_id`` via ``_require_datalayer_and_actor()``.
+    3. Resolve ``embargo_id`` and ``case_manager_id`` → ``_resolve_embargo_and_manager()``.
+    4. Call the factory → ``_call_factory(actor_id, embargo_id, case_manager_id)``.
+    5. Write the activity to the outbox; on failure → ``_on_outbox_write_failure()``.
+
+    Subclasses must override all four hook methods.  Subclasses that read from
+    the blackboard must also override ``setup()`` to register their keys (calling
+    ``super().setup(**kwargs)`` first).
+    """
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+
+    def _on_factory_unavailable(self) -> Status:
+        """Status to return when ``trigger_activity_factory`` is ``None``.
+
+        Implementations must set ``self.feedback_message``, log an appropriate
+        message, and return either ``SUCCESS`` (best-effort/skip) or ``FAILURE``
+        (fail-fast, per BT-14-001).
+        """
+        raise NotImplementedError
+
+    def _resolve_embargo_and_manager(self) -> "tuple[str, str] | Status":
+        """Resolve the embargo ID and Case Manager actor ID for the factory call.
+
+        Called after ``datalayer`` and ``actor_id`` have been validated.
+        Returns ``(embargo_id, case_manager_id)`` on success, or a ``Status``
+        value to return early (e.g. ``FAILURE`` on hard error, ``SUCCESS`` on
+        graceful skip).
+        """
+        raise NotImplementedError
+
+    def _call_factory(
+        self, _actor_id: str, _embargo_id: str, _case_manager_id: str
+    ) -> "tuple[str, object]":
+        """Invoke the appropriate ``TriggerActivityPort`` method.
+
+        Returns ``(activity_id, <extra>)``; raises on any factory error.
+        """
+        raise NotImplementedError
+
+    def _on_outbox_write_failure(
+        self, _activity_id: str, _exc: Exception
+    ) -> Status:
+        """Status to return when the outbox write fails after activity creation.
+
+        The activity has already been constructed at this point.  Return
+        ``SUCCESS`` for best-effort semantics (teardown must not be blocked) or
+        ``FAILURE`` for fail-fast semantics (BT-14-001).
+        """
+        raise NotImplementedError
+
+    def update(self) -> Status:
+        if self.trigger_activity_factory is None:
+            return self._on_factory_unavailable()
+
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+
+        params = self._resolve_embargo_and_manager()
+        if isinstance(params, Status):
+            return params
+        embargo_id, case_manager_id = params
+
+        try:
+            activity_id, _extra = self._call_factory(
+                self.actor_id, embargo_id, case_manager_id
+            )
+        except Exception as exc:
+            self.feedback_message = (
+                f"Factory call failed for case '{self._case_id}': {exc}"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        try:
+            add_activity_to_outbox(
+                self.actor_id,
+                activity_id,
+                self.datalayer,  # type: ignore[arg-type]
+            )
+        except Exception as exc:
+            return self._on_outbox_write_failure(activity_id, exc)
+
+        self.feedback_message = (
+            f"Queued '{activity_id}' for case '{self._case_id}'"
+        )
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -24,6 +24,7 @@ from vultron.core.behaviors.embargo.nodes.em_state import (
     ReadEmStateNode,
     WriteEmStateNode,
 )
+from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import EmDimension
@@ -38,7 +39,6 @@ from vultron.core.states.em import (
     is_valid_em_transition,
 )
 from vultron.core.models._helpers import _as_id
-from vultron.core.use_cases._helpers import add_activity_to_outbox
 from vultron.errors import (
     VultronError,
     VultronInvalidStateTransitionError,
@@ -335,7 +335,7 @@ class ReadEmbargoIdNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class SendTerminateEmbargoActivityNode(DataLayerAction):
+class SendTerminateEmbargoActivityNode(_SendEmbargoActivityBase):
     """Build and queue a ``Terminate(EmbargoEvent)`` activity.
 
     Reads ``embargo_id`` and ``case_manager_id`` from the blackboard and
@@ -347,8 +347,7 @@ class SendTerminateEmbargoActivityNode(DataLayerAction):
     """
 
     def __init__(self, case_id: str, name: str | None = None) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self._case_id = case_id
+        super().__init__(case_id=case_id, name=name)
 
     def setup(self, **kwargs: object) -> None:
         super().setup(**kwargs)
@@ -361,47 +360,43 @@ class SendTerminateEmbargoActivityNode(DataLayerAction):
             access=py_trees.common.Access.READ,
         )
 
-    def update(self) -> Status:
-        if (f := self._require_factory()) is not None:
-            self.feedback_message = (
-                "trigger_activity_factory not available"
-                " — broadcast FAILURE (BT-14-001)"
-            )
-            self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return f
-        assert self.trigger_activity_factory is not None
-        if (f := self._require_datalayer_and_actor()) is not None:
-            return f
-        assert self.datalayer is not None
-        assert self.actor_id is not None
+    def _on_factory_unavailable(self) -> Status:
+        self.feedback_message = (
+            "trigger_activity_factory not available"
+            " — broadcast FAILURE (BT-14-001)"
+        )
+        self.logger.warning("%s: %s", self.name, self.feedback_message)
+        return Status.FAILURE
 
+    def _resolve_embargo_and_manager(self) -> "tuple[str, str] | Status":
         try:
             embargo_id: str = self.blackboard.embargo_id
             case_manager_id: str = self.blackboard.case_manager_id
         except KeyError as exc:
             self.feedback_message = f"Required blackboard key missing: {exc}"
             return Status.FAILURE
+        return embargo_id, case_manager_id
 
-        try:
-            announce_id, _ = self.trigger_activity_factory.terminate_embargo(
-                embargo_id=embargo_id,
-                case_id=self._case_id,
-                actor=self.actor_id,
-                to=[case_manager_id],
-            )
-            add_activity_to_outbox(
-                self.actor_id,
-                announce_id,
-                self.datalayer,  # type: ignore[arg-type]
-            )
-        except Exception as exc:
-            self.feedback_message = (
-                f"activity dispatch failed for case '{self._case_id}': {exc}"
-            )
-            self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return Status.FAILURE
+    def _call_factory(
+        self, actor_id: str, embargo_id: str, case_manager_id: str
+    ) -> tuple[str, object]:
+        assert self.trigger_activity_factory is not None
+        return self.trigger_activity_factory.terminate_embargo(
+            embargo_id=embargo_id,
+            case_id=self._case_id,
+            actor=actor_id,
+            to=[case_manager_id],
+        )
 
-        return Status.SUCCESS
+    def _on_outbox_write_failure(
+        self, activity_id: str, exc: Exception
+    ) -> Status:
+        self.feedback_message = (
+            f"Outbox write failed for Terminate(EmbargoEvent)"
+            f" '{activity_id}': {exc}"
+        )
+        self.logger.warning("%s: %s", self.name, self.feedback_message)
+        return Status.FAILURE
 
 
 class SetEmbargoActiveNode(DataLayerAction):

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -18,13 +18,13 @@
 import py_trees
 from py_trees.common import Status
 
+from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import EmDimension
 from vultron.core.states.em import EM, is_valid_em_transition
 from vultron.core.use_cases._helpers import (
     _as_id,
-    add_activity_to_outbox,
     reset_case_participant_embargo_consent,
     _resolve_case_manager_id,
 )
@@ -111,7 +111,7 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class SendAnnounceEmbargoEventNode(DataLayerAction):
+class SendAnnounceEmbargoEventNode(_SendEmbargoActivityBase):
     """Emit an ``Announce(EmbargoEvent)`` after embargo teardown.
 
     Resolves the Case Manager actor ID from the case, builds the outbound
@@ -136,74 +136,19 @@ class SendAnnounceEmbargoEventNode(DataLayerAction):
         embargo_id: str,
         name: str | None = None,
     ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self._case_id = case_id
+        super().__init__(case_id=case_id, name=name)
         self._embargo_id = embargo_id
 
-    def _build_and_queue_announce(
-        self, actor_id: str, case_manager_id: str
-    ) -> Status:
-        """Build the Announce(EmbargoEvent) activity and write it to the outbox.
-
-        Separated from ``update()`` to keep cyclomatic complexity under the
-        project limit.  Returns FAILURE if the factory call raises, SUCCESS
-        (best-effort) if the outbox write fails after the activity is already
-        constructed.
-        """
-        assert self.trigger_activity_factory is not None
-        assert self.datalayer is not None
-
-        try:
-            announce_id, _ = self.trigger_activity_factory.announce_embargo(
-                embargo_id=self._embargo_id,
-                case_id=self._case_id,
-                actor=actor_id,
-                to=[case_manager_id],
-            )
-        except Exception as exc:
-            self.feedback_message = (
-                f"Announce(EmbargoEvent) factory failed for"
-                f" case '{self._case_id}': {exc}"
-            )
-            self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return Status.FAILURE
-
-        try:
-            add_activity_to_outbox(
-                actor_id,
-                announce_id,
-                self.datalayer,  # type: ignore[arg-type]
-            )
-        except Exception as exc:
-            self.feedback_message = (
-                f"Outbox write failed for Announce(EmbargoEvent)"
-                f" '{announce_id}': {exc}"
-                " — activity constructed but not queued"
-            )
-            self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return Status.SUCCESS
-
+    def _on_factory_unavailable(self) -> Status:
         self.feedback_message = (
-            f"Queued Announce(EmbargoEvent) '{announce_id}'"
-            f" for case '{self._case_id}'"
+            "trigger_activity_factory not available"
+            " — Announce(EmbargoEvent) skipped"
         )
-        self.logger.info("%s: %s", self.name, self.feedback_message)
+        self.logger.warning("%s: %s", self.name, self.feedback_message)
         return Status.SUCCESS
 
-    def update(self) -> Status:
-        if self.trigger_activity_factory is None:
-            self.feedback_message = (
-                "trigger_activity_factory not available"
-                " — Announce(EmbargoEvent) skipped"
-            )
-            self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return Status.SUCCESS
-
-        if (f := self._require_datalayer_and_actor()) is not None:
-            return f
+    def _resolve_embargo_and_manager(self) -> "tuple[str, str] | Status":
         assert self.datalayer is not None
-        assert self.actor_id is not None
-
         try:
             case = self.datalayer.read(self._case_id)
         except Exception as exc:
@@ -227,7 +172,29 @@ class SendAnnounceEmbargoEventNode(DataLayerAction):
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.SUCCESS
 
-        return self._build_and_queue_announce(self.actor_id, case_manager_id)
+        return self._embargo_id, case_manager_id
+
+    def _call_factory(
+        self, actor_id: str, embargo_id: str, case_manager_id: str
+    ) -> tuple[str, object]:
+        assert self.trigger_activity_factory is not None
+        return self.trigger_activity_factory.announce_embargo(
+            embargo_id=embargo_id,
+            case_id=self._case_id,
+            actor=actor_id,
+            to=[case_manager_id],
+        )
+
+    def _on_outbox_write_failure(
+        self, activity_id: str, exc: Exception
+    ) -> Status:
+        self.feedback_message = (
+            f"Outbox write failed for Announce(EmbargoEvent)"
+            f" '{activity_id}': {exc}"
+            " — activity constructed but not queued"
+        )
+        self.logger.warning("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
 
 
 class RemoveFromProposedEmbargoesNode(DataLayerAction):


### PR DESCRIPTION
- Closes #1707

## Summary

- Extracts the shared guard/factory-dispatch/outbox-write skeleton from `SendAnnounceEmbargoEventNode` and `SendTerminateEmbargoActivityNode` into a new abstract base class `_SendEmbargoActivityBase` (spec BTND-07-005)
- Mirrors the existing `_EmitCaseActorReportActivityBase` pattern in `vultron/core/behaviors/report/nodes/emit.py`
- Updates the architecture ratchet to track the consolidated import location

## Changes

**New file: `vultron/core/behaviors/embargo/nodes/emit.py`**
- `_SendEmbargoActivityBase(DataLayerAction)` with `update()` skeleton and four hook methods: `_on_factory_unavailable`, `_resolve_embargo_and_manager`, `_call_factory`, `_on_outbox_write_failure`

**Modified: `vultron/core/behaviors/embargo/nodes/teardown.py`**
- `SendAnnounceEmbargoEventNode` now inherits from `_SendEmbargoActivityBase`
- Best-effort semantics preserved: SUCCESS on factory-unavailable, no-case-manager, outbox-write-failure

**Modified: `vultron/core/behaviors/embargo/nodes/lifecycle.py`**
- `SendTerminateEmbargoActivityNode` now inherits from `_SendEmbargoActivityBase`
- Fail-fast semantics preserved per BT-14-001: FAILURE on factory-unavailable and outbox-write-failure

**Modified: `test/architecture/test_behaviors_no_use_case_imports.py`**
- Ratchet updated: `lifecycle.py` entry replaced with `emit.py` (the `add_activity_to_outbox` import consolidated there)

**New file: `test/core/behaviors/embargo/nodes/test_emit.py`**
- 7 contract tests covering all dispatch paths: happy path, factory-unavailable hook delegation, resolve failure/skip propagation, factory exception, outbox-write-failure hook delegation, missing datalayer

**Modified: `test/core/behaviors/embargo/nodes/test_teardown.py`**
- Patch target updated: `emit.add_activity_to_outbox` (was `teardown.add_activity_to_outbox`)

## Verification

- `uv run black vultron/ test/` — clean
- `uv run flake8 vultron/ test/` — clean (CC gate passed)
- `uv run mypy` — 0 errors
- `uv run pyright` — 0 errors, 0 warnings
- `uv run pytest --tb=short` — 5990 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)