### PR TITLE
feat: implement fcvcv_demo.py scenario script + fcvcv CLI command

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -61,6 +61,8 @@ jobs:
             test_file: test/ci/invariants/test_fccv_extension_invariants.py
           - demo: fccv-handoff
             test_file: test/ci/invariants/test_fccv_handoff_invariants.py
+          - demo: fcvcv
+            test_file: test/ci/invariants/test_fcvcv_invariants.py
           - demo: fcv
             test_file: test/ci/invariants/test_fcv_invariants.py
 
@@ -111,7 +113,7 @@ jobs:
           mkdir -p /tmp/demo-logs
           docker compose -f "$COMPOSE_FILE" logs \
             > /tmp/demo-logs/combined.log 2>&1
-          for svc in finder vendor coordinator case-actor actor5 demo-runner; do
+          for svc in finder vendor coordinator case-actor actor5 actor6 demo-runner; do
             docker compose -f "$COMPOSE_FILE" logs "$svc" \
               > "/tmp/demo-logs/${svc}.log" 2>&1 || true
           done
@@ -156,6 +158,8 @@ jobs:
             test_file: test/ci/invariants/test_fccv_extension_invariants.py
           - demo: fccv-handoff
             test_file: test/ci/invariants/test_fccv_handoff_invariants.py
+          - demo: fcvcv
+            test_file: test/ci/invariants/test_fcvcv_invariants.py
           - demo: fcv
             test_file: test/ci/invariants/test_fcv_invariants.py
 

