### PR TITLE
feat(skills): integrate graphify into orient-agent and deepen-context

### DIFF
--- a/.agents/skills/deepen-context/SKILL.md
+++ b/.agents/skills/deepen-context/SKILL.md
@@ -83,9 +83,21 @@ Read from `docs/reference/codebase/` based on task scope:
 
 ### Step 4 — Scan the codebase
 
-Search `vultron/` and `test/` to verify assumptions about what is currently
-implemented. Do not assert missing functionality without evidence from code
-search.
+If `graphify-out/graph.json` exists, use the graph as the primary search tool:
+
+- `graphify query "<focus hint or concept>"` — broad orientation: which files,
+  communities, and nodes are relevant to this area
+- `graphify path "<ConceptA>" "<ConceptB>"` — trace the connection between two
+  concepts when the task spans a seam (e.g. wire layer → BT integration)
+- `graphify explain "<ClassName or function>"` — plain-language summary of a
+  specific node before reading its source
+
+After graph traversal, read raw source files only for lines you need to
+verify or modify — the graph gives you the map; file reads give you the exact
+text. Do not grep blindly when `graphify query` will orient you first.
+
+If no graph exists, fall back to searching `vultron/` and `test/` directly.
+Do not assert missing functionality without evidence from code search.
 
 ## Notes
 

--- a/.agents/skills/orient-agent/SKILL.md
+++ b/.agents/skills/orient-agent/SKILL.md
@@ -14,6 +14,15 @@ description: >
 
 ## Procedure
 
+### Step 0 — Graph orientation (if graph exists)
+
+Check whether `graphify-out/GRAPH_REPORT.md` exists. If it does, read it now.
+It contains god nodes (highest-connectivity files), surprising cross-community
+connections, and community labels — the structural map of the codebase. This
+primes the agent with topology context before reading docs or selecting an issue.
+
+Skip this step silently if the file is absent.
+
 ### Step 1 — Read the ubiquitous language glossary
 
 Read `docs/reference/glossary.md`.
@@ -41,5 +50,16 @@ Read all files in `plan/incoming/learnings/`. Do not read `plan/history/`.
 ```bash
 bash .agents/skills/shared/query-now-epics.sh
 ```
+
+If `graphify-out/graph.json` exists, run a graph query for each Now-priority
+item returned. Use the issue title or affected area as the question:
+
+```bash
+graphify query "<issue title or affected area>"
+```
+
+This surfaces which graph communities each priority touches and identifies any
+god nodes or surprising connections in the blast radius. Run at most one query
+per Now-priority item; skip if there are no Now items.
 
 Do not skip this skill even for small tasks. After orient-agent, invoke `deepen-context` with task-specific hints once the target issue is known.


### PR DESCRIPTION
## Summary

- **orient-agent Step 0**: read `graphify-out/GRAPH_REPORT.md` if present before loading any other context — primes the agent with god nodes, community labels, and surprising cross-community connections (structural map of the codebase)
- **orient-agent Step 5**: after fetching Now-priority issues, run `graphify query` per item to map each priority's blast radius to graph communities and high-risk nodes
- **deepen-context Step 4**: replace blind grep with `graphify query`/`path`/`explain` as the primary codebase search tool; fall back to raw file search only when no graph exists

## Motivation

`orient-agent` loaded docs and specs but had no structural sense of codebase topology. `deepen-context` scanned files without any graph orientation. These changes make both skills graph-aware when `graphify-out/graph.json` is present, with silent no-ops when it isn't — so the skills degrade gracefully on repos without a built graph.

## Test plan

- [ ] Run `/orient-agent` with `graphify-out/GRAPH_REPORT.md` present — confirm Step 0 reads it
- [ ] Run `/orient-agent` without the file — confirm Step 0 is silently skipped
- [ ] Run `/deepen-context` on a task — confirm `graphify query` is used before raw file reads
- [ ] Run `/build` end-to-end — confirm no regressions in the orient → deepen → implement flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)