### PR TITLE
feat: add actor6 service to docker-compose + seed-actor6.yaml (FCVCV)

### DIFF
--- a/docker/docker-compose-multi-actor.yml
+++ b/docker/docker-compose-multi-actor.yml
@@ -1,7 +1,7 @@
 # Multi-Actor Vultron Demo — Docker Compose Configuration
 #
-# Defines five isolated actor services (finder, vendor, coordinator,
-# actor5, case-actor), each
+# Defines six isolated actor services (finder, vendor, coordinator,
+# actor5, actor6, case-actor), each
 # with its own DataLayer volume, health check, and network membership.
 #
 # DEMO-MA-02-001: Each actor service has a /health/ready healthcheck.
@@ -77,7 +77,7 @@
 # See docker/README.md for full usage instructions.
 
 # ── Shared actor-service template ─────────────────────────────────────────
-# All five actor services are built from the same Dockerfile target and share
+# All six actor services are built from the same Dockerfile target and share
 # the same health-check configuration.  Defining these once here and merging
 # them with <<: *actor-service avoids redundant image builds and keeps the
 # per-service stanzas focused on what actually differs (env, volumes, ports).
@@ -231,6 +231,32 @@ services:
       # Ephemeral host port → container 7999.  Set ACTOR5_HOST_PORT to pin.
       - "${ACTOR5_HOST_PORT:-0}:7999"
 
+  # ── Actor6 (VendorDeployer — FCVCV sixth actor slot) ─────────────────────
+  # Sixth actor container for the FCVCV scenario (DEMOMA-19-001).  Hosts V2
+  # (VendorDeployer), which holds both CVDRole.VENDOR and CVDRole.DEPLOYER and
+  # follows the full VFD fix path.  The neutral service name (actor6) avoids
+  # hard-coding a specific CVD role, consistent with the actor5 naming pattern.
+  actor6:
+    <<: *actor-service
+    environment:
+      - PYTHONPATH=/app
+      - VULTRON_SERVER__BASE_URL=http://actor6:7999/api/v2/
+      - VULTRON_DATABASE__DB_URL=sqlite:////app/data/mydb.sqlite
+      - VULTRON_ACTOR_ID=http://actor6:7999/api/v2/actors/vendor-deployer
+      - VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-actor6.yaml
+      - VULTRON_SERVER__LOG_LEVEL=${VULTRON_SERVER__LOG_LEVEL:-INFO}
+      # DEMOMA-19-001: actor6 hosts V2 (VendorDeployer) with both VENDOR and
+      # DEPLOYER roles so it can traverse the full VFD fix-deploy path.
+      - VULTRON_ACTOR__DEFAULT_CASE_ROLES=["vendor","deployer"]
+      # CP-08-003: actor6 self-hosts its CaseActors until #1700 is resolved.
+      - VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL=http://actor6:7999/api/v2
+    volumes:
+      - "../vultron:/app/vultron"
+      - actor6-data:/app/data
+    ports:
+      # Ephemeral host port → container 7999.  Set ACTOR6_HOST_PORT to pin.
+      - "${ACTOR6_HOST_PORT:-0}:7999"
+
   # ── Demo orchestration container ──────────────────────────────────────────
   # Runs the configured multi-actor acceptance workflow. The script resets
   # the participating containers to a clean baseline, seeds the required
@@ -256,6 +282,8 @@ services:
         condition: service_healthy
       actor5:
         condition: service_healthy
+      actor6:
+        condition: service_healthy
     environment:
       - PYTHONPATH=/app
       # Base URLs for each actor service, accessible via Docker network.
@@ -264,6 +292,7 @@ services:
       - VULTRON_COORDINATOR_BASE_URL=http://coordinator:7999/api/v2
       - VULTRON_CASE_ACTOR_BASE_URL=http://case-actor:7999/api/v2
       - VULTRON_VENDOR2_BASE_URL=http://actor5:7999/api/v2
+      - VULTRON_VENDOR_DEPLOYER_BASE_URL=http://actor6:7999/api/v2
       # Run the selected multi-actor demo non-interactively. Override DEMO
       # at runtime (for example, DEMO=fvv) to switch scenarios.
       - DEMO=${DEMO:-fv}
@@ -291,3 +320,4 @@ volumes:
   coordinator-data:
   case-actor-data:
   actor5-data:
+  actor6-data:

--- a/docker/seed-configs/seed-actor6.yaml
+++ b/docker/seed-configs/seed-actor6.yaml
@@ -1,0 +1,21 @@
+local_actor:
+  name: VendorDeployer
+  actor_type: Organization
+  id: http://actor6:7999/api/v2/actors/vendor-deployer
+
+peers:
+  - name: Finder
+    actor_type: Person
+    id: http://finder:7999/api/v2/actors/finder
+  - name: Vendor
+    actor_type: Organization
+    id: http://vendor:7999/api/v2/actors/vendor
+  - name: Coordinator
+    actor_type: Service
+    id: http://coordinator:7999/api/v2/actors/coordinator
+  - name: Coordinator2
+    actor_type: Service
+    id: http://actor5:7999/api/v2/actors/coordinator2
+  - name: CaseActor
+    actor_type: Service
+    id: http://case-actor:7999/api/v2/actors/case-actor