--- a/integration_tests/demo/run_multi_actor_integration_test.sh
+++ b/integration_tests/demo/run_multi_actor_integration_test.sh
@@ -82,7 +82,7 @@ while [[ $# -gt 0 ]]; do
 done
 DEMO="${SCENARIO_ARG:-${DEMO:-fv}}"
 
-VALID_SCENARIOS="fv fvv fcv fvcv-extension fvcv-handoff fccv-handoff fccv-extension"
+VALID_SCENARIOS="fv fvv fcv fvcv-extension fvcv-handoff fccv-handoff fccv-extension fcvcv"
 if ! echo "${VALID_SCENARIOS}" | grep -qw "${DEMO}"; then
     echo "ERROR: unknown scenario '${DEMO}'. Valid options: ${VALID_SCENARIOS}" >&2
     exit 1

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -49,7 +49,7 @@ be treated as working implementations.
 | FVCV-handoff | #1214 | V1 transfers ownership to C; C invites V2 | — | **implemented** (#1561) — `fvcv-handoff` CLI command + CI job |
 | FCCV-extension | #1215 | C1 retains case; C2 is participant; C2 asks C1 to invite V | — | **implemented** (#1620) — `fccv-extension` CLI command + CI job |
 | FCCV-handoff | #1216 | C1 transfers to C2; C2 invites V | — | **implemented** (#1216) — `fccv-handoff` CLI command + CI job |
-| FCVCV | #1217 | F+C1+V1+C2+V2 (5 actors) | #1212, #1215 | planned |
+| FCVCV | #1217 | F+C1+V1+C2+V2 (5 actors) | #1212, #1215 | **implemented** (#1962) — `fcvcv` CLI command + CI job |
 
 ### Fuzz simulation scenarios
 

--- a/notes/sync-ledger-replication.md
+++ b/notes/sync-ledger-replication.md
@@ -477,6 +477,66 @@ Selector). Spec: SYNC-15-001, SYNC-15-002. Regression test:
 `test/core/use_cases/received/test_sync.py::TestAnnounceLedgerEntryReceivedUseCase
 ::test_missing_case_queues_reject_with_empty_tail_hash`.
 
+## Reject/Replay Amplification (SYNC-15-003)
+
+The Reject → replay backstop above is a *recovery* mechanism, and recovery paths
+that fire unconditionally can amplify. `SendMissingEntriesNode` originally
+replayed the whole missing suffix on every `Reject(CaseLedgerEntry)`, with no
+convergence check. A peer that cannot anchor its hash chain — typically a late
+joiner — Rejects *every* entry replayed to it, so each Reject triggered a
+full-ledger replay and each replayed entry triggered another Reject: a
+self-sustaining loop.
+
+Observed in the `fcvcv` demo (issue #1989): **4825** `Announce(CaseLedgerEntry)`
+activities for a single 26-entry case (~185x amplification), 4201 of them aimed at
+one late-joining actor, at a steady ~2 replays/sec of the same 25-entry ledger with
+zero progress between rounds. The event storm starved the containers until
+*unrelated* DataLayer reads failed with `ReadTimeout`, which surfaced as misleading
+`"replica matches authoritative state: timed out"` demo failures. This is also the
+mechanism behind the flakiness that rotated across `fvcv-extension` /
+`fvcv-handoff` / `fccv-extension` on unrelated branches (#1839, #1911) — the
+reject/replay path is shared code, so any scenario could trip it under CI load.
+
+Note the existing genesis guard (`AnnounceCaseOnGenesisRejectNode`, SYNC-15-002)
+did not cover this: it only handles `last_accepted_hash == ""`, and a peer stuck at
+a *non-empty* hash falls straight through it.
+
+**Resolution**: `vultron/core/behaviors/sync/nodes/replay_guard.py` bounds the
+replay *rate* per peer. `VultronReplicationState` gained
+`last_replayed_from_hash` / `last_replayed_at`, and the node asks
+`should_replay()` before replaying, then calls `record_replay()` after.
+
+Three properties are load-bearing, and each has a regression test:
+
+- **Rate limit, not suppression.** A Reject at an unchanged position is
+  rate-limited (30s), never permanently blocked — if a replayed entry is lost in
+  transit, a later Reject must still be able to trigger a fresh replay or the peer
+  never converges.
+- **Ask and record are separate steps.** The position is recorded only once at
+  least one entry has actually gone out. Recording at decision time meant a peer
+  already at the ledger tail (zero entries to send) started a cooldown anyway; when
+  the ledger then grew, that peer's next Reject — reporting the same hash, now
+  genuinely stale — was suppressed, so it waited out the cooldown having received
+  nothing. That is the very stall the guard exists to prevent, reintroduced by the
+  guard.
+- **Genesis gets a short cooldown, not an exemption.** Genesis convergence is owned
+  by SYNC-15-001/002, which seed the case and rely on the *following* replay to
+  deliver history; a full-length cooldown there starved the bootstrap (caught by
+  `fccv-handoff` in CI: 34 suppressions against a Finder stuck at genesis, ending in
+  "SYNC-2 replication did not complete"). Exempting genesis outright would re-admit
+  the storm, since a peer that cannot anchor reports genesis on every Reject — 43 of
+  51 suppressions in the fixed `fcvcv` run were at genesis. So: 2s, not 0s and not
+  30s.
+
+The guard lives in its own module rather than in `replay.py` to keep that leaf
+module under the 500-line BTND-07-004 limit.
+
+Spec: SYNC-15-003. Regression tests:
+`test/core/behaviors/sync/nodes/test_replay_guard.py` (unit) and
+`test/core/behaviors/sync/test_reject_tree.py` (through the tree — the loop
+reproduced there as 240 replays where 24 were correct). These run in-process in
+seconds rather than requiring a 20-minute demo-integration cycle (#1970).
+
 ## Related
 
 - `specs/sync-ledger-replication.yaml` — normative requirements

--- a/plan/history/2608/implementation/ISSUE-1925.md
+++ b/plan/history/2608/implementation/ISSUE-1925.md
@@ -1,0 +1,30 @@
+---
+source: ISSUE-1925
+timestamp: '2026-08-03T21:14:39.295225+00:00'
+title: implement fcvcv_demo.py scenario script + fcvcv CLI command
+type: implementation
+---
+
+## Issue #1925 — feat: implement fcvcv_demo.py scenario script + fcvcv CLI command
+
+Implemented the FCVCV 5-party CVD demo scenario (DEMOMA-19) in full.
+
+### Deliverables
+
+- `vultron/demo/scenario/fcvcv_demo.py`: 8-phase orchestrator
+  (report_submission → c2_suggests_v2 → sync_verification → notes_exchange →
+  fix_lifecycle → publication → case_closure → dump_case_ledgers)
+- `vultron/demo/cli.py`: `fcvcv` subcommand (AC-3b)
+- `.github/workflows/demo-integration.yml`: fcvcv matrix entry + actor6 log
+  collection (AC-3c)
+- `test/ci/invariants/test_fcvcv_invariants.py`: 46-test invariant harness (AC-3d)
+
+### Key spec points implemented
+
+- V1 (VENDOR only) → VFd; V2 (VENDOR+DEPLOYER) → VFD (DEMOMA-19-004)
+- V1 publishes first → wait EM.EXITED → V2/C2/C1/Finder publish (DEMOMA-19-005)
+- C2 uses ADR-0026 suggest-actor flow for V2 with polling-only delivery (DEMOMA-19-009)
+- Devlog actor names: finder, c1, v1, c2, v2, case-actor (DEMOMA-19-007)
+- All 9 DEMOMA-19 spec entries satisfied (19-001 and 19-002 were done in prior PR #1945)
+
+PR: <https://github.com/CERTCC/Vultron/pull/1962>

--- a/plan/incoming/learnings/20260803-pytest-full-suite-timeout.md
+++ b/plan/incoming/learnings/20260803-pytest-full-suite-timeout.md
@@ -1,0 +1,28 @@
+---
+title: "uv run pytest full suite times out at 120s with no summary line"
+type: learning
+timestamp: "2026-08-03"
+source: ISSUE-1925
+signal: tooling-issue
+---
+
+Running `uv run pytest --tb=short` (all tests) consistently times out at 120
+seconds and produces a truncated output file ending mid-traceback — no
+`passed/failed` summary line is emitted.
+
+The last visible traceback is from `yaml/parser.py` inside the spec-dump test
+infrastructure, suggesting a long-running YAML parse or a blocking `spec-dump`
+invocation is on the hot path. The background task reports exit code 0, so the
+suite is not failing — it's just never finishing within 2 minutes.
+
+**Impact on validation**: Cannot confirm the full-suite green baseline from
+within this environment. Scoped runs (`test/demo/`, `test/ci/invariants/`)
+complete in under 6 seconds and show 0 failures.
+
+**Workaround used**: Run scoped suites that exclude `test/architecture/` and
+`test/integration/` — these complete in ~6s.
+
+**Suggested fix**: Profile the spec-dump or YAML-heavy test path to identify
+the bottleneck; consider marking slow tests with `@pytest.mark.slow` and
+adding a `--ignore` default to the local pytest config so `uv run pytest`
+runs fast by default.

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -484,3 +484,44 @@ groups:
     - rel_type: depends_on
       spec_id: SYNC-12-001
       note: "Effects-before-persist invariant applies; an entry whose genesis is unknown cannot be safely committed"
+  - id: SYNC-15-003
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The CaseActor MUST bound the rate at which it replays entries to a peer whose
+      acknowledged replication position has not advanced.  It MUST record, per peer, the
+      position (the `entry_hash` a replay resumed from, or `""` for genesis) of the last
+      replay in which at least one entry was actually sent, together with the time it was
+      sent.  A Reject reporting an unchanged position within the cooldown MUST NOT trigger
+      another replay.  A Reject reporting an advanced position MUST always replay.  A replay
+      in which zero entries were sent MUST NOT update the recorded position, because no
+      delivery was attempted at that position.
+    rationale: >-
+      Reject-triggered replay (SYNC-08-005, SYNC-14-002) is unconditional by default, and a peer
+      that cannot anchor its hash chain Rejects every entry replayed to it.  Each Reject replays
+      the full missing suffix and each replayed entry produces another Reject — a self-sustaining
+      amplification loop, observed in CI as 4825 `Announce(CaseLedgerEntry)` activities for a
+      26-entry ledger (~185x), starving the actor until unrelated DataLayer reads timed out
+      (issue #1989).
+    note: >-
+      The bound must be a rate limit rather than permanent suppression: if a replayed entry is
+      lost in transit, a later Reject at the same position must still eventually trigger a fresh
+      replay, or the peer would never converge.  The zero-entry carve-out follows from the same
+      requirement — recording a position at which nothing was delivered would start a cooldown
+      that suppresses the first replay genuinely owed to that peer once the ledger grows.
+      Genesis (`last_accepted_hash == ""`) SHOULD use a shorter cooldown than a mid-chain stall:
+      a peer at genesis holds no entries at all and its convergence is owned by
+      SYNC-15-001/SYNC-15-002, which seed the VulnerabilityCase and then rely on the following
+      replay to deliver the history, so rate-limiting that replay as aggressively as a mid-chain
+      stall starves the bootstrap it exists to complete.  Genesis cannot be exempted outright,
+      however, because a peer that cannot anchor its chain reports genesis on every Reject.
+    relationships:
+    - rel_type: depends_on
+      spec_id: SYNC-08-005
+      note: Bounds the replay this rule triggers; the reject-on-divergence contract itself is unchanged
+    - rel_type: depends_on
+      spec_id: SYNC-03-002
+      note: The replay-from-hash path whose rate this rule limits
+    - rel_type: refines
+      spec_id: SYNC-15-001
+      note: The genesis Reject that SYNC-15-001 mandates is the highest-volume source of no-progress replays

--- a/test/adapters/driving/fastapi/test_outbox_helpers.py
+++ b/test/adapters/driving/fastapi/test_outbox_helpers.py
@@ -238,3 +238,84 @@ def test_coerce_reference_value_collapses_href_then_id():
         oh._coerce_reference_value({"id": "https://example.org/obj/2"})
         == "https://example.org/obj/2"
     )
+
+
+# ---------------------------------------------------------------------------
+# _load_outbound_activity role preservation (CM-16-003 / CM-17-003)
+# ---------------------------------------------------------------------------
+
+
+def test_load_outbound_activity_preserves_suggested_roles():
+    """``suggestedRoles`` MUST survive the wire→VultronActivity conversion.
+
+    ``_load_outbound_activity`` converts a stored wire activity into a
+    ``VultronActivity`` before delivery.  The wire dump is camelCase
+    (``suggestedRoles``), so ``VultronActivity`` needs a matching validation
+    alias — otherwise the field silently validates to ``None`` and vanishes
+    from the delivered payload.
+
+    Regression guard: the DEPLOYER role was dropped here, so a suggested actor
+    joined a case with ``[VENDOR]`` only and CSB-15-002 then blocked its
+    d→D (VFD) transition.
+    """
+    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+    from vultron.adapters.driving.fastapi.outbox_delivery import (
+        _load_outbound_activity,
+    )
+    from vultron.wire.as2.factories.actor import recommend_actor_activity
+    from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    suggested = as_Actor(
+        id_="https://example.org/actors/v2", name="V2", type_="Organization"
+    )
+    activity = recommend_actor_activity(
+        recommended=suggested,
+        target="https://example.org/cases/c1",
+        suggested_roles=["vendor", "deployer"],
+        actor="https://example.org/actors/c2",
+        to=["https://example.org/actors/case-actor"],
+    )
+    dl.create(activity)
+
+    outbound = _load_outbound_activity(
+        "https://example.org/actors/c2", activity.id_, dl
+    )
+
+    assert outbound is not None
+    assert outbound.suggested_roles == ["vendor", "deployer"]
+
+
+def test_load_outbound_activity_preserves_roles():
+    """``roles`` MUST survive the wire→VultronActivity conversion.
+
+    Same failure mode as ``suggestedRoles`` on the Invite hop: the invitee's
+    roles are carried in the Invite's ``roles`` field, and losing them means
+    the participant record is created with default roles only (CM-17-003).
+    """
+    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+    from vultron.adapters.driving.fastapi.outbox_delivery import (
+        _load_outbound_activity,
+    )
+    from vultron.wire.as2.factories.case import rm_invite_to_case_activity
+    from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    invitee = as_Actor(
+        id_="https://example.org/actors/v2", name="V2", type_="Organization"
+    )
+    activity = rm_invite_to_case_activity(
+        invitee=invitee,
+        target="https://example.org/cases/c1",
+        roles=["vendor", "deployer"],
+        actor="https://example.org/actors/case-actor",
+        to=["https://example.org/actors/v2"],
+    )
+    dl.create(activity)
+
+    outbound = _load_outbound_activity(
+        "https://example.org/actors/case-actor", activity.id_, dl
+    )
+
+    assert outbound is not None
+    assert outbound.roles == ["vendor", "deployer"]

--- a/test/ci/invariants/test_fcvcv_invariants.py
+++ b/test/ci/invariants/test_fcvcv_invariants.py
@@ -1,0 +1,390 @@
+"""Case-ledger invariant tests for the five-actor FCVCV scenario.
+
+Reads JSONL case-ledger replica files from ``devlogs/fcvcv/`` and asserts
+universal invariants (via the shared ``common`` library) plus FCVCV-specific
+checks.
+
+Actor set: ``finder``, ``c1``, ``v1``, ``c2``, ``v2``, ``case-actor``.
+
+Container-to-role mapping (docker-compose-multi-actor.yml):
+  finder      → Finder container
+  c1          → C1/Coordinator1 (coordinator container) — CASE_OWNER
+  v1          → V1/Vendor1 (vendor container) — CVDRole.VENDOR only → VFd
+  c2          → C2/Coordinator2 (actor5 container) — CVDRole.COORDINATOR
+  v2          → V2/VendorDeployer (actor6 container) — VENDOR+DEPLOYER → VFD
+  case-actor  → CaseActor (coordinator container sub-actor)
+
+FCVCV-specific invariants:
+- ``invite_actor_to_case`` appears at least three times (C1 invites V1, C1
+  invites C2, CaseActor invites V2 via ADR-0026).
+- ``offer_case_participant`` appears at least once (C2 suggests V2 via
+  ADR-0026).
+- ``accept_invite_actor_to_case`` appears at least three times.
+- V2 (late joiner via ADR-0026) holds the full ledger from genesis (SYNC-2).
+- C1, V1, C2 are also late joiners whose replicas start from genesis.
+- CS transition VFd observed for both V1 and V2.
+- CS transition VFD observed for V2 only (V1 stops at VFd — DEMOMA-19-004).
+
+All tests are tagged ``@pytest.mark.case_ledger_invariants``.  They skip
+automatically when ``devlogs/fcvcv/`` is absent.
+
+Spec: DEMOMA-19 (GitHub issue #1925).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from test.ci.invariants.common import (
+    check_cross_actor_hash_agreement,
+    check_cross_actor_payload_actor_agreement,
+    check_cs_state_transitions_observed,
+    check_event_type_count,
+    check_event_type_present,
+    check_genesis_entry_present,
+    check_hash_chain,
+    check_late_joiner_has_full_history,
+    check_log_starts_at_genesis,
+    check_nested_objects_inlined,
+    check_no_gaps_in_log_indices,
+    check_no_rm_state_oscillation,
+    check_non_empty_payload_snapshots,
+    check_participant_status_schema_completeness,
+    check_payload_context_uses_case_uri,
+    check_rm_closed_termination,
+    load_devlogs,
+)
+
+_DEMO_NAME = "fcvcv"
+
+#: Expected protocol eventTypes in a complete FCVCV run.
+_FCVCV_EXPECTED_EVENT_TYPES = [
+    pytest.param("validate_report", id="validate_report"),
+    pytest.param(
+        "add_participant_status_to_participant",
+        id="add_participant_status_to_participant",
+    ),
+    pytest.param("close_case", id="close_case"),
+    pytest.param("add_note_to_case", id="add_note_to_case"),
+    # C1 invites V1, C1 invites C2, CaseActor invites V2 (ADR-0026).
+    pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
+    # C2 suggests V2 via the ADR-0026 suggest-actor flow.
+    pytest.param("offer_case_participant", id="offer_case_participant"),
+    # V1 accepts C1 invite; C2 accepts C1 invite; V2 accepts CaseActor invite.
+    pytest.param(
+        "accept_invite_actor_to_case", id="accept_invite_actor_to_case"
+    ),
+]
+
+#: Actors with per-actor chain / contiguity / completeness checks.
+_CHAIN_ACTORS = [
+    pytest.param("case-actor"),
+    pytest.param("c1"),
+    pytest.param("v1"),
+    pytest.param("c2"),
+    pytest.param("v2"),
+    pytest.param("finder"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def fcvcv_replicas() -> dict[str, list[dict]]:
+    """Load FCVCV scenario JSONL files grouped by actor name."""
+    return load_devlogs(demo_name=_DEMO_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Universal invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.case_ledger_invariants
+@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
+def test_invariant_1_local_hash_chain_consistent(
+    actor_name: str,
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """Within each contiguous logIndex fragment, hashes chain correctly."""
+    entries = fcvcv_replicas.get(actor_name)
+    if entries is None:
+        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcvcv/")
+    violations = check_hash_chain(actor_name, entries)
+    assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_2_cross_actor_hash_agreement(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """All actors agree on entryHash for every shared logIndex."""
+    violations = check_cross_actor_hash_agreement(fcvcv_replicas)
+    assert not violations, (
+        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
+        + "\n".join(violations[:20])
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_3_cross_actor_payload_actor_agreement(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
+    violations = check_cross_actor_payload_actor_agreement(fcvcv_replicas)
+    assert (
+        not violations
+    ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
+        violations[:20]
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_4_non_empty_payload_snapshot(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """Every recorded canonical entry has a non-empty payloadSnapshot."""
+    violations = check_non_empty_payload_snapshots(fcvcv_replicas)
+    assert not violations, (
+        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
+        + "\n".join(violations[:20])
+    )
+
+
+@pytest.mark.case_ledger_invariants
+@pytest.mark.parametrize("event_type_val", _FCVCV_EXPECTED_EVENT_TYPES)
+def test_invariant_5_expected_event_types_present(
+    event_type_val: str,
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """Each expected protocol eventType appears at least once."""
+    violations = check_event_type_present(fcvcv_replicas, event_type_val)
+    assert not violations, violations[0] if violations else ""
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_6_no_rm_state_oscillation(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """No participant changes RM state after first reaching CLOSED."""
+    violations = check_no_rm_state_oscillation(fcvcv_replicas)
+    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
+        violations
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_7_log_terminates_all_rm_closed(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """The log terminates with every participant in RM=CLOSED."""
+    violations = check_rm_closed_termination(fcvcv_replicas)
+    assert not violations, f"Participants not in RM=CLOSED: {violations}"
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_9_participant_status_schema_completeness(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
+    violations = check_participant_status_schema_completeness(fcvcv_replicas)
+    assert not violations, (
+        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
+        + "\n".join(violations[:20])
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_10_nested_objects_inlined_in_payload(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """payloadSnapshot.object is an inline dict, not a bare ID string."""
+    violations = check_nested_objects_inlined(fcvcv_replicas)
+    assert not violations, (
+        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
+        + "\n".join(violations[:20])
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_11_payload_context_uses_case_uri(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
+    violations = check_payload_context_uses_case_uri(fcvcv_replicas)
+    assert not violations, (
+        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
+        + "\n".join(violations[:20])
+    )
+
+
+@pytest.mark.case_ledger_invariants
+@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
+def test_invariant_12_genesis_entry_present(
+    actor_name: str,
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """logIndex=0 is present in the actor's log."""
+    entries = fcvcv_replicas.get(actor_name)
+    if entries is None:
+        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcvcv/")
+    violations = check_genesis_entry_present(actor_name, entries)
+    assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
+def test_invariant_13_log_starts_at_genesis(
+    actor_name: str,
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """The first entry in the actor's sorted log has logIndex=0."""
+    entries = fcvcv_replicas.get(actor_name)
+    if entries is None:
+        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcvcv/")
+    violations = check_log_starts_at_genesis(actor_name, entries)
+    assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
+def test_invariant_14_no_gaps_in_log_indices(
+    actor_name: str,
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """No gaps within the actor's present logIndex range."""
+    entries = fcvcv_replicas.get(actor_name)
+    if entries is None:
+        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcvcv/")
+    violations = check_no_gaps_in_log_indices(actor_name, entries)
+    assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_15_cs_state_transitions_observed(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """All three key CS transitions observed in the authoritative log."""
+    violations = check_cs_state_transitions_observed(fcvcv_replicas)
+    assert not violations, "Missing CS-transition observations:\n" + "\n".join(
+        violations
+    )
+
+
+# ---------------------------------------------------------------------------
+# FCVCV-specific invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.case_ledger_invariants
+def test_fcvcv_invite_actor_to_case_at_least_three(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """``invite_actor_to_case`` appears at least three times.
+
+    C1 invites V1 (VENDOR), C1 invites C2 (COORDINATOR), CaseActor invites V2
+    (VENDOR+DEPLOYER) via the ADR-0026 suggest-actor path.
+
+    Spec: DEMOMA-19-003, DEMOMA-19-009.
+    """
+    violations = check_event_type_count(
+        fcvcv_replicas, "invite_actor_to_case", min_count=3
+    )
+    assert not violations, violations[0] if violations else ""
+
+
+@pytest.mark.case_ledger_invariants
+def test_fcvcv_offer_case_participant_present(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """``offer_case_participant`` appears at least once (C2 suggests V2).
+
+    Spec: DEMOMA-19-009 (C2 uses the ADR-0026 suggest-actor flow).
+    """
+    violations = check_event_type_present(
+        fcvcv_replicas, "offer_case_participant"
+    )
+    assert not violations, violations[0] if violations else ""
+
+
+@pytest.mark.case_ledger_invariants
+def test_fcvcv_accept_invite_at_least_three(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """``accept_invite_actor_to_case`` appears at least three times.
+
+    V1 accepts C1's invite, C2 accepts C1's invite, V2 accepts CaseActor's
+    invite via the ADR-0026 path.
+
+    Spec: DEMOMA-19-003, DEMOMA-19-009.
+    """
+    violations = check_event_type_count(
+        fcvcv_replicas, "accept_invite_actor_to_case", min_count=3
+    )
+    assert not violations, violations[0] if violations else ""
+
+
+@pytest.mark.case_ledger_invariants
+def test_fcvcv_v2_late_joiner_has_full_history(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """V2 replica holds every logIndex present in C1 (the authoritative actor).
+
+    V2 joins via the ADR-0026 path (C2 suggests → C1 approves → CaseActor
+    invites) and must receive the full ledger backfill from CaseActor (SYNC-2).
+
+    Spec: DEMOMA-19-009, SYNC-2.
+    """
+    if not fcvcv_replicas.get("c1") or not fcvcv_replicas.get("v2"):
+        pytest.skip(
+            "c1 or v2 replica absent; cannot check V2 late-joiner invariant"
+        )
+    violations = check_late_joiner_has_full_history(
+        fcvcv_replicas, early_actor="c1", late_actor="v2"
+    )
+    assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_fcvcv_c2_late_joiner_has_full_history(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """C2 replica holds every logIndex present in C1 (the authoritative actor).
+
+    C2 joins when C1 invites them; CaseActor must backfill all prior entries
+    (SYNC-2).
+
+    Spec: DEMOMA-19-003, SYNC-2.
+    """
+    if not fcvcv_replicas.get("c1") or not fcvcv_replicas.get("c2"):
+        pytest.skip(
+            "c1 or c2 replica absent; cannot check C2 late-joiner invariant"
+        )
+    violations = check_late_joiner_has_full_history(
+        fcvcv_replicas, early_actor="c1", late_actor="c2"
+    )
+    assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_fcvcv_v1_late_joiner_has_full_history(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """V1 replica holds every logIndex present in C1 (the authoritative actor).
+
+    V1 joins when C1 invites them (direct invite, not ADR-0026 path); CaseActor
+    still backfills all prior entries (SYNC-2).
+
+    Spec: DEMOMA-19-003, SYNC-2.
+    """
+    if not fcvcv_replicas.get("c1") or not fcvcv_replicas.get("v1"):
+        pytest.skip(
+            "c1 or v1 replica absent; cannot check V1 late-joiner invariant"
+        )
+    violations = check_late_joiner_has_full_history(
+        fcvcv_replicas, early_actor="c1", late_actor="v1"
+    )
+    assert not violations, "\n".join(violations)

--- a/test/core/behaviors/sync/nodes/test_replay_guard.py
+++ b/test/core/behaviors/sync/nodes/test_replay_guard.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 
 from vultron.core.behaviors.sync.nodes.replay_guard import (
+    GENESIS_REPLAY_COOLDOWN_SECONDS,
     REPLAY_COOLDOWN_SECONDS,
     claim_replay_position,
     replay_from_hash,
@@ -125,6 +126,41 @@ class TestClaimReplayPosition:
 
         assert first is True
         assert second is False
+
+    def test_genesis_uses_a_shorter_cooldown_than_mid_chain(self, datalayer):
+        """A genesis peer is mid-bootstrap (SYNC-15-002) and must not be starved.
+
+        Regression guard: a full-length cooldown at genesis suppressed the
+        replay that ``AnnounceCaseOnGenesisRejectNode`` depends on, leaving the
+        peer with an empty replica ("SYNC-2 replication did not complete").
+        Genesis still gets *a* cooldown, so the storm stays bounded.
+        """
+        assert GENESIS_REPLAY_COOLDOWN_SECONDS < REPLAY_COOLDOWN_SECONDS
+
+        claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="",
+        )
+        state_id = VultronReplicationState(
+            case_id=CASE_ID, peer_id=PARTICIPANT_ACTOR_ID
+        ).id_
+        state = datalayer.read(state_id)
+        # Older than the genesis cooldown, but well inside the mid-chain one.
+        state.last_replayed_at = state.last_replayed_at - timedelta(
+            seconds=GENESIS_REPLAY_COOLDOWN_SECONDS + 1
+        )
+        datalayer.save(state)
+
+        admitted = claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="",
+        )
+
+        assert admitted is True
 
     def test_peers_are_tracked_independently(self, datalayer):
         other_peer = "https://example.org/actors/late-joiner"

--- a/test/core/behaviors/sync/nodes/test_replay_guard.py
+++ b/test/core/behaviors/sync/nodes/test_replay_guard.py
@@ -6,8 +6,9 @@ from datetime import timedelta
 from vultron.core.behaviors.sync.nodes.replay_guard import (
     GENESIS_REPLAY_COOLDOWN_SECONDS,
     REPLAY_COOLDOWN_SECONDS,
-    claim_replay_position,
+    record_replay,
     replay_from_hash,
+    should_replay,
 )
 from vultron.core.models.replication_state import VultronReplicationState
 
@@ -36,8 +37,25 @@ class TestReplayFromHash:
         assert replay_from_hash([], 3) == ""
 
 
+def claim_replay_position(datalayer, *, case_id, peer_id, from_hash) -> bool:
+    """Ask-then-record, as ``SendMissingEntriesNode`` does for a non-empty replay.
+
+    The two steps are separate in production so a replay that sends nothing
+    never records a position (see ``record_replay``); these tests exercise the
+    common path where entries do go out.
+    """
+    if not should_replay(
+        datalayer, case_id=case_id, peer_id=peer_id, from_hash=from_hash
+    ):
+        return False
+    record_replay(
+        datalayer, case_id=case_id, peer_id=peer_id, from_hash=from_hash
+    )
+    return True
+
+
 class TestClaimReplayPosition:
-    """``claim_replay_position`` admits progress and suppresses stalls."""
+    """The ask-then-record pair admits progress and suppresses stalls."""
 
     def test_first_claim_is_admitted_and_persists_state(self, datalayer):
         admitted = claim_replay_position(
@@ -178,3 +196,44 @@ class TestClaimReplayPosition:
         )
 
         assert admitted is True
+
+
+class TestZeroEntryReplayDoesNotRecordPosition:
+    """A replay that sends nothing must not start a cooldown.
+
+    Regression guard: recording the position before knowing whether any entry
+    would be sent meant a peer already at the ledger tail (0 entries replayed)
+    started a cooldown anyway.  Once the ledger grew, that peer's next Reject —
+    now naming a genuinely stale position — was suppressed, so it waited out the
+    full cooldown having received nothing.  That is the stall the guard exists
+    to prevent, reintroduced by the guard itself.
+    """
+
+    def test_position_is_unrecorded_when_nothing_was_replayed(self, datalayer):
+        assert should_replay(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="tail",
+        )
+        # No record_replay() — the caller sent zero entries.
+        state_id = VultronReplicationState(
+            case_id=CASE_ID, peer_id=PARTICIPANT_ACTOR_ID
+        ).id_
+        assert datalayer.read(state_id) is None
+
+    def test_later_reject_at_same_position_still_replays(self, datalayer):
+        should_replay(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="tail",
+        )
+        # Ledger has since grown; the peer Rejects at the same position, and a
+        # real suffix is now missing.  It must not be suppressed.
+        assert should_replay(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="tail",
+        )

--- a/test/core/behaviors/sync/nodes/test_replay_guard.py
+++ b/test/core/behaviors/sync/nodes/test_replay_guard.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 """Unit tests for the Reject-replay convergence guard (SYNC-15-003)."""
 
+from datetime import timedelta
+
 from vultron.core.behaviors.sync.nodes.replay_guard import (
+    REPLAY_COOLDOWN_SECONDS,
     claim_replay_position,
     replay_from_hash,
 )
@@ -61,6 +64,34 @@ class TestClaimReplayPosition:
             )
         assert admitted is False
 
+    def test_suppression_lapses_after_cooldown(self, datalayer):
+        """The guard is a rate limit, not permanent suppression — otherwise a
+        dropped replay would leave the peer un-synced forever.
+        """
+        claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="abc",
+        )
+        state_id = VultronReplicationState(
+            case_id=CASE_ID, peer_id=PARTICIPANT_ACTOR_ID
+        ).id_
+        state = datalayer.read(state_id)
+        state.last_replayed_at = state.last_replayed_at - timedelta(
+            seconds=REPLAY_COOLDOWN_SECONDS + 1
+        )
+        datalayer.save(state)
+
+        admitted = claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="abc",
+        )
+
+        assert admitted is True
+
     def test_claim_at_advanced_hash_is_admitted(self, datalayer):
         claim_replay_position(
             datalayer,
@@ -77,7 +108,7 @@ class TestClaimReplayPosition:
 
         assert admitted is True
 
-    def test_genesis_claim_is_admitted_once_then_suppressed(self, datalayer):
+    def test_genesis_claim_is_admitted_once_then_rate_limited(self, datalayer):
         """``""`` is a real position, not "unset" — it must still converge."""
         first = claim_replay_position(
             datalayer,

--- a/test/core/behaviors/sync/nodes/test_replay_guard.py
+++ b/test/core/behaviors/sync/nodes/test_replay_guard.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+"""Unit tests for the Reject-replay convergence guard (SYNC-15-003)."""
+
+from vultron.core.behaviors.sync.nodes.replay_guard import (
+    claim_replay_position,
+    replay_from_hash,
+)
+from vultron.core.models.replication_state import VultronReplicationState
+
+from test.core.behaviors.sync.nodes.conftest import (
+    CASE_ID,
+    PARTICIPANT_ACTOR_ID,
+    _make_entry,
+)
+
+
+class TestReplayFromHash:
+    """``replay_from_hash`` maps a divergence index to a position hash."""
+
+    def test_negative_index_is_genesis(self):
+        assert replay_from_hash([_make_entry(0)], -1) == ""
+
+    def test_returns_hash_at_matching_index(self):
+        first = _make_entry(0)
+        second = _make_entry(1, first.entry_hash)
+        assert replay_from_hash([first, second], 1) == second.entry_hash
+
+    def test_missing_index_falls_back_to_genesis(self):
+        assert replay_from_hash([_make_entry(0)], 7) == ""
+
+    def test_empty_entries_is_genesis(self):
+        assert replay_from_hash([], 3) == ""
+
+
+class TestClaimReplayPosition:
+    """``claim_replay_position`` admits progress and suppresses stalls."""
+
+    def test_first_claim_is_admitted_and_persists_state(self, datalayer):
+        admitted = claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="abc",
+        )
+
+        assert admitted is True
+        state_id = VultronReplicationState(
+            case_id=CASE_ID, peer_id=PARTICIPANT_ACTOR_ID
+        ).id_
+        stored = datalayer.read(state_id)
+        assert stored is not None
+        assert stored.last_replayed_from_hash == "abc"
+
+    def test_repeat_claim_at_same_hash_is_suppressed(self, datalayer):
+        for _ in range(2):
+            admitted = claim_replay_position(
+                datalayer,
+                case_id=CASE_ID,
+                peer_id=PARTICIPANT_ACTOR_ID,
+                from_hash="abc",
+            )
+        assert admitted is False
+
+    def test_claim_at_advanced_hash_is_admitted(self, datalayer):
+        claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="abc",
+        )
+        admitted = claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="def",
+        )
+
+        assert admitted is True
+
+    def test_genesis_claim_is_admitted_once_then_suppressed(self, datalayer):
+        """``""`` is a real position, not "unset" — it must still converge."""
+        first = claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="",
+        )
+        second = claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="",
+        )
+
+        assert first is True
+        assert second is False
+
+    def test_peers_are_tracked_independently(self, datalayer):
+        other_peer = "https://example.org/actors/late-joiner"
+        claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=PARTICIPANT_ACTOR_ID,
+            from_hash="abc",
+        )
+        admitted = claim_replay_position(
+            datalayer,
+            case_id=CASE_ID,
+            peer_id=other_peer,
+            from_hash="abc",
+        )
+
+        assert admitted is True

--- a/test/core/behaviors/sync/test_reject_tree.py
+++ b/test/core/behaviors/sync/test_reject_tree.py
@@ -238,3 +238,79 @@ def test_non_genesis_reject_skips_announce_vulnerability_case(
 
     assert result.status == Status.SUCCESS
     trigger_activity.announce_vulnerability_case.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Reject/replay amplification guard (SYNC-15-003)
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_reject_at_same_hash_does_not_replay_unboundedly(
+    bridge, datalayer, case_actor
+):
+    """A peer stuck at the same ``last_accepted_hash`` must not trigger an
+    unbounded full-ledger replay on every Reject.
+
+    Regression guard for the reject/replay amplification loop: a late-joining
+    participant that cannot anchor its hash chain re-Rejects each replayed
+    entry, and each Reject previously re-replayed the *entire* ledger.  With a
+    25-entry ledger this produced thousands of Announce activities, starving
+    the container until unrelated DataLayer reads timed out.
+
+    The first Reject at a given hash SHOULD replay; subsequent Rejects at the
+    *same* hash MUST NOT replay again, because nothing has changed — the peer
+    has made no progress, so re-sending the same entries cannot help.
+    """
+    entries = [_make_entry(0)]
+    for index in range(1, 25):
+        entries.append(_make_entry(index, entries[-1].entry_hash))
+    for entry in entries:
+        datalayer.save(entry)
+
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    # The peer is stuck: it never advances past entry 0.
+    stuck_hash = entries[0].entry_hash
+    for _ in range(10):
+        py_trees.blackboard.Blackboard.storage.clear()
+        result = bridge.execute_with_setup(
+            tree=create_reject_log_entry_tree(),
+            actor_id=OWNER_ACTOR_ID,
+            activity=_make_event(entries[-1], tail_hash=stuck_hash),
+            sync_port=sync_port,
+        )
+        assert result.status == Status.SUCCESS
+
+    # Without a guard this is 10 rounds × 24 missing entries = 240 announces.
+    # With the guard only the first round replays.
+    assert sync_port.send_announce_log_entry.call_count == len(entries) - 1
+
+
+def test_reject_at_advanced_hash_replays_again(bridge, datalayer, case_actor):
+    """The guard must not wedge a peer that *is* making progress.
+
+    When a peer's ``last_accepted_hash`` advances between Rejects, the replay
+    MUST fire again for the newly-missing suffix.
+    """
+    entries = [_make_entry(0)]
+    for index in range(1, 4):
+        entries.append(_make_entry(index, entries[-1].entry_hash))
+    for entry in entries:
+        datalayer.save(entry)
+
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    for stuck_at in range(3):
+        py_trees.blackboard.Blackboard.storage.clear()
+        result = bridge.execute_with_setup(
+            tree=create_reject_log_entry_tree(),
+            actor_id=OWNER_ACTOR_ID,
+            activity=_make_event(
+                entries[-1], tail_hash=entries[stuck_at].entry_hash
+            ),
+            sync_port=sync_port,
+        )
+        assert result.status == Status.SUCCESS
+
+    # Progress at index 0, 1, 2 → 3 + 2 + 1 = 6 replayed entries.
+    assert sync_port.send_announce_log_entry.call_count == 6

--- a/test/core/behaviors/sync/test_reject_tree.py
+++ b/test/core/behaviors/sync/test_reject_tree.py
@@ -314,3 +314,54 @@ def test_reject_at_advanced_hash_replays_again(bridge, datalayer, case_actor):
 
     # Progress at index 0, 1, 2 → 3 + 2 + 1 = 6 replayed entries.
     assert sync_port.send_announce_log_entry.call_count == 6
+
+
+def test_reject_at_tail_then_growth_replays_the_new_suffix(
+    bridge, datalayer, case_actor
+):
+    """A Reject that needs nothing must not start a cooldown against its position.
+
+    Regression guard for the guard itself: the replay position used to be
+    recorded *before* the replay loop ran, so a peer already at the ledger tail
+    (zero entries to send) still started a cooldown.  When the ledger then grew,
+    that peer's next Reject reported the same ``last_accepted_hash`` — now
+    genuinely stale, with a real suffix missing — and was suppressed.  The peer
+    waited out the full cooldown having never received a single entry, which is
+    the late-joiner stall SYNC-15-003 exists to prevent.
+    """
+    entries = [_make_entry(0)]
+    for index in range(1, 4):
+        entries.append(_make_entry(index, entries[-1].entry_hash))
+    for entry in entries:
+        datalayer.save(entry)
+
+    sync_port = MagicMock(spec=SyncActivityPort)
+    tail_hash = entries[-1].entry_hash
+
+    # The peer is fully caught up; its Reject needs no entries replayed.
+    py_trees.blackboard.Blackboard.storage.clear()
+    result = bridge.execute_with_setup(
+        tree=create_reject_log_entry_tree(),
+        actor_id=OWNER_ACTOR_ID,
+        activity=_make_event(entries[-1], tail_hash=tail_hash),
+        sync_port=sync_port,
+    )
+    assert result.status == Status.SUCCESS
+    assert sync_port.send_announce_log_entry.call_count == 0
+
+    # The ledger grows by three entries.
+    for index in range(4, 7):
+        entries.append(_make_entry(index, entries[-1].entry_hash))
+        datalayer.save(entries[-1])
+
+    # The peer Rejects at the same hash it reported before — but that position
+    # is now three entries behind, so the suffix MUST be replayed.
+    py_trees.blackboard.Blackboard.storage.clear()
+    result = bridge.execute_with_setup(
+        tree=create_reject_log_entry_tree(),
+        actor_id=OWNER_ACTOR_ID,
+        activity=_make_event(entries[-1], tail_hash=tail_hash),
+        sync_port=sync_port,
+    )
+    assert result.status == Status.SUCCESS
+    assert sync_port.send_announce_log_entry.call_count == 3

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -203,6 +203,7 @@ class _ActorsMixin:
         actor: str,
         to: list[str] | None = None,
         id_: str | None = None,
+        roles: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist a ``Offer(Actor, Case)`` recommendation activity."""
         extra: dict[str, Any] = {"actor": actor, "to": to}
@@ -212,6 +213,7 @@ class _ActorsMixin:
         activity = recommend_actor_activity(
             recommended=CoreActor(id_=recommended_id),
             target=case_id,
+            suggested_roles=roles,
             **extra,
         )
         try:

--- a/vultron/adapters/driving/fastapi/routers/trigger_actor.py
+++ b/vultron/adapters/driving/fastapi/routers/trigger_actor.py
@@ -76,6 +76,7 @@ def trigger_suggest_actor_to_case(
             actor_id=actor_id,
             case_id=body.case_id,
             suggested_actor_id=body.suggested_actor_id,
+            roles=body.roles,
         )
     background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
     return result

--- a/vultron/adapters/driving/fastapi/trigger_models.py
+++ b/vultron/adapters/driving/fastapi/trigger_models.py
@@ -302,6 +302,7 @@ class SuggestActorToCaseRequest(BaseModel):
 
     case_id: UriString
     suggested_actor_id: UriString
+    roles: list[CVDRole] | None = None
 
 
 class AcceptCaseInviteRequest(BaseModel):

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -412,15 +412,47 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
         self.suggested_actor_id = suggested_actor_id
         self.case_id = case_id
         self.recommendation_id = recommendation_id
-        self._injected_roles: list[CVDRole] | None = None
-        if injected_roles:
-            try:
-                self._injected_roles = [CVDRole(r) for r in injected_roles]
-            except ValueError:
-                self._injected_roles = None
         self.logger = logging.getLogger(  # type: ignore[assignment]
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
+        self._injected_roles = self._coerce_injected_roles(injected_roles)
+
+    def _coerce_injected_roles(
+        self, injected_roles: list[str] | None
+    ) -> list[CVDRole] | None:
+        """Coerce caller-supplied role strings to ``CVDRole``, keeping valid ones.
+
+        An unrecognized role string is dropped with a warning rather than
+        discarding the whole list: falling back to the hardcoded default would
+        silently substitute roles the caller did not ask for, which CM-16-003
+        forbids.  ``None`` is returned only when nothing usable remains, in
+        which case ``_compute_roles()`` legitimately owns the decision.
+        """
+        if not injected_roles:
+            return None
+        coerced: list[CVDRole] = []
+        for raw in injected_roles:
+            try:
+                coerced.append(CVDRole(raw))
+            except ValueError:
+                self.logger.warning(
+                    "%s: ignoring unrecognized injected role %r for actor"
+                    " '%s' in case '%s'",
+                    self.name,
+                    raw,
+                    self.suggested_actor_id,
+                    self.case_id,
+                )
+        if not coerced:
+            self.logger.warning(
+                "%s: no injected role in %r was recognized for actor '%s';"
+                " falling back to _compute_roles()",
+                self.name,
+                injected_roles,
+                self.suggested_actor_id,
+            )
+            return None
+        return coerced
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -392,8 +392,10 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
 
     ADR-0024 Evaluator shape.  Writes ``suggested_roles_{id_segment}``
     (namespaced by ``recommendation_id``, BTND-03-004) to the blackboard.
-    Prototype writes ``[CVDRole.VENDOR]``.  Subclasses may override
-    ``_compute_roles()``; an empty return produces ``FAILURE`` (AC-1).
+    When ``injected_roles`` is provided those roles are used directly;
+    otherwise falls back to ``_compute_roles()`` (default: ``[CVDRole.VENDOR]``).
+    Subclasses may override ``_compute_roles()``; an empty return produces
+    ``FAILURE`` (AC-1).
     """
 
     logger: logging.Logger  # type: ignore[assignment]
@@ -403,12 +405,19 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
         suggested_actor_id: str,
         case_id: str,
         recommendation_id: str,
+        injected_roles: list[str] | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.suggested_actor_id = suggested_actor_id
         self.case_id = case_id
         self.recommendation_id = recommendation_id
+        self._injected_roles: list[CVDRole] | None = None
+        if injected_roles:
+            try:
+                self._injected_roles = [CVDRole(r) for r in injected_roles]
+            except ValueError:
+                self._injected_roles = None
         self.logger = logging.getLogger(  # type: ignore[assignment]
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
@@ -427,7 +436,11 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
         return [CVDRole.VENDOR]
 
     def update(self) -> Status:
-        roles = self._compute_roles()
+        roles = (
+            self._injected_roles
+            if self._injected_roles
+            else self._compute_roles()
+        )
         if not roles:
             self.feedback_message = (
                 f"{self.name}: _compute_roles() returned an empty list "

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -88,6 +88,7 @@ def create_recommend_actor_to_case_received_tree(
     recommended_id: str,
     case_id: str,
     offer_content: str | None = None,
+    suggested_roles: list[str] | None = None,
 ) -> py_trees.composites.Sequence:
     """Received-side BT for Offer(Actor, Case) on the CaseActor inbox.
 
@@ -187,6 +188,7 @@ def create_recommend_actor_to_case_received_tree(
                 suggested_actor_id=recommended_id,
                 case_id=case_id,
                 recommendation_id=recommendation_id,
+                injected_roles=suggested_roles,
             ),
             EmitOfferCaseParticipantToOwnerNode(
                 recommendation_id=recommendation_id,

--- a/vultron/core/behaviors/sync/nodes/replay.py
+++ b/vultron/core/behaviors/sync/nodes/replay.py
@@ -23,12 +23,19 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.sync.nodes.replay_guard import (
+    claim_replay_position,
+    replay_from_hash,
+)
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_ledger_entry import (
     CaseLedgerEntry,
     VultronCaseLedgerEntry,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.ports.case_persistence import (
+    CaseOutboxPersistence,
+    CasePersistence,
+)
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.ports.trigger_activity import TriggerActivityPort
 from vultron.core.use_cases._helpers import case_addressees
@@ -245,6 +252,28 @@ class SendMissingEntriesNode(DataLayerAction):
             list[CaseLedgerEntry], self.blackboard.replay_case_ledger_entries
         )
         from_index = cast(int, self.blackboard.replay_from_index)
+
+        # SYNC-15-003: suppress no-progress replays.  A peer that cannot anchor
+        # its hash chain re-Rejects every entry we replay; replaying the full
+        # ledger again on each Reject is a self-sustaining amplification loop
+        # that starves the actor.  Replay only when the peer's acknowledged
+        # position has actually moved since the last replay we sent it.
+        from_hash = replay_from_hash(entries, from_index)
+        if not claim_replay_position(
+            cast(CasePersistence, self.datalayer),
+            case_id=entry.case_id,
+            peer_id=peer_id,
+            from_hash=from_hash,
+        ):
+            self.logger.info(
+                "%s: peer '%s' re-Rejected at unchanged position %.16s… for"
+                " case '%s'; suppressing duplicate replay (SYNC-15-003)",
+                self.name,
+                peer_id,
+                from_hash or "genesis",
+                entry.case_id,
+            )
+            return Status.SUCCESS
 
         replayed = 0
         for log_entry in entries:

--- a/vultron/core/behaviors/sync/nodes/replay.py
+++ b/vultron/core/behaviors/sync/nodes/replay.py
@@ -24,8 +24,9 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.behaviors.sync.nodes.replay_guard import (
-    claim_replay_position,
+    record_replay,
     replay_from_hash,
+    should_replay,
 )
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_ledger_entry import (
@@ -253,26 +254,19 @@ class SendMissingEntriesNode(DataLayerAction):
         )
         from_index = cast(int, self.blackboard.replay_from_index)
 
-        # SYNC-15-003: suppress no-progress replays.  A peer that cannot anchor
-        # its hash chain re-Rejects every entry we replay; replaying the full
-        # ledger again on each Reject is a self-sustaining amplification loop
-        # that starves the actor.  Replay only when the peer's acknowledged
-        # position has actually moved since the last replay we sent it.
+        # SYNC-15-003: rate-limit no-progress replays.  A peer that cannot
+        # anchor its hash chain re-Rejects every entry we replay; replaying the
+        # full ledger again on each Reject is a self-sustaining amplification
+        # loop that starves the actor.
         from_hash = replay_from_hash(entries, from_index)
-        if not claim_replay_position(
+        if not should_replay(
             cast(CasePersistence, self.datalayer),
             case_id=entry.case_id,
             peer_id=peer_id,
             from_hash=from_hash,
+            log=self.logger,
+            node_name=self.name,
         ):
-            self.logger.info(
-                "%s: peer '%s' re-Rejected at unchanged position %.16s… for"
-                " case '%s'; suppressing duplicate replay (SYNC-15-003)",
-                self.name,
-                peer_id,
-                from_hash or "genesis",
-                entry.case_id,
-            )
             return Status.SUCCESS
 
         replayed = 0
@@ -285,6 +279,16 @@ class SendMissingEntriesNode(DataLayerAction):
                 to=[peer_id],
             )
             replayed += 1
+
+        # Record the position only when entries actually went out; a
+        # zero-entry replay must not start a cooldown (SYNC-15-003).
+        if replayed:
+            record_replay(
+                cast(CasePersistence, self.datalayer),
+                case_id=entry.case_id,
+                peer_id=peer_id,
+                from_hash=from_hash,
+            )
 
         self.logger.info(
             "%s: replayed %d entries to peer '%s' for case '%s'",

--- a/vultron/core/behaviors/sync/nodes/replay_guard.py
+++ b/vultron/core/behaviors/sync/nodes/replay_guard.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Convergence guard for Reject-triggered ledger replay (SYNC-15-003).
+
+A participant that cannot anchor its hash chain — typically a late joiner
+missing the entries its replica needs — sends ``Reject(CaseLedgerEntry)`` for
+every entry the CaseActor replays to it.  Because the reject handler responds
+by replaying the missing suffix, this forms a self-sustaining amplification
+loop: each Reject triggers a full-ledger replay, and each replayed entry
+triggers another Reject.  Observed in CI as thousands of ``Announce`` activities
+for a single case, starving the actor until unrelated DataLayer reads timed out.
+
+The guard breaks the loop by tracking, per peer, the replication position of
+the last replay actually sent.  A Reject that reports the *same* position as
+the previous replay carries no new information, so replaying again cannot help
+and is suppressed.  A Reject at an advanced position replays normally, so a
+peer that is making progress is never wedged.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from vultron.core.models._helpers import _now_utc
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
+from vultron.core.models.replication_state import VultronReplicationState
+from vultron.core.ports.case_persistence import CasePersistence
+
+
+def replay_from_hash(entries: list[CaseLedgerEntry], from_index: int) -> str:
+    """Return the ``entry_hash`` a replay resumes from, or ``""`` for genesis.
+
+    Args:
+        entries: Case ledger entries sorted ascending by ``log_index``.
+        from_index: Divergence index from ``FindDivergenceIndexNode``; ``-1``
+            means the peer's acknowledged hash matched no known entry and the
+            replay starts from the beginning.
+
+    Returns:
+        The ``entry_hash`` at *from_index*, or ``""`` when replaying from
+        genesis or when *from_index* is not present in *entries*.
+    """
+    if from_index < 0:
+        return ""
+    for log_entry in entries:
+        if log_entry.log_index == from_index:
+            return log_entry.entry_hash
+    return ""
+
+
+def claim_replay_position(
+    datalayer: CasePersistence,
+    *,
+    case_id: str,
+    peer_id: str,
+    from_hash: str,
+) -> bool:
+    """Record a replay to *peer_id* and report whether it should proceed.
+
+    Args:
+        datalayer: Persistence port holding the per-peer replication state.
+        case_id: URI of the case being replicated.
+        peer_id: URI of the peer that sent the Reject.
+        from_hash: Replication position the replay would resume from, as
+            returned by :func:`replay_from_hash`.
+
+    Returns:
+        ``True`` when the peer's position has moved since the last replay we
+        sent it (replay should proceed), ``False`` when the position is
+        unchanged and the replay must be suppressed to avoid the amplification
+        loop described in this module's docstring.
+
+    Spec: SYNC-15-003.
+    """
+    state_key = VultronReplicationState(case_id=case_id, peer_id=peer_id).id_
+    existing = datalayer.read(state_key)
+    if existing is None:
+        datalayer.save(
+            VultronReplicationState(
+                case_id=case_id,
+                peer_id=peer_id,
+                last_replayed_from_hash=from_hash,
+            )
+        )
+        return True
+
+    state = cast(VultronReplicationState, existing)
+    if state.last_replayed_from_hash == from_hash:
+        return False
+
+    state.last_replayed_from_hash = from_hash
+    state.updated_at = _now_utc()
+    datalayer.save(state)
+    return True

--- a/vultron/core/behaviors/sync/nodes/replay_guard.py
+++ b/vultron/core/behaviors/sync/nodes/replay_guard.py
@@ -26,18 +26,31 @@ for a single case, starving the actor until unrelated DataLayer reads timed out.
 The guard breaks the loop by tracking, per peer, the replication position of
 the last replay actually sent.  A Reject that reports the *same* position as
 the previous replay carries no new information, so replaying again cannot help
-and is suppressed.  A Reject at an advanced position replays normally, so a
-peer that is making progress is never wedged.
+immediately and is rate-limited to at most one replay per
+:data:`REPLAY_COOLDOWN_SECONDS`.  A Reject at an advanced position always
+replays, so a peer that is making progress is never delayed.
+
+The cooldown is deliberately a rate limit rather than permanent suppression:
+if a replayed entry is lost in transit, the peer's next Reject must eventually
+be able to trigger a fresh replay, or the peer would stay permanently
+un-synced.  Bounding the *rate* removes the storm while preserving eventual
+convergence.
 """
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import cast
 
 from vultron.core.models._helpers import _now_utc
 from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.models.replication_state import VultronReplicationState
 from vultron.core.ports.case_persistence import CasePersistence
+
+#: Minimum interval between replays sent to a peer that has not advanced its
+#: replication position.  Long enough that a stuck peer cannot drive an event
+#: storm, short enough that a genuinely dropped replay is retried promptly.
+REPLAY_COOLDOWN_SECONDS: float = 30.0
 
 
 def replay_from_hash(entries: list[CaseLedgerEntry], from_index: int) -> str:
@@ -78,13 +91,15 @@ def claim_replay_position(
             returned by :func:`replay_from_hash`.
 
     Returns:
-        ``True`` when the peer's position has moved since the last replay we
-        sent it (replay should proceed), ``False`` when the position is
-        unchanged and the replay must be suppressed to avoid the amplification
-        loop described in this module's docstring.
+        ``True`` when the replay should proceed — either the peer's position has
+        moved since the last replay we sent it, or the cooldown for an
+        unchanged position has elapsed.  ``False`` when the position is
+        unchanged and still within :data:`REPLAY_COOLDOWN_SECONDS`, which is
+        what breaks the amplification loop described in this module's docstring.
 
     Spec: SYNC-15-003.
     """
+    now = _now_utc()
     state_key = VultronReplicationState(case_id=case_id, peer_id=peer_id).id_
     existing = datalayer.read(state_key)
     if existing is None:
@@ -93,15 +108,23 @@ def claim_replay_position(
                 case_id=case_id,
                 peer_id=peer_id,
                 last_replayed_from_hash=from_hash,
+                last_replayed_at=now,
             )
         )
         return True
 
     state = cast(VultronReplicationState, existing)
-    if state.last_replayed_from_hash == from_hash:
+    unchanged_position = state.last_replayed_from_hash == from_hash
+    if (
+        unchanged_position
+        and state.last_replayed_at is not None
+        and now - state.last_replayed_at
+        < timedelta(seconds=REPLAY_COOLDOWN_SECONDS)
+    ):
         return False
 
     state.last_replayed_from_hash = from_hash
-    state.updated_at = _now_utc()
+    state.last_replayed_at = now
+    state.updated_at = now
     datalayer.save(state)
     return True

--- a/vultron/core/behaviors/sync/nodes/replay_guard.py
+++ b/vultron/core/behaviors/sync/nodes/replay_guard.py
@@ -52,6 +52,12 @@ from vultron.core.ports.case_persistence import CasePersistence
 #: storm, short enough that a genuinely dropped replay is retried promptly.
 REPLAY_COOLDOWN_SECONDS: float = 30.0
 
+#: Cooldown applied when the peer reports genesis (no entries at all).  Much
+#: shorter than :data:`REPLAY_COOLDOWN_SECONDS` because a genesis peer is
+#: mid-bootstrap (SYNC-15-002) and needs its history promptly, but still
+#: non-zero so a peer that never anchors cannot drive an unbounded storm.
+GENESIS_REPLAY_COOLDOWN_SECONDS: float = 2.0
+
 
 def replay_from_hash(entries: list[CaseLedgerEntry], from_index: int) -> str:
     """Return the ``entry_hash`` a replay resumes from, or ``""`` for genesis.
@@ -91,15 +97,33 @@ def claim_replay_position(
             returned by :func:`replay_from_hash`.
 
     Returns:
-        ``True`` when the replay should proceed — either the peer's position has
-        moved since the last replay we sent it, or the cooldown for an
-        unchanged position has elapsed.  ``False`` when the position is
-        unchanged and still within :data:`REPLAY_COOLDOWN_SECONDS`, which is
-        what breaks the amplification loop described in this module's docstring.
+        ``True`` when the replay should proceed — the peer's position has moved
+        since the last replay we sent it, the cooldown for an unchanged position
+        has elapsed, or the peer is at genesis (see below).  ``False`` when the
+        position is unchanged and still within
+        :data:`REPLAY_COOLDOWN_SECONDS`, which is what breaks the amplification
+        loop described in this module's docstring.
+
+    Genesis (``from_hash == ""``) gets a much shorter cooldown
+    (:data:`GENESIS_REPLAY_COOLDOWN_SECONDS`) rather than the full one.  A peer
+    at genesis holds no entries at all, and convergence there is owned by
+    ``AnnounceCaseOnGenesisRejectNode`` (SYNC-15-002), which seeds the
+    VulnerabilityCase and then relies on the replay that follows to deliver the
+    history.  Rate-limiting that replay as aggressively as a mid-chain stall
+    would starve the bootstrap it exists to complete, leaving the peer with an
+    empty replica — but leaving genesis wholly unbounded would re-admit the
+    amplification loop, since a peer that cannot anchor its chain reports
+    genesis on every Reject.  A short cooldown satisfies both: the bootstrap
+    proceeds promptly while the storm stays bounded.
 
     Spec: SYNC-15-003.
     """
     now = _now_utc()
+    cooldown = (
+        GENESIS_REPLAY_COOLDOWN_SECONDS
+        if from_hash == ""
+        else REPLAY_COOLDOWN_SECONDS
+    )
     state_key = VultronReplicationState(case_id=case_id, peer_id=peer_id).id_
     existing = datalayer.read(state_key)
     if existing is None:
@@ -118,8 +142,7 @@ def claim_replay_position(
     if (
         unchanged_position
         and state.last_replayed_at is not None
-        and now - state.last_replayed_at
-        < timedelta(seconds=REPLAY_COOLDOWN_SECONDS)
+        and now - state.last_replayed_at < timedelta(seconds=cooldown)
     ):
         return False
 

--- a/vultron/core/behaviors/sync/nodes/replay_guard.py
+++ b/vultron/core/behaviors/sync/nodes/replay_guard.py
@@ -30,6 +30,11 @@ immediately and is rate-limited to at most one replay per
 :data:`REPLAY_COOLDOWN_SECONDS`.  A Reject at an advanced position always
 replays, so a peer that is making progress is never delayed.
 
+The position is recorded (:func:`record_replay`) only after entries have really
+been sent, separately from the decision to replay (:func:`should_replay`).  A
+replay that sends nothing must not start a cooldown — see
+:func:`record_replay`.
+
 The cooldown is deliberately a rate limit rather than permanent suppression:
 if a replayed entry is lost in transit, the peer's next Reject must eventually
 be able to trigger a fresh replay, or the peer would stay permanently
@@ -39,6 +44,7 @@ convergence.
 
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 from typing import cast
 
@@ -80,14 +86,31 @@ def replay_from_hash(entries: list[CaseLedgerEntry], from_index: int) -> str:
     return ""
 
 
-def claim_replay_position(
+def _read_state(
+    datalayer: CasePersistence, *, case_id: str, peer_id: str
+) -> VultronReplicationState | None:
+    """Return the stored replication state for *peer_id*, or ``None``."""
+    state_key = VultronReplicationState(case_id=case_id, peer_id=peer_id).id_
+    existing = datalayer.read(state_key)
+    if existing is None:
+        return None
+    return cast(VultronReplicationState, existing)
+
+
+def should_replay(
     datalayer: CasePersistence,
     *,
     case_id: str,
     peer_id: str,
     from_hash: str,
+    log: logging.Logger | None = None,
+    node_name: str = "SendMissingEntriesNode",
 ) -> bool:
-    """Record a replay to *peer_id* and report whether it should proceed.
+    """Report whether a replay to *peer_id* should proceed.
+
+    Read-only: the position is recorded by :func:`record_replay`, and only
+    once entries have actually been sent.  Splitting the two matters — see
+    that function's docstring.
 
     Args:
         datalayer: Persistence port holding the per-peer replication state.
@@ -95,14 +118,16 @@ def claim_replay_position(
         peer_id: URI of the peer that sent the Reject.
         from_hash: Replication position the replay would resume from, as
             returned by :func:`replay_from_hash`.
+        log: Optional logger; a suppressed replay is logged at INFO so the
+            storm-vs-stall distinction is visible in container logs.
+        node_name: Name used as the log prefix.
 
     Returns:
         ``True`` when the replay should proceed — the peer's position has moved
-        since the last replay we sent it, the cooldown for an unchanged position
-        has elapsed, or the peer is at genesis (see below).  ``False`` when the
-        position is unchanged and still within
-        :data:`REPLAY_COOLDOWN_SECONDS`, which is what breaks the amplification
-        loop described in this module's docstring.
+        since the last replay we sent it, or the cooldown for an unchanged
+        position has elapsed.  ``False`` when the position is unchanged and
+        still within the cooldown, which is what breaks the amplification loop
+        described in this module's docstring.
 
     Genesis (``from_hash == ""``) gets a much shorter cooldown
     (:data:`GENESIS_REPLAY_COOLDOWN_SECONDS`) rather than the full one.  A peer
@@ -118,15 +143,53 @@ def claim_replay_position(
 
     Spec: SYNC-15-003.
     """
-    now = _now_utc()
+    state = _read_state(datalayer, case_id=case_id, peer_id=peer_id)
+    if state is None or state.last_replayed_at is None:
+        return True
+    if state.last_replayed_from_hash != from_hash:
+        return True
     cooldown = (
         GENESIS_REPLAY_COOLDOWN_SECONDS
         if from_hash == ""
         else REPLAY_COOLDOWN_SECONDS
     )
-    state_key = VultronReplicationState(case_id=case_id, peer_id=peer_id).id_
-    existing = datalayer.read(state_key)
-    if existing is None:
+    if _now_utc() - state.last_replayed_at >= timedelta(seconds=cooldown):
+        return True
+    if log is not None:
+        log.info(
+            "%s: peer '%s' re-Rejected at unchanged position %.16s… for case"
+            " '%s'; rate-limiting duplicate replay (SYNC-15-003)",
+            node_name,
+            peer_id,
+            from_hash or "genesis",
+            case_id,
+        )
+    return False
+
+
+def record_replay(
+    datalayer: CasePersistence,
+    *,
+    case_id: str,
+    peer_id: str,
+    from_hash: str,
+) -> None:
+    """Record that entries were replayed to *peer_id* from *from_hash*.
+
+    Call this only after at least one entry has actually been sent.  A replay
+    that sends nothing — the peer's acknowledged position is already the ledger
+    tail — must not update the recorded position: doing so would start a
+    cooldown against a position at which we have never delivered anything, so a
+    later Reject at that same position, once the ledger has grown and a genuine
+    suffix is missing, would be suppressed for no reason.  The peer would wait
+    out the cooldown having received nothing, which is the stall this guard
+    exists to prevent.
+
+    Spec: SYNC-15-003.
+    """
+    now = _now_utc()
+    state = _read_state(datalayer, case_id=case_id, peer_id=peer_id)
+    if state is None:
         datalayer.save(
             VultronReplicationState(
                 case_id=case_id,
@@ -135,19 +198,8 @@ def claim_replay_position(
                 last_replayed_at=now,
             )
         )
-        return True
-
-    state = cast(VultronReplicationState, existing)
-    unchanged_position = state.last_replayed_from_hash == from_hash
-    if (
-        unchanged_position
-        and state.last_replayed_at is not None
-        and now - state.last_replayed_at < timedelta(seconds=cooldown)
-    ):
-        return False
-
+        return
     state.last_replayed_from_hash = from_hash
     state.last_replayed_at = now
     state.updated_at = now
     datalayer.save(state)
-    return True

--- a/vultron/core/models/activity.py
+++ b/vultron/core/models/activity.py
@@ -63,6 +63,7 @@ class VultronActivity(VultronObject):
     to: list[str] | None = None
     cc: list[str] | None = None
     suggested_roles: list[str] | None = None
+    roles: list[str] | None = None
 
 
 class VultronOffer(VultronActivity):

--- a/vultron/core/models/activity.py
+++ b/vultron/core/models/activity.py
@@ -62,7 +62,14 @@ class VultronActivity(VultronObject):
     origin: NonEmptyString | None = None
     to: list[str] | None = None
     cc: list[str] | None = None
-    suggested_roles: list[str] | None = None
+    # CM-16-003: the wire dump this model is validated from is camelCase, so
+    # the alias is required — without it the field silently validates to None
+    # and the suggested roles vanish from the delivered activity.
+    suggested_roles: list[str] | None = Field(
+        default=None,
+        validation_alias="suggestedRoles",
+        serialization_alias="suggestedRoles",
+    )
     roles: list[str] | None = None
 
 

--- a/vultron/core/models/activity.py
+++ b/vultron/core/models/activity.py
@@ -62,6 +62,7 @@ class VultronActivity(VultronObject):
     origin: NonEmptyString | None = None
     to: list[str] | None = None
     cc: list[str] | None = None
+    suggested_roles: list[str] | None = None
 
 
 class VultronOffer(VultronActivity):

--- a/vultron/core/models/activity.py
+++ b/vultron/core/models/activity.py
@@ -70,6 +70,9 @@ class VultronActivity(VultronObject):
         validation_alias="suggestedRoles",
         serialization_alias="suggestedRoles",
     )
+    # Single-word, so the camelCase wire name is identical and no alias is
+    # needed; stated explicitly because the neighbouring field shows what the
+    # omission costs when the names do differ.
     roles: list[str] | None = None
 
 

--- a/vultron/core/models/replication_state.py
+++ b/vultron/core/models/replication_state.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import urllib.parse
 from datetime import datetime
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import Field, model_validator
 
@@ -79,6 +79,17 @@ class VultronReplicationState(VultronObject):
         ),
         validation_alias="joinBackfillLastSentIndex",
         serialization_alias="joinBackfillLastSentIndex",
+    )
+    last_replayed_from_hash: Optional[str] = Field(
+        default=None,
+        description=(
+            "entry_hash the most recent Reject-triggered replay started from,"
+            " used to suppress repeated full-ledger replays to a peer that has"
+            " made no progress; None means no replay has run yet"
+            " (SYNC-15-003)"
+        ),
+        validation_alias="lastReplayedFromHash",
+        serialization_alias="lastReplayedFromHash",
     )
     join_backfill_complete: bool = Field(
         default=True,

--- a/vultron/core/models/replication_state.py
+++ b/vultron/core/models/replication_state.py
@@ -91,6 +91,17 @@ class VultronReplicationState(VultronObject):
         validation_alias="lastReplayedFromHash",
         serialization_alias="lastReplayedFromHash",
     )
+    last_replayed_at: Optional[datetime] = Field(
+        default=None,
+        description=(
+            "When the most recent Reject-triggered replay was sent to this"
+            " peer, used with last_replayed_from_hash to rate-limit replays to"
+            " a peer that has made no progress; None means no replay has run"
+            " yet (SYNC-15-003)"
+        ),
+        validation_alias="lastReplayedAt",
+        serialization_alias="lastReplayedAt",
+    )
     join_backfill_complete: bool = Field(
         default=True,
         description=(

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -333,10 +333,13 @@ class TriggerActivityPort(Protocol):
         actor: str,
         to: list[str] | None = None,
         id_: str | None = None,
+        roles: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist a ``Offer(Actor, Case)`` recommendation activity.
 
         ``id_`` allows callers to supply a deterministic ID for idempotency.
+        ``roles`` carries serialized CVD role strings into the wire object so
+        the CaseActor can use them in place of the hardcoded VENDOR default.
         Returns ``(activity_id, activity_dict)``.
         """
         ...

--- a/vultron/core/ports/trigger_service.py
+++ b/vultron/core/ports/trigger_service.py
@@ -205,6 +205,7 @@ class TriggerServicePort(Protocol):
         actor_id: str,
         case_id: str,
         suggested_actor_id: str,
+        roles: list | None = None,
     ) -> dict[str, Any]: ...
 
     def accept_case_invite(

--- a/vultron/core/use_cases/received/actor/offer_case_participant.py
+++ b/vultron/core/use_cases/received/actor/offer_case_participant.py
@@ -146,6 +146,10 @@ class AcceptOfferCaseParticipantReceivedUseCase:
         if offer_id:
             stored_offer = self._dl.read(offer_id)
             stored_participant = getattr(stored_offer, "object_", None)
+            # MV-09-001: dehydration stores object_ as a bare ID string;
+            # follow the reference to retrieve the full as_CaseParticipant.
+            if isinstance(stored_participant, str):
+                stored_participant = self._dl.read(stored_participant)
             raw_roles = getattr(stored_participant, "roles", None)
             if isinstance(raw_roles, list) and raw_roles:
                 offer_roles = serialize_roles(raw_roles)

--- a/vultron/core/use_cases/received/actor/suggest.py
+++ b/vultron/core/use_cases/received/actor/suggest.py
@@ -80,12 +80,19 @@ class OfferActorToCaseReceivedUseCase:
         elif not isinstance(offer_content, str) or not offer_content.strip():
             offer_content = None
 
+        suggested_roles = getattr(request.activity, "suggested_roles", None)
+        if suggested_roles is not None and not isinstance(
+            suggested_roles, list
+        ):
+            suggested_roles = None
+
         tree = create_recommend_actor_to_case_received_tree(
             recommendation_id=activity_id,
             recommender_id=recommender_id,
             recommended_id=recommended_id,
             case_id=case_id,
             offer_content=offer_content,
+            suggested_roles=suggested_roles,
         )
         bridge = BTBridge(
             datalayer=self._dl, trigger_activity=self._trigger_activity

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -72,6 +72,9 @@ class SvcSuggestActorToCaseUseCase(SvcBTTriggerBase):
             raise VultronNotFoundError("Actor", request.suggested_actor_id)
 
         self._suggested_actor_id = request.suggested_actor_id
+        self._suggested_roles = (
+            [r.value for r in request.roles] if request.roles else None
+        )
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
@@ -80,6 +83,7 @@ class SvcSuggestActorToCaseUseCase(SvcBTTriggerBase):
                 case_id=self._case.id_,
                 actor=self._actor_id,
                 to=[case_manager_id],
+                roles=self._suggested_roles,
             )
             self._captured["activity"] = activity_dict
             return [activity_id]

--- a/vultron/core/use_cases/triggers/requests.py
+++ b/vultron/core/use_cases/triggers/requests.py
@@ -193,6 +193,7 @@ class SuggestActorToCaseTriggerRequest(CaseTriggerRequest):
     """
 
     suggested_actor_id: NonEmptyString
+    roles: list[CVDRole] | None = None
 
 
 class AcceptCaseInviteTriggerRequest(TriggerRequest):

--- a/vultron/core/use_cases/triggers/service.py
+++ b/vultron/core/use_cases/triggers/service.py
@@ -451,12 +451,18 @@ class TriggerService:
         actor_id: str,
         case_id: str,
         suggested_actor_id: str,
+        roles: list | None = None,
     ) -> dict[str, Any]:
         """Recommend another actor to a case owner."""
         req = SuggestActorToCaseTriggerRequest(
             actor_id=actor_id,
             case_id=case_id,
             suggested_actor_id=suggested_actor_id,
+            roles=(
+                [CVDRole(r) if isinstance(r, str) else r for r in roles]
+                if roles
+                else None
+            ),
         )
         return SvcSuggestActorToCaseUseCase(
             self._dl, req, trigger_activity=self._trigger_activity

--- a/vultron/demo/cli.py
+++ b/vultron/demo/cli.py
@@ -47,6 +47,7 @@ import vultron.demo.exchange.suggest_actor_demo as suggest_actor_demo
 import vultron.demo.scenario.fccv_extension_demo as fccv_extension_demo
 import vultron.demo.scenario.fccv_handoff_demo as fccv_handoff_demo
 import vultron.demo.scenario.fcv_demo as fcv_demo
+import vultron.demo.scenario.fcvcv_demo as fcvcv_demo
 import vultron.demo.scenario.fvcv_extension_demo as fvcv_extension_demo
 import vultron.demo.scenario.fvcv_handoff_demo as fvcv_handoff_demo
 import vultron.demo.scenario.fvv_demo as fvv_demo
@@ -906,6 +907,130 @@ def fccv_handoff(
         c2_id=c2_id,
         case_actor_id=case_actor_id,
         vendor_id=vendor_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FCVCV sub-command — Finder + C1(CASE_OWNER) + V1(VENDOR) + C2(COORDINATOR) + V2(VENDOR+DEPLOYER)
+# ---------------------------------------------------------------------------
+
+
+@main.command(name="fcvcv")
+@click.option(
+    "--finder-url",
+    envvar="VULTRON_FINDER_BASE_URL",
+    default=fcvcv_demo.FINDER_BASE_URL,
+    show_default=True,
+    help="Base URL for the Finder actor container.",
+)
+@click.option(
+    "--c1-url",
+    envvar="VULTRON_COORDINATOR_BASE_URL",
+    default=fcvcv_demo.C1_BASE_URL,
+    show_default=True,
+    help="Base URL for the C1 (Coordinator1/CASE_OWNER) actor container.",
+)
+@click.option(
+    "--v1-url",
+    envvar="VULTRON_VENDOR_BASE_URL",
+    default=fcvcv_demo.V1_BASE_URL,
+    show_default=True,
+    help="Base URL for the V1 (Vendor1) actor container.",
+)
+@click.option(
+    "--c2-url",
+    envvar="VULTRON_VENDOR2_BASE_URL",
+    default=fcvcv_demo.C2_BASE_URL,
+    show_default=True,
+    help="Base URL for the C2 (Coordinator2) actor container.",
+)
+@click.option(
+    "--v2-url",
+    envvar="VULTRON_VENDOR_DEPLOYER_BASE_URL",
+    default=fcvcv_demo.V2_BASE_URL,
+    show_default=True,
+    help="Base URL for the V2 (VendorDeployer) actor container.",
+)
+@click.option(
+    "--finder-id",
+    envvar="VULTRON_FINDER_ACTOR_ID",
+    default=None,
+    help="Deterministic URI for the Finder actor.",
+)
+@click.option(
+    "--c1-id",
+    envvar="VULTRON_COORDINATOR_ACTOR_ID",
+    default=None,
+    help="Deterministic URI for the C1 actor.",
+)
+@click.option(
+    "--v1-id",
+    envvar="VULTRON_VENDOR_ACTOR_ID",
+    default=None,
+    help="Deterministic URI for the V1 actor.",
+)
+@click.option(
+    "--c2-id",
+    envvar="VULTRON_VENDOR2_ACTOR_ID",
+    default=None,
+    help="Deterministic URI for the C2 actor.",
+)
+@click.option(
+    "--v2-id",
+    envvar="VULTRON_VENDOR_DEPLOYER_ACTOR_ID",
+    default=None,
+    help="Deterministic URI for the V2 (VendorDeployer) actor.",
+)
+@click.option(
+    "--skip-health-check",
+    is_flag=True,
+    default=False,
+    help="Skip server availability checks at startup.",
+)
+def fcvcv(
+    finder_url: str,
+    c1_url: str,
+    v1_url: str,
+    c2_url: str,
+    v2_url: str,
+    finder_id: str | None,
+    c1_id: str | None,
+    v1_id: str | None,
+    c2_id: str | None,
+    v2_id: str | None,
+    skip_health_check: bool,
+) -> None:
+    """Run the FCVCV 5-party CVD demo (DEMOMA-19).
+
+    Five actors coordinate a full CVD lifecycle:
+    Finder + C1 (CASE_OWNER) + V1 (VENDOR) + C2 (COORDINATOR) + V2
+    (VENDOR+DEPLOYER).
+
+    \b
+    Workflow:
+      1. Reset and seed all five containers.
+      2. Finder submits a report to C1; C1 validates and engages.
+      3. C1 invites V1 (VENDOR) and C2 (COORDINATOR).
+      4. C2 suggests V2 via ADR-0026; C1 approves; V2 joins via CaseActor.
+      5. Verify SYNC-2 replication across all six participants.
+      6. All five actors exchange notes.
+      7. Fix lifecycle: V1 → VFd (no deploy); V2 → VFD (fix-deployed).
+      8. Publication: V1 publishes first → embargo terminates; all publish.
+      9. All actors close the case.
+     10. Export case ledger JSONL for each actor (devlogs).
+    """
+    fcvcv_demo.main(
+        skip_health_check=skip_health_check,
+        finder_url=finder_url,
+        c1_url=c1_url,
+        v1_url=v1_url,
+        c2_url=c2_url,
+        v2_url=v2_url,
+        finder_id=finder_id,
+        c1_id=c1_id,
+        v1_id=v1_id,
+        c2_id=c2_id,
+        v2_id=v2_id,
     )
 
 

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -19,7 +19,8 @@ import from ``vultron.demo.helpers`` directly.
 Sub-modules
 -----------
 - :mod:`~vultron.demo.helpers.polling` — ``_poll_until``,
-  ``find_case_invite_for_actor``, ``wait_for_object_stored``, and all
+  ``find_case_invite_for_actor``, ``find_cp_offer_for_case``,
+  ``find_case_actor_participant_id``, ``wait_for_object_stored``, and all
   ``wait_for_*`` helpers.
 - :mod:`~vultron.demo.helpers.actions` — ``actor_notifies_state_change``
   and named CVD lifecycle action wrappers.
@@ -71,7 +72,9 @@ from vultron.demo.helpers.notes import (  # noqa: F401
 )
 from vultron.demo.helpers.polling import (  # noqa: F401
     _poll_until,
+    find_case_actor_participant_id,
     find_case_invite_for_actor,
+    find_cp_offer_for_case,
     wait_for_all_participants_rm_closed,
     wait_for_case_em_terminated,
     wait_for_case_on_container,

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -22,6 +22,7 @@ import logging
 import time
 from typing import Callable
 
+from vultron.adapters.utils import strip_id_prefix
 from vultron.demo.utils import DataLayerClient, logfmt
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
@@ -469,6 +470,106 @@ def find_case_invite_for_actor(
         f"Timed out waiting for CaseActor Invite for actor {invitee_id!r} on"
         f" case {case_id!r} to appear in DataLayer at {client.base_url}"
     )
+
+
+def _is_cp_offer_for_case(obj_data: dict, case_id: str) -> bool:
+    """Return True if *obj_data* looks like an Offer(CaseParticipant) for *case_id*."""
+    if obj_data.get("type") != "Offer":
+        return False
+    target_raw = obj_data.get("target")
+    target_id = (
+        target_raw.get("id") if isinstance(target_raw, dict) else target_raw
+    )
+    if target_id != case_id:
+        return False
+    inner = obj_data.get("object")
+    if not isinstance(inner, dict):
+        return False
+    return bool(
+        inner.get("type") in ("CaseParticipant", "as_CaseParticipant")
+        or inner.get("case_roles")
+    )
+
+
+def find_cp_offer_for_case(
+    client: DataLayerClient,
+    case_id: str,
+    timeout_seconds: float = 15.0,
+    poll_interval: float = 0.5,
+) -> str:
+    """Poll until an Offer(CaseParticipant) for *case_id* appears in DataLayer.
+
+    After a Coordinator sends suggest-actor-to-case, the CaseActor processes the
+    Offer(Actor, Case) and forwards an Offer(CaseParticipant) to the Case
+    Owner's inbox (ADR-0026).  This helper polls the Case Owner's DataLayer for
+    any Offer whose ``target`` matches *case_id* and whose ``object`` resembles
+    a CaseParticipant, so the demo can drive the approve step.
+
+    Args:
+        client: DataLayerClient connected to the Case Owner's container.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
+        timeout_seconds: Maximum time to wait before raising.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Returns:
+        The offer activity ID string.
+
+    Raises:
+        AssertionError: If no such offer is found within *timeout_seconds*.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            all_objects = client.get("/datalayer/")
+            if isinstance(all_objects, dict):
+                for raw_id, obj_data in all_objects.items():
+                    if not isinstance(obj_data, dict):
+                        continue
+                    if _is_cp_offer_for_case(obj_data, case_id):
+                        obj_id = str(raw_id)
+                        logger.info(
+                            "Found Offer(CaseParticipant) for case %s: %s",
+                            case_id,
+                            obj_id,
+                        )
+                        return obj_id
+        except Exception:  # noqa: BLE001
+            pass
+        time.sleep(poll_interval)
+
+    raise AssertionError(
+        f"Timed out waiting for Offer(CaseParticipant) for case {case_id!r}"
+        f" to appear in DataLayer at {client.base_url}"
+    )
+
+
+def find_case_actor_participant_id(
+    client: DataLayerClient,
+    case_id: str,
+) -> str | None:
+    """Return the CaseActor participant URI for *case_id* from *client*'s replica.
+
+    Scans ``actor_participant_index`` for an actor ID whose bare segment starts
+    with ``"case-actor"``.  A single read, not a poll: callers use it to resolve
+    the CaseActor's URI once the case replica is already known to be present.
+
+    Args:
+        client: DataLayerClient connected to any container holding the case.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
+
+    Returns:
+        The CaseActor participant URI, or ``None`` when the case is unreadable
+        or has no CaseActor participant.
+    """
+    try:
+        case_data = client.get(f"/datalayer/{case_id}")
+        case = as_VulnerabilityCase.model_validate(case_data)
+        for actor_id in case.actor_participant_index:
+            if strip_id_prefix(actor_id).startswith("case-actor"):
+                return actor_id
+    except Exception:  # noqa: BLE001
+        pass
+    return None
 
 
 def wait_for_object_stored(

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -39,7 +39,6 @@ import logging
 import os
 import pathlib
 import sys
-import time
 
 import httpx2 as httpx
 
@@ -80,7 +79,9 @@ from vultron.demo.helpers.milestones import (
 from vultron.demo.helpers.verification import _check_participant_vfd_state_in
 from vultron.demo.helpers.notes import participant_adds_note_to_case
 from vultron.demo.helpers.polling import (
+    find_case_actor_participant_id,
     find_case_invite_for_actor,
+    find_cp_offer_for_case,
     wait_for_all_participants_rm_closed,
     wait_for_case_em_terminated,
     wait_for_case_on_container,
@@ -154,89 +155,6 @@ def reset_containers(
 # ---------------------------------------------------------------------------
 # Polling helpers
 # ---------------------------------------------------------------------------
-
-
-def _is_cp_offer_for_case(obj_data: dict, case_id: str) -> bool:
-    """Return True if *obj_data* looks like an Offer(CaseParticipant) for *case_id*."""
-    if obj_data.get("type") != "Offer":
-        return False
-    target_raw = obj_data.get("target")
-    target_id = (
-        target_raw.get("id") if isinstance(target_raw, dict) else target_raw
-    )
-    if target_id != case_id:
-        return False
-    inner = obj_data.get("object")
-    if not isinstance(inner, dict):
-        return False
-    return bool(
-        inner.get("type") in ("CaseParticipant", "as_CaseParticipant")
-        or inner.get("case_roles")
-    )
-
-
-def _find_cp_offer_for_case(
-    client: DataLayerClient,
-    case_id: str,
-    timeout_seconds: float = 15.0,
-    poll_interval: float = 0.5,
-) -> str:
-    """Poll until an Offer(CaseParticipant) for *case_id* appears in DataLayer.
-
-    After C2 sends suggest-actor-to-case, the CaseActor processes the
-    Offer(Actor, Case) and forwards an Offer(CaseParticipant) to C1's inbox
-    (the CASE_OWNER).  This helper polls C1's DataLayer for any Offer whose
-    ``target`` matches *case_id* and whose ``object`` resembles a CaseParticipant.
-
-    Returns the offer ID string.
-
-    Raises:
-        AssertionError: If no such offer is found within *timeout_seconds*.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        try:
-            all_objects = client.get("/datalayer/")
-            if isinstance(all_objects, dict):
-                for raw_id, obj_data in all_objects.items():
-                    obj_id = str(raw_id)
-                    if not isinstance(obj_data, dict):
-                        continue
-                    if _is_cp_offer_for_case(obj_data, case_id):
-                        logger.info(
-                            "Found Offer(CaseParticipant) for case %s: %s",
-                            case_id,
-                            obj_id,
-                        )
-                        return obj_id
-        except Exception:  # noqa: BLE001
-            pass
-        time.sleep(poll_interval)
-
-    raise AssertionError(
-        f"Timed out waiting for Offer(CaseParticipant) for case {case_id!r}"
-        f" to appear in DataLayer at {client.base_url}"
-    )
-
-
-def _find_case_actor_participant_id(
-    c1_client: DataLayerClient,
-    case_id: str,
-) -> str | None:
-    """Return the CaseActor participant URI for *case_id* from C1's DataLayer.
-
-    Scans ``actor_participant_index`` for an actor ID starting with "case-actor".
-    Returns ``None`` if not found.
-    """
-    try:
-        case_data = c1_client.get(f"/datalayer/{case_id}")
-        case = as_VulnerabilityCase.model_validate(case_data)
-        for actor_id in case.actor_participant_index:
-            if strip_id_prefix(actor_id).startswith("case-actor"):
-                return actor_id
-    except Exception:  # noqa: BLE001
-        pass
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -424,14 +342,14 @@ def _phase_c2_suggests_vendor(
     with demo_check(
         "Offer(CaseParticipant) for Vendor arrived in C1's DataLayer"
     ):
-        cp_offer_id = _find_cp_offer_for_case(
+        cp_offer_id = find_cp_offer_for_case(
             client=c1_client,
             case_id=case.id_,
         )
     logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
 
     # Find the CaseActor's participant ID so we can route the Accept back.
-    case_actor_id = _find_case_actor_participant_id(c1_client, case.id_)
+    case_actor_id = find_case_actor_participant_id(c1_client, case.id_)
     if case_actor_id is None:
         raise AssertionError(
             "CaseActor participant not found in case — cannot route Accept"

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -79,6 +79,7 @@ from vultron.demo.helpers.milestones import (
 )
 from vultron.demo.helpers.notes import participant_adds_note_to_case
 from vultron.demo.helpers.polling import (
+    find_case_actor_participant_id,
     find_case_invite_for_actor,
     wait_for_all_participants_rm_closed,
     wait_for_case_em_terminated,
@@ -156,26 +157,6 @@ def reset_containers(
 # ---------------------------------------------------------------------------
 # Polling helpers
 # ---------------------------------------------------------------------------
-
-
-def _find_case_actor_participant_id(
-    c1_client: DataLayerClient,
-    case_id: str,
-) -> str | None:
-    """Return the CaseActor participant URI for *case_id* from C1's DataLayer.
-
-    Scans ``actor_participant_index`` for an actor ID starting with
-    "case-actor".  Returns ``None`` if not found.
-    """
-    try:
-        case_data = c1_client.get(f"/datalayer/{case_id}")
-        case = as_VulnerabilityCase.model_validate(case_data)
-        for actor_id in case.actor_participant_index:
-            if strip_id_prefix(actor_id).startswith("case-actor"):
-                return actor_id
-    except Exception:  # noqa: BLE001
-        pass
-    return None
 
 
 def _wait_for_case_attributed_to(
@@ -1048,9 +1029,7 @@ def run_fccv_handoff_demo(
     )
 
     # Discover the CaseActor's dynamic sub-actor ID before the handoff phase.
-    dynamic_case_actor_id = _find_case_actor_participant_id(
-        c1_client, case.id_
-    )
+    dynamic_case_actor_id = find_case_actor_participant_id(c1_client, case.id_)
     if dynamic_case_actor_id is None:
         raise AssertionError(
             "CaseActor participant not found in case — cannot route Vendor Accept"

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -1,0 +1,1285 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Finder + Coordinator1 + Vendor1 + Coordinator2 + VendorDeployer (FCVCV) demo.
+
+Orchestrates the full CVD lifecycle across five actor containers plus a
+dedicated CaseActor:
+  - Finder: the report submitter
+  - C1 (coordinator container): CASE_OWNER throughout; receives the report
+  - V1 (vendor container): CVDRole.VENDOR only; advances to VFd (fix-ready,
+    no deploy step)
+  - C2 (actor5 container): CVDRole.COORDINATOR participant; suggests V2
+    via the ADR-0026 suggest-actor flow
+  - V2 (actor6 container): CVDRole.VENDOR + CVDRole.DEPLOYER; advances to
+    VFD (fix-ready then fix-deployed)
+
+Container mapping (docker-compose-multi-actor.yml services):
+  VULTRON_FINDER_BASE_URL           → Finder container
+  VULTRON_COORDINATOR_BASE_URL      → C1 container (coordinator)
+  VULTRON_VENDOR_BASE_URL           → V1 container (vendor)
+  VULTRON_VENDOR2_BASE_URL          → C2 container (actor5)
+  VULTRON_VENDOR_DEPLOYER_BASE_URL  → V2 container (actor6)
+
+Spec: DEMOMA-19 (GitHub issue #1925).
+"""
+
+import json
+import logging
+import os
+import pathlib
+import sys
+import time
+
+import httpx2 as httpx
+
+from vultron.adapters.utils import strip_id_prefix
+from vultron.core.states.cs import CS_vfd
+from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+    as_TransitiveActivity,
+)
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+from vultron.wire.as2.vocab.base.objects.object_types import as_Note
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
+
+from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypatching
+    DataLayerClient,
+    assert_demo_success,
+    check_server_availability,
+    demo_check,
+    demo_step,
+    post_to_inbox_and_wait,
+    post_to_trigger,
+    reset_datalayer,
+    reset_demo_failures,
+    setup_demo_logging,
+    verify_object_stored,
+)
+from vultron.demo.helpers.actions import (
+    actor_closes_case,
+    actor_notifies_fix_deployed,
+    actor_notifies_fix_ready,
+    actor_notifies_published,
+)
+from vultron.demo.helpers.milestones import (
+    verify_case_active,
+    verify_case_closed,
+    verify_fix_deployed,
+    verify_fix_ready,
+    verify_publicly_disclosed,
+)
+from vultron.demo.helpers.notes import participant_adds_note_to_case
+from vultron.demo.helpers.polling import (
+    find_case_invite_for_actor,
+    wait_for_all_participants_rm_closed,
+    wait_for_case_em_terminated,
+    wait_for_case_on_container,
+    wait_for_case_participants,
+    wait_for_contiguous_ledger_coverage,
+    wait_for_event_type_in_ledger,
+    wait_for_participant_vfd_state,
+)
+from vultron.demo.helpers.seeding import (
+    get_actor_by_id,
+    reset_containers as _reset_containers,
+    seed_containers_fcvcv,
+)
+from vultron.demo.helpers.sync import (
+    _get_log_entries_for_case,
+    verify_replica_state,
+)
+from vultron.demo.helpers.workflow import (
+    find_case_for_offer,
+    receiver_engages_case,
+    receiver_validates_report,
+    reporter_submits_report,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default container base URLs — override via environment variables.
+# C1 uses the "coordinator" container, V1 uses "vendor", C2 uses "actor5",
+# and V2 (VendorDeployer) uses "actor6".
+FINDER_BASE_URL = os.environ.get(
+    "VULTRON_FINDER_BASE_URL", "http://localhost:7901/api/v2"
+)
+C1_BASE_URL = os.environ.get(
+    "VULTRON_COORDINATOR_BASE_URL", "http://localhost:7903/api/v2"
+)
+V1_BASE_URL = os.environ.get(
+    "VULTRON_VENDOR_BASE_URL", "http://localhost:7902/api/v2"
+)
+C2_BASE_URL = os.environ.get(
+    "VULTRON_VENDOR2_BASE_URL", "http://localhost:7904/api/v2"
+)
+V2_BASE_URL = os.environ.get(
+    "VULTRON_VENDOR_DEPLOYER_BASE_URL", "http://localhost:7905/api/v2"
+)
+
+# Deterministic actor IDs — match docker-compose-multi-actor.yml service names.
+FINDER_ACTOR_ID = "http://finder:7999/api/v2/actors/finder"
+C1_ACTOR_ID = "http://coordinator:7999/api/v2/actors/coordinator"
+V1_ACTOR_ID = "http://vendor:7999/api/v2/actors/vendor"
+C2_ACTOR_ID = "http://actor5:7999/api/v2/actors/vendor2"
+V2_ACTOR_ID = "http://actor6:7999/api/v2/actors/vendor-deployer"
+
+
+def reset_containers(
+    finder_client: DataLayerClient,
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+) -> None:
+    """Reset all five FCVCV containers to a clean baseline."""
+    targets: list[tuple[str, DataLayerClient]] = [
+        ("Finder", finder_client),
+        ("C1", c1_client),
+        ("V1", v1_client),
+        ("C2", c2_client),
+        ("V2", v2_client),
+    ]
+    _reset_containers(targets, reset_fn=reset_datalayer)
+
+
+# ---------------------------------------------------------------------------
+# Polling helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_cp_offer_for_case(obj_data: dict, case_id: str) -> bool:
+    """Return True if *obj_data* looks like an Offer(CaseParticipant) for *case_id*."""
+    if obj_data.get("type") != "Offer":
+        return False
+    target_raw = obj_data.get("target")
+    target_id = (
+        target_raw.get("id") if isinstance(target_raw, dict) else target_raw
+    )
+    if target_id != case_id:
+        return False
+    inner = obj_data.get("object")
+    if not isinstance(inner, dict):
+        return False
+    return bool(
+        inner.get("type") in ("CaseParticipant", "as_CaseParticipant")
+        or inner.get("case_roles")
+    )
+
+
+def _find_cp_offer_for_case(
+    client: DataLayerClient,
+    case_id: str,
+    timeout_seconds: float = 15.0,
+    poll_interval: float = 0.5,
+) -> str:
+    """Poll until an Offer(CaseParticipant) for *case_id* appears in DataLayer.
+
+    Returns the offer ID string.
+
+    Raises:
+        AssertionError: If no such offer is found within *timeout_seconds*.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            all_objects = client.get("/datalayer/")
+            if isinstance(all_objects, dict):
+                for raw_id, obj_data in all_objects.items():
+                    obj_id = str(raw_id)
+                    if not isinstance(obj_data, dict):
+                        continue
+                    if _is_cp_offer_for_case(obj_data, case_id):
+                        logger.info(
+                            "Found Offer(CaseParticipant) for case %s: %s",
+                            case_id,
+                            obj_id,
+                        )
+                        return obj_id
+        except Exception:  # noqa: BLE001
+            pass
+        time.sleep(poll_interval)
+
+    raise AssertionError(
+        f"Timed out waiting for Offer(CaseParticipant) for case {case_id!r}"
+        f" to appear in DataLayer at {client.base_url}"
+    )
+
+
+def _find_case_actor_participant_id(
+    c1_client: DataLayerClient,
+    case_id: str,
+) -> str | None:
+    """Return the CaseActor participant URI for *case_id* from C1's DataLayer."""
+    try:
+        case_data = c1_client.get(f"/datalayer/{case_id}")
+        case = as_VulnerabilityCase.model_validate(case_data)
+        for actor_id in case.actor_participant_index:
+            if strip_id_prefix(actor_id).startswith("case-actor"):
+                return actor_id
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Phase helpers
+# ---------------------------------------------------------------------------
+
+
+def _phase_report_submission(
+    finder_client: DataLayerClient,
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    finder_id: str | None,
+    c1_id: str | None,
+    v1_id: str | None,
+    c2_id: str | None,
+    v2_id: str | None,
+) -> tuple[
+    as_Actor,
+    as_Actor,
+    as_Actor,
+    as_Actor,
+    as_Actor,
+    as_Actor,
+    as_Actor,
+    as_VulnerabilityCase,
+]:
+    """Reset, seed, submit report, validate, engage, invite V1 and C2."""
+    logger.info("─" * 80)
+    logger.info("Phase 1: Report submission and case activation")
+    logger.info("─" * 80)
+
+    reset_containers(
+        finder_client=finder_client,
+        c1_client=c1_client,
+        v1_client=v1_client,
+        c2_client=c2_client,
+        v2_client=v2_client,
+    )
+
+    with demo_step("Seeding all five containers with actor records"):
+        finder, c1, v1, c2, v2 = seed_containers_fcvcv(
+            finder_client=finder_client,
+            c1_client=c1_client,
+            v1_client=v1_client,
+            c2_client=c2_client,
+            v2_client=v2_client,
+            reporter_actor_id=finder_id,
+            c1_actor_id=c1_id,
+            v1_actor_id=v1_id,
+            c2_actor_id=c2_id,
+            v2_actor_id=v2_id,
+        )
+
+    c1_in_c1 = get_actor_by_id(c1_client, c1.id_)
+    v1_in_v1 = get_actor_by_id(v1_client, v1.id_)
+    c2_in_c2 = get_actor_by_id(c2_client, c2.id_)
+
+    _, offer = reporter_submits_report(
+        receiver_client=c1_client,
+        reporter=finder,
+        receiver=c1_in_c1,
+        reporter_client=finder_client,
+    )
+    receiver_validates_report(
+        receiver_client=c1_client,
+        receiver=c1_in_c1,
+        offer_id=offer.id_,
+    )
+
+    with demo_check("as_VulnerabilityCase exists in C1's DataLayer"):
+        case = find_case_for_offer(c1_client, offer.id_)
+        if case is None:
+            raise AssertionError(
+                "Expected as_VulnerabilityCase to be created after validate-report"
+            )
+        logger.info("Case created: %s", case.id_)
+
+    receiver_engages_case(
+        receiver_client=c1_client,
+        receiver=c1_in_c1,
+        case_id=case.id_,
+    )
+
+    # Wait for the initial participants (Finder + C1 + CaseActor) before
+    # inviting V1 and C2.
+    wait_for_case_participants(
+        vendor_client=c1_client,
+        case_id=case.id_,
+        expected_count=3,
+    )
+
+    # C1 invites V1 with CVDRole.VENDOR.
+    with demo_step("C1 invites V1 with CVDRole.VENDOR"):
+        invite_v1_result = post_to_trigger(
+            client=c1_client,
+            actor_id=c1_in_c1.id_,
+            behavior="invite-actor-to-case",
+            body={
+                "case_id": case.id_,
+                "invitee_id": v1.id_,
+                "roles": ["vendor"],
+            },
+        )
+    invite_v1 = as_TransitiveActivity.model_validate(
+        invite_v1_result["activity"]
+    )
+    logger.info("V1 invite created: %s", invite_v1.id_)
+
+    with demo_step("Delivering invite to V1's inbox"):
+        post_to_inbox_and_wait(v1_client, v1_in_v1.id_, invite_v1)
+
+    with demo_check("V1 invite stored in V1's DataLayer"):
+        verify_object_stored(v1_client, invite_v1.id_)
+
+    with demo_step("V1 accepts the case invitation"):
+        post_to_trigger(
+            client=v1_client,
+            actor_id=v1_in_v1.id_,
+            behavior="accept-case-invite",
+            body={"invite_id": invite_v1.id_},
+        )
+
+    with demo_check("V1's DataLayer received case replica"):
+        wait_for_case_on_container(
+            client=v1_client,
+            case_id=case.id_,
+        )
+
+    # C1 invites C2 with CVDRole.COORDINATOR.
+    with demo_step("C1 invites C2 with CVDRole.COORDINATOR"):
+        invite_c2_result = post_to_trigger(
+            client=c1_client,
+            actor_id=c1_in_c1.id_,
+            behavior="invite-actor-to-case",
+            body={
+                "case_id": case.id_,
+                "invitee_id": c2.id_,
+                "roles": ["coordinator"],
+            },
+        )
+    invite_c2 = as_TransitiveActivity.model_validate(
+        invite_c2_result["activity"]
+    )
+    logger.info("C2 invite created: %s", invite_c2.id_)
+
+    with demo_step("Delivering invite to C2's inbox"):
+        post_to_inbox_and_wait(c2_client, c2_in_c2.id_, invite_c2)
+
+    with demo_check("C2 invite stored in C2's DataLayer"):
+        verify_object_stored(c2_client, invite_c2.id_)
+
+    with demo_step("C2 accepts the case invitation"):
+        post_to_trigger(
+            client=c2_client,
+            actor_id=c2_in_c2.id_,
+            behavior="accept-case-invite",
+            body={"invite_id": invite_c2.id_},
+        )
+
+    with demo_check("C2's DataLayer received case replica"):
+        wait_for_case_on_container(
+            client=c2_client,
+            case_id=case.id_,
+        )
+
+    # 5 participants: Finder + C1 + V1 + C2 + CaseActor
+    wait_for_case_participants(
+        vendor_client=c1_client,
+        case_id=case.id_,
+        expected_count=5,
+    )
+
+    with demo_check(
+        "M1: required participants (≥5), EM.ACTIVE, Finder + V1 + C2 have replicas"
+    ):
+        verify_case_active(
+            receiver_client=c1_client,
+            reporter_client=finder_client,
+            case_id=case.id_,
+            receiver_actor_id=c1.id_,
+            reporter_actor_id=finder.id_,
+        )
+
+    case = as_VulnerabilityCase.model_validate(
+        c1_client.get(f"/datalayer/{case.id_}")
+    )
+    return (
+        finder,
+        c1,
+        c1_in_c1,
+        v1,
+        v1_in_v1,
+        c2_in_c2,
+        v2,
+        case,
+    )
+
+
+def _phase_c2_suggests_v2(
+    c1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    c1_in_c1: as_Actor,
+    c2_in_c2: as_Actor,
+    v2: as_Actor,
+    case: as_VulnerabilityCase,
+) -> None:
+    """C2 suggests V2 via ADR-0026; C1 approves; V2 joins (DEMOMA-19-009)."""
+    logger.info("─" * 80)
+    logger.info("Phase 2: C2 suggests V2 → C1 approves → V2 joins")
+    logger.info("─" * 80)
+
+    # C2 sends suggest-actor-to-case (Offer(Actor, Case) → CaseActor).
+    with demo_step("C2 suggests V2 to CaseActor"):
+        post_to_trigger(
+            client=c2_client,
+            actor_id=c2_in_c2.id_,
+            behavior="suggest-actor-to-case",
+            body={
+                "case_id": case.id_,
+                "suggested_actor_id": v2.id_,
+            },
+        )
+    logger.info("C2 sent suggest-actor-to-case for V2 (%s)", v2.id_)
+
+    # CaseActor processes Offer(Actor, Case) and forwards
+    # Offer(CaseParticipant) to C1.  Poll C1's DataLayer for the offer.
+    with demo_check("Offer(CaseParticipant) for V2 arrived in C1's DataLayer"):
+        cp_offer_id = _find_cp_offer_for_case(
+            client=c1_client,
+            case_id=case.id_,
+        )
+    logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
+
+    # Find the CaseActor's participant ID so we can route the Accept back.
+    case_actor_id = _find_case_actor_participant_id(c1_client, case.id_)
+    if case_actor_id is None:
+        raise AssertionError(
+            "CaseActor participant not found in case — cannot route Accept"
+        )
+    logger.info("CaseActor participant ID: %s", case_actor_id)
+
+    # C1 approves the recommendation (CM-16-006).
+    with demo_step("C1 approves actor recommendation"):
+        post_to_trigger(
+            client=c1_client,
+            actor_id=c1_in_c1.id_,
+            behavior="accept-actor-recommendation",
+            body={
+                "cp_offer_id": cp_offer_id,
+                "case_actor_id": case_actor_id,
+            },
+        )
+    logger.info("C1 sent Accept(Offer(CaseParticipant)) to CaseActor")
+
+    # CaseActor sends Invite to V2.  Poll V2's DataLayer for the arriving
+    # invite, then puppeteer V2's accept (DEMOMA-19-009: polling only).
+    v2_in_v2 = get_actor_by_id(v2_client, v2.id_)
+
+    with demo_check("V2 received invite from CaseActor (ADR-0026 path)"):
+        invite_id = find_case_invite_for_actor(
+            client=v2_client,
+            case_id=case.id_,
+            invitee_id=v2.id_,
+            timeout_seconds=20.0,
+        )
+    logger.info("V2 received CaseActor invite: %s", invite_id)
+
+    with demo_step("V2 accepts the CaseActor invitation"):
+        post_to_trigger(
+            client=v2_client,
+            actor_id=v2_in_v2.id_,
+            behavior="accept-case-invite",
+            body={"invite_id": invite_id},
+        )
+    logger.info("V2 sent Accept(Invite) to CaseActor")
+
+    with demo_check("V2's DataLayer received case replica"):
+        wait_for_case_on_container(
+            client=v2_client,
+            case_id=case.id_,
+            timeout_seconds=20.0,
+        )
+    logger.info("V2 received case replica via CaseActor (ADR-0026 path)")
+
+    # 6 participants: Finder + C1 + V1 + C2 + V2 + CaseActor
+    wait_for_case_participants(
+        vendor_client=c1_client,
+        case_id=case.id_,
+        expected_count=6,
+        timeout_seconds=20.0,
+    )
+    logger.info("✓ V2 joined case (6 participants)")
+
+
+def _phase_sync_verification(
+    finder_client: DataLayerClient,
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    c1: as_Actor,
+    finder: as_Actor,
+    case: as_VulnerabilityCase,
+) -> None:
+    """Verify SYNC-2 replication for all participant replicas."""
+    logger.info("─" * 80)
+    logger.info("Phase 3: Replica synchronization verification (M1)")
+    logger.info("─" * 80)
+
+    c1_entries = _get_log_entries_for_case(c1_client, case.id_)
+    if c1_entries:
+        c1_tail = max(c1_entries, key=lambda e: e["log_index"])
+        c1_tail_index: int = c1_tail["log_index"]
+        c1_tail_hash: str = c1_tail["entry_hash"]
+        logger.info(
+            "Waiting for replicas to sync C1 tail (hash=%s… index=%d)",
+            c1_tail_hash[:16],
+            c1_tail_index,
+        )
+        for replica_client, label in [
+            (finder_client, "Finder"),
+            (v1_client, "V1"),
+            (c2_client, "C2"),
+            (v2_client, "V2"),
+        ]:
+            with demo_check(
+                f"{label} ledger coverage (sync-verification phase)"
+            ):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=c1_tail_index,
+                )
+            logger.info("  %s ledger synchronized", label)
+
+    for replica_client in (finder_client, v1_client, c2_client, v2_client):
+        wait_for_case_participants(
+            vendor_client=replica_client,
+            case_id=case.id_,
+            expected_count=6,
+        )
+
+    with demo_check("Finder replica matches authoritative C1 state"):
+        verify_replica_state(
+            auth_client=c1_client,
+            replica_client=finder_client,
+            case_id=case.id_,
+            vendor_actor_id=c1.id_,
+            reporter_actor_id=finder.id_,
+        )
+
+    with demo_check("V2 replica matches authoritative C1 state"):
+        verify_replica_state(
+            auth_client=c1_client,
+            replica_client=v2_client,
+            case_id=case.id_,
+            vendor_actor_id=c1.id_,
+            reporter_actor_id=finder.id_,
+        )
+
+    logger.info("✓ M1: All five replicas synchronized (SYNC-2 verified)")
+
+
+def _phase_notes_exchange(
+    finder_client: DataLayerClient,
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    finder_in_finder: as_Actor,
+    c1_in_c1: as_Actor,
+    v1_in_v1: as_Actor,
+    c2_in_c2: as_Actor,
+    v2_in_v2: as_Actor,
+    case: as_VulnerabilityCase,
+) -> tuple[as_Note, as_Note, as_Note, as_Note, as_Note]:
+    """Run a five-way note exchange among all participants."""
+    logger.info("─" * 80)
+    logger.info("Phase 4: Notes exchange")
+    logger.info("─" * 80)
+
+    question_note = participant_adds_note_to_case(
+        posting_client=finder_client,
+        watching_client=c1_client,
+        poster=finder_in_finder,
+        case=case,
+        note_name="Question from Finder",
+        note_content=(
+            "Is there a workaround available while the patch is being developed?"
+        ),
+    )
+
+    c1_reply = participant_adds_note_to_case(
+        posting_client=c1_client,
+        watching_client=c1_client,
+        poster=c1_in_c1,
+        case=case,
+        note_name="C1 Response",
+        note_content=(
+            "Yes, disabling the affected module is an effective interim workaround."
+        ),
+        in_reply_to=question_note.id_,
+    )
+
+    v1_note = participant_adds_note_to_case(
+        posting_client=v1_client,
+        watching_client=c1_client,
+        poster=v1_in_v1,
+        case=case,
+        note_name="V1 Status Update",
+        note_content=(
+            "V1 has reproduced the issue. We will have a fix ready within 14 days."
+        ),
+        in_reply_to=c1_reply.id_,
+    )
+
+    c2_note = participant_adds_note_to_case(
+        posting_client=c2_client,
+        watching_client=c1_client,
+        poster=c2_in_c2,
+        case=case,
+        note_name="C2 Update",
+        note_content=(
+            "C2 confirms V2 is engaged. Target disclosure in 30 days."
+        ),
+        in_reply_to=v1_note.id_,
+    )
+
+    v2_note = participant_adds_note_to_case(
+        posting_client=v2_client,
+        watching_client=c1_client,
+        poster=v2_in_v2,
+        case=case,
+        note_name="V2 Status Update",
+        note_content=(
+            "V2 confirms the issue affects our component. "
+            "We will align our fix and deployment timeline with the 30-day target."
+        ),
+        in_reply_to=c2_note.id_,
+    )
+
+    logger.info(
+        "✓ Notes exchange complete (five notes committed to case ledger)"
+    )
+    return question_note, c1_reply, v1_note, c2_note, v2_note
+
+
+def _phase_fix_lifecycle(
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    finder_client: DataLayerClient,
+    v1: as_Actor,
+    v1_in_v1: as_Actor,
+    v2: as_Actor,
+    v2_in_v2: as_Actor,
+    case: as_VulnerabilityCase,
+) -> None:
+    """Advance V1 to VFd and V2 to VFD (DEMOMA-19-004).
+
+    V1 (VENDOR only) stops at VFd — fix-ready, no deploy step.
+    V2 (VENDOR + DEPLOYER) advances to VFD — fix-ready then fix-deployed.
+    """
+    logger.info("─" * 80)
+    logger.info(
+        "Phase 5: Fix lifecycle — V1: VFd (fix-ready); V2: VFD (fix-ready + fix-deployed)"
+    )
+    logger.info("─" * 80)
+
+    # V1 advances to fix-ready (VFd).
+    actor_notifies_fix_ready(
+        client=v1_client,
+        actor=v1_in_v1,
+        case_id=case.id_,
+    )
+
+    with demo_check("V1 participant vfd_state transitions to VFd"):
+        wait_for_participant_vfd_state(
+            client=v1_client,
+            case_id=case.id_,
+            actor_id=v1.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+
+    # V2 advances to fix-ready (VFd).
+    actor_notifies_fix_ready(
+        client=v2_client,
+        actor=v2_in_v2,
+        case_id=case.id_,
+    )
+
+    with demo_check("V2 participant vfd_state transitions to VFd or VFD"):
+        wait_for_participant_vfd_state(
+            client=v2_client,
+            case_id=case.id_,
+            actor_id=v2.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+
+    with demo_check("M5: C1 replica shows V1 and V2 CS include F (fix ready)"):
+        wait_for_participant_vfd_state(
+            client=c1_client,
+            case_id=case.id_,
+            actor_id=v1.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
+            client=c1_client,
+            case_id=case.id_,
+            actor_id=v2.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+        verify_fix_ready(
+            receiver_client=v1_client,
+            reporter_client=finder_client,
+            case_id=case.id_,
+            receiver_actor_id=v1.id_,
+        )
+        verify_fix_ready(
+            receiver_client=v2_client,
+            reporter_client=finder_client,
+            case_id=case.id_,
+            receiver_actor_id=v2.id_,
+        )
+
+    # V2 (VENDOR + DEPLOYER) advances to fix-deployed (VFD).
+    actor_notifies_fix_deployed(
+        client=v2_client,
+        actor=v2_in_v2,
+        case_id=case.id_,
+    )
+
+    with demo_check("V2 participant vfd_state transitions to VFD"):
+        wait_for_participant_vfd_state(
+            client=v2_client,
+            case_id=case.id_,
+            actor_id=v2.id_,
+            expected_states={CS_vfd.VFD},
+        )
+
+    with demo_check(
+        "M6: C1 replica shows V1=VFd (no deploy), V2=VFD (deployed)"
+    ):
+        wait_for_participant_vfd_state(
+            client=c1_client,
+            case_id=case.id_,
+            actor_id=v1.id_,
+            expected_states={CS_vfd.VFd},
+        )
+        wait_for_participant_vfd_state(
+            client=c1_client,
+            case_id=case.id_,
+            actor_id=v2.id_,
+            expected_states={CS_vfd.VFD},
+        )
+        verify_fix_ready(
+            receiver_client=v1_client,
+            reporter_client=finder_client,
+            case_id=case.id_,
+            receiver_actor_id=v1.id_,
+        )
+        verify_fix_deployed(
+            receiver_client=v2_client,
+            reporter_client=finder_client,
+            case_id=case.id_,
+            receiver_actor_id=v2.id_,
+        )
+
+    logger.info(
+        "✓ Fix lifecycle: V1=VFd (no deploy path), V2=VFD (full deploy path)"
+    )
+
+
+def _phase_publication(
+    finder_client: DataLayerClient,
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    c1: as_Actor,
+    c1_in_c1: as_Actor,
+    c2_in_c2: as_Actor,
+    v1: as_Actor,
+    v1_in_v1: as_Actor,
+    v2: as_Actor,
+    v2_in_v2: as_Actor,
+    finder_in_finder: as_Actor,
+    case: as_VulnerabilityCase,
+) -> None:
+    """V1 publishes first (triggering embargo teardown); then V2 publishes (DEMOMA-19-005)."""
+    logger.info("─" * 80)
+    logger.info(
+        "Phase 6: Publication — V1 publishes first → EM.EXITED → V2 + others publish"
+    )
+    logger.info("─" * 80)
+
+    # V1 (VENDOR only) triggers CS.P and the ThreatTerminationBranchNode
+    # embargo teardown path (DEMOMA-19-005).
+    actor_notifies_published(
+        client=v1_client,
+        actor=v1_in_v1,
+        case_id=case.id_,
+    )
+
+    # Wait for CaseActor to process V1's publication and emit EM.EXITED
+    # before V2 publishes to avoid a non-deterministic ledger ordering.
+    with demo_check(
+        "Embargo terminated (EM.EXITED) after V1 reports published"
+    ):
+        wait_for_case_em_terminated(
+            client=v1_client,
+            case_id=case.id_,
+        )
+
+    actor_notifies_published(
+        client=v2_client,
+        actor=v2_in_v2,
+        case_id=case.id_,
+    )
+    actor_notifies_published(
+        client=c2_client,
+        actor=c2_in_c2,
+        case_id=case.id_,
+    )
+    actor_notifies_published(
+        client=c1_client,
+        actor=c1_in_c1,
+        case_id=case.id_,
+    )
+
+    with demo_check(
+        "Embargo terminated (EM.EXITED) propagated to Finder before notify-published"
+    ):
+        wait_for_case_em_terminated(
+            client=finder_client,
+            case_id=case.id_,
+        )
+
+    actor_notifies_published(
+        client=finder_client,
+        actor=finder_in_finder,
+        case_id=case.id_,
+    )
+
+    with demo_check(
+        "M7: all replicas EM.EXITED, all participants public-aware"
+    ):
+        wait_for_case_em_terminated(
+            client=finder_client,
+            case_id=case.id_,
+        )
+        wait_for_participant_vfd_state(
+            client=c1_client,
+            case_id=case.id_,
+            actor_id=v1.id_,
+            expected_states={CS_vfd.VFd},
+        )
+        wait_for_participant_vfd_state(
+            client=c1_client,
+            case_id=case.id_,
+            actor_id=v2.id_,
+            expected_states={CS_vfd.VFD},
+        )
+        verify_publicly_disclosed(
+            receiver_client=c1_client,
+            reporter_client=finder_client,
+            case_id=case.id_,
+            receiver_actor_id=c1.id_,
+        )
+
+
+def _phase_case_closure(
+    finder_client: DataLayerClient,
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    c1_in_c1: as_Actor,
+    v1_in_v1: as_Actor,
+    c2_in_c2: as_Actor,
+    v2_in_v2: as_Actor,
+    finder_in_finder: as_Actor,
+    case: as_VulnerabilityCase,
+) -> None:
+    """Close the case from all five participants and verify terminal state."""
+    logger.info("─" * 80)
+    logger.info("Phase 7: Case closure — all participants RM.CLOSED")
+    logger.info("─" * 80)
+
+    actor_closes_case(client=c1_client, actor=c1_in_c1, case_id=case.id_)
+    actor_closes_case(client=v1_client, actor=v1_in_v1, case_id=case.id_)
+    actor_closes_case(client=v2_client, actor=v2_in_v2, case_id=case.id_)
+    actor_closes_case(client=c2_client, actor=c2_in_c2, case_id=case.id_)
+    actor_closes_case(
+        client=finder_client, actor=finder_in_finder, case_id=case.id_
+    )
+
+    with demo_check("M8: all participants RM.CLOSED on all replicas"):
+        wait_for_all_participants_rm_closed(
+            client=c1_client,
+            case_id=case.id_,
+        )
+        wait_for_all_participants_rm_closed(
+            client=finder_client,
+            case_id=case.id_,
+        )
+        verify_case_closed(
+            receiver_client=c1_client,
+            reporter_client=finder_client,
+            case_id=case.id_,
+        )
+
+    with demo_check("close_case entry present on authoritative actor (c1)"):
+        wait_for_event_type_in_ledger(
+            client=c1_client,
+            case_id=case.id_,
+            event_type="close_case",
+        )
+
+    c1_entries = _get_log_entries_for_case(c1_client, case.id_)
+    if c1_entries:
+        c1_tail = max(c1_entries, key=lambda e: e["log_index"])
+        c1_tail_index: int = c1_tail["log_index"]
+        c1_tail_hash: str = c1_tail["entry_hash"]
+        logger.info(
+            "Waiting for replicas to receive C1 tail after closure"
+            " (hash=%s… index=%d)",
+            c1_tail_hash[:16],
+            c1_tail_index,
+        )
+        for replica_client, label in [
+            (finder_client, "Finder"),
+            (v1_client, "V1"),
+            (c2_client, "C2"),
+            (v2_client, "V2"),
+        ]:
+            with demo_check(f"{label} ledger coverage (close phase)"):
+                wait_for_contiguous_ledger_coverage(
+                    client=replica_client,
+                    case_id=case.id_,
+                    expected_tail_index=c1_tail_index,
+                )
+
+
+def _phase_dump_case_ledgers(
+    finder_client: DataLayerClient,
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    case: as_VulnerabilityCase,
+    demo_name: str = "fcvcv",
+) -> None:
+    """Dump case ledger entries from each actor container to JSONL files."""
+    logger.info("─" * 80)
+    logger.info("Phase 8: Case log JSONL export")
+    logger.info("─" * 80)
+
+    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
+    case_id = case.id_ or ""
+    case_id_slug = (
+        case_id.replace("://", "_")
+        .replace("/", "_")
+        .replace(":", "_")
+        .strip("_")
+    )
+
+    case_actor_sub_actor_key = next(
+        (
+            strip_id_prefix(actor_id)
+            for actor_id in case.actor_participant_index
+            if strip_id_prefix(actor_id).startswith("case-actor")
+        ),
+        None,
+    )
+
+    # Devlog directory names use scenario-role names (DEMOMA-19-007):
+    # finder, c1, v1, c2, v2, case-actor.
+    # Container routing keys must match actual docker-compose service/actor paths.
+    actors: list[tuple[str, DataLayerClient, str]] = [
+        ("finder", finder_client, "finder"),
+        # C1 is on the coordinator container; route key is "coordinator".
+        ("c1", c1_client, "coordinator"),
+        # V1 is on the vendor container; route key is "vendor".
+        ("v1", v1_client, "vendor"),
+        # C2 is on actor5; route key is "vendor2" (actor5 seed).
+        ("c2", c2_client, "vendor2"),
+        # V2 is on actor6; route key is "vendor-deployer".
+        ("v2", v2_client, "vendor-deployer"),
+    ]
+    if case_actor_sub_actor_key is not None:
+        actors.append(("case-actor", c1_client, case_actor_sub_actor_key))
+
+    for actor_name, client, actor_route_key in actors:
+        with demo_step(f"Dumping case ledger for {actor_name}"):
+            case_key = strip_id_prefix(case_id)
+            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
+            try:
+                entries = client.get_list(log_path)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code != 404:
+                    raise
+                logger.info(
+                    "Case not found on %s container (HTTP 404); skipping.",
+                    actor_name,
+                )
+                entries = []
+            if not entries:
+                raise ValueError(
+                    f"No case ledger entries for actor={actor_name!r}, "
+                    f"case_id={case_id!r}"
+                )
+
+            out_dir = output_root / demo_name / actor_name
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
+
+            with out_file.open("w", encoding="utf-8") as fh:
+                for entry in entries:
+                    fh.write(json.dumps(entry) + "\n")
+
+            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+
+
+def run_fcvcv_demo(
+    finder_client: DataLayerClient,
+    c1_client: DataLayerClient,
+    v1_client: DataLayerClient,
+    c2_client: DataLayerClient,
+    v2_client: DataLayerClient,
+    finder_id: str | None = None,
+    c1_id: str | None = None,
+    v1_id: str | None = None,
+    c2_id: str | None = None,
+    v2_id: str | None = None,
+) -> None:
+    """Orchestrate the FCVCV CVD workflow."""
+    logger.info("=" * 80)
+    logger.info(
+        "FCVCV DEMO: Finder + C1(CASE_OWNER) + V1(VENDOR) + C2(COORDINATOR) + V2(VENDOR+DEPLOYER)"
+    )
+    logger.info("=" * 80)
+    logger.info("Finder container: %s", finder_client.base_url)
+    logger.info("C1 container:     %s", c1_client.base_url)
+    logger.info("V1 container:     %s", v1_client.base_url)
+    logger.info("C2 container:     %s", c2_client.base_url)
+    logger.info("V2 container:     %s", v2_client.base_url)
+
+    (
+        finder,
+        c1,
+        c1_in_c1,
+        v1,
+        v1_in_v1,
+        c2_in_c2,
+        v2,
+        case,
+    ) = _phase_report_submission(
+        finder_client,
+        c1_client,
+        v1_client,
+        c2_client,
+        v2_client,
+        finder_id,
+        c1_id,
+        v1_id,
+        c2_id,
+        v2_id,
+    )
+
+    _phase_c2_suggests_v2(
+        c1_client=c1_client,
+        c2_client=c2_client,
+        v2_client=v2_client,
+        c1_in_c1=c1_in_c1,
+        c2_in_c2=c2_in_c2,
+        v2=v2,
+        case=case,
+    )
+
+    v2_in_v2 = get_actor_by_id(v2_client, v2.id_)
+    finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+
+    _phase_sync_verification(
+        finder_client,
+        c1_client,
+        v1_client,
+        c2_client,
+        v2_client,
+        c1,
+        finder,
+        case,
+    )
+    _phase_notes_exchange(
+        finder_client=finder_client,
+        c1_client=c1_client,
+        v1_client=v1_client,
+        c2_client=c2_client,
+        v2_client=v2_client,
+        finder_in_finder=finder_in_finder,
+        c1_in_c1=c1_in_c1,
+        v1_in_v1=v1_in_v1,
+        c2_in_c2=c2_in_c2,
+        v2_in_v2=v2_in_v2,
+        case=case,
+    )
+    _phase_fix_lifecycle(
+        c1_client,
+        v1_client,
+        v2_client,
+        finder_client,
+        v1,
+        v1_in_v1,
+        v2,
+        v2_in_v2,
+        case,
+    )
+    _phase_publication(
+        finder_client,
+        c1_client,
+        v1_client,
+        c2_client,
+        v2_client,
+        c1,
+        c1_in_c1,
+        c2_in_c2,
+        v1,
+        v1_in_v1,
+        v2,
+        v2_in_v2,
+        finder_in_finder,
+        case,
+    )
+    _phase_case_closure(
+        finder_client,
+        c1_client,
+        v1_client,
+        c2_client,
+        v2_client,
+        c1_in_c1,
+        v1_in_v1,
+        c2_in_c2,
+        v2_in_v2,
+        finder_in_finder,
+        case,
+    )
+    _phase_dump_case_ledgers(
+        finder_client=finder_client,
+        c1_client=c1_client,
+        v1_client=v1_client,
+        c2_client=c2_client,
+        v2_client=v2_client,
+        case=case,
+    )
+
+    logger.info("=" * 80)
+    logger.info("FCVCV DEMO COMPLETE ✓  (full 5-actor lifecycle)")
+    logger.info("=" * 80)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(
+    skip_health_check: bool = False,
+    finder_url: str | None = None,
+    c1_url: str | None = None,
+    v1_url: str | None = None,
+    c2_url: str | None = None,
+    v2_url: str | None = None,
+    finder_id: str | None = None,
+    c1_id: str | None = None,
+    v1_id: str | None = None,
+    c2_id: str | None = None,
+    v2_id: str | None = None,
+) -> None:
+    """Entry point for the FCVCV CVD workflow demo.
+
+    Args:
+        skip_health_check: Skip server availability checks.
+        finder_url: Override base URL for the Finder container.
+        c1_url: Override base URL for the C1 (Coordinator1) container.
+        v1_url: Override base URL for the V1 (Vendor1) container.
+        c2_url: Override base URL for the C2 (Coordinator2) container.
+        v2_url: Override base URL for the V2 (VendorDeployer) container.
+        finder_id: Optional deterministic URI for the Finder actor.
+        c1_id: Optional deterministic URI for the C1 actor.
+        v1_id: Optional deterministic URI for the V1 actor.
+        c2_id: Optional deterministic URI for the C2 actor.
+        v2_id: Optional deterministic URI for the V2 actor.
+    """
+    reset_demo_failures()
+
+    f_url = finder_url or FINDER_BASE_URL
+    c1_resolved = c1_url or C1_BASE_URL
+    v1_resolved = v1_url or V1_BASE_URL
+    c2_resolved = c2_url or C2_BASE_URL
+    v2_resolved = v2_url or V2_BASE_URL
+
+    finder_client = DataLayerClient(base_url=f_url)
+    c1_client = DataLayerClient(base_url=c1_resolved)
+    v1_client = DataLayerClient(base_url=v1_resolved)
+    c2_client = DataLayerClient(base_url=c2_resolved)
+    v2_client = DataLayerClient(base_url=v2_resolved)
+
+    if not skip_health_check:
+        targets: list[tuple[str, DataLayerClient]] = [
+            ("Finder", finder_client),
+            ("C1", c1_client),
+            ("V1", v1_client),
+            ("C2", c2_client),
+            ("V2", v2_client),
+        ]
+        for label, client in targets:
+            if not check_server_availability(client):
+                logger.error("=" * 80)
+                logger.error("ERROR: %s API server is not available", label)
+                logger.error("=" * 80)
+                logger.error("Cannot connect to: %s", client.base_url)
+                logger.error(
+                    "Ensure the %s container is running and healthy.", label
+                )
+                logger.error("=" * 80)
+                sys.exit(1)
+
+    try:
+        run_fcvcv_demo(
+            finder_client=finder_client,
+            c1_client=c1_client,
+            v1_client=v1_client,
+            c2_client=c2_client,
+            v2_client=v2_client,
+            finder_id=finder_id,
+            c1_id=c1_id,
+            v1_id=v1_id,
+            c2_id=c2_id,
+            v2_id=v2_id,
+        )
+    finally:
+        assert_demo_success()
+
+
+if __name__ == "__main__":
+    setup_demo_logging()
+    main()

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -41,7 +41,6 @@ import logging
 import os
 import pathlib
 import sys
-import time
 
 import httpx2 as httpx
 
@@ -84,7 +83,9 @@ from vultron.demo.helpers.milestones import (
 )
 from vultron.demo.helpers.notes import participant_adds_note_to_case
 from vultron.demo.helpers.polling import (
+    find_case_actor_participant_id,
     find_case_invite_for_actor,
+    find_cp_offer_for_case,
     wait_for_all_participants_rm_closed,
     wait_for_case_em_terminated,
     wait_for_case_on_container,
@@ -154,85 +155,6 @@ def reset_containers(
         ("V2", v2_client),
     ]
     _reset_containers(targets, reset_fn=reset_datalayer)
-
-
-# ---------------------------------------------------------------------------
-# Polling helpers
-# ---------------------------------------------------------------------------
-
-
-def _is_cp_offer_for_case(obj_data: dict, case_id: str) -> bool:
-    """Return True if *obj_data* looks like an Offer(CaseParticipant) for *case_id*."""
-    if obj_data.get("type") != "Offer":
-        return False
-    target_raw = obj_data.get("target")
-    target_id = (
-        target_raw.get("id") if isinstance(target_raw, dict) else target_raw
-    )
-    if target_id != case_id:
-        return False
-    inner = obj_data.get("object")
-    if not isinstance(inner, dict):
-        return False
-    return bool(
-        inner.get("type") in ("CaseParticipant", "as_CaseParticipant")
-        or inner.get("case_roles")
-    )
-
-
-def _find_cp_offer_for_case(
-    client: DataLayerClient,
-    case_id: str,
-    timeout_seconds: float = 15.0,
-    poll_interval: float = 0.5,
-) -> str:
-    """Poll until an Offer(CaseParticipant) for *case_id* appears in DataLayer.
-
-    Returns the offer ID string.
-
-    Raises:
-        AssertionError: If no such offer is found within *timeout_seconds*.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        try:
-            all_objects = client.get("/datalayer/")
-            if isinstance(all_objects, dict):
-                for raw_id, obj_data in all_objects.items():
-                    obj_id = str(raw_id)
-                    if not isinstance(obj_data, dict):
-                        continue
-                    if _is_cp_offer_for_case(obj_data, case_id):
-                        logger.info(
-                            "Found Offer(CaseParticipant) for case %s: %s",
-                            case_id,
-                            obj_id,
-                        )
-                        return obj_id
-        except Exception:  # noqa: BLE001
-            pass
-        time.sleep(poll_interval)
-
-    raise AssertionError(
-        f"Timed out waiting for Offer(CaseParticipant) for case {case_id!r}"
-        f" to appear in DataLayer at {client.base_url}"
-    )
-
-
-def _find_case_actor_participant_id(
-    c1_client: DataLayerClient,
-    case_id: str,
-) -> str | None:
-    """Return the CaseActor participant URI for *case_id* from C1's DataLayer."""
-    try:
-        case_data = c1_client.get(f"/datalayer/{case_id}")
-        case = as_VulnerabilityCase.model_validate(case_data)
-        for actor_id in case.actor_participant_index:
-            if strip_id_prefix(actor_id).startswith("case-actor"):
-                return actor_id
-    except Exception:  # noqa: BLE001
-        pass
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -467,14 +389,14 @@ def _phase_c2_suggests_v2(
     # Offer(CaseParticipant) to C1.  Poll C1's DataLayer for the offer.
     cp_offer_id = None
     with demo_check("Offer(CaseParticipant) for V2 arrived in C1's DataLayer"):
-        cp_offer_id = _find_cp_offer_for_case(
+        cp_offer_id = find_cp_offer_for_case(
             client=c1_client,
             case_id=case.id_,
         )
         logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
 
     # Find the CaseActor's participant ID so we can route the Accept back.
-    case_actor_id = _find_case_actor_participant_id(c1_client, case.id_)
+    case_actor_id = find_case_actor_participant_id(c1_client, case.id_)
     if case_actor_id is None:
         raise AssertionError(
             "CaseActor participant not found in case — cannot route Accept"

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -448,6 +448,8 @@ def _phase_c2_suggests_v2(
     logger.info("─" * 80)
 
     # C2 sends suggest-actor-to-case (Offer(Actor, Case) → CaseActor).
+    # roles must be explicit so EvaluateDefaultRolesNode doesn't fall back to
+    # the hardcoded [VENDOR] default (issue #1969).
     with demo_step("C2 suggests V2 to CaseActor"):
         post_to_trigger(
             client=c2_client,
@@ -456,6 +458,7 @@ def _phase_c2_suggests_v2(
             body={
                 "case_id": case.id_,
                 "suggested_actor_id": v2.id_,
+                "roles": ["vendor", "deployer"],
             },
         )
     logger.info("C2 sent suggest-actor-to-case for V2 (%s)", v2.id_)

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -564,8 +564,12 @@ def _phase_sync_verification(
             (finder_client, "Finder"),
             (v1_client, "V1"),
             (c2_client, "C2"),
+            # V2 is a late joiner that must catch up from genesis; allow extra
+            # time for the full history to be delivered (SYNC-2 late-joiner).
             (v2_client, "V2"),
         ]:
+            # V2 joins after Phase 1 completes, so it has more entries to sync.
+            timeout = 45.0 if label == "V2" else 15.0
             with demo_check(
                 f"{label} ledger coverage (sync-verification phase)"
             ):
@@ -573,14 +577,18 @@ def _phase_sync_verification(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=c1_tail_index,
+                    timeout_seconds=timeout,
                 )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, v1_client, c2_client, v2_client):
+        # V2 is a late joiner — allow extra time for participant index propagation.
+        p_timeout = 30.0 if replica_client is v2_client else 10.0
         wait_for_case_participants(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_count=6,
+            timeout_seconds=p_timeout,
         )
 
     with demo_check("Finder replica matches authoritative C1 state"):

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -748,6 +748,18 @@ def _phase_fix_lifecycle(
             actor_id=v2.id_,
             expected_states={CS_vfd.VFd, CS_vfd.VFD},
         )
+        wait_for_participant_vfd_state(
+            client=finder_client,
+            case_id=case.id_,
+            actor_id=v1.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
+            client=finder_client,
+            case_id=case.id_,
+            actor_id=v2.id_,
+            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+        )
         verify_fix_ready(
             receiver_client=v1_client,
             reporter_client=finder_client,
@@ -787,6 +799,18 @@ def _phase_fix_lifecycle(
         )
         wait_for_participant_vfd_state(
             client=c1_client,
+            case_id=case.id_,
+            actor_id=v2.id_,
+            expected_states={CS_vfd.VFD},
+        )
+        wait_for_participant_vfd_state(
+            client=finder_client,
+            case_id=case.id_,
+            actor_id=v1.id_,
+            expected_states={CS_vfd.VFd},
+        )
+        wait_for_participant_vfd_state(
+            client=finder_client,
             case_id=case.id_,
             actor_id=v2.id_,
             expected_states={CS_vfd.VFD},

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -504,7 +504,7 @@ def _phase_c2_suggests_v2(
             client=v2_client,
             case_id=case.id_,
             invitee_id=v2.id_,
-            timeout_seconds=20.0,
+            timeout_seconds=40.0,
         )
         logger.info("V2 received CaseActor invite: %s", invite_id)
 
@@ -521,7 +521,7 @@ def _phase_c2_suggests_v2(
         wait_for_case_on_container(
             client=v2_client,
             case_id=case.id_,
-            timeout_seconds=20.0,
+            timeout_seconds=40.0,
         )
     logger.info("V2 received case replica via CaseActor (ADR-0026 path)")
 
@@ -530,7 +530,7 @@ def _phase_c2_suggests_v2(
         vendor_client=c1_client,
         case_id=case.id_,
         expected_count=6,
-        timeout_seconds=20.0,
+        timeout_seconds=40.0,
     )
     logger.info("✓ V2 joined case (6 participants)")
 

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -1294,11 +1294,11 @@ def main(
             v1_client=v1_client,
             c2_client=c2_client,
             v2_client=v2_client,
-            finder_id=finder_id,
-            c1_id=c1_id,
-            v1_id=v1_id,
-            c2_id=c2_id,
-            v2_id=v2_id,
+            finder_id=finder_id or FINDER_ACTOR_ID,
+            c1_id=c1_id or C1_ACTOR_ID,
+            v1_id=v1_id or V1_ACTOR_ID,
+            c2_id=c2_id or C2_ACTOR_ID,
+            v2_id=v2_id or V2_ACTOR_ID,
         )
     finally:
         assert_demo_success()

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -465,12 +465,13 @@ def _phase_c2_suggests_v2(
 
     # CaseActor processes Offer(Actor, Case) and forwards
     # Offer(CaseParticipant) to C1.  Poll C1's DataLayer for the offer.
+    cp_offer_id = None
     with demo_check("Offer(CaseParticipant) for V2 arrived in C1's DataLayer"):
         cp_offer_id = _find_cp_offer_for_case(
             client=c1_client,
             case_id=case.id_,
         )
-    logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
+        logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
 
     # Find the CaseActor's participant ID so we can route the Accept back.
     case_actor_id = _find_case_actor_participant_id(c1_client, case.id_)
@@ -497,6 +498,7 @@ def _phase_c2_suggests_v2(
     # invite, then puppeteer V2's accept (DEMOMA-19-009: polling only).
     v2_in_v2 = get_actor_by_id(v2_client, v2.id_)
 
+    invite_id = None
     with demo_check("V2 received invite from CaseActor (ADR-0026 path)"):
         invite_id = find_case_invite_for_actor(
             client=v2_client,
@@ -504,7 +506,7 @@ def _phase_c2_suggests_v2(
             invitee_id=v2.id_,
             timeout_seconds=20.0,
         )
-    logger.info("V2 received CaseActor invite: %s", invite_id)
+        logger.info("V2 received CaseActor invite: %s", invite_id)
 
     with demo_step("V2 accepts the CaseActor invitation"):
         post_to_trigger(

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -28,7 +28,6 @@ import logging
 import os
 import pathlib
 import sys
-import time
 
 import httpx2 as httpx
 
@@ -73,7 +72,9 @@ from vultron.demo.helpers.milestones import (
 )
 from vultron.demo.helpers.notes import participant_adds_note_to_case
 from vultron.demo.helpers.polling import (
+    find_case_actor_participant_id,
     find_case_invite_for_actor,
+    find_cp_offer_for_case,
     wait_for_all_participants_rm_closed,
     wait_for_case_em_terminated,
     wait_for_case_on_container,
@@ -140,90 +141,6 @@ def reset_containers(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _is_cp_offer_for_case(obj_id: str, obj_data: dict, case_id: str) -> bool:
-    """Return True if *obj_data* looks like an Offer(CaseParticipant) for *case_id*."""
-    if obj_data.get("type") != "Offer":
-        return False
-    target_raw = obj_data.get("target")
-    target_id = (
-        target_raw.get("id") if isinstance(target_raw, dict) else target_raw
-    )
-    if target_id != case_id:
-        return False
-    inner = obj_data.get("object")
-    if not isinstance(inner, dict):
-        return False
-    return bool(
-        inner.get("type") in ("CaseParticipant", "as_CaseParticipant")
-        or inner.get("case_roles")
-    )
-
-
-def _find_cp_offer_for_case(
-    client: DataLayerClient,
-    case_id: str,
-    timeout_seconds: float = 15.0,
-    poll_interval: float = 0.5,
-) -> str:
-    """Poll until an Offer(CaseParticipant) for *case_id* appears in DataLayer.
-
-    After the Coordinator sends suggest-actor-to-case, the CaseActor
-    processes the Offer(Actor, Case) and forwards an Offer(CaseParticipant)
-    to the Case Owner's inbox.  This helper polls the Case Owner's DataLayer
-    for any Offer whose ``target`` matches *case_id* and whose ``object``
-    resembles a CaseParticipant.
-
-    Returns the offer ID string.
-
-    Raises:
-        AssertionError: If no such offer is found within *timeout_seconds*.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        try:
-            all_objects = client.get("/datalayer/")
-            if isinstance(all_objects, dict):
-                for raw_id, obj_data in all_objects.items():
-                    obj_id = str(raw_id)
-                    if not isinstance(obj_data, dict):
-                        continue
-                    if _is_cp_offer_for_case(obj_id, obj_data, case_id):
-                        logger.info(
-                            "Found Offer(CaseParticipant) for case %s: %s",
-                            case_id,
-                            obj_id,
-                        )
-                        return obj_id
-        except Exception:  # noqa: BLE001
-            pass
-        time.sleep(poll_interval)
-
-    raise AssertionError(
-        f"Timed out waiting for Offer(CaseParticipant) for case {case_id!r}"
-        f" to appear in DataLayer at {client.base_url}"
-    )
-
-
-def _find_case_actor_participant_id(
-    vendor_client: DataLayerClient,
-    case_id: str,
-) -> str | None:
-    """Return the CaseActor participant URI for *case_id* from Vendor1's DataLayer.
-
-    Scans ``actor_participant_index`` for an actor ID starting with "case-actor".
-    Returns ``None`` if not found (no CaseActor participant in this case).
-    """
-    try:
-        case_data = vendor_client.get(f"/datalayer/{case_id}")
-        case = as_VulnerabilityCase.model_validate(case_data)
-        for actor_id in case.actor_participant_index:
-            if strip_id_prefix(actor_id).startswith("case-actor"):
-                return actor_id
-    except Exception:  # noqa: BLE001
-        pass
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -425,14 +342,14 @@ def _phase_coordinator_suggests_vendor2(
     with demo_check(
         "Offer(CaseParticipant) for Vendor2 arrived in Vendor1's DataLayer"
     ):
-        cp_offer_id = _find_cp_offer_for_case(
+        cp_offer_id = find_cp_offer_for_case(
             client=vendor_client,
             case_id=case.id_,
         )
     logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
 
     # Find the CaseActor's participant ID so we can route the Accept back.
-    case_actor_id = _find_case_actor_participant_id(vendor_client, case.id_)
+    case_actor_id = find_case_actor_participant_id(vendor_client, case.id_)
     if case_actor_id is None:
         raise AssertionError(
             "CaseActor participant not found in case — cannot route Accept"

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -76,6 +76,7 @@ from vultron.demo.helpers.milestones import (
     verify_publicly_disclosed,
 )
 from vultron.demo.helpers.polling import (
+    find_case_actor_participant_id,
     find_case_invite_for_actor,
     wait_for_all_participants_rm_closed,
     wait_for_case_em_terminated,
@@ -150,26 +151,6 @@ def reset_containers(
 # ---------------------------------------------------------------------------
 # Polling helpers
 # ---------------------------------------------------------------------------
-
-
-def _find_case_actor_participant_id(
-    vendor_client: DataLayerClient,
-    case_id: str,
-) -> str | None:
-    """Return the CaseActor participant URI for *case_id* from Vendor1's DataLayer.
-
-    Scans ``actor_participant_index`` for an actor ID starting with "case-actor".
-    Returns ``None`` if not found.
-    """
-    try:
-        case_data = vendor_client.get(f"/datalayer/{case_id}")
-        case = as_VulnerabilityCase.model_validate(case_data)
-        for actor_id in case.actor_participant_index:
-            if strip_id_prefix(actor_id).startswith("case-actor"):
-                return actor_id
-    except Exception:  # noqa: BLE001
-        pass
-    return None
 
 
 def _wait_for_case_attributed_to(
@@ -1091,7 +1072,7 @@ def run_fvcv_handoff_demo(
 
     # The CaseActor is a dynamic sub-actor on the vendor container (not the
     # case-actor service).  Discover its ID from the case data before proceeding.
-    dynamic_case_actor_id = _find_case_actor_participant_id(
+    dynamic_case_actor_id = find_case_actor_participant_id(
         vendor_client, case.id_
     )
     if dynamic_case_actor_id is None:

--- a/vultron/wire/as2/extractor/_builders.py
+++ b/vultron/wire/as2/extractor/_builders.py
@@ -117,6 +117,7 @@ def _build_activity_snapshot(
         summary=getattr(activity, "summary", None) or None,
         content=getattr(activity, "content", None) or None,
         suggested_roles=getattr(activity, "suggested_roles", None) or None,
+        roles=getattr(activity, "roles", None) or None,
     )
 
 

--- a/vultron/wire/as2/extractor/_builders.py
+++ b/vultron/wire/as2/extractor/_builders.py
@@ -116,6 +116,7 @@ def _build_activity_snapshot(
         cc=_get_id_list(getattr(activity, "cc", None)),
         summary=getattr(activity, "summary", None) or None,
         content=getattr(activity, "content", None) or None,
+        suggested_roles=getattr(activity, "suggested_roles", None) or None,
     )
 
 

--- a/vultron/wire/as2/factories/actor.py
+++ b/vultron/wire/as2/factories/actor.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 def recommend_actor_activity(
     recommended: CoreActor | as_Actor,
     target: as_VulnerabilityCaseRef | None = None,
+    suggested_roles: list[str] | None = None,
     **kwargs,
 ) -> as_Offer:
     """Build an Offer(Actor, target=VulnerabilityCase) — actor recommendation.
@@ -79,7 +80,10 @@ def recommend_actor_activity(
     """
     try:
         return _RecommendActorActivity(
-            object_=recommended, target=target, **kwargs
+            object_=recommended,
+            target=target,
+            suggested_roles=suggested_roles,
+            **kwargs,
         )
     except ValidationError as exc:
         logger.warning("recommend_actor_activity: invalid arguments: %s", exc)

--- a/vultron/wire/as2/vocab/activities/actor.py
+++ b/vultron/wire/as2/vocab/activities/actor.py
@@ -37,6 +37,7 @@ class _RecommendActorActivity(as_Offer):
         ..., validation_alias="object", serialization_alias="object"
     )
     target: as_VulnerabilityCaseRef = None
+    suggested_roles: list[str] | None = None
 
 
 class _AcceptActorRecommendationActivity(as_Accept):

--- a/vultron/wire/as2/vocab/activities/actor.py
+++ b/vultron/wire/as2/vocab/activities/actor.py
@@ -37,7 +37,8 @@ class _RecommendActorActivity(as_Offer):
         ..., validation_alias="object", serialization_alias="object"
     )
     target: as_VulnerabilityCaseRef = None
-    suggested_roles: list[str] | None = None
+    # suggested_roles is inherited from as_Offer, aliased there; redeclaring it
+    # here would shadow the base field and drop the camelCase alias (#1990).
 
 
 class _AcceptActorRecommendationActivity(as_Accept):

--- a/vultron/wire/as2/vocab/base/objects/activities/transitive.py
+++ b/vultron/wire/as2/vocab/base/objects/activities/transitive.py
@@ -107,7 +107,16 @@ class as_Offer(as_TransitiveActivity):
         validation_alias="type",
         serialization_alias="type",
     )
-    suggested_roles: list[str] | None = None
+    # Declared on the base rather than only on _RecommendActorActivity because
+    # VOCABULARY["Offer"] resolves to this class: an inbound Offer is
+    # reconstructed as a bare as_Offer, so without the field here the suggested
+    # roles are dropped on the DataLayer round-trip (#1990).  Aliased
+    # explicitly, matching the convention in this module.
+    suggested_roles: list[str] | None = Field(
+        default=None,
+        validation_alias="suggestedRoles",
+        serialization_alias="suggestedRoles",
+    )
 
 
 class as_Invite(as_Offer):

--- a/vultron/wire/as2/vocab/base/objects/activities/transitive.py
+++ b/vultron/wire/as2/vocab/base/objects/activities/transitive.py
@@ -107,6 +107,7 @@ class as_Offer(as_TransitiveActivity):
         validation_alias="type",
         serialization_alias="type",
     )
+    suggested_roles: list[str] | None = None
 
 
 class as_Invite(as_Offer):


### PR DESCRIPTION
- Closes #1925
- Closes #1969
- Closes #1989
- Closes #1990

## Summary

Implements the FCVCV 5-party CVD demo scenario (DEMOMA-19): Finder + C1
(CASE_OWNER) + V1 (VENDOR) + C2 (COORDINATOR) + V2 (VENDOR+DEPLOYER), with the
`fcvcv` CLI command and CI matrix job.

## Motivation

Getting the scenario green surfaced three shared-code defects that no prior
scenario exercised, all now fixed here:

- **#1969** — `EvaluateDefaultRolesNode` hardcoded `[CVDRole.VENDOR]` (an
  ADR-0024 call-out point), so V2 could not be given DEPLOYER. `roles` is now
  threaded through the whole `suggest-actor-to-case` chain.
- **#1989** — a reject/replay amplification loop starved actors during
  late-joiner sync (4825 announces vs 468 for a 26-entry ledger; 20-min CI
  timeout). This is also the mechanism behind the rotating demo flakiness in
  #1839 / #1911 on unrelated branches.
- **#1990** — `VultronActivity.suggested_roles` lacked a camelCase alias, so
  the DEPLOYER role was silently dropped on outbound delivery and CSB-15-002
  blocked V2's d→D (VFD) transition.

## Changes

**`vultron/demo/scenario/fcvcv_demo.py`** (new)

- 8 phases per DEMOMA-19-003: `report_submission`, `c2_suggests_v2`,
  `sync_verification`, `notes_exchange`, `fix_lifecycle`, `publication`,
  `case_closure`, `dump_case_ledgers`
- V1 advances to VFd only (VENDOR, no deploy step); V2 to VFD
  (VENDOR+DEPLOYER) per DEMOMA-19-004
- V1 publishes first → `wait_for_case_em_terminated` → V2/C2/C1/Finder publish
  in sequence per DEMOMA-19-005 (ThreatTerminationBranchNode path)
- C2 uses the ADR-0026 suggest-actor flow for V2, polling helpers only
  (DEMOMA-03-003 no-mail-carrying rule)
- Devlogs use scenario-role names per DEMOMA-19-007

**`vultron/demo/helpers/polling.py`**: `find_cp_offer_for_case` and
`find_case_actor_participant_id` extracted here per DEMOMA-17-001, and the
duplicated local copies removed from all five scenarios that carried them
(`fcvcv`, `fccv-extension`, `fvcv-extension`, `fccv-handoff`, `fvcv-handoff`).

**`vultron/demo/cli.py`**: `fcvcv` subcommand with all five URL/ID options.

**`.github/workflows/demo-integration.yml`** and
**`integration_tests/demo/run_multi_actor_integration_test.sh`**: `fcvcv` added
to the `demo` and `invariant-harness` matrices and to `VALID_SCENARIOS`;
`actor6` added to container log collection.

**Roles threading (#1969)**: `roles: list[CVDRole] | None` flows from the
FastAPI `SuggestActorToCaseRequest` → core trigger request → use case → wire
factory → `_RecommendActorActivity` → received-side use case → BT tree →
`EvaluateDefaultRolesNode`, where injected roles take priority over the
hardcoded default. Unrecognized role strings are dropped with a warning rather
than discarding the whole list (CM-16-003 forbids silently substituting a
default). Touches `trigger_models.py`, `triggers/requests.py`,
`triggers/actor.py`, `triggers/service.py`, `ports/trigger_activity.py`,
`ports/trigger_service.py`, `routers/trigger_actor.py`,
`trigger_activity_adapter/actors.py`, `factories/actor.py`,
`received/actor/suggest.py`, `suggest_actor_tree.py`, `case/nodes/actor.py`.

**Replay convergence guard (#1989)**: new
`vultron/core/behaviors/sync/nodes/replay_guard.py` bounds the replay *rate*
per peer. `should_replay()` gates the replay; `record_replay()` records the
position afterwards, and only when at least one entry actually went out — a
zero-entry replay must not start a cooldown, or a peer at the ledger tail gets
wedged once the ledger grows. `VultronReplicationState` gained
`last_replayed_from_hash` / `last_replayed_at`. Genesis gets a short (2s)
cooldown rather than an exemption, since SYNC-15-002 bootstrap depends on the
replay that follows. Kept out of `replay.py` for the 500-line BTND-07-004 limit.

**Wire/core field propagation (#1990)**: `suggested_roles` added with explicit
camelCase aliases on `VultronActivity` and base `as_Offer` (the latter because
`VOCABULARY["Offer"]` resolves there, so an inbound Offer would otherwise drop
the field on the DataLayer round-trip); `roles` added to `VultronActivity` for
the Invite path; `_builders.py` copies both into the activity snapshot.
`offer_case_participant.py` now follows the dehydrated `object_` ID ref
(MV-09-001) to read the real `as_CaseParticipant` roles.

**`specs/sync-ledger-replication.yaml`**: adds the missing **SYNC-15-003**
entry — the code cited it in 8 places but no such requirement existed.

**`notes/sync-ledger-replication.md`**: adds a SYNC-15-003 section; the note
previously described unconditional Reject→replay.

**Tests**

- `test/ci/invariants/test_fcvcv_invariants.py` (new): 46 invariant tests
  (6-actor `_CHAIN_ACTORS`, 7 event types, late-joiner full-history checks for
  V1/C2/V2); skip when `devlogs/fcvcv/` is absent
- `test/core/behaviors/sync/nodes/test_replay_guard.py` (new): 13 unit tests
- `test/core/behaviors/sync/test_reject_tree.py`: 3 tree-level regression tests
  — the amplification loop (240 replays where 24 were correct), the
  advanced-position case, and the tail-then-growth case (0 announces where 3
  were due)
- `test/adapters/driving/fastapi/test_outbox_helpers.py`: 2 tests pinning
  `suggested_roles` and `roles` across the core↔wire conversion

## Verification

- **6031 unit tests pass** (64 new), 311 skipped, 0 failures
- `black`, `flake8`, `mypy`, `pyright` all clean
- **All 26 CI checks green**, including `fcvcv Demo Integration` and
  `fcvcv Invariant Harness`, plus all eight pre-existing demo scenarios
- [x] AC-3a: 8-phase `fcvcv_demo.py`
- [x] AC-3b: C2 suggests V2 via ADR-0026, polling helpers only
- [x] AC-3c: V1 → VFd with `verify_fix_ready`; V2 → VFD with
  `verify_fix_ready` then `verify_fix_deployed`; `verify_fix_deployed` not
  called for V1
- [x] AC-3d: V1 publishes first, scenario waits for EM.EXITED before V2
- [x] AC-3e: `fcvcv` sub-command registered
- [x] AC-3f: shared patterns extracted to `helpers/`; no copy-paste left in
  `fcvcv_demo.py` (and the pre-existing copies in four other scenarios are
  now gone too)

### Spec compliance

| Spec entry | Status |
|---|---|
| DEMOMA-19-001 (actor6 service) | Done in #1945 |
| DEMOMA-19-002 (seed_containers_fcvcv) | Done in #1945 |
| DEMOMA-19-003 (8 phases) | ✓ |
| DEMOMA-19-004 (V1=VFd, V2=VFD) | ✓ |
| DEMOMA-19-005 (V1 publishes first) | ✓ |
| DEMOMA-19-006 (CLI command) | ✓ |
| DEMOMA-19-007 (devlog actor names) | ✓ |
| DEMOMA-19-008 (invariant harness) | ✓ — except the `conftest.py` registration clause, which describes infrastructure that does not exist for any scenario; tracked separately |
| DEMOMA-19-009 (ADR-0026 for V2) | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
