### PR TITLE
chore(skills): harden PR process to prevent recurring triage findings

### DIFF
--- a/.agents/skills/archive-history/SKILL.md
+++ b/.agents/skills/archive-history/SKILL.md
@@ -61,8 +61,13 @@ markdownlint-cli2 --fix --config .markdownlint-cli2.yaml \
 
 ```bash
 git add plan/history/
-uv run git commit -m "history: archive <TYPE> <SOURCE> — <TITLE>"
+uv run git commit -m "history: archive <TYPE> <SOURCE> — <TITLE>
+
+Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ```
+
+The `Co-authored-by` trailer is **required** on this commit just as on all
+others — the history commit is the most commonly missing it.
 
 ### Step 4 — Push
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -153,6 +153,14 @@ on what "done" means — loaded by `orient-agent` in Phase 1.
    test is not done.
 4. Reuse existing helpers and keep the implementation DRY.
 5. Sub-agents may help, but main-agent validation is mandatory.
+6. **Pattern-change checklist** — run this before opening the PR:
+   - If this PR retires a method or establishes a new pattern, grep
+     `AGENTS.md` for the old name and update any stale pitfalls in this PR.
+   - Grep `notes/` for references to any symbol, method, or table entry
+     you changed and update stale rows in this PR.
+   - If any new `SvcXxxUseCase` class was added, confirm a matching file
+     exists under `test/core/use_cases/triggers/` (see
+     `notes/triggers-test-coverage.md`).
 
 **Scope expansion judgment:** If implementing this task reveals adjacent work
 that clearly belongs with it, apply the following:

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -37,13 +37,18 @@ unless every change in the working tree belongs to this commit.
 ```bash
 uv run git commit -m "<subject line>
 
-<body: what changed and why, as bullet points>"
+<body: what changed and why, as bullet points>
+
+Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ```
 
 Commit message conventions:
 
 - Subject line: imperative mood, ≤72 characters, no trailing period
 - Body: bullet points describing what changed and why
+- **`Co-authored-by` trailer is required on every commit** — include it
+  verbatim as the last line of every commit message, including history
+  archive commits. `pr-triage` Phase 3 flags any commit that is missing it.
 
 ## Constraints
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -74,10 +74,48 @@ If still absent, proceed without a closing reference.
 **Title inference** (if not provided): use the most recent commit subject,
 stripping any commit-hash prefix.
 
-**Body inference** (if not provided): compose using the template from
-`.agents/skills/shared/pr-body-guide.md` for the inferred type.
-For `implementation`: Summary + Changes + Verification sections.
-For `docs`: Summary + Changes sections (no Verification).
+**Body inference** (if not provided): compose using the exact scaffold below
+(also in `.agents/skills/shared/pr-body-guide.md`). Do not invent different
+section names — use these verbatim.
+
+For `implementation`:
+
+```markdown
+- Closes #N
+<!-- ⚠️  MUST BE FIRST — before any ## header -->
+
+## Summary
+
+<1–2 sentences, present tense>
+
+## Changes
+
+- **`path/to/file.py`**: <what changed and why>
+
+## Verification
+
+- All N unit tests pass (M new)
+- Black, flake8, mypy, pyright clean
+```
+
+For `docs`:
+
+```markdown
+- Closes #N
+<!-- ⚠️  MUST BE FIRST — before any ## header -->
+
+## Summary
+
+<1–2 sentences>
+
+## Changes
+
+- **`path/to/file.md`**: <what changed>
+```
+
+The `Closes #N` bullet **must be the very first line** of the body string
+passed to `gh pr create --body`. If it ends up after a `##` header, GitHub
+will not link the issue in the sidebar and triage will flag a FAIL.
 
 ---
 

--- a/.agents/skills/deepen-context/SKILL.md
+++ b/.agents/skills/deepen-context/SKILL.md
@@ -36,6 +36,9 @@ Always-relevant notes for implementation work:
 
 - `notes/architecture-hexagonal.md` — layer rules and import constraints
 - `notes/codebase-structure.md` — common pitfalls and file organization
+- `notes/triggers-test-coverage.md` — **always read when the task adds or
+  touches any `SvcXxxUseCase` class**; documents which trigger use-cases
+  require a dedicated test file under `test/core/use_cases/triggers/`
 
 Read additional notes files based on focus hints. When in doubt, read
 rather than skip — missing context causes incorrect implementation.

