### PR TITLE
chore: add graphify-out to .gitignore; document hook setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ plan/data/
 # Board/project node-ID cache — auto-regenerated on first run, contains volatile timestamp
 .agents/skills/shared/board-ids.json
 .idea/
+
+# graphify knowledge graph output
+graphify-out/

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -64,3 +64,20 @@ docker-compose up docs
 Then browse to <http://localhost:8000>
 
 The "real" site lives at <https://certcc.github.io/Vultron/>
+
+## Set up local development hooks
+
+After cloning, install the git hooks used in this project:
+
+```shell
+# Code quality hooks (black, markdownlint, flake8, spec/ADR validators)
+pre-commit install
+
+# Knowledge graph hooks (rebuilds graphify-out/ after commits and branch switches)
+# Optional — requires graphify: pip install graphifyy
+graphify hook install
+```
+
+The graphify hooks run in the background and only fire when `graphify-out/` already
+exists (i.e., after you've run `/graphify .` at least once). They won't interfere
+with the pre-commit hooks or slow down your commits.


### PR DESCRIPTION
## Summary

- Adds `graphify-out/` to `.gitignore` so the knowledge graph build artifacts are never accidentally committed
- Documents the two-step hook setup (`pre-commit install` + `graphify hook install`) in `README-DEV.md` so new contributors know both hooks exist and how to install them

## Changes

- `.gitignore` — new entry for `graphify-out/`
- `README-DEV.md` — new *Set up local development hooks* section at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)