### PR TITLE
docs: plan issue #1826 — create_deploy_mitigation_tree factory

### DIFF
--- a/notes/bt-fuzzer-rm-fix.md
+++ b/notes/bt-fuzzer-rm-fix.md
@@ -272,3 +272,81 @@ the process of deploying a developed fix or mitigation to affected systems.
   Sequence context and removed `deploy_mitigation_factory` from the bundle.
 
 ---
+
+## Production Collapse: Mitigation Deployment Subtree → `create_deploy_mitigation_tree`
+
+**Simulator nodes involved**: `MitigationDeployed`, `MitigationAvailable`,
+`DeployMitigation` (all in
+`vultron/demo/fuzzer/report_management/deploy_fix.py`)
+
+**Planning issue**: #1826 (peer Idea to #1248)
+
+**Spec**: `specs/behavior-tree-integration.yaml` BT-20-005
+
+### Structural difference from `create_deploy_fix_tree`
+
+The fix deployment tree persists a CS state transition (`VFD` d→D) and emits
+a `CD` protocol message (`EmitCDActivity`). The mitigation tree does **not**:
+mitigation deployment is tracked externally (CMDB, case record, or asset
+inventory) and the 29-message Vultron protocol has no dedicated
+mitigation-deployed message type. The short-circuit guard (`MitigationDeployed`)
+and the availability gate (`MitigationAvailable`) are therefore call-out
+Retrievers, not `DataLayerCondition` nodes reading a CS state bit.
+
+A follow-on Idea under epic #1935 (Protocol authority & lifecycle semantics)
+tracks the open question of whether a dedicated mitigation-deployed message
+type should be added to the protocol.
+
+### Production tree shape
+
+```text
+DeployMitigationBT (Fallback)
+├─ <MitigationDeployed>                    # Retriever call-out — short-circuit
+├─ _ShouldStayInRmDeferred (Sequence)
+│  ├─ RMinStateDeferred                    # reused from deploy_fix nodes
+│  └─ CheckNoNewDeploymentInfoNode         # reused from deploy_fix nodes
+├─ _DeployMitigationIfAvailable (Sequence)
+│  ├─ CheckDeployerRoleNode                # reused from vfd_role_guards
+│  ├─ CheckRMStateAccepted                 # reused from develop_fix nodes
+│  ├─ <MitigationAvailable>               # Retriever call-out — availability gate
+│  ├─ <PrioritizeDeployment>              # Evaluator call-out (shared seam)
+│  └─ <DeployMitigation>                  # Evaluator call-out
+└─ _MonitorDeploymentIfDesired (Sequence)
+   ├─ <MonitoringRequirement>             # Evaluator call-out (shared seam)
+   └─ <MonitorDeployment>                # Actuator call-out (shared seam)
+```
+
+No `TransitionCS` or `EmitActivity` nodes — mitigation has no CS state bit
+and no protocol message counterpart.
+
+### Bundle structure
+
+`DeploymentMonitoringBundle` (shared base,
+`vultron/core/behaviors/call_out/bundles/deploy_monitoring.py`):
+
+- `prioritize_deployment_factory` — Evaluator (p=0.90 → AlwaysSucceed)
+- `monitoring_requirement_factory` — Evaluator (p=0.70 → AlwaysSucceed)
+- `monitor_deployment_factory` — Actuator (p=1.00 → AlwaysSucceed)
+
+`DeployFixCallOutBundle(DeploymentMonitoringBundle)` — adds:
+
+- `deploy_fix_factory` — Evaluator (p=0.10 → AlwaysFail)
+
+`DeployMitigationCallOutBundle(DeploymentMonitoringBundle)` — adds:
+
+- `mitigation_deployed_factory` — Retriever (p=0.25 → AlwaysFail)
+- `mitigation_available_factory` — Retriever (p=0.70 → AlwaysSucceed)
+- `deploy_mitigation_factory` — Evaluator (p=0.75 → AlwaysSucceed)
+
+### Combinator tree
+
+`create_deploy_tree()` in `vultron/core/behaviors/report/deploy_tree.py`
+composes the overarching deployment decision:
+
+```text
+DeployOrMitigateBT (Fallback)
+├─ create_deploy_fix_tree(...)      # fix arm — preferred
+└─ create_deploy_mitigation_tree(...)  # mitigation arm — fallback
+```
+
+---

