### PR TITLE
docs: plan issue #1257 — inbound embargo-response decision seam

### DIFF
--- a/notes/bt-fuzzer-nodes-embargo.md
+++ b/notes/bt-fuzzer-nodes-embargo.md
@@ -231,10 +231,14 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Call-out point shape**: Evaluator
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`stop_proposing_embargo_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
-  (issue #1257) — Evaluator condition guard in
-  `_ConsiderAbandoningProposedEmbargo` Selector
+  (`stop_proposing_embargo_factory` param). FUTURE full placement (revised by
+  #1257 planning): **simulator-only** — this gates the sim's tick-based
+  "keep proposing until effort exhausted" negotiation loop
+  (`_EnsureSufficientEffortToAchieveEmbargo`), which has no event trigger in
+  the trunk-removed prototype. Like `StopProposingEmbargo` in the #1256
+  termination analysis, it is dropped from production factory placement. The
+  Phase-1 stub seam remains for simulation parity only; there is no
+  `create_propose_embargo_decision_tree`.
 
 ### `SelectEmbargoOfferTerms`
 
@@ -254,10 +258,13 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Call-out point shape**: Evaluator
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`select_embargo_offer_terms_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
-  (issue #1257) — Evaluator action node in `_ProposeNewEmbargo` and
-  `_ProposeEmbargoRevision` Sequences, before the proposal trigger BT
+  (`select_embargo_offer_terms_factory` param). FUTURE full placement (revised
+  by #1257 planning): belongs to the **outbound propose** flow, not the inbound
+  response seam. The outbound propose decision is already the propose trigger
+  use case (`SvcProposeEmbargoUseCase` → `propose_embargo_trigger_bt`); this
+  term-selection Evaluator is the seam that supplies proposal terms ahead of
+  it. It is also reused by the EMB-15-003 counter arm (counter = re-propose).
+  No monolithic `create_propose_embargo_decision_tree`.
 
 ### `WantToProposeEmbargo`
 
@@ -276,10 +283,13 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Call-out point shape**: Evaluator
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`want_to_propose_embargo_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
-  (issue #1257) — Evaluator condition guard in `_ConsiderProposingEmbargo`
-  Sequence (within `_EmNone` Selector)
+  (`want_to_propose_embargo_factory` param). FUTURE full placement (revised by
+  #1257 planning): belongs to the **outbound propose** flow, not the inbound
+  response seam. In the trunk-removed prototype, "do I want to propose an
+  embargo?" is the operator/policy decision to *invoke*
+  `SvcProposeEmbargoUseCase` at all — i.e. a gate on triggering the propose
+  use case, not a node in a decision tree. The Phase-1 stub seam is retained;
+  no monolithic `create_propose_embargo_decision_tree`.
 
 ### `WillingToCounterEmbargoProposal`
 
@@ -299,11 +309,13 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Call-out point shape**: Evaluator
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`willing_to_counter_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
-  (issue #1257) — Evaluator condition guard in `_AvoidCounterProposal`
-  Selector; determines whether a counter-proposal is sent instead of
-  accept/reject
+  (`willing_to_counter_factory` param). FUTURE full placement (revised by
+  #1257 planning): Evaluator gating the **counter arm** of the inbound
+  embargo-response decision seam (spec `EMB-15-003`), Flow A (EP) only. Its
+  DETERMINISTIC default is FAILURE (do not counter — accept-then-revise is
+  preferred). When SUCCESS, the arm delegates to `propose_embargo_trigger_bt`
+  (counter = re-propose; no new mechanism). Not a monolithic
+  `create_propose_embargo_decision_tree`.
 
 ### `ReasonToProposeEmbargoWhenDeployed`
 
@@ -322,10 +334,12 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Call-out point shape**: Evaluator
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`reason_to_propose_when_deployed_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
-  (issue #1257) — Evaluator condition guard in
-  `_AvoidNewEmbargoesInCsDeployedUnlessReason` Selector
+  (`reason_to_propose_when_deployed_factory` param). FUTURE full placement
+  (revised by #1257 planning): belongs to the **outbound propose** flow as an
+  exceptional-case guard on invoking `SvcProposeEmbargoUseCase` after fix
+  deployment (CS ···D··). It is a precondition on the propose trigger, not a
+  node in a monolithic decision tree; no
+  `create_propose_embargo_decision_tree`.
 
 ### `EvaluateEmbargoProposal`
 
@@ -345,11 +359,14 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Call-out point shape**: Evaluator
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`evaluate_embargo_proposal_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
-  (issue #1257) — Evaluator condition guard in
-  `_EvaluateAndAcceptProposedEmbargo` Sequence; precedes
-  `accept_embargo_trigger_bt`
+  (`evaluate_embargo_proposal_factory` param). FUTURE full placement
+  (revised by #1257 planning): the **inbound embargo-response decision seam**
+  (spec `EMB-15`), NOT a monolithic `create_propose_embargo_decision_tree`.
+  This is the default-accept Evaluator (EMB-15-001): under the DETERMINISTIC
+  bundle it returns SUCCESS so the actor accepts, then delegates to the
+  flow-appropriate accept BT (`accept_embargo_trigger_bt` for a Flow A EP;
+  `accept_invite_to_embargo_tree` for a Flow B invitation). Sits behind the
+  CASE_OWNER-bypass authorization Selector (EMB-15-002).
 
 ### `OnEmbargoAccept`
 
@@ -366,11 +383,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **High** — notification dispatch, timer initialization, and state-update actions are all integration-automatable via APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoAccept`
 - **Call-out point shape**: Actuator — fires integration hooks on embargo acceptance; invokes notification APIs, embargo timer-service initialization calls, and case-management state writes. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
-  (issue #1257) — Actuator effect node in
-  `_EvaluateAndAcceptProposedEmbargo` Sequence, after the Evaluator and
-  `accept_embargo_trigger_bt`
+- **Factory-fn placement**: FUTURE (revised by #1257 planning): Actuator
+  effect node on the accept arm of the **inbound embargo-response decision
+  seam** (spec `EMB-15`), firing after the flow-appropriate accept BT. Not a
+  monolithic `create_propose_embargo_decision_tree`.
 
 ### `OnEmbargoReject`
 
@@ -387,11 +403,11 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **High** — notification dispatch and logging actions are fully automatable via APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoReject`
 - **Call-out point shape**: Actuator — fires integration hooks on embargo rejection; invokes notification APIs and case-management state writes for the rejection rationale. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
-  (issue #1257) — Actuator effect node in `_RejectProposedEmbargo`
-  Sequence (within `_ChooseEmProposedResponse`), after
-  `reject_embargo_trigger_bt`
+- **Factory-fn placement**: FUTURE (revised by #1257 planning): Actuator
+  effect node on the reject arm of the **inbound embargo-response decision
+  seam** (spec `EMB-15-004`), firing after the flow-appropriate reject BT
+  (`reject_embargo_trigger_bt` for Flow A; `reject_invite_to_embargo_tree`
+  for Flow B). Not a monolithic `create_propose_embargo_decision_tree`.
 
 ### `CurrentEmbargoAcceptable`
 
@@ -410,10 +426,11 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Call-out point shape**: Evaluator
 - **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`current_embargo_acceptable_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
-  (issue #1257) — Evaluator condition guard in `_ChooseEmActiveResponse`
-  Selector; SUCCESS = no revision needed, FAILURE = revision proposal path
-  taken
+  (`current_embargo_acceptable_factory` param). FUTURE full placement (revised
+  by #1257 planning): this is a **continuous-monitoring** evaluator with no
+  inbound-message trigger — it belongs to the active-embargo review/monitoring
+  concern (Sentinel shape, like `EmbargoTimerExpired`), tracked as a companion
+  Idea under monitoring epic #1147, NOT the inbound embargo-response decision
+  seam (EMB-15) and NOT a monolithic `create_propose_embargo_decision_tree`.
 
 ---

--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -204,3 +204,76 @@ When implementing any code that transitions embargo state:
 5. **OBSERVED mode** (received-side): pass
    `transition_mode=TransitionMode.OBSERVED` to sync local state with a remote
    assertion. All guards and PEC cascades are bypassed in OBSERVED mode.
+
+---
+
+## Inbound Embargo-Response Decision (EMB-15)
+
+**Status**: Planned — issue #1257 (plan/1257). Spec group `EMB-15` in
+`specs/em-behavior.yaml`; call-out catalog in
+`notes/bt-fuzzer-nodes-embargo.md`.
+
+### Two overture flows the simulator conflated
+
+The pre-PEC simulator collapsed embargo-response into a single
+`_ChooseEmProposedResponse` fallback (`vultron/bt/embargo_management/behaviors.py`).
+The production protocol separates two distinct inbound overtures:
+
+| | **Flow A — EM proposal** | **Flow B — PEC invitation** |
+|---|---|---|
+| Inbound message | `ProposeEmbargo` / EP | `InviteToEmbargoOnCase` |
+| Question asked | "here are terms" | "become a signatory to this embargo" |
+| Accept advances | shared EM (`NONE → PROPOSED → ACTIVE`) | this participant's PEC (`INVITED → SIGNATORY`) |
+| Accept mechanism | `accept_embargo_trigger_bt` | `accept_invite_to_embargo_tree` |
+| Reject mechanism | `reject_embargo_trigger_bt` (ER; EM → NONE) | `reject_invite_to_embargo_tree` (PEC → DECLINED) |
+| Status | **decision layer missing** | mechanics built, **decision layer missing** |
+
+The mechanical BTs for both flows already exist and are purely
+transition-recording — they act on whatever arrived. What is missing (and
+what #1257 adds) is the **decision layer** that chooses *how to respond*,
+layered over both flows as a single seam.
+
+### Design: default-accept with an owner-adjudication seam
+
+Mirrors the two-seam authorization model (ADR-0046) and
+`case_proposal_received_tree` (CASE_OWNER gospel bypass → owner-approval
+call-out → deterministic default):
+
+```text
+Selector (response decision):
+  Sequence("AcceptArm"):
+    Selector("Authorize"):
+      CheckIsCaseOwner            # hard bypass — owner's response is gospel (EMB-15-002)
+      CaseOwnerApprovesEmbargoResponse   # call-out; DETERMINISTIC → SUCCESS
+    EvaluateEmbargoProposal       # call-out; DETERMINISTIC → SUCCESS (accept, EMB-15-001)
+    → delegate to flow-appropriate accept BT
+  Sequence("CounterArm"):         # Flow A only (EMB-15-003)
+    WillingToCounterEmbargoProposal   # call-out; DETERMINISTIC → FAILURE (off by default)
+    → delegate to propose_embargo_trigger_bt (counter = re-propose; no new mechanism)
+  RejectArm:                      # (EMB-15-004)
+    → delegate to reject_embargo_trigger_bt (Flow A) / reject_invite_to_embargo_tree (Flow B)
+```
+
+Hard rule: EMB-01-002 (reject when CS is public/exploit/attacks) overrides the
+default-accept policy regardless of adjudication outcome.
+
+### Policy: "shortest embargo wins, then propose extensions"
+
+The recommended CVD default is to **accept** an offered embargo rather than
+counter, and negotiate extensions/revisions separately (accept-then-revise).
+This is why `EvaluateEmbargoProposal` defaults to accept and
+`WillingToCounterEmbargoProposal` defaults to *not* counter. A future
+adjudication backend (UI or LLM agent) may poll other participants, apply an
+organizational "shortest-embargo-wins" rule, or defer to the case owner — but
+that logic lives behind the call-out points, not in the tree.
+
+### Not overtaken; not a monolithic port
+
+Unlike the original Idea framing (one `create_propose_embargo_decision_tree`
+mirroring `_ProposeEmbargoBt` + `_ChooseEmProposedResponse` +
+`_ChooseEmActiveResponse` as a tick-loop), the outbound "want to propose /
+select terms" decision is already the propose trigger use case plus thin
+call-out seams in `create_manage_embargo_tree`, and the **active-embargo
+review loop** (`CurrentEmbargoAcceptable`) is a continuous-monitoring
+Sentinel with no event trigger — tracked separately for monitoring
+epic #1147 (companion Idea to #1257), not built here.

--- a/plan/history/2608/idea/IDEA-1257.md
+++ b/plan/history/2608/idea/IDEA-1257.md
@@ -1,0 +1,24 @@
+---
+source: IDEA-1257
+timestamp: '2026-08-03T19:27:25.186200+00:00'
+title: Inbound embargo-response decision seam (reframed from monolithic decision tree)
+type: idea
+---
+
+## Original idea
+
+`create_propose_embargo_decision_tree`: a factory function composing the embargo proposal decision workflow as a prototype BT subtree, mirroring the simulator's `_ProposeEmbargoBt` + `_ChooseEmProposedResponse` + `_ChooseEmActiveResponse` (from `vultron/bt/embargo_management/behaviors.py`) sitting above the existing proposal trigger BTs.
+
+## Resolution — reframed (2026-08-03)
+
+Consistent with how sibling embargo/report Ideas in epic #1285 resolved (#1256 terminate, #1253 close-report), the original "port the simulator's decision subtrees as one tick-loop factory" framing was overtaken by the trunk-removed prototype architecture. The plan decomposed #1257 by trigger event:
+
+- **Real missing behavior**: the *inbound embargo-response decision seam* — deciding accept / defer-to-owner / reject / counter when an actor receives an embargo overture. Modeled over the two flows the pre-PEC simulator conflated: Flow A (EM-level EP proposal; accept moves shared EM) and Flow B (PEC-level `InviteToEmbargoOnCase`; accept advances participant PEC). Design: default-accept + CASE_OWNER gospel bypass + owner-approval call-out (ADR-0046 / `case_proposal_received_tree` pattern); counter = re-propose via the existing `propose_embargo_trigger_bt` (no new mechanism). No new ADR (reuses ADR-0025 + ADR-0046).
+- **Already covered**: the outbound "want to propose / select terms" decision is the propose trigger use case (`SvcProposeEmbargoUseCase`) plus thin call-out seams in `create_manage_embargo_tree`.
+- **Routed to monitoring**: the active-embargo review loop (`CurrentEmbargoAcceptable`) is a continuous-monitoring Sentinel with no event trigger — companion Idea #1943 under epic #1147.
+- **Simulator-only, dropped**: `StopProposingEmbargo` (tick-based negotiation-fatigue loop).
+
+**Processed**: 2026-08-03 — implementation tracked in #1942 (Task, EMB-15); active-review monitoring tracked in #1943 (Idea).
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1941>.
+Spec: `specs/em-behavior.yaml` (EMB-15 group).
+Notes: `notes/embargo-lifecycle.md`, `notes/bt-fuzzer-nodes-embargo.md`.

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -1430,8 +1430,6 @@ groups:
     - description: >-
         Counter EP emitted via the existing proposal mechanism; no new
         counter-specific transition introduced
-    lint_suppress:
-    - testable_without_steps
     relationships:
     - rel_type: refines
       spec_id: EMB-15-001

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -5,7 +5,7 @@ description: >-
   is triggered by either a received EM message or a local EM state transition, and
   specifies typed preconditions, ordered steps, and postconditions that implementations
   must satisfy.
-version: 0.1.0
+version: 0.2.0
 tags:
 - behavioral
 - state-machine
@@ -1273,3 +1273,208 @@ groups:
     - rel_type: refines
       spec_id: EMB-14-002
       note: Override is the fallback arm of the policy authorization Selector
+
+- id: EMB-15
+  title: Inbound Embargo-Response Decision (Received Side)
+  description: >-
+    Behaviors triggered when an actor receives an inbound embargo overture and
+    must decide how to respond. Two overture flows are distinguished: (Flow A)
+    an EM-level embargo proposal (EP) proposing terms, whose acceptance moves
+    the shared EM state; and (Flow B) a PEC-level invitation
+    (InviteToEmbargoOnCase) asking the actor to become a signatory to an
+    embargo, whose acceptance advances that participant's Participant Embargo
+    Consent (PEC) state. The pre-PEC simulator conflated these into a single
+    _ChooseEmProposedResponse fallback; the production protocol separates the
+    shared EM lifecycle (EMB-01..EMB-09) from per-participant consent (CM-18,
+    ADR-0048). This group specifies a single decision seam layered over both
+    flows: it selects the response (accept / defer-to-owner / reject / counter)
+    while delegating the mechanical transition to the existing received and
+    trigger BTs. The mechanics already exist (invite/accept/reject trees,
+    propose/accept/reject trigger use cases); what is missing is the decision
+    layer that chooses among them, with a default-accept policy and a
+    plug-in seam for owner adjudication.
+  trigger:
+    type: message_received
+    value: EP | InviteToEmbargoOnCase
+  specs:
+  - id: EMB-15-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The inbound embargo-response decision seam MUST default to accepting a
+      well-formed embargo overture (Flow A: EP proposing terms; Flow B:
+      InviteToEmbargoOnCase). When no external adjudication backend is injected,
+      the EvaluateEmbargoProposal Evaluator call-out point MUST return SUCCESS
+      so the actor accepts by default, delegating to the existing acceptance
+      mechanism (accept_embargo_trigger_bt for Flow A;
+      accept_invite_to_embargo_tree for Flow B).
+    rationale: >-
+      The recommended CVD behavior is to accept an offered embargo and negotiate
+      revisions separately rather than block coordination. A deterministic
+      accept-by-default keeps actors runnable without a human in the loop, and
+      the DETERMINISTIC call-out bundle (BT-23) supplies the default. Structuring
+      acceptance as an Evaluator call-out point preserves the seam for later
+      owner/agent adjudication without changing the tree.
+    testable: true
+    preconditions:
+    - description: >-
+        Inbound EP or InviteToEmbargoOnCase received; case is embargo-eligible
+        (CS not public/exploit/attacks per EMB-01-002); no external
+        adjudication backend injected (deterministic default in force).
+    steps:
+    - order: 1
+      actor: system
+      action: Run EvaluateEmbargoProposal Evaluator call-out point
+      expected: Returns SUCCESS (default-accept) under the DETERMINISTIC bundle
+    - order: 2
+      actor: system
+      action: Delegate to the flow-appropriate acceptance BT
+      expected: >-
+        Flow A activates/records via accept_embargo_trigger_bt; Flow B advances
+        PEC to SIGNATORY via accept_invite_to_embargo_tree
+    postconditions:
+    - description: >-
+        Overture accepted by default; EM (Flow A) or PEC (Flow B) advanced by
+        the existing mechanism
+    relationships:
+    - rel_type: satisfies
+      spec_id: BT-18-004
+      note: Decision node accepts a CallOutBackendFactory; deterministic default
+    - rel_type: refines
+      spec_id: EMB-01-001
+      note: Adds the response-decision layer above EP receipt
+    - rel_type: refines
+      spec_id: CM-18-003
+      note: Flow B acceptance advances the PEC state machine (INVITED → SIGNATORY)
+
+  - id: EMB-15-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The decision seam MUST include a CASE_OWNER hard-bypass arm ahead of the
+      adjudication call-out point: when the deciding actor holds
+      CVDRole.CASE_OWNER, the owner's stated response is authoritative and the
+      seam MUST NOT require external approval. Non-owner actors (e.g. a CaseActor
+      processing an overture on the owner's behalf) MUST route through the
+      CaseOwnerApprovesEmbargoResponse call-out point, which defaults to SUCCESS
+      under the DETERMINISTIC bundle.
+    rationale: >-
+      This mirrors the two-seam authorization model (ADR-0046) and the
+      case_proposal_received_tree pattern: the CASE_OWNER is the human
+      decision-maker whose choice is gospel, while other actors need an
+      adjudication seam that a UI or LLM agent can later fulfil. The distinction
+      matters because a CaseActor may process an overture routed to it without
+      being the party whose consent is being recorded.
+    testable: true
+    preconditions:
+    - description: Inbound EP or InviteToEmbargoOnCase received by the deciding actor
+    steps:
+    - order: 1
+      actor: system
+      action: Run CheckIsCaseOwner guard (hard-bypass arm of the Selector)
+      expected: >-
+        SUCCESS when actor holds CASE_OWNER (owner's response is authoritative);
+        FAILURE otherwise, falling through to the adjudication call-out point
+    - order: 2
+      actor: system
+      action: >-
+        For non-owners, run CaseOwnerApprovesEmbargoResponse call-out point
+      expected: Returns SUCCESS (default) or FAILURE (adjudication withholds)
+    postconditions:
+    - description: >-
+        Owner responses proceed unconditionally; non-owner responses gated by
+        the adjudication seam
+    relationships:
+    - rel_type: satisfies
+      spec_id: BT-18-004
+    - rel_type: refines
+      spec_id: EMB-15-001
+
+  - id: EMB-15-003
+    priority: SHOULD
+    kind: protocol
+    statement: >-
+      For Flow A (EP proposing terms), the decision seam SHOULD provide a
+      counter-proposal arm gated by a WillingToCounterEmbargoProposal Evaluator
+      call-out point. Countering MUST NOT introduce a new mechanism: when the
+      arm is taken, the seam delegates to the existing embargo proposal trigger
+      (propose_embargo_trigger_bt via SvcProposeEmbargoUseCase), which emits a
+      fresh EP while the EM state remains PROPOSED. The default DETERMINISTIC
+      backend for this call-out point SHOULD return FAILURE (do not counter),
+      reflecting the recommended practice of accepting and revising rather than
+      countering.
+    rationale: >-
+      A counter-proposal is operationally identical to proposing: the propose
+      trigger already records a "counter-proposed, no state change" outcome when
+      invoked in PROPOSED. Modeling counter as routing to the existing trigger
+      avoids duplicate mechanism and keeps the EM lifecycle single-sourced.
+      Countering is intentionally low-automation and off by default; the
+      recommended path is accept-then-revise.
+    testable: true
+    preconditions:
+    - em_state:
+        - PROPOSED
+      description: >-
+        Flow A only; inbound EP received; actor declined to accept outright and
+        the adjudication arm elects to counter
+    steps:
+    - order: 1
+      actor: system
+      action: Run WillingToCounterEmbargoProposal Evaluator call-out point
+      expected: SUCCESS elects the counter arm; FAILURE (default) skips it
+    - order: 2
+      actor: actor
+      action: Delegate to propose_embargo_trigger_bt with new terms
+      expected: New EP emitted; EM remains PROPOSED (counter recorded)
+    postconditions:
+    - description: >-
+        Counter EP emitted via the existing proposal mechanism; no new
+        counter-specific transition introduced
+    lint_suppress:
+    - testable_without_steps
+    relationships:
+    - rel_type: refines
+      spec_id: EMB-15-001
+    - rel_type: satisfies
+      spec_id: EMB-01-001
+      note: Counter reuses the EP proposal path
+
+  - id: EMB-15-004
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When the decision resolves to reject, the seam MUST delegate to the
+      flow-appropriate existing rejection mechanism rather than duplicating the
+      transition: reject_embargo_trigger_bt (Flow A, emitting ER and returning
+      the shared EM to NONE per EMB-06) or reject_invite_to_embargo_tree
+      (Flow B, advancing that participant's PEC to DECLINED per CM-18-003). The
+      seam MUST also honor the mandatory rejection required by EMB-01-002 when
+      CS is public/exploit/attacks, independent of any adjudication outcome.
+    rationale: >-
+      Rejection paths are already implemented and carry the correct EM-vs-PEC
+      semantics. The decision layer selects among them; it must not re-implement
+      the transition. The pre-public constraint (EMB-01-002) is a hard protocol
+      rule that overrides the default-accept policy.
+    testable: true
+    preconditions:
+    - description: >-
+        Inbound overture received; decision resolves to reject, OR CS is
+        public/exploit/attacks forcing rejection (EMB-01-002)
+    steps:
+    - order: 1
+      actor: system
+      action: Select the flow-appropriate rejection BT
+      expected: >-
+        Flow A emits ER (EM → NONE); Flow B advances PEC to DECLINED
+    postconditions:
+    - description: Overture rejected via the existing mechanism with correct semantics
+    relationships:
+    - rel_type: refines
+      spec_id: EMB-06-001
+      note: Flow A rejection reuses the ER emission path
+    - rel_type: refines
+      spec_id: CM-18-003
+      note: Flow B rejection advances PEC to DECLINED
+    - rel_type: satisfies
+      spec_id: EMB-01-002
+      note: Mandatory rejection when public/exploit/attacks overrides default-accept


### PR DESCRIPTION
- Closes #1257

## Summary

Plans #1257 (`create_propose_embargo_decision_tree`) — but reframes it. Consistent with how the sibling embargo/report Ideas in epic #1285 resolved (#1256, #1253), the original "port the simulator's `_ProposeEmbargoBt` + `_ChooseEmProposedResponse` + `_ChooseEmActiveResponse` as one tick-loop factory" framing is a simulation-era artifact. This plan decomposes it by trigger event.

The genuinely-missing production behavior is the **inbound embargo-response decision seam**: when an actor receives an embargo overture, how does it decide to accept / defer-to-owner / reject / counter? The mechanical BTs already exist; the decision layer that chooses among them does not.

### The two-flow distinction (PEC-era)

The pre-PEC simulator conflated two now-distinct inbound overtures:

| | Flow A — EM proposal (EP) | Flow B — PEC invitation |
|---|---|---|
| Accept advances | shared EM (`None→Proposed→Active`) | participant PEC (`INVITED→SIGNATORY`) |
| Accept mechanism | `accept_embargo_trigger_bt` | `accept_invite_to_embargo_tree` |
| Status | decision layer missing | mechanics built, decision layer missing |

Per the planning interview, the seam is modeled over **both** flows: default-accept policy, CASE_OWNER gospel bypass + owner-approval call-out (reusing ADR-0046 / the `case_proposal_received_tree` pattern), counter = re-propose (no new mechanism). No new ADR — reuses ADR-0025 (call-out injection) + ADR-0046 (two-seam authorization).

## Changes

- **`specs/em-behavior.yaml`**: new `EMB-15` group (EMB-15-001..004) — default-accept (`EvaluateEmbargoProposal`), CASE_OWNER bypass + `CaseOwnerApprovesEmbargoResponse` call-out, counter-as-re-propose via existing trigger, delegate-to-existing reject mechanisms; EMB-01-002 (public/exploit/attacks) overrides default-accept. Version 0.1.0 → 0.2.0.
- **`notes/embargo-lifecycle.md`**: document the two-flow distinction, the default-accept + owner-adjudication design, and the "shortest-embargo-wins, then propose extensions" policy; record that active-review is monitoring (epic #1147), not built here.
- **`notes/bt-fuzzer-nodes-embargo.md`**: correct all 8 stale FUTURE placement entries that pointed at the monolithic `create_propose_embargo_decision_tree`, routing each node to its real home (received-response seam / outbound-propose seam / monitoring / simulator-only).

## Disposition

Started down the "decompose by trigger event" path with the explicit understanding we may conclude parts are fully overtaken. Outcome: the outbound-propose decision is already the propose trigger use case + `create_manage_embargo_tree` seams; the active-review loop is monitoring (companion Idea, epic #1147); the inbound-response decision is the real new behavior, tracked as an implementation Task.

## Implementation Issues

- #1942 — Task: Implement inbound embargo-response decision seam (EMB-15) [blocked-by #1257, child of epic #1285]
- #1943 — Idea: Active-embargo review monitoring (CurrentEmbargoAcceptable) [child of monitoring epic #1147]
