### PR TITLE
CaseActor CaseParticipant RM lifecycle bootstrap (CM-23-005/006/007)

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1917.md
+++ b/plan/history/2608/implementation/ISSUE-1917.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-1917
+timestamp: '2026-08-04T13:34:22.069555+00:00'
+title: CaseActor RM lifecycle bootstrap (CM-23-005/006/007)
+type: implementation
+---
+
+## Issue #1917 — CaseActor CaseParticipant RM lifecycle bootstrap
+
+Implemented CM-23-005/006/007 and ADR-0051. The CaseActor's `_AddCaseActorParticipantNode` now emits three bootstrap `ParticipantStatus` records (RM.RECEIVED → RM.VALID → RM.ACCEPTED) during case initialization. `_CommitNativeLedgerEntriesNode` picks these up automatically as `CaseLedgerEntry` records. Removed the obsolete `CVDRole.CASE_MANAGER` skip from `AllParticipantsRMClosedConditionNode` so the CaseActor's RM.CLOSED now participates in the all-closed check.
+
+5 new tests added; 3 regression tests updated. 6050 tests passing.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1965>

--- a/test/core/behaviors/case/test_case_proposal_received_tree.py
+++ b/test/core/behaviors/case/test_case_proposal_received_tree.py
@@ -1125,9 +1125,12 @@ class TestCM18007InitLedgerEntries:
     def test_exactly_one_participant_status_entry_per_participant(
         self, make_payload
     ):
-        """Each participant gets exactly one add_participant_status_to_participant
-        ledger entry — no NO_EMBARGO placeholder followed by a corrective entry
-        (CM-18-007 AC-3)."""
+        """CaseActor gets 3 bootstrap entries (CM-23-007); other participants get 1.
+
+        Total add_participant_status_to_participant ledger entries ==
+        (participant_count - 1) + 3 == participant_count + 2 (CM-18-007 AC-3,
+        CM-23-005/ADR-0051).
+        """
         from vultron.core.models.case import VulnerabilityCase
 
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -1147,10 +1150,13 @@ class TestCM18007InitLedgerEntries:
             if getattr(e, "event_type", None)
             == "add_participant_status_to_participant"
         ]
