### PR TITLE
feat: add seed_containers_fcvcv to seeding.py (FCVCV)

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1924.md
+++ b/plan/history/2608/implementation/ISSUE-1924.md
@@ -1,0 +1,21 @@
+---
+source: ISSUE-1924
+timestamp: '2026-08-03T20:07:35.977534+00:00'
+title: 'feat: add seed_containers_fcvcv (FCVCV)'
+type: implementation
+---
+
+## Issue #1924 — feat: add seed_containers_fcvcv to seeding.py (FCVCV)
+
+Added `seed_containers_fcvcv` to `vultron/demo/helpers/seeding.py` for the
+5-actor FCVCV scenario (DEMOMA-19-002). The function accepts five
+`DataLayerClient` args plus five optional deterministic actor ID args, creates
+Finder (Person) and four Organization actors (Coordinator1, Vendor1,
+Coordinator2, VendorDeployer) in Phase 1, then performs 20 cross-registrations
+in Phase 2. Idempotent, matching the pattern of all prior seed functions.
+
+Six integration tests added in `test/demo/test_seed_containers_fcvcv.py`
+covering tuple shape, actor names, IDs, peer mesh, deterministic IDs, and
+idempotency. Full suite: 6012 passed, 0 new failures.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1946>

--- a/test/demo/test_seed_containers_fcvcv.py
+++ b/test/demo/test_seed_containers_fcvcv.py
@@ -1,0 +1,143 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for seed_containers_fcvcv (DEMOMA-19-002)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from test.demo._helpers import make_client, make_testclient_call
+from vultron.demo.helpers.seeding import seed_containers_fcvcv
+
+
+@pytest.fixture(scope="module")
+def base(client: TestClient) -> str:
+    return str(client.base_url).rstrip("/") + "/api/v2"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def patch_datalayer_call(client: TestClient, base: str):
+    from _pytest.monkeypatch import MonkeyPatch
+    from vultron.demo.utils import DataLayerClient
+
+    mp = MonkeyPatch()
+    try:
+        mp.setattr(DataLayerClient, "call", make_testclient_call(client, base))
+        yield
+    finally:
+        mp.undo()
+
+
+class TestSeedContainersFcvcv:
+    """seed_containers_fcvcv creates five actors and 20 cross-registrations."""
+
+    def test_returns_five_actors(self, base: str):
+        result = seed_containers_fcvcv(
+            finder_client=make_client(base),
+            c1_client=make_client(base),
+            v1_client=make_client(base),
+            c2_client=make_client(base),
+            v2_client=make_client(base),
+        )
+        assert len(result) == 5
+
+    def test_actor_names_and_types(self, base: str):
+        finder, c1, v1, c2, v2 = seed_containers_fcvcv(
+            finder_client=make_client(base),
+            c1_client=make_client(base),
+            v1_client=make_client(base),
+            c2_client=make_client(base),
+            v2_client=make_client(base),
+        )
+        assert finder.name == "Finder"
+        assert c1.name == "Coordinator1"
+        assert v1.name == "Vendor1"
+        assert c2.name == "Coordinator2"
+        assert v2.name == "VendorDeployer"
+
+    def test_all_actors_have_ids(self, base: str):
+        finder, c1, v1, c2, v2 = seed_containers_fcvcv(
+            finder_client=make_client(base),
+            c1_client=make_client(base),
+            v1_client=make_client(base),
+            c2_client=make_client(base),
+            v2_client=make_client(base),
+        )
+        for actor in (finder, c1, v1, c2, v2):
+            assert actor.id_ is not None
+
+    def test_finder_container_knows_all_peers(self, base: str):
+        finder_client = make_client(base)
+        seed_containers_fcvcv(
+            finder_client=finder_client,
+            c1_client=make_client(base),
+            v1_client=make_client(base),
+            c2_client=make_client(base),
+            v2_client=make_client(base),
+        )
+        actors = finder_client.get("/actors/")
+        names = {a.get("name") for a in actors if isinstance(a, dict)}
+        assert "Finder" in names
+        assert "Coordinator1" in names
+        assert "Vendor1" in names
+        assert "Coordinator2" in names
+        assert "VendorDeployer" in names
+
+    def test_deterministic_ids_are_honored(self, base: str):
+        finder_id = f"{base}/actors/finder-fcvcv-det"
+        c1_id = f"{base}/actors/c1-fcvcv-det"
+        v1_id = f"{base}/actors/v1-fcvcv-det"
+        c2_id = f"{base}/actors/c2-fcvcv-det"
+        v2_id = f"{base}/actors/v2-fcvcv-det"
+
+        finder, c1, v1, c2, v2 = seed_containers_fcvcv(
+            finder_client=make_client(base),
+            c1_client=make_client(base),
+            v1_client=make_client(base),
+            c2_client=make_client(base),
+            v2_client=make_client(base),
+            reporter_actor_id=finder_id,
+            c1_actor_id=c1_id,
+            v1_actor_id=v1_id,
+            c2_actor_id=c2_id,
+            v2_actor_id=v2_id,
+        )
+
+        assert finder.id_ == finder_id
+        assert c1.id_ == c1_id
+        assert v1.id_ == v1_id
+        assert c2.id_ == c2_id
+        assert v2.id_ == v2_id
+
+    def test_idempotent_second_call_succeeds(self, base: str):
+        finder_id = f"{base}/actors/finder-idem"
+        c1_id = f"{base}/actors/c1-idem"
+        v1_id = f"{base}/actors/v1-idem"
+        c2_id = f"{base}/actors/c2-idem"
+        v2_id = f"{base}/actors/v2-idem"
+        shared_kwargs = dict(
+            finder_client=make_client(base),
+            c1_client=make_client(base),
+            v1_client=make_client(base),
+            c2_client=make_client(base),
+            v2_client=make_client(base),
+            reporter_actor_id=finder_id,
+            c1_actor_id=c1_id,
+            v1_actor_id=v1_id,
+            c2_actor_id=c2_id,
+            v2_actor_id=v2_id,
+        )
+        first = seed_containers_fcvcv(**shared_kwargs)  # type: ignore[arg-type]
+        second = seed_containers_fcvcv(**shared_kwargs)  # type: ignore[arg-type]
+        for a, b in zip(first, second):
+            assert a.id_ == b.id_