--- a/docker/service-colors.env
+++ b/docker/service-colors.env
@@ -21,4 +21,5 @@ vendor=#008F91
 coordinator=#C41230
 case-actor=#FDB515
 actor5=#043673
+actor6=#7B2D8B
 demo-runner=#E0E0E0

--- a/integration_tests/demo/run_multi_actor_integration_test.sh
+++ b/integration_tests/demo/run_multi_actor_integration_test.sh
@@ -29,6 +29,7 @@
 #   CASE_ACTOR_HOST_PORT  Pin a specific host port for the case-actor service.
 #   COORDINATOR_HOST_PORT Pin a specific host port for the coordinator service.
 #   ACTOR5_HOST_PORT      Pin a specific host port for the actor5 service.
+#   ACTOR6_HOST_PORT      Pin a specific host port for the actor6 service.
 #   COMPOSE_SERVICE_COLORS
 #                         Path to a service-colors.env file that maps service
 #                         names to hex colors (default: docker/service-colors.env).

--- a/plan/history/2608/implementation/ISSUE-1923.md
+++ b/plan/history/2608/implementation/ISSUE-1923.md
@@ -1,0 +1,20 @@
+---
+source: ISSUE-1923
+timestamp: '2026-08-03T20:04:12.256134+00:00'
+title: Add actor6 service to docker-compose + seed-actor6.yaml (FCVCV)
+type: implementation
+---
+
+## Issue #1923 — feat: add actor6 service to docker-compose + seed-actor6.yaml (FCVCV)
+
+Added the `actor6` container (VendorDeployer, V2) to the multi-actor Docker
+Compose stack for the FCVCV 5-party scenario (DEMOMA-19-001).
+
+Changes: actor6 service in docker-compose-multi-actor.yml using *actor-service
+anchor with VENDOR+DEPLOYER roles; seed-actor6.yaml with five peers (Finder,
+Vendor, Coordinator, Coordinator2/actor5, CaseActor); actor6 added to
+demo-runner depends_on and VULTRON_VENDOR_DEPLOYER_BASE_URL env var; actor6-data
+named volume; service-colors.env entry; ACTOR6_HOST_PORT in integration test
+usage doc; TestSeedActor6Config (8 tests).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1945>

--- a/test/demo/test_multi_actor_seed.py
+++ b/test/demo/test_multi_actor_seed.py
@@ -37,6 +37,8 @@ VENDOR_ID = "http://vendor:7999/api/v2/actors/vendor"
 COORDINATOR_ID = "http://coordinator:7999/api/v2/actors/coordinator"
 CASE_ACTOR_ID = "http://case-actor:7999/api/v2/actors/case-actor"
 VENDOR2_ID = "http://actor5:7999/api/v2/actors/vendor2"
+VENDOR_DEPLOYER_ID = "http://actor6:7999/api/v2/actors/vendor-deployer"
+COORDINATOR2_ID = "http://actor5:7999/api/v2/actors/coordinator2"
 
 # Path to the docker/seed-configs/ directory (relative to project root).
 _REPO_ROOT = Path(__file__).parents[2]
@@ -175,6 +177,52 @@ class TestSeedCaseActorConfig:
         assert VENDOR_ID in peer_ids
         assert COORDINATOR_ID in peer_ids
         assert VENDOR2_ID in peer_ids
+
+
+# ---------------------------------------------------------------------------
+# Tests for seed-actor6.yaml (FCVCV VendorDeployer — DEMOMA-19-001)
+# ---------------------------------------------------------------------------
+
+
+class TestSeedActor6Config:
+    def test_file_exists(self):
+        assert (_SEED_CONFIGS_DIR / "seed-actor6.yaml").exists()
+
+    def test_valid_seed_config_schema(self):
+        cfg = _load_seed_config("seed-actor6.yaml")
+        assert isinstance(cfg, SeedConfig)
+
+    def test_local_actor_id_is_deterministic(self):
+        cfg = _load_seed_config("seed-actor6.yaml")
+        assert cfg.local_actor.id_ == VENDOR_DEPLOYER_ID
+
+    def test_local_actor_type_is_organization(self):
+        cfg = _load_seed_config("seed-actor6.yaml")
+        assert cfg.local_actor.actor_type == "Organization"
+
+    def test_local_actor_name(self):
+        cfg = _load_seed_config("seed-actor6.yaml")
+        assert cfg.local_actor.name == "VendorDeployer"
+
+    def test_peers_include_finder_vendor_coordinator_coordinator2_case_actor(
+        self,
+    ):
+        cfg = _load_seed_config("seed-actor6.yaml")
+        peer_ids = {p.id_ for p in cfg.peers}
+        assert FINDER_ID in peer_ids
+        assert VENDOR_ID in peer_ids
+        assert COORDINATOR_ID in peer_ids
+        assert COORDINATOR2_ID in peer_ids
+        assert CASE_ACTOR_ID in peer_ids
+
+    def test_does_not_list_itself_as_peer(self):
+        cfg = _load_seed_config("seed-actor6.yaml")
+        peer_ids = {p.id_ for p in cfg.peers}
+        assert VENDOR_DEPLOYER_ID not in peer_ids
+
+    def test_has_exactly_five_peers(self):
+        cfg = _load_seed_config("seed-actor6.yaml")
+        assert len(cfg.peers) == 5, f"expected 5 peers, got {len(cfg.peers)}"
 
 
 # ---------------------------------------------------------------------------