--- a/plan/history/2608/idea/IDEA-1826.md
+++ b/plan/history/2608/idea/IDEA-1826.md
@@ -1,0 +1,48 @@
+---
+source: IDEA-1826
+timestamp: '2026-08-03T20:47:25.583560+00:00'
+title: 'create_deploy_mitigation_tree: factory function for mitigation deployment
+  BT'
+type: idea
+---
+
+## Summary
+
+Create a `create_deploy_mitigation_tree` factory function in
+`vultron/core/behaviors/report/` that composes the mitigation deployment
+workflow as a production BT subtree, peer to `create_deploy_fix_tree` (#1248).
+
+The overall intent is that an overarching tree constructs the deploy logic as:
+"if fix available, deploy fix; else if mitigation available, deploy mitigation".
+This Idea captures the mitigation branch of that logic as a distinct tree,
+keeping the fix-deploy and mitigation-deploy concerns separate.
+
+## Context
+
+This Idea was scoped out of `create_deploy_fix_tree` (#1248) during planning.
+The Phase 1 stub for deploy_fix (PR #1357) included `deploy_mitigation_factory`,
+`MitigationDeployed`, and `MitigationAvailable` — these belong in a distinct
+mitigation deployment tree, not the fix deployment tree.
+
+Relevant simulation nodes from `vultron/bt/report_management/_behaviors/deploy_fix.py`:
+
+- `MitigationDeployed` (Retriever shape, p=0.25) — early-exit check
+- `MitigationAvailable` (Retriever shape, p=0.70) — gate before deployment
+- `DeployMitigation` (Evaluator shape, p=0.75) — primary mitigation deployment action
+
+## Acceptance Criteria (TBD in planning)
+
+- `create_deploy_mitigation_tree` factory in `vultron/core/behaviors/report/`
+- `DeployMitigationCallOutBundle` with appropriate factory seams per ADR-0025
+- Guard nodes: deployer role check, CS state check, mitigation availability check
+- Unit tests for tree structure and call-out injection
+- Notes updated in `notes/bt-fuzzer-rm-fix.md`
+
+## Reference
+
+Peer Idea: #1248 (create_deploy_fix_tree)
+Parent epic: #1285
+
+**Processed**: 2026-08-03 — implementation tracked in #1953, #1954, #1956.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1952>.
+Notes: `notes/bt-fuzzer-rm-fix.md`.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -737,6 +737,56 @@ groups:
     adr:
     - ADR-0024
     - ADR-0030
+  - id: BT-20-005
+    priority: SHOULD
+    kind: project
+    statement: >
+      The production `create_deploy_mitigation_tree` factory SHOULD implement
+      a `DeployMitigationBT` Fallback tree with four arms: (1) a
+      `MitigationDeployed` Retriever call-out for short-circuit success when
+      a mitigation is already active; (2) a `_ShouldStayInRmDeferred` Sequence
+      reusing `RMinStateDeferred` and `CheckNoNewDeploymentInfoNode` from the
+      fix deployment tree; (3) a `_DeployMitigationIfAvailable` Sequence with
+      `CheckDeployerRoleNode`, `CheckRMStateAccepted`, a `MitigationAvailable`
+      Retriever call-out, a `PrioritizeDeployment` Evaluator call-out, and a
+      `DeployMitigation` Evaluator call-out; and (4) a
+      `_MonitorDeploymentIfDesired` Sequence reusing `MonitoringRequirement`
+      and `MonitorDeployment` call-outs from the fix deployment tree. The tree
+      MUST NOT include a CS state transition or protocol activity emission node
+      — mitigation deployment is tracked externally (CMDB or case record) and
+      the protocol has no dedicated mitigation-deployed message type. The shared
+      monitoring/prioritization call-out seams (PrioritizeDeployment,
+      MonitoringRequirement, MonitorDeployment) SHOULD be factored into a
+      `DeploymentMonitoringBundle` base dataclass inherited by both
+      `DeployFixCallOutBundle` and `DeployMitigationCallOutBundle`. A
+      `create_deploy_tree` combinator factory SHOULD compose fix and mitigation
+      arms into an overarching `DeployOrMitigateBT` Fallback (fix arm first).
+    rationale: >
+      Mitigation deployment is the fallback path when a definitive fix is not
+      yet available, as noted in the Phase 1 scoping of `create_deploy_fix_tree`
+      (issue #1248). The structural difference from the fix tree — no CS state
+      transition and no protocol emission — follows from the VFD state machine
+      tracking only vendor-aware/fix-ready/fix-deployed bits; there is no
+      mitigation-deployed bit. This makes `MitigationDeployed` and
+      `MitigationAvailable` call-out Retrievers rather than DataLayerCondition
+      nodes. Sharing the monitoring/prioritization seams via a base dataclass
+      follows BT-23-003 (domain bundle pattern) and avoids field duplication
+      across two closely-related bundles. The combinator tree delivers the
+      stated goal of the parent epic (#1285): a composed deployment decision
+      tree that prefers fix deployment over mitigation deployment.
+    tracking_issue: '#1826 (planning Idea — peer to #1248)'
+    relationships:
+    - rel_type: extends
+      spec_id: BT-23-003
+      note: >
+        DeployMitigationCallOutBundle and DeploymentMonitoringBundle follow the
+        domain bundle pattern from BT-23-003.
+    - rel_type: refines
+      spec_id: BT-20-004
+      note: >
+        Peer production collapse for the fix deployment arm; mitigation and fix
+        trees compose into create_deploy_tree.
+
 - id: BT-21
   title: Fuzzer Node Replacement Lifecycle
   specs:

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -781,11 +781,6 @@ groups:
       note: >
         DeployMitigationCallOutBundle and DeploymentMonitoringBundle follow the
         domain bundle pattern from BT-23-003.
-    - rel_type: refines
-      spec_id: BT-20-004
-      note: >
-        Peer production collapse for the fix deployment arm; mitigation and fix
-        trees compose into create_deploy_tree.
 
 - id: BT-21
   title: Fuzzer Node Replacement Lifecycle


### PR DESCRIPTION
Closes #1826

## Summary

- Adds production collapse design for `create_deploy_mitigation_tree` to `notes/bt-fuzzer-rm-fix.md`: tree shape, `DeploymentMonitoringBundle` shared-base refactor, and combinator `create_deploy_tree`
- Adds BT-20-005 to `specs/behavior-tree-integration.yaml` capturing the mitigation deployment production collapse with explicit rationale for no CS state transition and no protocol emission

## Key design decisions

- **No `TransitionCS`/`EmitActivity` analog**: VFD state machine tracks V/F/D only; mitigation is tracked externally (CMDB/case record). `MitigationDeployed` and `MitigationAvailable` are call-out Retrievers, not `DataLayerCondition` nodes.
- **`DeploymentMonitoringBundle` shared base**: three shared seams (`PrioritizeDeployment`, `MonitoringRequirement`, `MonitorDeployment`) factored into a base dataclass inherited by both `DeployFixCallOutBundle` and `DeployMitigationCallOutBundle`.
- **`deploy_tree.py` combinator**: `create_deploy_tree()` composes fix and mitigation arms per the issue body's stated goal.
- **Spin-off Idea**: whether a dedicated mitigation-deployed protocol message should be added is tracked as a new Idea under epic #1935.

## Implementation Issues

- #1953 (DeploymentMonitoringBundle shared base + DeployMitigationCallOutBundle)
- #1954 (create_deploy_mitigation_tree factory + nodes)
- #1956 (create_deploy_tree combinator)
- #1955 (spin-off Idea: mitigation-deployed protocol message)