### PR TITLE
feat(embargo): FUZZ-08a-ter create_terminate_active_embargo_tree factory

### DIFF
--- a/notes/bt-fuzzer-nodes-embargo.md
+++ b/notes/bt-fuzzer-nodes-embargo.md
@@ -68,12 +68,12 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — deployment status check is automatable via patch-management or case-state APIs; the *decision* to exit still requires policy-rule evaluation or human confirmation.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ExitEmbargoWhenDeployed`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+- **Factory-fn placement**: Wired in two factories —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`exit_embargo_when_deployed_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
-  (issue #1256) — condition guard in the Reason Selector, checked
-  before delegating to `terminate_embargo_bt`
+  (`exit_embargo_when_deployed_factory` param, PR #1357) and
+  `vultron.core.behaviors.embargo.terminate_active_embargo_tree.create_terminate_active_embargo_tree`
+  (`exit_embargo_when_deployed_factory` param, PR #1957 / issue #1891) —
+  condition guard in the ReasonSelector, checked before delegating to `terminate_embargo_bt`
 
 ### `ExitEmbargoWhenFixReady`
 
@@ -90,12 +90,12 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — fix-readiness flag is queryable automatically; the exit decision depends on configurable organizational policy that may require human override.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ExitEmbargoWhenFixReady`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+- **Factory-fn placement**: Wired in two factories —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`exit_embargo_when_fix_ready_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
-  (issue #1256) — condition guard in the Reason Selector, checked
-  before delegating to `terminate_embargo_bt`
+  (`exit_embargo_when_fix_ready_factory` param, PR #1357) and
+  `vultron.core.behaviors.embargo.terminate_active_embargo_tree.create_terminate_active_embargo_tree`
+  (`exit_embargo_when_fix_ready_factory` param, PR #1957 / issue #1891) —
+  condition guard in the ReasonSelector, checked before delegating to `terminate_embargo_bt`
 
 ### `ExitEmbargoForOtherReason`
 
@@ -112,12 +112,12 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Low** — rare edge case representing extraordinary circumstances; fundamentally requires human judgment that cannot be anticipated by a general policy rule.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ExitEmbargoForOtherReason`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+- **Factory-fn placement**: Wired in two factories —
   `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-  (`exit_embargo_for_other_reason_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
-  (issue #1256) — rare fallback condition guard in the Reason
-  Selector for extraordinary circumstances
+  (`exit_embargo_for_other_reason_factory` param, PR #1357) and
+  `vultron.core.behaviors.embargo.terminate_active_embargo_tree.create_terminate_active_embargo_tree`
+  (`exit_embargo_for_other_reason_factory` param, PR #1957 / issue #1891) —
+  rare fallback condition guard in the ReasonSelector for extraordinary circumstances
 
 ### `EmbargoTimerExpired`
 
@@ -161,18 +161,18 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **High** — integration hook (notifications, state updates, downstream triggers); can be fully automated via API calls to notification and case-management systems.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoExit`
 - **Call-out point shape**: Actuator — fires integration hooks on embargo exit; invokes notification APIs, case-management state-write calls, and downstream trigger endpoints. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
-  (issue #1256) — Actuator effect node in
-  `_ConsiderTerminatingActiveEmbargo` Sequence, after the condition Selector
-  succeeds and before `terminate_embargo_bt`
+- **Factory-fn placement**: Implemented in PR #1957 (issue #1891) —
+  `vultron.core.behaviors.embargo.terminate_active_embargo_tree.create_terminate_active_embargo_tree`
+  (`on_embargo_exit_factory` param) — Actuator effect node in the
+  `TerminateActiveEmbargoBT` Sequence, after the AuthorizeEmbargoExit Selector
+  and before `terminate_embargo_bt`
 
 ### `EmbargoExitPolicyGuard`
 
 - **Node name**: `EmbargoExitPolicyGuard`
 - **btz type**: `AlwaysSucceed` (p=1.00)
-- **Source file**: `vultron/demo/fuzzer/embargo.py` (to be added)
-- **Parent tree**: `_AuthorizeEmbargoExit` (within
+- **Source file**: `vultron/demo/fuzzer/embargo.py`
+- **Parent tree**: `AuthorizeEmbargoExit` (within
   `create_terminate_active_embargo_tree`)
 - **Semantic function**: Condition — check whether site policy permits the
   actor to proceed with voluntary embargo termination after a reason has been
@@ -185,17 +185,18 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
   approval status) are fully automatable via case-management API calls.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.EmbargoExitPolicyGuard`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
-  (issue #1256) — first arm of the authorization Selector, after the reason
-  Selector succeeds and before OnEmbargoExit
+- **Factory-fn placement**: Implemented in PR #1957 (issue #1891) —
+  `vultron.core.behaviors.embargo.terminate_active_embargo_tree.create_terminate_active_embargo_tree`
+  (`embargo_exit_policy_guard_factory` param) — first arm of the
+  AuthorizeEmbargoExit Selector, after the ReasonSelector succeeds and before
+  OnEmbargoExit
 
 ### `EmbargoExitOverride`
 
 - **Node name**: `EmbargoExitOverride`
 - **btz type**: `AlwaysFail` (p=0.00)
-- **Source file**: `vultron/demo/fuzzer/embargo.py` (to be added)
-- **Parent tree**: `_AuthorizeEmbargoExit` (within
+- **Source file**: `vultron/demo/fuzzer/embargo.py`
+- **Parent tree**: `AuthorizeEmbargoExit` (within
   `create_terminate_active_embargo_tree`)
 - **Semantic function**: Condition — actor explicitly accepts responsibility
   for overriding a policy veto and proceeding with voluntary embargo
@@ -209,10 +210,11 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
   acknowledgment for accountability; should not be auto-approved.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.EmbargoExitOverride`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.embargo.create_terminate_active_embargo_tree`
-  (issue #1256) — second (fallback) arm of the authorization Selector;
-  reached only when EmbargoExitPolicyGuard returns FAILURE
+- **Factory-fn placement**: Implemented in PR #1957 (issue #1891) —
+  `vultron.core.behaviors.embargo.terminate_active_embargo_tree.create_terminate_active_embargo_tree`
+  (`embargo_exit_override_factory` param) — second (fallback) arm of the
+  AuthorizeEmbargoExit Selector; reached only when EmbargoExitPolicyGuard
+  returns FAILURE
 
 ### `StopProposingEmbargo`
 

--- a/plan/history/2608/implementation/ISSUE-1891.md
+++ b/plan/history/2608/implementation/ISSUE-1891.md
@@ -1,0 +1,24 @@
+---
+source: ISSUE-1891
+timestamp: '2026-08-03T20:48:00.308948+00:00'
+title: create_terminate_active_embargo_tree factory
+type: implementation
+---
+
+## Issue #1891 — FUZZ-08a-ter: create_terminate_active_embargo_tree factory
+
+Implemented the actor-voluntary active embargo termination BT factory (EMB-14).
+
+### What was built
+
+- `create_terminate_active_embargo_tree` in `vultron/core/behaviors/embargo/terminate_active_embargo_tree.py`
+- 5-child memory=False Sequence: HasActiveEmbargoNode → ReasonSelector → AuthorizeEmbargoExit → OnEmbargoExit → terminate_embargo_bt
+- `EmbargoExitPolicyGuard` and `EmbargoExitOverride` fuzzer stubs in `vultron/demo/fuzzer/embargo.py`
+- Stochastic factories wired into `EMBARGO_STOCHASTIC` in `vultron/demo/fuzzer/bundles/embargo.py`
+- 33 tests covering structure, memory=False regression guards, ceiling/floor, factory injection, result_out propagation
+
+### Notable discovery
+
+`EmbargoExitPolicyGuard` and `EmbargoExitOverride` were fully designed in the notes/spec but had zero implementation — both were created as part of this issue.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1957>

--- a/plan/incoming/learnings/20260803-fuzzer-stub-implementation-gap.md
+++ b/plan/incoming/learnings/20260803-fuzzer-stub-implementation-gap.md
@@ -1,0 +1,22 @@
+---
+title: Fuzzer stub nodes may be spec'd and bundle-wired but not yet implemented
+type: learning
+timestamp: 2026-08-03
+source: ISSUE-1891
+signal: concern
+---
+
+During ISSUE-1891, `EmbargoExitPolicyGuard` and `EmbargoExitOverride` were found to be fully
+designed (spec entries in `notes/bt-fuzzer-nodes-embargo.md`, bundle fields with correct
+deterministic defaults in `EmbargoCallOutBundle`) but had zero implementation in
+`vultron/demo/fuzzer/embargo.py`. The bundle fields silently fell back to `AlwaysSucceed`/`AlwaysFail`
+stubs rather than raising an error, so the gap was invisible until a factory injection test was written.
+
+**Risk**: Other call-out bundle domains (report management, CVD participant, etc.) may have the same
+pattern — fields defined in the core bundle dataclass and wired into a DETERMINISTIC singleton, but no
+corresponding fuzzer class in the demo layer and no stochastic factory in the demo bundle. A simulation
+run using EMBARGO_STOCHASTIC-style bundles for those domains would silently use deterministic stubs
+instead of exercising the probabilistic path.
+
+**Suggested follow-up**: Audit all `CallOutBundle` dataclasses for fields whose stochastic bundle
+factory is absent or points to a non-existent class. Create a Concern issue to track the gap.

--- a/test/core/behaviors/embargo/test_terminate_active_embargo_tree.py
+++ b/test/core/behaviors/embargo/test_terminate_active_embargo_tree.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for create_terminate_active_embargo_tree (EMB-14).
+
+Verifies:
+- Tree structure: Sequence root with correct sub-tree shape.
+- Call-out injection: bundle factories are wired at each call-out slot.
+- Deterministic defaults: ceiling/floor rule applied per BT-23-002.
+- Stochastic bundle: produces the expected fuzzer classes.
+- terminate_embargo_bt delegation: final child is the existing mechanism.
+"""
+
+import pytest
+import py_trees
+
+from vultron.core.behaviors.embargo.terminate_active_embargo_tree import (
+    create_terminate_active_embargo_tree,
+)
+from vultron.core.behaviors.embargo.nodes import HasActiveEmbargoNode
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.bundles.embargo import (
+    EMBARGO_DETERMINISTIC,
+    EmbargoCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.embargo import EMBARGO_STOCHASTIC
+from vultron.demo.fuzzer.embargo import (
+    EmbargoExitOverride,
+    EmbargoExitPolicyGuard,
+    ExitEmbargoForOtherReason,
+    ExitEmbargoWhenDeployed,
+    ExitEmbargoWhenFixReady,
+    OnEmbargoExit,
+)
+
+CASE_ID = "https://example.org/cases/test-terminate-001"
+
+
+def _make_result_out() -> dict:
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Basic structure
+# ---------------------------------------------------------------------------
+
+
+def test_returns_behaviour():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_root_name():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert tree.name == "TerminateActiveEmbargoBT"
+
+
+def test_root_is_sequence():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert isinstance(tree, py_trees.composites.Sequence)
+
+
+def test_root_has_five_children():
+    """Root Sequence: HasActiveEmbargo, ReasonSelector, AuthorizeSelector, OnEmbargoExit, terminate_embargo_bt."""
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert len(tree.children) == 5
+
+
+def test_root_sequence_memory_false():
+    """memory=False on root ensures stateless restart every tick."""
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert isinstance(tree, py_trees.composites.Sequence)
+    assert tree.memory is False
+
+
+def test_reason_selector_memory_false():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    reason = tree.children[1]
+    assert isinstance(reason, py_trees.composites.Selector)
+    assert reason.memory is False
+
+
+def test_authorize_selector_memory_false():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    auth = tree.children[2]
+    assert isinstance(auth, py_trees.composites.Selector)
+    assert auth.memory is False
+
+
+# ---------------------------------------------------------------------------
+# Child 0 — HasActiveEmbargoNode precondition guard
+# ---------------------------------------------------------------------------
+
+
+def test_child_0_is_has_active_embargo():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert isinstance(tree.children[0], HasActiveEmbargoNode)
+
+
+# ---------------------------------------------------------------------------
+# Child 1 — ReasonSelector (EMB-14-001)
+# ---------------------------------------------------------------------------
+
+
+def test_child_1_is_reason_selector():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    reason = tree.children[1]
+    assert isinstance(reason, py_trees.composites.Selector)
+    assert reason.name == "ReasonSelector"
+
+
+def test_reason_selector_has_three_children():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert len(tree.children[1].children) == 3
+
+
+@pytest.mark.parametrize(
+    "index,cls",
+    [
+        (0, AlwaysFail),  # ExitEmbargoWhenDeployed (p=0.33)
+        (1, AlwaysFail),  # ExitEmbargoWhenFixReady (p=0.25)
+        (2, AlwaysFail),  # ExitEmbargoForOtherReason (p=0.005)
+    ],
+)
+def test_reason_selector_deterministic_defaults(index, cls):
+    """DETERMINISTIC: all reason nodes are AlwaysFail (p < 0.5 for all three)."""
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert isinstance(tree.children[1].children[index], cls)
+
+
+@pytest.mark.parametrize(
+    "index,cls",
+    [
+        (0, ExitEmbargoWhenDeployed),
+        (1, ExitEmbargoWhenFixReady),
+        (2, ExitEmbargoForOtherReason),
+    ],
+)
+def test_reason_selector_stochastic_classes(index, cls):
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID,
+        result_out=_make_result_out(),
+        call_out=EMBARGO_STOCHASTIC,
+    )
+    assert isinstance(tree.children[1].children[index], cls)
+
+
+# ---------------------------------------------------------------------------
+# Child 2 — AuthorizeEmbargoExit Selector (EMB-14-002, EMB-14-003)
+# ---------------------------------------------------------------------------
+
+
+def test_child_2_is_authorize_selector():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    auth = tree.children[2]
+    assert isinstance(auth, py_trees.composites.Selector)
+    assert auth.name == "AuthorizeEmbargoExit"
+
+
+def test_authorize_selector_has_two_children():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert len(tree.children[2].children) == 2
+
+
+def test_authorize_first_child_deterministic_is_always_succeed():
+    """EmbargoExitPolicyGuard (p=1.0) → AlwaysSucceed."""
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert isinstance(tree.children[2].children[0], AlwaysSucceed)
+
+
+def test_authorize_second_child_deterministic_is_always_fail():
+    """EmbargoExitOverride (p=0.0) → AlwaysFail."""
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert isinstance(tree.children[2].children[1], AlwaysFail)
+
+
+def test_authorize_first_child_stochastic_is_policy_guard():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID,
+        result_out=_make_result_out(),
+        call_out=EMBARGO_STOCHASTIC,
+    )
+    assert isinstance(tree.children[2].children[0], EmbargoExitPolicyGuard)
+
+
+def test_authorize_second_child_stochastic_is_override():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID,
+        result_out=_make_result_out(),
+        call_out=EMBARGO_STOCHASTIC,
+    )
+    assert isinstance(tree.children[2].children[1], EmbargoExitOverride)
+
+
+# ---------------------------------------------------------------------------
+# Child 3 — OnEmbargoExit Actuator
+# ---------------------------------------------------------------------------
+
+
+def test_child_3_on_embargo_exit_deterministic_is_always_succeed():
+    """OnEmbargoExit (p=1.0) → AlwaysSucceed in DETERMINISTIC bundle."""
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    assert isinstance(tree.children[3], AlwaysSucceed)
+
+
+def test_child_3_on_embargo_exit_stochastic_class():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID,
+        result_out=_make_result_out(),
+        call_out=EMBARGO_STOCHASTIC,
+    )
+    assert isinstance(tree.children[3], OnEmbargoExit)
+
+
+# ---------------------------------------------------------------------------
+# Child 4 — terminate_embargo_bt delegation
+# ---------------------------------------------------------------------------
+
+
+def test_child_4_is_terminate_embargo_bt_sequence():
+    """The final child must be the TerminateEmbargoBT Sequence (BT-19-001)."""
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out()
+    )
+    term = tree.children[4]
+    assert isinstance(term, py_trees.composites.Sequence)
+    assert term.name == "TerminateEmbargoBT"
+
+
+# ---------------------------------------------------------------------------
+# Factory injection — each call-out slot accepts a custom factory
+# ---------------------------------------------------------------------------
+
+
+_TERMINATE_FACTORY_FIELDS = [
+    ("exit_embargo_when_deployed_factory", 1, 0),
+    ("exit_embargo_when_fix_ready_factory", 1, 1),
+    ("exit_embargo_for_other_reason_factory", 1, 2),
+    ("embargo_exit_policy_guard_factory", 2, 0),
+    ("embargo_exit_override_factory", 2, 1),
+    ("on_embargo_exit_factory", None, None),  # direct child 3
+]
+
+
+@pytest.mark.parametrize(
+    "field,parent_idx,child_idx", _TERMINATE_FACTORY_FIELDS
+)
+def test_factory_field_is_wired(field, parent_idx, child_idx):
+    sentinel = {"called": False}
+
+    def custom_factory(name: str) -> py_trees.behaviour.Behaviour:
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            IS_CUSTOM_MARKER = True
+
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=name)
+
+    bundle = EmbargoCallOutBundle(**{field: custom_factory})  # type: ignore[arg-type]
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=_make_result_out(), call_out=bundle
+    )
+    assert sentinel["called"], f"factory {field!r} was not called"
+
+    if parent_idx is None:
+        # on_embargo_exit is child 3 directly
+        assert getattr(tree.children[3], "IS_CUSTOM_MARKER", False)
+    else:
+        node = tree.children[parent_idx].children[child_idx]
+        assert getattr(node, "IS_CUSTOM_MARKER", False)
+
+
+# ---------------------------------------------------------------------------
+# result_out propagation
+# ---------------------------------------------------------------------------
+
+
+def test_result_out_passed_through():
+    """result_out dict is the same object passed to HasActiveEmbargoNode."""
+    result = _make_result_out()
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID, result_out=result
+    )
+    guard = tree.children[0]
+    assert isinstance(guard, HasActiveEmbargoNode)
+    # HasActiveEmbargoNode stores result_out as an instance attribute
+    assert guard._result_out is result
+
+
+# ---------------------------------------------------------------------------
+# Deterministic singleton accepted
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_singleton_accepted():
+    tree = create_terminate_active_embargo_tree(
+        case_id=CASE_ID,
+        result_out=_make_result_out(),
+        call_out=EMBARGO_DETERMINISTIC,
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)

--- a/vultron/core/behaviors/call_out/bundles/embargo.py
+++ b/vultron/core/behaviors/call_out/bundles/embargo.py
@@ -61,8 +61,9 @@ class EmbargoCallOutBundle:
 
     Fields map to the corresponding factory parameters on
     :func:`~vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
-    and (for termination-specific fields) the future
-    ``create_terminate_active_embargo_tree`` factory (issue #1256).
+    and (for termination-specific fields)
+    :func:`~vultron.core.behaviors.embargo.terminate_active_embargo_tree.create_terminate_active_embargo_tree`
+    (issue #1891).
     """
 
     exit_embargo_when_deployed_factory: CallOutBackendFactory = field(

--- a/vultron/core/behaviors/embargo/terminate_active_embargo_tree.py
+++ b/vultron/core/behaviors/embargo/terminate_active_embargo_tree.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Actor-voluntary active embargo termination BT (EMB-14).
+
+Provides :func:`create_terminate_active_embargo_tree`, which models the
+production "actor chooses reason, system executes" pattern for voluntarily
+exiting an active embargo.
+
+Tree structure::
+
+    Sequence("TerminateActiveEmbargoBT"):
+      HasActiveEmbargoNode(case_id)        # precondition guard
+      Selector("ReasonSelector"):          # why are we exiting?
+        ExitEmbargoWhenDeployed            # Evaluator call-out (EMB-14-001)
+        ExitEmbargoWhenFixReady            # Evaluator call-out (EMB-14-001)
+        ExitEmbargoForOtherReason          # Evaluator call-out (EMB-14-001)
+      Selector("AuthorizeEmbargoExit"):    # are we allowed to proceed?
+        EmbargoExitPolicyGuard             # Evaluator call-out (EMB-14-002)
+        EmbargoExitOverride                # Evaluator call-out (EMB-14-003)
+      OnEmbargoExit                        # Actuator call-out point
+      terminate_embargo_bt(case_id, ...)   # existing mechanism (BT-19-001)
+
+References
+----------
+- Spec: ``specs/em-behavior.yaml`` EMB-14-001, EMB-14-002, EMB-14-003
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+- Notes: ``notes/bt-fuzzer-nodes-embargo.md`` § EmbargoExitPolicyGuard,
+  EmbargoExitOverride
+"""
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import py_trees
+
+from vultron.core.behaviors.embargo.nodes import HasActiveEmbargoNode
+from vultron.core.behaviors.embargo.trigger_tree import terminate_embargo_bt
+
+if TYPE_CHECKING:
+    from vultron.core.behaviors.call_out.bundles.embargo import (
+        EmbargoCallOutBundle,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+def create_terminate_active_embargo_tree(
+    *,
+    case_id: str,
+    result_out: dict[str, object],
+    activity_builder: Callable[[str], list[str]] | None = None,
+    call_out: "EmbargoCallOutBundle | None" = None,
+) -> py_trees.behaviour.Behaviour:
+    """Create the actor-voluntary active embargo termination BT (EMB-14).
+
+    Models the production "actor chooses reason, system executes" pattern:
+
+    1. Guard that an active embargo exists (precondition).
+    2. Reason Selector — one of three Evaluator call-out points must return
+       SUCCESS to supply a termination reason (EMB-14-001).
+    3. Authorization Selector — EmbargoExitPolicyGuard (happy path, EMB-14-002)
+       or EmbargoExitOverride (audit-trail fallback, EMB-14-003) must allow the
+       exit to proceed.
+    4. OnEmbargoExit Actuator fires integration hooks before state mutation.
+    5. ``terminate_embargo_bt`` performs the actual EM state transition and
+       activity dispatch (BT-19-001).
+
+    Args:
+        case_id: ID of the VulnerabilityCase whose active embargo to terminate.
+        result_out: Mutable dict for BT result propagation; passed to
+            :func:`~vultron.core.behaviors.embargo.trigger_tree.terminate_embargo_bt`.
+        activity_builder: Optional activity builder for the trigger path.
+            ``None`` uses the cascade path (SendTerminateEmbargoActivityNode).
+            Forwarded to :func:`terminate_embargo_bt`.
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to
+            :data:`~vultron.core.behaviors.call_out.bundles.embargo.EMBARGO_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
+
+    Returns:
+        Root node of the terminate-active-embargo behavior tree.
+    """
+    from vultron.core.behaviors.call_out.bundles.embargo import (
+        EMBARGO_DETERMINISTIC,
+    )
+
+    bundle = call_out if call_out is not None else EMBARGO_DETERMINISTIC
+
+    reason_selector = py_trees.composites.Selector(
+        name="ReasonSelector",
+        memory=False,
+        children=[
+            bundle.exit_embargo_when_deployed_factory(
+                "ExitEmbargoWhenDeployed"
+            ),
+            bundle.exit_embargo_when_fix_ready_factory(
+                "ExitEmbargoWhenFixReady"
+            ),
+            bundle.exit_embargo_for_other_reason_factory(
+                "ExitEmbargoForOtherReason"
+            ),
+        ],
+    )
+
+    authorize_selector = py_trees.composites.Selector(
+        name="AuthorizeEmbargoExit",
+        memory=False,
+        children=[
+            bundle.embargo_exit_policy_guard_factory("EmbargoExitPolicyGuard"),
+            bundle.embargo_exit_override_factory("EmbargoExitOverride"),
+        ],
+    )
+
+    root = py_trees.composites.Sequence(
+        name="TerminateActiveEmbargoBT",
+        memory=False,
+        children=[
+            HasActiveEmbargoNode(case_id=case_id, result_out=result_out),
+            reason_selector,
+            authorize_selector,
+            bundle.on_embargo_exit_factory("OnEmbargoExit"),
+            terminate_embargo_bt(
+                case_id=case_id,
+                result_out=result_out,
+                activity_builder=activity_builder,
+            ),
+        ],
+    )
+
+    logger.info("Created TerminateActiveEmbargoBT for case=%s", case_id)
+    return root

--- a/vultron/demo/fuzzer/bundles/embargo.py
+++ b/vultron/demo/fuzzer/bundles/embargo.py
@@ -33,6 +33,8 @@ Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 - ``on_embargo_exit_factory``                  — OnEmbargoExit                 (p=1.0) → AlwaysSucceed
 - ``on_embargo_accept_factory``                — OnEmbargoAccept               (p=1.0) → AlwaysSucceed
 - ``on_embargo_reject_factory``                — OnEmbargoReject               (p=1.0) → AlwaysSucceed
+- ``embargo_exit_policy_guard_factory``        — EmbargoExitPolicyGuard        (p=1.0) → AlwaysSucceed
+- ``embargo_exit_override_factory``            — EmbargoExitOverride           (p=0.0) → AlwaysFail
 """
 
 from __future__ import annotations
@@ -127,6 +129,22 @@ def _stochastic_on_reject(name: str) -> py_trees.behaviour.Behaviour:
     return OnEmbargoReject(name)
 
 
+def _stochastic_embargo_exit_policy_guard(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import EmbargoExitPolicyGuard
+
+    return EmbargoExitPolicyGuard(name)
+
+
+def _stochastic_embargo_exit_override(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import EmbargoExitOverride
+
+    return EmbargoExitOverride(name)
+
+
 EMBARGO_STOCHASTIC = EmbargoCallOutBundle(
     exit_embargo_when_deployed_factory=_stochastic_exit_when_deployed,  # type: ignore[arg-type]
     exit_embargo_when_fix_ready_factory=_stochastic_exit_when_fix_ready,  # type: ignore[arg-type]
@@ -141,6 +159,8 @@ EMBARGO_STOCHASTIC = EmbargoCallOutBundle(
     on_embargo_exit_factory=_stochastic_on_exit,  # type: ignore[arg-type]
     on_embargo_accept_factory=_stochastic_on_accept,  # type: ignore[arg-type]
     on_embargo_reject_factory=_stochastic_on_reject,  # type: ignore[arg-type]
+    embargo_exit_policy_guard_factory=_stochastic_embargo_exit_policy_guard,  # type: ignore[arg-type]
+    embargo_exit_override_factory=_stochastic_embargo_exit_override,  # type: ignore[arg-type]
 )
 """Stochastic bundle: all nodes use probabilistic fuzzer classes."""
 

--- a/vultron/demo/fuzzer/embargo.py
+++ b/vultron/demo/fuzzer/embargo.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 from vultron.demo.fuzzer.base import (
     AlmostAlwaysSucceed,
     AlmostCertainlyFail,
+    AlwaysFail,
     AlwaysSucceed,
     OneInOneHundred,
     OneInTwoHundred,
@@ -398,6 +399,59 @@ class OnEmbargoReject(ActuatorCallOutPoint, AlwaysSucceed):
     Automation potential: **High** — notification dispatch and logging
     actions are fully automatable via APIs.
     """
+
+
+# ---------------------------------------------------------------------------
+# Embargo exit authorization nodes
+# ---------------------------------------------------------------------------
+
+
+class EmbargoExitPolicyGuard(EvaluatorCallOutPoint, AlwaysSucceed):
+    """Check whether site policy permits voluntary embargo termination.
+
+    Semantic function:
+        Condition — evaluate whether site policy allows the actor to proceed
+        with voluntary embargo termination after a reason has been selected
+        (e.g., no active revision negotiation, no pending approvals).
+        Modeled as always permitting (happy path) in simulation.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — reads policy state from caller's DataLayer)
+      Output keys: embargo_exit_policy_guard_verdict: str  (SUCCESS only)
+
+    Input category: Automated policy evaluation.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — rule-based checks (pending revision,
+    approval status) are fully automatable via case-management API calls.
+    """
+
+    output_keys = {"embargo_exit_policy_guard_verdict": str}
+
+
+class EmbargoExitOverride(EvaluatorCallOutPoint, AlwaysFail):
+    """Actor explicitly overrides a policy veto to terminate the embargo.
+
+    Semantic function:
+        Condition — the actor accepts responsibility for overriding a
+        policy veto and produces a distinct audit-trail entry for the
+        override.  Modeled as never succeeding in simulation (override is
+        not active by default).
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — override is actor-initiated)
+      Output keys: embargo_exit_override_verdict: str  (SUCCESS only)
+
+    Input category: Explicit actor acknowledgment.
+
+    Success probability: 0.00 (``AlwaysFail``).
+
+    Automation potential: **Low** — override requires explicit actor
+    acknowledgment for accountability; should not be auto-approved.
+    """
+
+    output_keys = {"embargo_exit_override_verdict": str}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Closes #1891

## Summary

Implements `create_terminate_active_embargo_tree` — the actor-voluntary active embargo termination BT factory (EMB-14), and the two previously unimplemented fuzzer stub nodes it requires.

### Changes

**`vultron/core/behaviors/embargo/terminate_active_embargo_tree.py`** (new)
- `create_terminate_active_embargo_tree(*, case_id, result_out, activity_builder, call_out)` factory
- 5-child `memory=False` Sequence per EMB-14 spec:
  1. `HasActiveEmbargoNode` — precondition guard
  2. `ReasonSelector` — 3-child Selector (EMB-14-001): `ExitEmbargoWhenDeployed`, `ExitEmbargoWhenFixReady`, `ExitEmbargoForOtherReason`
  3. `AuthorizeEmbargoExit` — 2-child Selector (EMB-14-002/003): `EmbargoExitPolicyGuard`, `EmbargoExitOverride`
  4. `OnEmbargoExit` actuator
  5. `terminate_embargo_bt` delegation (BT-19-001)
- `EmbargoCallOutBundle` injected via `call_out`; defaults to `EMBARGO_DETERMINISTIC`
- Lazy `EMBARGO_DETERMINISTIC` import inside function body avoids circular imports

**`vultron/demo/fuzzer/embargo.py`** (modified)
- `EmbargoExitPolicyGuard(EvaluatorCallOutPoint, AlwaysSucceed)` — p=1.0, policy guard (EMB-14-002)
- `EmbargoExitOverride(EvaluatorCallOutPoint, AlwaysFail)` — p=0.0, override audit trail (EMB-14-003)

**`vultron/demo/fuzzer/bundles/embargo.py`** (modified)
- `_stochastic_embargo_exit_policy_guard` and `_stochastic_embargo_exit_override` factory functions
- Wired into `EMBARGO_STOCHASTIC`; docstring ceiling/floor table updated

**`test/core/behaviors/embargo/test_terminate_active_embargo_tree.py`** (new)
- 33 tests: tree structure, `memory=False` regression guards, deterministic ceiling/floor, stochastic bundle classes, factory injection at all 6 call-out slots, `result_out` identity propagation, `TerminateEmbargoBT` delegation

### Spec compliance

| Spec entry | Coverage |
|---|---|
| EMB-14-001 — reason selection | `ReasonSelector` with 3 factories |
| EMB-14-002 — policy guard | `AuthorizeEmbargoExit[0]` via `embargo_exit_policy_guard_factory` |
| EMB-14-003 — override audit | `AuthorizeEmbargoExit[1]` via `embargo_exit_override_factory` |
| BT-19-001 — terminate_embargo_bt | delegated as child 4 |
| BT-23-002 — ceiling/floor | all 6 call-out points use correct deterministic defaults |
| ADR-0025 — call-out abstraction | full `EmbargoCallOutBundle` injection, no hard-coded nodes |

## Verification

- [x] `uv run pytest test/core/behaviors/embargo/test_terminate_active_embargo_tree.py` — 33 new tests pass
- [x] `uv run pytest` — 6045 passed, 0 failed (full suite, no regressions)
- [x] `uv run black vultron/ test/` — no changes
- [x] `uv run flake8 vultron/ test/` — clean
- [x] `uv run mypy` — success
- [x] `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)