--- a/test/demo/test_multi_actor_seed.py
+++ b/test/demo/test_multi_actor_seed.py
@@ -231,9 +231,15 @@ class TestSeedActor6Config:
 
 
 class TestSeedConfigCrossConsistency:
-    """All five configs must describe a consistent peer mesh."""
+    """All five original configs must describe a consistent peer mesh.
+
+    actor6 (seed-actor6.yaml) is excluded here: it has 5 peers (not 4) and the
+    other five actors do not yet list actor6 as a peer — that cross-registration
+    is deferred to DEMOMA-19-002 (seed_containers_fcvcv function).
+    """
 
     def test_all_configs_load_successfully(self):
+        # actor6 excluded — see class docstring (DEMOMA-19-002 pending)
         for filename in (
             "seed-finder.yaml",
             "seed-vendor.yaml",
@@ -408,3 +414,23 @@ class TestSeedCLIWithDeterministicId:
                 f"{filename}: expected 5 seed_actor calls "
                 f"(1 local + 4 peers), got {len(calls)}"
             )
+
+    def test_vendor_deployer_seed_uses_deterministic_id(self):
+        config_path = _SEED_CONFIGS_DIR / "seed-actor6.yaml"
+        calls, exit_code = self._run_seed_with_config(config_path)
+        assert exit_code == 0
+        local_call = next(
+            (c for c in calls if c["name"] == "VendorDeployer"), None
+        )
+        assert local_call is not None
+        assert local_call["actor_id"] == VENDOR_DEPLOYER_ID
+
+    def test_actor6_seed_call_count_is_six(self):
+        """actor6 has 5 peers (not 4), so CLI must make 6 seed_actor calls."""
+        config_path = _SEED_CONFIGS_DIR / "seed-actor6.yaml"
+        calls, exit_code = self._run_seed_with_config(config_path)
+        assert exit_code == 0
+        assert len(calls) == 6, (
+            f"seed-actor6.yaml: expected 6 seed_actor calls "
+            f"(1 local + 5 peers), got {len(calls)}"
+        )


### PR DESCRIPTION
- Closes #1923

## Summary

Adds the `actor6` container (VendorDeployer, V2) to the multi-actor Docker Compose stack for the FCVCV 5-party scenario (DEMOMA-19-001).

### Changes

- **`docker/docker-compose-multi-actor.yml`**: Add `actor6` service using the `*actor-service` anchor with `VULTRON_ACTOR_ID=http://actor6:7999/api/v2/actors/vendor-deployer`, `VULTRON_ACTOR__DEFAULT_CASE_ROLES=["vendor","deployer"]`, and `VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-actor6.yaml`. Update `demo-runner` to depend on `actor6` and expose `VULTRON_VENDOR_DEPLOYER_BASE_URL`. Add `actor6-data` named volume.
- **`docker/seed-configs/seed-actor6.yaml`**: New seed config for VendorDeployer (actor6) with five peers: Finder, Vendor, Coordinator, Coordinator2 (actor5 in FCVCV), CaseActor.
- **`docker/service-colors.env`**: Add `actor6=#7B2D8B` for colored log output.
- **`integration_tests/demo/run_multi_actor_integration_test.sh`**: Document `ACTOR6_HOST_PORT` in usage block.
- **`test/demo/test_multi_actor_seed.py`**: Add `TestSeedActor6Config` (8 tests) validating seed-actor6.yaml schema, actor ID, type, name, peers, and self-exclusion.

### Notes

- `seed-actor6.yaml` lists actor5 as `Coordinator2` (`http://actor5:7999/api/v2/actors/coordinator2`) because actor5 serves as C2 in the FCVCV scenario.
- The static seed files for the other five actors (finder, vendor, coordinator, actor5, case-actor) are **not** updated to include VendorDeployer as a peer. DEMOMA-19-002 specifies that FCVCV uses a programmatic `seed_containers_fcvcv` function (not static YAML) for cross-registration — that work is tracked by the next FCVCV sub-issue.

## Test plan

- [x] All 6012 tests pass (40 new/existing seed config tests pass with `-m ""`).
- [x] `seed-actor6.yaml` validates as `SeedConfig` and contains all five expected peers.
- [x] linters clean: black, flake8, mypy, pyright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)