--- a/test/demo/test_seed_containers_fcvcv.py
+++ b/test/demo/test_seed_containers_fcvcv.py
@@ -76,22 +76,38 @@ class TestSeedContainersFcvcv:
         for actor in (finder, c1, v1, c2, v2):
             assert actor.id_ is not None
 
-    def test_finder_container_knows_all_peers(self, base: str):
+    def test_all_containers_know_all_peers(self, base: str):
         finder_client = make_client(base)
+        c1_client = make_client(base)
+        v1_client = make_client(base)
+        c2_client = make_client(base)
+        v2_client = make_client(base)
         seed_containers_fcvcv(
             finder_client=finder_client,
-            c1_client=make_client(base),
-            v1_client=make_client(base),
-            c2_client=make_client(base),
-            v2_client=make_client(base),
+            c1_client=c1_client,
+            v1_client=v1_client,
+            c2_client=c2_client,
+            v2_client=v2_client,
         )
-        actors = finder_client.get("/actors/")
-        names = {a.get("name") for a in actors if isinstance(a, dict)}
-        assert "Finder" in names
-        assert "Coordinator1" in names
-        assert "Vendor1" in names
-        assert "Coordinator2" in names
-        assert "VendorDeployer" in names
+        expected_names = {
+            "Finder",
+            "Coordinator1",
+            "Vendor1",
+            "Coordinator2",
+            "VendorDeployer",
+        }
+        for label, client in [
+            ("finder", finder_client),
+            ("c1", c1_client),
+            ("v1", v1_client),
+            ("c2", c2_client),
+            ("v2", v2_client),
+        ]:
+            actors = client.get_list("/actors/")
+            names = {a.get("name") for a in actors if isinstance(a, dict)}
+            assert (
+                expected_names <= names
+            ), f"{label} container missing peers: {expected_names - names}"
 
     def test_deterministic_ids_are_honored(self, base: str):
         finder_id = f"{base}/actors/finder-fcvcv-det"

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -27,7 +27,9 @@ Sub-modules
 - :mod:`~vultron.demo.helpers.runner` — ``run_exchange_demos`` and
   ``check_all_containers``.
 - :mod:`~vultron.demo.helpers.seeding` — ``_dl_key``, ``get_actor_by_id``,
-  ``seed_containers``, ``seed_containers_fvv``, and ``reset_containers``.
+  ``seed_containers``, ``seed_containers_fvv``, ``seed_containers_fccv``,
+  ``seed_containers_fcv``, ``seed_containers_fcvcv``, and
+  ``reset_containers``.
 - :mod:`~vultron.demo.helpers.sync` — SYNC-2 ``trigger_log_commit`` and
   ``verify_replica_state``.
 - :mod:`~vultron.demo.helpers.verification` — lower-level participant and
