### PR TITLE
docs: plan issue #1892 — P/X/A cascade for EM PROPOSED state

### DIFF
--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -156,10 +156,21 @@ in [#1484](https://github.com/CERTCC/Vultron/issues/1484)). Migrating the
 received-side EM transitions to `EmbargoLifecycle` (AC-3 of #1484) is still
 pending.
 
-**Auto-terminate on publication** (CS.P event): handled by
-`PublicDisclosureBranchNode` in `vultron/core/behaviors/status/nodes/lifecycle.py`,
-which delegates to the shared `terminate_embargo_bt` factory. This is the
-cascade path for AC-2 of issue #1454.
+**Auto-terminate on publication** (CS.P/X/A event): handled by
+`PublicDisclosureBranchNode` in `vultron/core/behaviors/status/nodes/lifecycle.py`.
+The node is a Selector with two arms depending on the current EM state:
+
+- **EM ACTIVE or REVISE** → delegates to `terminate_embargo_bt` (ET + EM →
+  EXITED). This is the cascade path for AC-2 of issue #1454.
+- **EM PROPOSED** → delegates to `reject_embargo_trigger_bt` (ER + EM →
+  NO_EMBARGO). EMB-16-001: continuing to negotiate a proposed embargo after
+  P/X/A is set is not viable; the proposal must be abandoned immediately.
+- **EM NO_EMBARGO or EXITED** → skip (nothing to tear down).
+
+Prior to the fix in issue #1892, the skip condition used
+`case.active_embargo is None` to detect "no embargo", which silently bypassed
+the PROPOSED arm — `active_embargo` is always None when EM is PROPOSED because
+the embargo has not yet been activated. The fix checks EM state directly.
 
 Trigger use cases are thin orchestrators: resolve actors/cases → call
 `EmbargoLifecycle` → build and send the outbound activity.
@@ -204,6 +215,12 @@ When implementing any code that transitions embargo state:
 5. **OBSERVED mode** (received-side): pass
    `transition_mode=TransitionMode.OBSERVED` to sync local state with a remote
    assertion. All guards and PEC cascades are bypassed in OBSERVED mode.
+6. **PROPOSED + P/X/A**: when a CS public/exploit/attacks event fires while EM
+   is PROPOSED, use `reject_embargo_trigger_bt` (not `terminate_embargo_bt`).
+   `terminate_embargo_bt` requires an active embargo (`HasActiveEmbargoNode`
+   guard); it fails when EM is PROPOSED. `reject_embargo_trigger_bt` calls
+   `reject_embargo_invite()` which handles PROPOSED → NO_EMBARGO correctly
+   (EMB-16-001).
 
 ---
 

--- a/plan/history/2608/idea/IDEA-1892.md
+++ b/plan/history/2608/idea/IDEA-1892.md
@@ -1,0 +1,36 @@
+---
+source: IDEA-1892
+timestamp: '2026-08-03T20:55:12.863502+00:00'
+title: P/X/A cascade for EM PROPOSED state
+type: idea
+---
+
+## Outcome
+
+Converted to implementation plan. The original idea proposed a
+`create_abandon_proposed_embargo_tree` factory for voluntary abandonment of a
+proposed embargo. Research revealed:
+
+1. The voluntary path (actor-initiated rejection of a proposed embargo) is
+   already covered by `SvcRejectEmbargoUseCase` via `reject_embargo_trigger_bt`.
+2. The real gap is that `PublicDisclosureBranchNode` silently skips the P/X/A
+   cascade when EM is PROPOSED — because the skip condition checks
+   `case.active_embargo is None`, which is always true in PROPOSED state.
+
+## What was built
+
+- **EMB-16-001** added to `specs/em-behavior.yaml`: A Participant in EM PROPOSED
+  that detects a CS transition to public/exploit/attacks MUST abandon the
+  proposed embargo (EM P→N) and emit ER. Extends EMB-01-002 to cover the
+  symmetric in-flight case.
+- **`notes/embargo-lifecycle.md`** updated: Auto-terminate section documents the
+  two-arm Selector (PROPOSED→`reject_embargo_trigger_bt` vs
+  ACTIVE/REVISE→`terminate_embargo_bt`) and the `active_embargo is None` skip
+  bug. Guidance rule #6 added for agents.
+- **No new factory** — `reject_embargo_trigger_bt` is reused directly.
+
+## References
+
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/1958>
+- Implementation issue: #1959 (fix `_PublicDisclosureSkipConditionNode` + refactor `PublicDisclosureBranchNode`)
+- Source idea: #1892

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -1476,3 +1476,68 @@ groups:
     - rel_type: satisfies
       spec_id: EMB-01-002
       note: Mandatory rejection when public/exploit/attacks overrides default-accept
+
+- id: EMB-16
+  title: CS Public/Exploit/Attacks Detected While EM Proposed
+  description: >-
+    Behaviors required when a Participant detects that the vulnerability has
+    become public (q^cs ∈ ···P··), an exploit is available (q^cs ∈ ····X·),
+    or attacks have been observed (q^cs ∈ ·····A) while the case EM state is
+    still Proposed (q^em ∈ P). Embargo negotiation is not viable in any of
+    these states; the proposed embargo MUST be abandoned.
+  trigger:
+    type: state_entered
+    value: CS.public_exploit_attacks
+  specs:
+  - id: EMB-16-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      A Participant in EM Proposed (q^em ∈ P) that detects a CS transition into
+      a public (q^cs ∈ ···P··), exploit-available (q^cs ∈ ····X·), or
+      attacks-observed (q^cs ∈ ·····A) state MUST abandon the proposed embargo
+      by transitioning EM from Proposed to None (q^em P → N) and MUST emit ER
+      to notify other Participants.
+    rationale: >-
+      EMB-01-002 establishes that embargo negotiation is not viable once public
+      disclosure, exploit availability, or attacks have occurred. EMB-01-002 is
+      framed as a guard on receiving EP, but the same viability constraint
+      applies when a P/X/A state change arrives while a proposal is already in
+      flight. Continuing to negotiate a proposed embargo in these conditions
+      would be misleading to other Participants and counter to the purpose of
+      coordinated disclosure. The existing reject path (EM P → N + ER) is the
+      correct mechanism; no new transition is introduced.
+    testable: true
+    preconditions:
+    - em_state:
+        - PROPOSED
+      description: EM state is Proposed
+    - cs_pattern: "...P.."
+      description: CS transitions to public (q^cs ∈ ···P··)
+    - cs_pattern: "....X."
+      description: CS transitions to exploit-available (q^cs ∈ ····X·)
+    - cs_pattern: ".....A"
+      description: CS transitions to attacks-observed (q^cs ∈ ·····A)
+    steps:
+    - order: 1
+      actor: system
+      action: >-
+        Detect that CS has transitioned to a P/X/A state while EM is Proposed
+      expected: PublicDisclosureBranchNode recognises EM is Proposed (not skipped)
+    - order: 2
+      actor: system
+      action: >-
+        Transition EM from Proposed to None via reject_embargo_trigger_bt
+        (RejectEmbargoLifecycleNode → sender_side_bt)
+      expected: EM state transitions to NO_EMBARGO; ER queued for sender
+    postconditions:
+    - description: EM state is NO_EMBARGO; ER emitted; proposed embargo abandoned
+    relationships:
+    - rel_type: extends
+      spec_id: EMB-01-002
+      note: >-
+        EMB-01-002 guards against entering PROPOSED with P/X/A set;
+        this entry covers the symmetric case where P/X/A fires while already in PROPOSED
+    - rel_type: refines
+      spec_id: EMB-06-001
+      note: ER emission semantics apply; EM returns to NONE


### PR DESCRIPTION
- Closes #1892

## Summary

- Adds **EMB-16-001** to `specs/em-behavior.yaml`: a Participant in EM PROPOSED that detects a CS transition to public/exploit/attacks MUST abandon the proposed embargo (EM P→N) and emit ER — extends EMB-01-002 to cover the symmetric in-flight case
- Updates `notes/embargo-lifecycle.md`: documents the two-arm `PublicDisclosureBranchNode` selector (PROPOSED→`reject_embargo_trigger_bt` vs ACTIVE/REVISE→`terminate_embargo_bt`), explains the `active_embargo is None` skip bug, and adds Guidance rule #6 for agents

## Changes

| File | What changed |
|---|---|
| `specs/em-behavior.yaml` | New group EMB-16 with EMB-16-001 (MUST abandon proposed embargo on P/X/A) |
| `notes/embargo-lifecycle.md` | Auto-terminate section rewritten; Guidance rule #6 added |

## Background

`PublicDisclosureBranchNode` has a skip condition that returns SUCCESS when `case.active_embargo is None`. In EM PROPOSED state, `active_embargo` is always None (the embargo hasn't been activated yet). This means a P/X/A event silently bypasses the cascade rather than abandoning the proposed embargo.

The simulator had the right answer: `_ConsiderAbandoningProposedEmbargo` = `[EMinStateProposed → SufficientCause(P/X/A) → q_em_to_N → EmitER]`. The production event-driven model had no equivalent — and no spec entry covering it. This PR adds the spec entry; the BT fix is tracked in the implementation issue created below.

## Implementation Issues

- #1959