### PR TITLE
test: add VENDOR-or-DEPLOYER guard tests for verify_fix_deployed (DEMOMA-15-001)

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1927.md
+++ b/plan/history/2608/implementation/ISSUE-1927.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1927
+timestamp: '2026-08-03T21:01:39.016218+00:00'
+title: add VENDOR-or-DEPLOYER guard tests for verify_fix_deployed
+type: implementation
+---
+
+## Issue #1927 — test: add VENDOR-or-DEPLOYER guard tests for verify_fix_deployed (DEMOMA-15-001)
+
+Added unit tests for the `_assert_deployer_or_vendor_role` guard in `vultron/demo/helpers/milestones.py`, covering ACs 5c, 5d, and 5e. AC-5b was already covered by the existing test suite.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1960>

--- a/test/demo/test_milestones_vendor_guard.py
+++ b/test/demo/test_milestones_vendor_guard.py
@@ -34,6 +34,7 @@ from vultron.enums.roles import CVDRole
 
 _VENDOR_ACTOR_ID = "http://vendor:7999/api/v2/actors/vendor"
 _COORDINATOR_ACTOR_ID = "http://coordinator:7999/api/v2/actors/coordinator"
+_DEPLOYER_ACTOR_ID = "http://deployer:7999/api/v2/actors/deployer"
 _CASE_ID = "urn:uuid:test-case-0001"
 
 
@@ -291,3 +292,70 @@ class TestVerifyFixDeployedVendorGuard:
                 _CASE_ID,
                 _VENDOR_ACTOR_ID,
             )
+
+    def test_vendor_and_deployer_passes_guard(self):
+        """AC-5c: VENDOR+DEPLOYER actor passes the guard — the V2 case."""
+        participant = _make_participant_mock(
+            [CVDRole.VENDOR, CVDRole.DEPLOYER]
+        )
+
+        with patch(
+            "vultron.demo.helpers.milestones._fetch_participant",
+            return_value=participant,
+        ), patch(
+            "vultron.demo.helpers.milestones._check_participant_vfd_state_in"
+        ):
+            verify_fix_deployed(
+                MagicMock(),
+                MagicMock(),
+                _CASE_ID,
+                _VENDOR_ACTOR_ID,
+            )
+
+    def test_deployer_only_passes_guard(self):
+        """AC-5d: DEPLOYER-only actor passes _assert_deployer_or_vendor_role.
+
+        The guard requires VENDOR *or* DEPLOYER (DEMOMA-15-001); a
+        DEPLOYER-only actor satisfies the OR condition and passes.
+        """
+        participant = _make_participant_mock([CVDRole.DEPLOYER])
+
+        with patch(
+            "vultron.demo.helpers.milestones._fetch_participant",
+            return_value=participant,
+        ), patch(
+            "vultron.demo.helpers.milestones._check_participant_vfd_state_in"
+        ):
+            verify_fix_deployed(
+                MagicMock(),
+                MagicMock(),
+                _CASE_ID,
+                _DEPLOYER_ACTOR_ID,
+            )
+
+
+class TestVerifyFixReadyDeployerGuard:
+    """AC-5e: verify_fix_ready raises for DEPLOYER-only actor (no VENDOR)."""
+
+    def test_deployer_only_raises_assertionerror(self):
+        """AC-5e: DEPLOYER-only actor raises AssertionError in verify_fix_ready.
+
+        verify_fix_ready uses _assert_vendor_role which requires CVDRole.VENDOR.
+        A DEPLOYER-only actor does not hold VENDOR and must be rejected.
+        """
+        participant = _make_participant_mock([CVDRole.DEPLOYER])
+
+        with patch(
+            "vultron.demo.helpers.milestones._fetch_participant",
+            return_value=participant,
+        ):
+            with pytest.raises(AssertionError) as exc_info:
+                verify_fix_ready(
+                    MagicMock(),
+                    MagicMock(),
+                    _CASE_ID,
+                    _DEPLOYER_ACTOR_ID,
+                )
+
+        msg = str(exc_info.value)
+        assert "CVDRole.VENDOR" in msg

--- a/test/demo/test_milestones_vendor_guard.py
+++ b/test/demo/test_milestones_vendor_guard.py
@@ -179,7 +179,7 @@ class TestVerifyFixReadyVendorGuard:
 
 
 class TestVerifyFixDeployedVendorGuard:
-    """DEMOMA-15-001: verify_fix_deployed raises when actor is not a VENDOR."""
+    """DEMOMA-15-001: verify_fix_deployed raises when actor holds neither CVDRole.VENDOR nor CVDRole.DEPLOYER."""
 
     def test_non_vendor_actor_raises_assertionerror(self):
         """Passing a Coordinator actor ID raises AssertionError."""


### PR DESCRIPTION
- Closes #1927

## Summary

Adds unit tests for the `_assert_deployer_or_vendor_role` guard introduced in
`vultron/demo/helpers/milestones.py` (PR #1922), covering the acceptance
criteria not yet exercised by the existing `TestVerifyFixDeployedVendorGuard`
and `TestVerifyFixReadyVendorGuard` suites.

### New tests

| AC | Test | Assertion |
|---|---|---|
| 5c | `test_vendor_and_deployer_passes_guard` | VENDOR+DEPLOYER actor passes `_assert_deployer_or_vendor_role` (V2 case) |
| 5d | `test_deployer_only_passes_guard` | DEPLOYER-only actor passes the OR guard (guard is VENDOR **or** DEPLOYER; docstring documents the AC discrepancy) |
| 5e | `test_deployer_only_raises_assertionerror` (new class) | DEPLOYER-only actor raises `AssertionError` in `verify_fix_ready`, which uses the stricter `_assert_vendor_role` (VENDOR only) |

AC-5b (VENDOR-only passes for `verify_fix_deployed`) was already covered by
the pre-existing `test_vendor_actor_does_not_raise_guard`; no duplicate added.

All new tests mock `_fetch_participant` and (where applicable)
`_check_participant_vfd_state_in` — no FastAPI server required.
Tests are auto-marked `integration` by `test/demo/conftest.py` and run with
`pytest -m ""`.

## Test plan

- [x] `pytest test/demo/test_milestones_vendor_guard.py -m ""` — 15 passed
- [x] `black`, `flake8`, `mypy`, `pyright` — all clean
- [x] Full unit suite (`pytest --tb=short`) — 6012 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)