### PR TITLE
test(case-init): one participant-status ledger entry per participant; vendor is SIGNATORY

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1867.md
+++ b/plan/history/2608/implementation/ISSUE-1867.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1867
+timestamp: '2026-08-03T19:10:36.178551+00:00'
+title: 'test(case-init): one participant-status ledger entry per participant; vendor
+  is SIGNATORY'
+type: implementation
+---
+
+## Issue #1867 — feat(case-init): embargo before participant PEC; one status entry per participant (CM-18-007)
+
+Added `TestCM18007InitLedgerEntries` to `test/core/behaviors/case/test_case_proposal_received_tree.py` with two tests:
+
+- `test_exactly_one_participant_status_entry_per_participant` (CM-18-007 AC-3): asserts exactly one `add_participant_status_to_participant` ledger entry per participant, guarding against the two-entry bug (NO_EMBARGO placeholder + correction) that previously broke `log_index` ordering and caused PR #1746 to be reverted.
+- `test_vendor_case_owner_appears_as_signatory_in_init_ledger` (CM-14-003 AC-4): asserts the vendor's initialization snapshot carries `emConsentState=SIGNATORY`.
+
+The implementation was already correct (delivered by #1865 + #1866 dependency chain). `notes/case-ledger-authority.md` already documented the one-entry guarantee (AC-5 satisfied). Tests confirmed the behavior; this PR locks it in as a regression guard.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1940>

--- a/test/core/behaviors/case/test_case_proposal_received_tree.py
+++ b/test/core/behaviors/case/test_case_proposal_received_tree.py
@@ -913,6 +913,74 @@ class TestADR0041LedgerEntries:
             ), f"add_case_status_to_case actor must be vendor URI, got {actor!r}"
 
 
+class TestCM18007InitLedgerEntries:
+    """CM-18-007 and CM-14-003: one init entry per participant; vendor is SIGNATORY."""
+
+    def test_exactly_one_participant_status_entry_per_participant(
+        self, make_payload
+    ):
+        """Each participant gets exactly one add_participant_status_to_participant
+        ledger entry — no NO_EMBARGO placeholder followed by a corrective entry
+        (CM-18-007 AC-3)."""
+        from vultron.core.models.case import VulnerabilityCase
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _seed_report(dl)
+        _run_full_bt(make_payload, dl)
+
+        cases = list(dl.list_objects("VulnerabilityCase"))
+        assert cases
+        case = cases[0]
+        assert isinstance(case, VulnerabilityCase)
+        participant_count = len(case.case_participants)
+
+        entries = list(dl.list_objects("CaseLedgerEntry"))
+        ps_entries = [
+            e
+            for e in entries
+            if getattr(e, "event_type", None)
+            == "add_participant_status_to_participant"
+        ]
+        assert len(ps_entries) == participant_count, (
+            f"Expected exactly {participant_count} "
+            "add_participant_status_to_participant entries (one per participant),"
+            f" got {len(ps_entries)} (CM-18-007)"
+        )
+
+    def test_vendor_case_owner_appears_as_signatory_in_init_ledger(
+        self, make_payload
+    ):
+        """Vendor (CASE_OWNER) init ledger entry must show SIGNATORY consent
+        (CM-14-003 AC-4)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _seed_report(dl)
+        _run_full_bt(make_payload, dl)
+
+        entries = list(dl.list_objects("CaseLedgerEntry"))
+        vendor_ps_entries = [
+            e
+            for e in entries
+            if getattr(e, "event_type", None)
+            == "add_participant_status_to_participant"
+            and _VENDOR_URI
+            in str(
+                getattr(e, "payload_snapshot", {})
+                .get("object", {})
+                .get("attributedTo", "")
+            )
+        ]
+        assert vendor_ps_entries, (
+            "Vendor must have an add_participant_status_to_participant"
+            " init ledger entry (CM-14-003)"
+        )
+        entry = vendor_ps_entries[0]
+        obj = getattr(entry, "payload_snapshot", {}).get("object", {})
+        assert obj.get("emConsentState") == "SIGNATORY", (
+            f"Vendor init entry must show SIGNATORY, got"
+            f" {obj.get('emConsentState')!r} (CM-14-003)"
+        )
+
+
 class TestADR0041InlineParticipantsPayload:
     """ADR-0041 AC-5: Create(VulnerabilityCase) embeds inline participant objects."""
 


### PR DESCRIPTION
- Closes #1867

## Summary

Adds two regression tests that guard the case-initialization ledger contract: exactly one `add_participant_status_to_participant` entry per participant (CM-18-007), and the vendor's entry carries `emConsentState=SIGNATORY` (CM-14-003).

## Changes

- **`test/core/behaviors/case/test_case_proposal_received_tree.py`**: adds `TestCM18007InitLedgerEntries` with two tests:
  - `test_exactly_one_participant_status_entry_per_participant` — asserts `len(ps_entries) == len(case.case_participants)`, preventing the two-entry (NO_EMBARGO placeholder + correction) bug that shifted `log_index` values and caused PR #1746 to be reverted (CM-18-007 AC-3).
  - `test_vendor_case_owner_appears_as_signatory_in_init_ledger` — asserts `payload_snapshot.object.emConsentState == "SIGNATORY"` for the vendor's init entry (CM-14-003 AC-4).

## Verification

- All 5984 unit tests pass (2 new in `TestCM18007InitLedgerEntries`)
- Black, flake8, mypy, pyright clean
- [x] AC-3: test asserts exactly one `add_participant_status_to_participant` entry per participant
- [x] AC-4: test asserts vendor (CASE_OWNER) appears as SIGNATORY in committed initialization entry
- [x] AC-5: `notes/case-ledger-authority.md` already documents the one-entry-per-participant guarantee (no update needed)