-        assert len(ps_entries) == participant_count, (
-            f"Expected exactly {participant_count} "
-            "add_participant_status_to_participant entries (one per participant),"
-            f" got {len(ps_entries)} (CM-18-007)"
+        # CaseActor contributes 3 bootstrap RM entries (CM-23-007/ADR-0051);
+        # every other participant contributes 1.
+        expected = participant_count + 2
+        assert len(ps_entries) == expected, (
+            f"Expected {expected} add_participant_status_to_participant entries"
+            f" ({participant_count} participants, CaseActor has 3 bootstrap"
+            f" entries per CM-23-007), got {len(ps_entries)} (CM-18-007)"
         )
 
     def test_vendor_case_owner_appears_as_signatory_in_init_ledger(
@@ -1405,4 +1411,295 @@ class TestADR0041GenesisCommitFailure:
         assert node.update() == Status.SUCCESS, (
             "case-not-found must be best-effort SUCCESS (the ledger is an"
             " audit record, not a precondition for the outbound emissions)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CM-23-005/006/007 — CaseActor RM lifecycle bootstrap (ADR-0051)
+# ---------------------------------------------------------------------------
+
+
+class TestCaseActorRMLifecycleBootstrap:
+    """CM-23-005/007: CaseActor emits 3 bootstrap ParticipantStatus records."""
+
+    def test_bootstrap_statuses_created_on_case_init(self, make_payload):
+        """Three bootstrap ParticipantStatus records exist after initialization.
+
+        CM-23-005: CaseActor MUST track its own RM lifecycle via a
+        CaseParticipant record with RM.RECEIVED, RM.VALID, and RM.ACCEPTED
+        ParticipantStatus entries during case initialization.
+        """
+        from vultron.core.models.case import VulnerabilityCase
+        from vultron.core.models.case_participant import CaseParticipant
+        from vultron.core.models.participant_status import ParticipantStatus
+        from vultron.core.states.rm import RM
+        from vultron.enums.roles import CVDRole
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _seed_report(dl)
+        _run_full_bt(make_payload, dl)
+
+        cases = list(dl.list_objects("VulnerabilityCase"))
+        assert cases, "A VulnerabilityCase must be created"
+        case = cases[0]
+        assert isinstance(case, VulnerabilityCase)
+
+        # Locate the CaseActor participant
+        participant_id = case.actor_participant_index.get(_CASE_ACTOR_URI)
+        assert (
+            participant_id is not None
+        ), "CaseActor must be in actor_participant_index"
+        participant = dl.read(participant_id)
+        assert isinstance(participant, CaseParticipant)
+        assert CVDRole.CASE_MANAGER in participant.roles
+
+        # Extract inline or persisted ParticipantStatus records
+        statuses = []
+        for ps_ref in participant.participant_statuses:
+            if isinstance(ps_ref, ParticipantStatus):
+                statuses.append(ps_ref)
+            elif isinstance(ps_ref, str):
+                ps = dl.read(ps_ref)
+                if isinstance(ps, ParticipantStatus):
+                    statuses.append(ps)
+
+        rm_states = [ps.rm.state for ps in statuses if ps.rm is not None]
+        assert (
+            RM.RECEIVED in rm_states
+        ), "Bootstrap must include RM.RECEIVED (CM-23-005, CM-23-006)"
+        assert (
+            RM.VALID in rm_states
+        ), "Bootstrap must include RM.VALID (CM-23-005, CM-23-006)"
+        assert (
+            RM.ACCEPTED in rm_states
+        ), "Bootstrap must include RM.ACCEPTED (CM-23-005, CM-23-006)"
+
+    def test_bootstrap_statuses_produce_ledger_entries(self, make_payload):
+        """Three RM transitions are represented in the canonical ledger.
+
+        CM-23-007: CaseActor MUST emit CaseLedgerEntry records for each of its
+        RM transitions (RM.RECEIVED, RM.VALID, RM.ACCEPTED) during
+        initialization.  _CommitNativeLedgerEntriesNode iterates all
+        participant_statuses entries, including the CaseActor's three bootstrap
+        records.
+        """
+        from vultron.core.states.rm import RM
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _seed_report(dl)
+        _run_full_bt(make_payload, dl)
+
+        # Each CaseLedgerEntry for add_participant_status_to_participant has
+        # payload_snapshot["object"]["attributedTo"] = the actor URI and
+        # payload_snapshot["object"]["rmState"] (or "rm_state") for RM state.
+        entries = list(dl.list_objects("CaseLedgerEntry"))
+        case_actor_rm_states = set()
+        for entry in entries:
+            et = getattr(entry, "event_type", None)
+            if et != "add_participant_status_to_participant":
+                continue
+            snap = getattr(entry, "payload_snapshot", {}) or {}
+            obj = snap.get("object", {}) or {}
+            attributed = obj.get("attributedTo") or obj.get("attributed_to")
+            if attributed != _CASE_ACTOR_URI:
+                continue
+            rm_val = obj.get("rmState") or obj.get("rm_state")
+            if rm_val is None:
+                # Try nested dimension object: {"rm": {"state": "..."}}
+                rm_dim = obj.get("rm") or {}
+                rm_val = (
+                    rm_dim.get("state") if isinstance(rm_dim, dict) else None
+                )
+            if rm_val is not None:
+                try:
+                    case_actor_rm_states.add(RM(rm_val))
+                except ValueError:
+                    pass
+
+        assert RM.RECEIVED in case_actor_rm_states, (
+            "Ledger must have add_participant_status entry for CaseActor"
+            " RM.RECEIVED (CM-23-007)"
+        )
+        assert RM.VALID in case_actor_rm_states, (
+            "Ledger must have add_participant_status entry for CaseActor"
+            " RM.VALID (CM-23-007)"
+        )
+        assert RM.ACCEPTED in case_actor_rm_states, (
+            "Ledger must have add_participant_status entry for CaseActor"
+            " RM.ACCEPTED (CM-23-007)"
+        )
+
+    def test_bootstrap_statuses_idempotent_on_duplicate(self, make_payload):
+        """Duplicate proposal does not add extra CaseActor statuses.
+
+        The idempotency guard in _AddCaseActorParticipantNode returns SUCCESS
+        immediately when the CaseActor is already in actor_participant_index,
+        so a second CreateCaseProposalReceivedUseCase run must not grow the
+        participant's status list.
+        """
+        from vultron.core.models.case import VulnerabilityCase
+        from vultron.core.models.case_participant import CaseParticipant
+        from vultron.core.models.participant_status import ParticipantStatus
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _seed_report(dl)
+        _run_full_bt(make_payload, dl)
+
+        # Run a second time — duplicate delivery
+        _run_full_bt(make_payload, dl)
+
+        cases = list(dl.list_objects("VulnerabilityCase"))
+        assert cases
+        case = cases[0]
+        assert isinstance(case, VulnerabilityCase)
+
+        participant_id = case.actor_participant_index.get(_CASE_ACTOR_URI)
+        assert participant_id is not None
+        participant = dl.read(participant_id)
+        assert isinstance(participant, CaseParticipant)
+
+        statuses = [
+            ps
+            for ps_ref in participant.participant_statuses
+            for ps in [
+                (
+                    ps_ref
+                    if isinstance(ps_ref, ParticipantStatus)
+                    else dl.read(ps_ref)
+                )
+            ]
+            if isinstance(ps, ParticipantStatus)
+            and getattr(ps, "attributed_to", None) == _CASE_ACTOR_URI
+        ]
+        assert len(statuses) == 3, (
+            f"Expected exactly 3 bootstrap statuses for CaseActor, got"
+            f" {len(statuses)} — duplicate delivery must not add extras"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AllParticipantsRMClosedConditionNode — Case Actor participates in check
+# ---------------------------------------------------------------------------
+
+
+class TestAllParticipantsRMClosedIncludesCaseActor:
+    """ADR-0051: CASE_MANAGER skip removed; CaseActor RM.CLOSED is required."""
+
+    def _make_case_with_participants(self, dl):
+        """Seed a case with vendor (CASE_OWNER) and case-actor (CASE_MANAGER)."""
+        from vultron.core.models.case import VulnerabilityCase
+        from vultron.core.models.case_participant import CaseParticipant
+        from vultron.core.models.dimensions import PecDimension, RmDimension
+        from vultron.core.models.participant_status import ParticipantStatus
+        from vultron.core.states.participant_embargo_consent import PEC
+        from vultron.core.states.rm import RM
+        from vultron.enums.roles import CVDRole
+
+        def _mk_ps(actor_uri, rm_state):
+            ps = ParticipantStatus(
+                context=_CASE_URI,
+                rm=RmDimension(state=rm_state),
+                attributed_to=actor_uri,
+                cvd_role=[CVDRole.CASE_OWNER],
+                consent=PecDimension(state=PEC.NO_EMBARGO),
+            )
+            dl.save(ps)
+            return ps
+
+        vendor_ps = _mk_ps(_VENDOR_URI, RM.CLOSED)
+        vendor_participant = CaseParticipant(
+            attributed_to=_VENDOR_URI,
+            context=_CASE_URI,
+            case_roles=[CVDRole.CASE_OWNER],
+            participant_statuses=[vendor_ps],
+        )
+        dl.save(vendor_participant)
+
+        case_actor_ps_list = [
+            _mk_ps(_CASE_ACTOR_URI, RM.RECEIVED),
+            _mk_ps(_CASE_ACTOR_URI, RM.VALID),
+            _mk_ps(_CASE_ACTOR_URI, RM.ACCEPTED),
+        ]
+        case_actor_participant = CaseParticipant(
+            attributed_to=_CASE_ACTOR_URI,
+            context=_CASE_URI,
+            case_roles=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
+            participant_statuses=case_actor_ps_list,
+        )
+        dl.save(case_actor_participant)
+
+        case = VulnerabilityCase(id_=_CASE_URI, attributed_to=_CASE_ACTOR_URI)
+        case.add_participant(vendor_participant)
+        case.add_participant(case_actor_participant)
+        dl.save(case)
+        return case
+
+    def test_returns_failure_when_case_actor_not_closed(self):
+        """FAILURE when CaseActor is at RM.ACCEPTED, not RM.CLOSED.
+
+        ADR-0051: the CASE_MANAGER skip was removed so that the CaseActor's
+        RM.CLOSED participates in the all-closed check.
+        """
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.behaviors.status.nodes.conditions import (
+            AllParticipantsRMClosedConditionNode,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        self._make_case_with_participants(dl)
+        # CaseActor is at RM.ACCEPTED (not RM.CLOSED) — should block.
+
+        node = AllParticipantsRMClosedConditionNode(case_id=_CASE_URI)
+        node.datalayer = dl
+
+        from py_trees.common import Status
+
+        result = node.update()
+        assert result == Status.FAILURE, (
+            "AllParticipantsRMClosed must return FAILURE when CaseActor is"
+            " not yet at RM.CLOSED (ADR-0051 — CASE_MANAGER skip removed)"
+        )
+
+    def test_returns_success_when_all_including_case_actor_closed(self):
+        """SUCCESS when every participant (including CaseActor) is RM.CLOSED."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.behaviors.status.nodes.conditions import (
+            AllParticipantsRMClosedConditionNode,
+        )
+        from vultron.core.models.case_participant import CaseParticipant
+        from vultron.core.models.dimensions import PecDimension, RmDimension
+        from vultron.core.models.participant_status import ParticipantStatus
+        from vultron.core.states.participant_embargo_consent import PEC
+        from vultron.core.states.rm import RM
+        from vultron.enums.roles import CVDRole
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = self._make_case_with_participants(dl)
+
+        # Advance CaseActor to RM.CLOSED
+        participant_id = case.actor_participant_index.get(_CASE_ACTOR_URI)
+        assert participant_id is not None
+        participant = dl.read(participant_id)
+        assert isinstance(participant, CaseParticipant)
+
+        closed_ps = ParticipantStatus(
+            context=_CASE_URI,
+            rm=RmDimension(state=RM.CLOSED),
+            attributed_to=_CASE_ACTOR_URI,
+            cvd_role=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
+            consent=PecDimension(state=PEC.NO_EMBARGO),
+        )
+        dl.save(closed_ps)
+        participant.participant_statuses.append(closed_ps)
+        dl.save(participant)
+
+        node = AllParticipantsRMClosedConditionNode(case_id=_CASE_URI)
+        node.datalayer = dl
+
+        from py_trees.common import Status
+
+        result = node.update()
+        assert result == Status.SUCCESS, (
+            "AllParticipantsRMClosed must return SUCCESS when all participants"
+            " including the CaseActor are at RM.CLOSED (ADR-0051)"
         )

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -776,44 +776,53 @@ class TestAllParticipantsRMClosedConditionNode:
         self,
         populated_dl,
         participant,
+        case_manager_participant,
     ):
-        """All CVD participants RM.CLOSED → SUCCESS."""
-        closed_status = as_ParticipantStatus(
+        """All CVD participants (including CaseActor) at RM.CLOSED → SUCCESS (ADR-0051)."""
+        closed_vendor = as_ParticipantStatus(
             id_=f"{STATUS_ID}/closed",
             context=CASE_ID,
             rm_state=RM.CLOSED,
         )
-        populated_dl.create(closed_status)
-        participant.participant_statuses.append(closed_status)
+        closed_cm = as_ParticipantStatus(
+            id_=f"{CM_PARTICIPANT_ID}/statuses/closed",
+            context=CASE_ID,
+            rm_state=RM.CLOSED,
+        )
+        populated_dl.create(closed_vendor)
+        populated_dl.create(closed_cm)
+        participant.participant_statuses.append(closed_vendor)
         populated_dl.save(participant)
+        case_manager_participant.participant_statuses.append(closed_cm)
+        populated_dl.save(case_manager_participant)
 
         bridge = BTBridge(datalayer=populated_dl)
         node = AllParticipantsRMClosedConditionNode(case_id=CASE_ID)
         result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
         assert result.status == Status.SUCCESS
 
-    def test_skips_case_manager_participant(
+    def test_fails_when_case_manager_participant_not_closed(
         self,
         populated_dl,
         participant,
         case_manager_participant,
     ):
-        """CASE_MANAGER participant is excluded from the RM.CLOSED check."""
-        # Only vendor has CLOSED — case_manager_participant has no status
-        closed_status = as_ParticipantStatus(
+        """CaseActor not at RM.CLOSED → FAILURE; no CASE_MANAGER skip (ADR-0051)."""
+        # Only the vendor is CLOSED; case_manager_participant has no RM.CLOSED status
+        closed_vendor = as_ParticipantStatus(
             id_=f"{STATUS_ID}/closed",
             context=CASE_ID,
             rm_state=RM.CLOSED,
         )
-        populated_dl.create(closed_status)
-        participant.participant_statuses.append(closed_status)
+        populated_dl.create(closed_vendor)
+        participant.participant_statuses.append(closed_vendor)
         populated_dl.save(participant)
 
         bridge = BTBridge(datalayer=populated_dl)
         node = AllParticipantsRMClosedConditionNode(case_id=CASE_ID)
         result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
-        # CASE_MANAGER is skipped, so only vendor matters → SUCCESS
-        assert result.status == Status.SUCCESS
+        # CaseActor is not RM.CLOSED → FAILURE (ADR-0051 removes the old skip)
+        assert result.status == Status.FAILURE
 
     def test_fails_when_no_case_id(self, bridge):
         """No case_id → FAILURE."""

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -310,8 +310,13 @@ class _AddCaseActorParticipantNode(DataLayerAction):
         for status in bootstrap_statuses:
             try:
                 self.datalayer.create(status)
-            except ValueError:
-                pass
+            except ValueError as e:
+                logger.debug(
+                    "_register_participant: create status idempotent or"
+                    " error for actor '%s': %s",
+                    self.actor_id,
+                    e,
+                )
 
         participant = VultronParticipant(
             attributed_to=self.actor_id,

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -93,6 +93,7 @@ from vultron.core.models.activity import (
 from vultron.core.models.case import VulnerabilityCase, VultronCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.case_status import CaseStatus
+from vultron.core.models.dimensions import PecDimension, RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.pending_create_case_activity import (
     PendingCreateCaseActivity,
@@ -249,6 +250,15 @@ class _AddCaseActorParticipantNode(DataLayerAction):
     also register itself as the CASE_MANAGER so that ResolveCaseManagerNode
     can locate it later (e.g. add-note-to-case, send_tree).
 
+    Per CM-23-005 and ADR-0051, the CaseActor MUST have a full RM lifecycle.
+    Three bootstrap ParticipantStatus records are emitted at creation:
+      - RM.RECEIVED  = CaseProposal received and being evaluated
+      - RM.VALID     = CaseProposal validated; case creation begun
+      - RM.ACCEPTED  = VulnerabilityCase successfully created and coordinated
+
+    These statuses are later committed as CaseLedgerEntries by
+    _CommitNativeLedgerEntriesNode (CM-23-007).
+
     Reads ``case_id`` from the blackboard.  No-ops if the CaseActor is
     already in ``actor_participant_index`` (idempotent on duplicate delivery).
     """
@@ -261,6 +271,77 @@ class _AddCaseActorParticipantNode(DataLayerAction):
         self.blackboard.register_key(
             key="case_id", access=py_trees.common.Access.READ
         )
+
+    def _build_bootstrap_statuses(
+        self, case_id: str
+    ) -> list[ParticipantStatus]:
+        """Return the three bootstrap ParticipantStatus records (CM-23-005/006)."""
+        assert self.actor_id is not None
+        return [
+            ParticipantStatus(
+                context=case_id,
+                rm=RmDimension(state=RM.RECEIVED),
+                attributed_to=self.actor_id,
+                cvd_role=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
+                consent=PecDimension(state=PEC.NO_EMBARGO),
+            ),
+            ParticipantStatus(
+                context=case_id,
+                rm=RmDimension(state=RM.VALID),
+                attributed_to=self.actor_id,
+                cvd_role=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
+                consent=PecDimension(state=PEC.NO_EMBARGO),
+            ),
+            ParticipantStatus(
+                context=case_id,
+                rm=RmDimension(state=RM.ACCEPTED),
+                attributed_to=self.actor_id,
+                cvd_role=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
+                consent=PecDimension(state=PEC.NO_EMBARGO),
+            ),
+        ]
+
+    def _register_participant(self, case_id: str) -> Status:
+        """Create the participant with bootstrap statuses and attach to case."""
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+
+        bootstrap_statuses = self._build_bootstrap_statuses(case_id)
+        for status in bootstrap_statuses:
+            try:
+                self.datalayer.create(status)
+            except ValueError:
+                pass
+
+        participant = VultronParticipant(
+            attributed_to=self.actor_id,
+            context=case_id,
+            name=f"CaseActor for {case_id}",
+            case_roles=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
+            participant_statuses=bootstrap_statuses,
+        )
+
+        updated_case = _create_and_attach_participant(
+            self.datalayer,
+            participant,
+            case_id,
+            self.actor_id,
+            self.logger,
+        )
+        if updated_case is None:
+            self.feedback_message = f"Case '{case_id}' not found in DataLayer"
+            return Status.FAILURE
+
+        self.datalayer.save(updated_case)
+        logger.info(
+            "%s: Registered CaseActor '%s' as CASE_MANAGER for case '%s'"
+            " with bootstrap RM lifecycle (RM.RECEIVED → RM.VALID →"
+            " RM.ACCEPTED) per CM-23-005/ADR-0051",
+            self.name,
+            self.actor_id,
+            case_id,
+        )
+        return Status.SUCCESS
 
     def update(self) -> Status:
         if (f := self._require_datalayer_and_actor()) is not None:
@@ -282,32 +363,7 @@ class _AddCaseActorParticipantNode(DataLayerAction):
             if self.actor_id in stored_case.actor_participant_index:
                 return Status.SUCCESS
 
-        participant = VultronParticipant(
-            attributed_to=self.actor_id,
-            context=case_id,
-            name=f"CaseActor for {case_id}",
-            case_roles=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
-        )
-
-        updated_case = _create_and_attach_participant(
-            self.datalayer,
-            participant,
-            case_id,
-            self.actor_id,
-            self.logger,
-        )
-        if updated_case is None:
-            self.feedback_message = f"Case '{case_id}' not found in DataLayer"
-            return Status.FAILURE
-
-        self.datalayer.save(updated_case)
-        logger.info(
-            "%s: Registered CaseActor '%s' as CASE_MANAGER for case '%s'",
-            self.name,
-            self.actor_id,
-            case_id,
-        )
-        return Status.SUCCESS
+        return self._register_participant(case_id)
 
 
 class _AddVendorOwnerParticipantNode(DataLayerAction):

--- a/vultron/core/behaviors/status/nodes/conditions.py
+++ b/vultron/core/behaviors/status/nodes/conditions.py
@@ -31,12 +31,10 @@ from vultron.core.behaviors.helpers import (
     FindParticipantByActorIdNode,
 )
 from vultron.core.models.case import VulnerabilityCase
-from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.states.rm import RM
-from vultron.enums.roles import CVDRole
 
 logger = logging.getLogger(__name__)
 
@@ -116,11 +114,15 @@ class VerifySenderIsParticipantNode(FindParticipantByActorIdNode):
 class AllParticipantsRMClosedConditionNode(DataLayerCondition):
     """Precondition: all CVD participants in the case have RM.CLOSED.
 
-    Iterates ``case.actor_participant_index``, skips any participant whose
-    ``roles`` include ``CVDRole.CASE_MANAGER`` (the Case Actor), and returns
-    ``FAILURE`` if any remaining participant's latest status ``rm_state`` is
-    not ``RM.CLOSED``.  Returns ``SUCCESS`` when every non-CASE_MANAGER
-    participant is at ``RM.CLOSED``.
+    Iterates ``case.actor_participant_index`` and returns ``FAILURE`` if any
+    participant's latest status ``rm_state`` is not ``RM.CLOSED``.  Returns
+    ``SUCCESS`` when every participant (including the Case Actor) is at
+    ``RM.CLOSED``.
+
+    The Case Actor now has a full RM lifecycle (ADR-0051, CM-23-005), so the
+    former ``CVDRole.CASE_MANAGER`` skip is no longer needed.  Including the
+    Case Actor's RM.CLOSED in this check ensures that owner-Leave processing
+    (CM-23-002) has completed before the auto-close Selector fires.
 
     Per DEMOMA-07-006(a)(b)(c).
     """
@@ -141,9 +143,6 @@ class AllParticipantsRMClosedConditionNode(DataLayerCondition):
             p = self.datalayer.read(p_id)
             if p is None:
                 return False
-            roles = p.roles if isinstance(p, CaseParticipant) else []
-            if CVDRole.CASE_MANAGER in roles:
-                continue
             statuses = getattr(p, "participant_statuses", [])
             if not statuses:
                 return False


### PR DESCRIPTION
- Closes #1917

## Summary

Implements CM-23-005, CM-23-006, CM-23-007, and ADR-0051: wires the CaseActor's own `CaseParticipant` record to emit three bootstrap `ParticipantStatus` records (`RM.RECEIVED`, `RM.VALID`, `RM.ACCEPTED`) during case initialization, and removes the obsolete `CVDRole.CASE_MANAGER` skip from `AllParticipantsRMClosedConditionNode`.

## Changes

- **`vultron/core/behaviors/case/case_proposal_received_tree.py`**: Added `_build_bootstrap_statuses()` and `_register_participant()` to `_AddCaseActorParticipantNode`. The three bootstrap `ParticipantStatus` records (RM.RECEIVED → RM.VALID → RM.ACCEPTED) are created via `datalayer.create()` and attached to the `VultronParticipant` so `_CommitNativeLedgerEntriesNode` picks them up as `CaseLedgerEntry` records automatically (CM-23-007). The `update()` method delegates to `_register_participant()` to keep cyclomatic complexity within limits.
- **`vultron/core/behaviors/status/nodes/conditions.py`**: Removed the `CVDRole.CASE_MANAGER in roles: continue` skip from `_all_participants_closed()`. The CaseActor now has a tracked RM lifecycle (ADR-0051), so its `RM.CLOSED` must be present before the auto-close Selector fires. Removed now-unused `CaseParticipant` and `CVDRole` imports.
- **`test/core/behaviors/case/test_case_proposal_received_tree.py`**: Added `TestCaseActorRMLifecycleBootstrap` (3 tests: bootstrap statuses created, ledger entries emitted, idempotency on duplicate) and `TestAllParticipantsRMClosedIncludesCaseActor` (2 tests: FAILURE when CaseActor not closed, SUCCESS when all closed). Updated `TestCM18007InitLedgerEntries::test_exactly_one_participant_status_entry_per_participant` to expect `participant_count + 2` entries (CaseActor contributes 3 bootstrap entries per CM-23-007).
- **`test/core/behaviors/status/test_add_participant_status_bt.py`**: Updated `test_succeeds_when_all_participants_closed` to seed CaseActor at RM.CLOSED. Renamed `test_skips_case_manager_participant` → `test_fails_when_case_manager_participant_not_closed` to document the removal of the old skip (ADR-0051).

## Verification

- All 6050 unit tests pass (5 new)
- Black, flake8, mypy, pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)