@@ -86,6 +88,9 @@ from vultron.demo.helpers.seeding import (  # noqa: F401
     get_actor_by_id,
     reset_containers,
     seed_containers,
+    seed_containers_fccv,
+    seed_containers_fcv,
+    seed_containers_fcvcv,
     seed_containers_fvv,
 )
 from vultron.demo.helpers.sync import (  # noqa: F401

--- a/vultron/demo/helpers/seeding.py
+++ b/vultron/demo/helpers/seeding.py
@@ -682,6 +682,229 @@ def seed_containers_fcv(
     return finder, coordinator, vendor
 
 
+def seed_containers_fcvcv(
+    finder_client: DataLayerClient,
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    reporter_actor_id: str | None = None,
+    c1_actor_id: str | None = None,
+    v1_actor_id: str | None = None,
+    c2_actor_id: str | None = None,
+    v2_actor_id: str | None = None,
+) -> tuple[as_Actor, as_Actor, as_Actor, as_Actor, as_Actor]:
+    """Seed five containers for the FCVCV scenario.
+
+    Containers: Finder (Person), Coordinator1 (Organization), Vendor1
+    (Organization), Coordinator2 (Organization), VendorDeployer (Organization).
+
+    The seeding is done in two phases:
+
+    1. Create the local actor on each container independently.
+    2. Register every actor as a known peer on the other four containers
+       (N×(N-1) = 20 cross-registrations total).
+
+    This function is idempotent: re-running it returns existing actors
+    unchanged (the ``POST /actors/`` endpoint is idempotent).
+
+    Args:
+        finder_client: DataLayerClient connected to the Finder container.
+        c1_client: DataLayerClient connected to the Coordinator1 container.
+        v1_client: DataLayerClient connected to the Vendor1 container.
+        c2_client: DataLayerClient connected to the Coordinator2 container.
+        v2_client: DataLayerClient connected to the VendorDeployer container.
+        reporter_actor_id: Optional deterministic URI for the Finder actor.
+        c1_actor_id: Optional deterministic URI for the Coordinator1 actor.
+        v1_actor_id: Optional deterministic URI for the Vendor1 actor.
+        c2_actor_id: Optional deterministic URI for the Coordinator2 actor.
+        v2_actor_id: Optional deterministic URI for the VendorDeployer actor.
+
+    Returns:
+        Tuple of ``(finder, c1, v1, c2, v2)`` ``as_Actor`` objects as
+        created on their respective containers.
+    """
+    logger.info("Phase 1: creating local actors on each container...")
+    finder = seed_actor(
+        client=finder_client,
+        name="Finder",
+        actor_type="Person",
+        actor_id=reporter_actor_id,
+    )
+    logger.info("Finder actor seeded: %s", finder.id_)
+
+    c1 = seed_actor(
+        client=c1_client,
+        name="Coordinator1",
+        actor_type="Organization",
+        actor_id=c1_actor_id,
+    )
+    logger.info("C1 actor seeded: %s", c1.id_)
+
+    v1 = seed_actor(
+        client=v1_client,
+        name="Vendor1",
+        actor_type="Organization",
+        actor_id=v1_actor_id,
+    )
+    logger.info("V1 actor seeded: %s", v1.id_)
+
+    c2 = seed_actor(
+        client=c2_client,
+        name="Coordinator2",
+        actor_type="Organization",
+        actor_id=c2_actor_id,
+    )
+    logger.info("C2 actor seeded: %s", c2.id_)
+
+    v2 = seed_actor(
+        client=v2_client,
+        name="VendorDeployer",
+        actor_type="Organization",
+        actor_id=v2_actor_id,
+    )
+    logger.info("V2 actor seeded: %s", v2.id_)
+
+    logger.info("Phase 2: registering cross-container peers...")
+
+    # Register C1, V1, C2, and V2 as peers on Finder's container.
+    seed_actor(
+        client=finder_client,
+        name="Coordinator1",
+        actor_type="Organization",
+        actor_id=c1.id_,
+    )
+    seed_actor(
+        client=finder_client,
+        name="Vendor1",
+        actor_type="Organization",
+        actor_id=v1.id_,
+    )
+    seed_actor(
+        client=finder_client,
+        name="Coordinator2",
+        actor_type="Organization",
+        actor_id=c2.id_,
+    )
+    seed_actor(
+        client=finder_client,
+        name="VendorDeployer",
+        actor_type="Organization",
+        actor_id=v2.id_,
+    )
+    logger.info("C1, V1, C2, and V2 registered as peers on Finder container")
+
+    # Register Finder, V1, C2, and V2 as peers on C1's container.
+    seed_actor(
+        client=c1_client,
+        name="Finder",
+        actor_type="Person",
+        actor_id=finder.id_,
+    )
+    seed_actor(
+        client=c1_client,
+        name="Vendor1",
+        actor_type="Organization",
+        actor_id=v1.id_,
+    )
+    seed_actor(
+        client=c1_client,
+        name="Coordinator2",
+        actor_type="Organization",
+        actor_id=c2.id_,
+    )
+    seed_actor(
+        client=c1_client,
+        name="VendorDeployer",
+        actor_type="Organization",
+        actor_id=v2.id_,
+    )
+    logger.info("Finder, V1, C2, and V2 registered as peers on C1 container")
+
+    # Register Finder, C1, C2, and V2 as peers on V1's container.
+    seed_actor(
+        client=v1_client,
+        name="Finder",
+        actor_type="Person",
+        actor_id=finder.id_,
+    )
+    seed_actor(
+        client=v1_client,
+        name="Coordinator1",
+        actor_type="Organization",
+        actor_id=c1.id_,
+    )
+    seed_actor(
+        client=v1_client,
+        name="Coordinator2",
+        actor_type="Organization",
+        actor_id=c2.id_,
+    )
+    seed_actor(
+        client=v1_client,
+        name="VendorDeployer",
+        actor_type="Organization",
+        actor_id=v2.id_,
+    )
+    logger.info("Finder, C1, C2, and V2 registered as peers on V1 container")
+
+    # Register Finder, C1, V1, and V2 as peers on C2's container.
+    seed_actor(
+        client=c2_client,
+        name="Finder",
+        actor_type="Person",
+        actor_id=finder.id_,
+    )
+    seed_actor(
+        client=c2_client,
+        name="Coordinator1",
+        actor_type="Organization",
+        actor_id=c1.id_,
+    )
+    seed_actor(
+        client=c2_client,
+        name="Vendor1",
+        actor_type="Organization",
+        actor_id=v1.id_,
+    )
+    seed_actor(
+        client=c2_client,
+        name="VendorDeployer",
+        actor_type="Organization",
+        actor_id=v2.id_,
+    )
+    logger.info("Finder, C1, V1, and V2 registered as peers on C2 container")
+
+    # Register Finder, C1, V1, and C2 as peers on V2's container.
+    seed_actor(
+        client=v2_client,
+        name="Finder",
+        actor_type="Person",
+        actor_id=finder.id_,
+    )
+    seed_actor(
+        client=v2_client,
+        name="Coordinator1",
+        actor_type="Organization",
+        actor_id=c1.id_,
+    )
+    seed_actor(
+        client=v2_client,
+        name="Vendor1",
+        actor_type="Organization",
+        actor_id=v1.id_,
+    )
+    seed_actor(
+        client=v2_client,
+        name="Coordinator2",
+        actor_type="Organization",
+        actor_id=c2.id_,
+    )
+    logger.info("Finder, C1, V1, and C2 registered as peers on V2 container")
+
+    return finder, c1, v1, c2, v2
+
+
 def reset_containers(
     labeled_clients: Sequence[tuple[str, DataLayerClient]],
     reset_fn: Callable[..., Any],


### PR DESCRIPTION
- Closes #1924

## Summary

Implements `seed_containers_fcvcv` in `vultron/demo/helpers/seeding.py` for
the FCVCV 5-actor scenario (DEMOMA-19-002).

### What changed

- **`vultron/demo/helpers/seeding.py`** — added `seed_containers_fcvcv`
  accepting five `DataLayerClient` args and five optional deterministic actor
  ID args; creates Finder (Person), Coordinator1, Vendor1, Coordinator2,
  VendorDeployer (all Organization) in Phase 1 then performs all N×(N-1)=20
  cross-registrations in Phase 2; idempotent per established pattern.
- **`test/demo/test_seed_containers_fcvcv.py`** — six integration tests covering
  return tuple shape, actor names, actor IDs, peer mesh on Finder container,
  deterministic IDs, and idempotency.

### Acceptance criteria

- AC-2a ✅ Five `DataLayerClient` args + five optional `str | None` ID args
- AC-2b ✅ Finder (Person), Coordinator1/Vendor1/Coordinator2/VendorDeployer (Organization)
- AC-2c ✅ 20 cross-registrations (N×(N-1) pattern)
- AC-2d ✅ Idempotent — test confirms second call returns same IDs

## Verification

- `uv run pytest test/demo/test_seed_containers_fcvcv.py -m ""` → 6 passed
- `uv run pytest --tb=short` → 6012 passed, 0 new failures
- `uv run black`, `uv run flake8`, `uv run mypy`, `uv run pyright` → all clean