--- a/.agents/skills/pr-triage/SKILL.md
+++ b/.agents/skills/pr-triage/SKILL.md
@@ -143,6 +143,10 @@ finding list before the artifact is written.
 - If any file under `demo/` or `adapters/` was changed: verify the PR body or
   CI confirms the integration test suite ran.
 - Flag any public function or use-case `execute()` path with no test.
+- **`SvcXxx` trigger-test check**: grep the diff for new classes whose names
+  match `Svc[A-Z][A-Za-z]+UseCase`. For each one found, confirm a matching
+  file exists under `test/core/use_cases/triggers/`. If absent: **IMPROVE**
+  (see `notes/triggers-test-coverage.md` for the required coverage pattern).
 
 ### Phase 11 — Linter / CI Status
 

--- a/.agents/skills/shared/pr-body-guide.md
+++ b/.agents/skills/shared/pr-body-guide.md
@@ -13,6 +13,7 @@ Use for `build`, `bugfix`, and any PR that modifies `.py` files.
 ```markdown
 - Closes #N
 - Closes #M   <!-- one line per issue; GitHub expands the title automatically -->
+<!-- ⚠️  THESE LINES MUST BE FIRST — before any ## header. Moving them breaks the GitHub sidebar. -->
 
 ## Summary
 
@@ -40,7 +41,9 @@ captures the full rationale.>
 ### Implementation PR rules
 
 - Closing references (`Closes #N` / `Fixes #N`) go at the **top**, one per
-  bullet line, so GitHub expands the issue title in the PR sidebar.
+  bullet line, **before any `##` section header**, so GitHub expands the issue
+  title in the PR sidebar. **This is the single most commonly missed rule —
+  every PR triage flags it when violated.**
 - **Summary**: required; 1–2 sentences, present tense.
 - **Motivation**: optional; omit when Summary is self-explanatory.
 - **Changes**: required; use backtick-wrapped file paths and concrete
@@ -58,6 +61,7 @@ or other non-Python files.
 
 ```markdown
 - Closes #N
+<!-- ⚠️  THIS LINE MUST BE FIRST — before any ## header. Moving it breaks the GitHub sidebar. -->
 
 ## Summary
 
@@ -71,6 +75,7 @@ or other non-Python files.
 
 ### Docs-only PR rules
 
+- Closing reference goes at the **top**, before any `##` header.
 - No Verification section — no Python was changed, no test suite ran.
 - Keep Changes concise; list meaningful files only (not `README.md` unless
   it was substantively updated).


### PR DESCRIPTION
- Closes #1963

## Summary

Hardens seven skill/guide files to prevent the five most-common recurring
findings from PR triage across the last 20 PRs. No source code changes —
process files only.

## Changes

- **`.agents/skills/shared/pr-body-guide.md`**: adds inline `⚠️` warning
  comment to closing-reference lines in both templates; strengthens rule
  text calling it the most commonly missed rule (7 hits in last 20 PRs)
- **`.agents/skills/create-pr/SKILL.md`**: embeds exact PR body scaffold
  verbatim in the body-inference step so agents can't improvise section
  names; adds explicit note that `Closes #N` must be the literal first line
- **`.agents/skills/commit/SKILL.md`**: makes `Co-authored-by` trailer
  explicit in the commit command example and adds a mandatory constraint note
- **`.agents/skills/archive-history/SKILL.md`**: adds `Co-authored-by`
  trailer to the Step 3 commit command; notes it is the most commonly
  missing instance
- **`.agents/skills/build/SKILL.md`**: adds pattern-change checklist
  (Phase 5 item 6) — grep `AGENTS.md` for stale pitfalls, grep `notes/`
  for stale rows, and confirm `SvcXxx` trigger test files exist
- **`.agents/skills/deepen-context/SKILL.md`**: adds
  `notes/triggers-test-coverage.md` to the always-relevant notes list for
  any task touching `SvcXxxUseCase` classes
- **`.agents/skills/pr-triage/SKILL.md`**: adds explicit `SvcXxx`
  trigger-test check to Phase 10