### PR TITLE
feat(bt-nodes): migrate inline em_state reads to ReadEmStateNode (closes #1554)

### DIFF
--- a/notes/bt-canonical-reference.md
+++ b/notes/bt-canonical-reference.md
@@ -299,11 +299,14 @@ boundary and creates circular dependency risk. If a helper is needed in
 both a use case and a BT node, it MUST be extracted to a shared utility
 module (e.g., `vultron/core/behaviors/shared/` or a domain-model method).
 
-Example violation: `ApplyEmbargoTeardownNode` in
-`vultron/core/behaviors/embargo/nodes.py` imported
-`_reset_case_participant_embargo_consent` from
-`vultron.core.use_cases.received.embargo`. Fix: move the helper to a
-shared location importable by both layers.
+Example pattern (resolved): the former `ApplyEmbargoTeardownNode` in
+`vultron/core/behaviors/embargo/nodes/teardown.py` once imported a
+helper from `vultron.core.use_cases.received.embargo`. The violation was
+resolved by moving `reset_case_participant_embargo_consent` to
+`vultron.core.use_cases._helpers` (a shared utility module importable by
+both layers) and by decomposing the god node into three single-responsibility
+nodes: `HasEmbargoActiveNode`, `ClearActiveEmbargoNode`, and
+`ResetParticipantConsentNode` (issue #1554).
 
 ---
 

--- a/plan/history/2608/implementation/ISSUE-1554.md
+++ b/plan/history/2608/implementation/ISSUE-1554.md
@@ -1,0 +1,24 @@
+---
+source: ISSUE-1554
+timestamp: '2026-08-05T14:47:20.803993+00:00'
+title: 'Migrate inline em_state reads to ReadEmStateNode (issue #1554)'
+type: implementation
+---
+
+## Issue #1554 — Migrate remaining inline em_state accesses in BT nodes
+
+Migrated inline `case.current_status.em.state` reads in `SetEmbargoActiveNode` and the former monolithic `ApplyEmbargoTeardownNode` to use `ReadEmStateNode` throughout.
+
+**AC-1**: `SetEmbargoActiveNode._apply_transition()` now accepts `current_em: EM`; `update()` reads via `ReadEmStateNode`.
+
+**AC-2/AC-3**: Three new single-responsibility teardown nodes added to `teardown.py`:
+
+- `HasEmbargoActiveNode` — EM-state guard (FAILURE when already EXITED)
+- `ClearActiveEmbargoNode` — EM→EXITED + `active_embargo=None` in one batched `datalayer.save()`
+- `ResetParticipantConsentNode` — resets all participant PEC to NO_EMBARGO
+
+`ActiveTeardown` sequence in `announce_teardown_tree.py` updated to wire the three new nodes.
+
+**AC-4**: 5 new test classes, 18 new test methods.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1971>

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -24,6 +24,7 @@ import pytest
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.embargo.nodes.lifecycle import (
+    SetEmbargoActiveNode,
     ValidateEmbargoRevisionStateNode,
 )
 from vultron.core.behaviors.embargo.trigger_tree import terminate_embargo_bt
@@ -48,7 +49,7 @@ def _make_case_with_manager(
 ) -> tuple[as_VulnerabilityCase, as_CaseParticipant, SqliteDataLayer]:
     """Return a populated DataLayer with a case + CASE_MANAGER participant."""
     dl = SqliteDataLayer("sqlite:///:memory:")
-    case, _embargo = make_case_and_embargo(suffix, em_state=em_state)
+    case, _ = make_case_and_embargo(suffix, em_state=em_state)
 
     cm_participant = as_CaseParticipant(
         id_=f"{case.id_}/participants/cm",
@@ -403,6 +404,24 @@ class TestValidateEmbargoRevisionStateNode:
         assert status == py_trees.common.Status.FAILURE
         assert "error" in result_out
 
+    def test_reads_em_state_via_read_em_state_node(self):
+        """AC-1: em_before in result_out is populated by ReadEmStateNode."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("rev7", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        result_out: dict = {}
+        self._setup_blackboard(dl)
+        node = ValidateEmbargoRevisionStateNode(
+            case_id=case.id_, result_out=result_out
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert result_out.get("em_before") == EM.ACTIVE
+
     def test_returns_failure_when_current_status_raises_value_error(self):
         """FAILURE when case.current_status raises ValueError (no materialized status).
 
@@ -435,3 +454,117 @@ class TestValidateEmbargoRevisionStateNode:
 
         assert result == py_trees.common.Status.FAILURE
         assert "error" in result_out
+
+
+# ---------------------------------------------------------------------------
+# SetEmbargoActiveNode — AC-1 of issue #1554
+# ---------------------------------------------------------------------------
+
+
+def _setup_blackboard_simple(dl: SqliteDataLayer) -> None:
+    py_trees.blackboard.Blackboard.enable_activity_stream()
+    py_trees.blackboard.Blackboard.storage.clear()
+    bb = py_trees.blackboard.Client(name="test-sea")
+    for key in ("datalayer", "actor_id"):
+        bb.register_key(key=key, access=py_trees.common.Access.WRITE)
+    bb.datalayer = dl
+    bb.actor_id = ACTOR_ID
+
+
+class TestSetEmbargoActiveNode:
+    """Tests for SetEmbargoActiveNode (AC-1 of issue #1554)."""
+
+    def _run(
+        self, dl: SqliteDataLayer, case_id: str, embargo_id: str
+    ) -> py_trees.common.Status:
+        _setup_blackboard_simple(dl)
+        node = SetEmbargoActiveNode(case_id=case_id, embargo_id=embargo_id)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+        return node.status
+
+    def test_transitions_proposed_to_active(self):
+        """Transitions EM.PROPOSED → EM.ACTIVE and persists."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = make_case_and_embargo("sea1", em_state=EM.PROPOSED)
+        case.active_embargo = None
+        dl.create(case)
+
+        status = self._run(dl, case.id_, embargo.id_)
+
+        assert status == py_trees.common.Status.SUCCESS
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.ACTIVE
+
+    def test_idempotent_when_embargo_already_active(self):
+        """Returns SUCCESS without state mutation when embargo is already active."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = make_case_and_embargo("sea2", em_state=EM.ACTIVE)
+        case.active_embargo = embargo.id_
+        dl.create(case)
+
+        status = self._run(dl, case.id_, embargo.id_)
+
+        assert status == py_trees.common.Status.SUCCESS
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.ACTIVE
+
+    def test_reads_em_state_via_read_em_state_node(self):
+        """AC-1: _apply_transition receives em_state read by ReadEmStateNode."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = make_case_and_embargo("sea3", em_state=EM.PROPOSED)
+        case.active_embargo = None
+        dl.create(case)
+
+        _setup_blackboard_simple(dl)
+        node = SetEmbargoActiveNode(case_id=case.id_, embargo_id=embargo.id_)
+
+        calls: list = []
+        original_apply = node._apply_transition
+
+        def recording_apply(case, current_em):  # type: ignore[override]
+            calls.append(current_em)
+            return original_apply(case, current_em)
+
+        node._apply_transition = recording_apply  # type: ignore[method-assign]
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert calls == [EM.PROPOSED]
+
+    def test_returns_failure_when_case_missing(self):
+        """Returns FAILURE when the case is not found in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        status = self._run(
+            dl,
+            "https://example.org/cases/nonexistent",
+            "https://example.org/cases/nonexistent/embargo_events/e1",
+        )
+
+        assert status == py_trees.common.Status.FAILURE
+
+    def test_state_sync_override_logs_warning(self, caplog):
+        """Logs WARNING for non-standard EM transitions (state-sync override)."""
+        import logging
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = make_case_and_embargo("sea5", em_state=EM.NONE)
+        case.active_embargo = None
+        dl.create(case)
+
+        _setup_blackboard_simple(dl)
+        node = SetEmbargoActiveNode(case_id=case.id_, embargo_id=embargo.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        with caplog.at_level(logging.WARNING):
+            bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert any("state-sync override" in r.message for r in caplog.records)
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.ACTIVE

--- a/test/core/behaviors/embargo/nodes/test_teardown.py
+++ b/test/core/behaviors/embargo/nodes/test_teardown.py
@@ -24,7 +24,10 @@ import py_trees
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.embargo.nodes.teardown import (
     ApplyEmbargoTeardownNode,
+    ClearActiveEmbargoNode,
+    HasEmbargoActiveNode,
     RemoveFromProposedEmbargoesNode,
+    ResetParticipantConsentNode,
     SendAnnounceEmbargoEventNode,
 )
 from vultron.core.states.em import EM
@@ -58,6 +61,236 @@ def _setup_blackboard_with_factory(
     bb.datalayer = dl
     bb.actor_id = actor_id
     bb.trigger_activity_factory = factory
+
+
+class TestHasEmbargoActiveNode:
+    """Tests for HasEmbargoActiveNode."""
+
+    def test_returns_success_when_em_active(self):
+        """Returns SUCCESS when EM state is ACTIVE."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("hea1", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = HasEmbargoActiveNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+
+    def test_returns_success_when_em_revise(self):
+        """Returns SUCCESS when EM state is REVISE (also an active embargo)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("hea2", em_state=EM.REVISE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = HasEmbargoActiveNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+
+    def test_returns_failure_when_em_exited(self):
+        """Returns FAILURE when EM state is EXITED (teardown already done)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("hea3", em_state=EM.EXITED)
+        case.active_embargo = None
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = HasEmbargoActiveNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+    def test_returns_failure_when_case_missing(self):
+        """Returns FAILURE when case is not found in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        setup_blackboard(dl)
+
+        node = HasEmbargoActiveNode(
+            case_id="https://example.org/cases/nonexistent"
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+
+class TestClearActiveEmbargoNode:
+    """Tests for ClearActiveEmbargoNode."""
+
+    def test_transitions_em_active_to_exited_and_clears_pointer(self):
+        """Transitions EM.ACTIVE → EXITED and sets active_embargo = None."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("caen1", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ClearActiveEmbargoNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
+        assert updated.active_embargo is None
+
+    def test_transitions_em_revise_to_exited(self):
+        """Transitions EM.REVISE → EXITED."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("caen2", em_state=EM.REVISE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ClearActiveEmbargoNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
+
+    def test_idempotent_when_already_exited(self):
+        """Returns SUCCESS without modifying state when EM already EXITED."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("caen3", em_state=EM.EXITED)
+        case.active_embargo = None
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ClearActiveEmbargoNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
+
+    def test_state_sync_override_for_unexpected_em_state(self, caplog):
+        """Logs WARNING and applies state-sync override for non-standard EM state."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("caen4", em_state=EM.NONE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ClearActiveEmbargoNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        with caplog.at_level(logging.WARNING):
+            bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert any("state-sync override" in r.message for r in caplog.records)
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
+
+    def test_returns_failure_when_case_missing(self):
+        """Returns FAILURE when the case is not found in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        setup_blackboard(dl)
+
+        node = ClearActiveEmbargoNode(
+            case_id="https://example.org/cases/nonexistent"
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+    def test_single_save_call(self):
+        """Both em_state and active_embargo are committed in a single datalayer.save()."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("caen5", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ClearActiveEmbargoNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        original_save = dl.save
+        save_calls = []
+
+        def recording_save(obj):
+            save_calls.append(obj)
+            return original_save(obj)
+
+        dl.save = recording_save
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert (
+            len(save_calls) == 1
+        ), f"Expected exactly 1 datalayer.save() call, got {len(save_calls)}"
+
+
+class TestResetParticipantConsentNode:
+    """Tests for ResetParticipantConsentNode."""
+
+    def test_resets_participant_pec_to_no_embargo(self):
+        """Resets all participant PEC states to NO_EMBARGO."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("rpcn1", em_state=EM.ACTIVE)
+        participant = as_CaseParticipant(
+            id_=f"{case.id_}/participants/p1",
+            attributed_to="https://example.org/users/finder",
+        )
+        participant.embargo_consent_state = PEC.SIGNATORY.value
+        case.case_participants.append(participant.id_)
+        dl.create(case)
+        dl.create(participant)
+
+        setup_blackboard(dl)
+        node = ResetParticipantConsentNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        updated_p = cast(as_CaseParticipant, dl.read(participant.id_))
+        assert updated_p.embargo_consent_state == PEC.NO_EMBARGO.value
+
+    def test_returns_success_with_no_participants(self):
+        """Returns SUCCESS when case has no participants."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("rpcn2", em_state=EM.ACTIVE)
+        case.case_participants = []
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ResetParticipantConsentNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+
+    def test_returns_failure_when_case_missing(self):
+        """Returns FAILURE when the case is not found in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        setup_blackboard(dl)
+
+        node = ResetParticipantConsentNode(
+            case_id="https://example.org/cases/nonexistent"
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
 
 
 class TestApplyEmbargoTeardownNode:

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -28,7 +28,9 @@ activity (protocol ET message).  Sequence:
     └─ TeardownIfActive (Selector)        # run teardown if active; skip silently
        ├─ ActiveTeardown (Sequence)
        │  ├─ IsActiveEmbargoNode          # guard: is this the active embargo?
-       │  ├─ ApplyEmbargoTeardownNode     # ACTIVE/REVISE→EXITED, clear, reset PEC
+       │  ├─ HasEmbargoActiveNode         # guard: EM state not already EXITED
+       │  ├─ ClearActiveEmbargoNode       # ACTIVE/REVISE→EXITED + clear active_embargo
+       │  ├─ ResetParticipantConsentNode  # reset all participant PEC to NO_EMBARGO
        │  └─ SendAnnounceEmbargoEventNode # emit Announce(EmbargoEvent) to CaseActor
        └─ Success                         # embargo was only in proposed — not an error
 
@@ -43,13 +45,15 @@ from vultron.core.behaviors.case.nodes import (
     create_receive_activity_tree,
 )
 from vultron.core.behaviors.embargo.nodes import (
-    ApplyEmbargoTeardownNode,
+    ClearActiveEmbargoNode,
     CreateAndStoreInviteNode,
+    HasEmbargoActiveNode,
     IsActiveEmbargoNode,
     OptionalLookupParticipantNode,
     RecordParticipantAcceptanceNode,
     RemoveFromProposedEmbargoesNode,
     RemoveStaleAcceptanceNode,
+    ResetParticipantConsentNode,
     SendAnnounceEmbargoEventNode,
     SetEmbargoActiveNode,
     UpdateParticipantEmbargoPecNode,
@@ -99,7 +103,9 @@ def remove_embargo_from_case_tree(
                     IsActiveEmbargoNode(
                         case_id=case_id, embargo_id=embargo_id
                     ),
-                    ApplyEmbargoTeardownNode(case_id=case_id),
+                    HasEmbargoActiveNode(case_id=case_id),
+                    ClearActiveEmbargoNode(case_id=case_id),
+                    ResetParticipantConsentNode(case_id=case_id),
                     SendAnnounceEmbargoEventNode(
                         case_id=case_id, embargo_id=embargo_id
                     ),

--- a/vultron/core/behaviors/embargo/nodes/__init__.py
+++ b/vultron/core/behaviors/embargo/nodes/__init__.py
@@ -51,7 +51,10 @@ from vultron.core.behaviors.embargo.nodes.proposal import (
 )
 from vultron.core.behaviors.embargo.nodes.teardown import (
     ApplyEmbargoTeardownNode,
+    ClearActiveEmbargoNode,
+    HasEmbargoActiveNode,
     RemoveFromProposedEmbargoesNode,
+    ResetParticipantConsentNode,
     SendAnnounceEmbargoEventNode,
 )
 
@@ -67,6 +70,9 @@ __all__ = [
     "ReadEmStateNode",
     "WriteEmStateNode",
     # Teardown
+    "HasEmbargoActiveNode",
+    "ClearActiveEmbargoNode",
+    "ResetParticipantConsentNode",
     "ApplyEmbargoTeardownNode",
     "RemoveFromProposedEmbargoesNode",
     "SendAnnounceEmbargoEventNode",

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -426,9 +426,8 @@ class SetEmbargoActiveNode(DataLayerAction):
             return None
         return case
 
-    def _apply_transition(self, case: Any) -> None:
+    def _apply_transition(self, case: Any, current_em: EM) -> None:
         """Apply EM → ACTIVE transition and persist; warn on non-standard path."""
-        current_em = case.current_status.em.state
         if not is_valid_em_transition(current_em, EM.ACTIVE):
             self.logger.warning(
                 "%s: EM transition %s → ACTIVE is not a standard machine"
@@ -465,5 +464,17 @@ class SetEmbargoActiveNode(DataLayerAction):
             self.logger.info("%s: %s", self.name, self.feedback_message)
             return Status.SUCCESS
 
-        self._apply_transition(case)
+        result_out: dict[str, object] = {}
+        read_node = ReadEmStateNode(
+            case_id=self.case_id, result_out=result_out
+        )
+        read_node.datalayer = self.datalayer
+        read_status = read_node.update()
+        if read_status != Status.SUCCESS:
+            self.feedback_message = read_node.feedback_message
+            return Status.FAILURE
+        current_em = result_out["em_before"]
+        assert isinstance(current_em, EM)
+
+        self._apply_transition(case, current_em)
         return Status.SUCCESS

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -18,8 +18,9 @@
 import py_trees
 from py_trees.common import Status
 
+from vultron.core.behaviors.embargo.nodes.em_state import ReadEmStateNode
 from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import EmDimension
 from vultron.core.states.em import EM, is_valid_em_transition
@@ -28,6 +29,144 @@ from vultron.core.use_cases._helpers import (
     reset_case_participant_embargo_consent,
     _resolve_case_manager_id,
 )
+
+
+class HasEmbargoActiveNode(DataLayerCondition):
+    """Condition: EM state is ACTIVE or REVISE (embargo is active).
+
+    Returns SUCCESS when ``case.current_status.em.state`` is not EXITED
+    (i.e., the embargo is still active and teardown has not been applied).
+    Returns FAILURE when EM is EXITED (teardown already done — idempotent
+    guard) or when the case is not found.
+
+    Uses ``ReadEmStateNode`` to read EM state (AC-1 of issue #1554).
+    """
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        result_out: dict[str, object] = {}
+        read_node = ReadEmStateNode(
+            case_id=self.case_id, result_out=result_out
+        )
+        read_node.datalayer = self.datalayer
+        read_status = read_node.update()
+        if read_status != Status.SUCCESS:
+            self.feedback_message = read_node.feedback_message
+            return Status.FAILURE
+
+        em_state = result_out["em_before"]
+        assert isinstance(em_state, EM)
+        if em_state == EM.EXITED:
+            self.feedback_message = f"Case '{self.case_id}' EM already EXITED — teardown not needed"
+            return Status.FAILURE
+
+        return Status.SUCCESS
+
+
+class ClearActiveEmbargoNode(DataLayerAction):
+    """Apply EM → EXITED transition and clear active_embargo.
+
+    Reads the current EM state via ``ReadEmStateNode``, transitions
+    ``em_state`` to EXITED, clears ``active_embargo = None``, and persists
+    both fields in a single ``datalayer.save()`` (batched write — AC-3 of
+    issue #1554).
+
+    Handles idempotency: returns SUCCESS without modifying state when EM is
+    already EXITED.  Logs a WARNING for non-standard transitions (state-sync
+    override).
+    """
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        result_out: dict[str, object] = {}
+        read_node = ReadEmStateNode(
+            case_id=self.case_id, result_out=result_out
+        )
+        read_node.datalayer = self.datalayer
+        read_status = read_node.update()
+        if read_status != Status.SUCCESS:
+            self.feedback_message = read_node.feedback_message
+            return Status.FAILURE
+        current_em = result_out["em_before"]
+        assert isinstance(current_em, EM)
+
+        if current_em == EM.EXITED:
+            self.feedback_message = (
+                f"Case '{self.case_id}' EM already EXITED — idempotent no-op"
+            )
+            self.logger.info("%s: %s", self.name, self.feedback_message)
+            return Status.SUCCESS
+
+        if not is_valid_em_transition(current_em, EM.EXITED):
+            self.logger.warning(
+                "%s: EM transition %s → EXITED is not a standard machine"
+                " transition for case '%s'; applying state-sync override",
+                self.name,
+                current_em,
+                self.case_id,
+            )
+
+        case = self.datalayer.read(self.case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        case.current_status.em = EmDimension(state=EM.EXITED)
+        case.active_embargo = None
+        self.datalayer.save(case)
+
+        self.feedback_message = (
+            f"Cleared active embargo on case '{self.case_id}'"
+            f" (EM {current_em} → EXITED)"
+        )
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
+
+
+class ResetParticipantConsentNode(DataLayerAction):
+    """Reset all participant embargo consent states to NO_EMBARGO.
+
+    Calls ``reset_case_participant_embargo_consent`` for the given case.
+    Returns FAILURE when the case is not found.  Returns SUCCESS when
+    consent reset completes (including when the case has no participants).
+    """
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self.case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        reset_case_participant_embargo_consent(self.datalayer, case)
+        self.feedback_message = (
+            f"Reset participant embargo consent for case '{self.case_id}'"
+        )
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
 
 
 class ApplyEmbargoTeardownNode(DataLayerAction):


### PR DESCRIPTION
- Closes #1554

## Summary

Migrates the two remaining inline `case.current_status.em.state` reads in BT nodes to `ReadEmStateNode`, and decomposes the monolithic `ApplyEmbargoTeardownNode` into three single-responsibility nodes.

## Changes

- **`vultron/core/behaviors/embargo/nodes/lifecycle.py`**: `SetEmbargoActiveNode._apply_transition()` now accepts `current_em: EM` as a parameter; `update()` reads em_state via `ReadEmStateNode` before calling it (AC-1).
- **`vultron/core/behaviors/embargo/nodes/teardown.py`**: Added three new nodes — `HasEmbargoActiveNode` (EM-state guard, FAILURE when already EXITED), `ClearActiveEmbargoNode` (EM→EXITED + `active_embargo=None` in one `datalayer.save()`), `ResetParticipantConsentNode` (resets all participant PEC to NO_EMBARGO) (AC-2/AC-3).
- **`vultron/core/behaviors/embargo/announce_teardown_tree.py`**: `ActiveTeardown` sequence updated to `IsActiveEmbargoNode → HasEmbargoActiveNode → ClearActiveEmbargoNode → ResetParticipantConsentNode → SendAnnounceEmbargoEventNode` (AC-2).
- **`vultron/core/behaviors/embargo/nodes/__init__.py`**: Re-exports three new node classes.
- **`test/core/behaviors/embargo/nodes/test_teardown.py`**: Added `TestHasEmbargoActiveNode` (4 tests), `TestClearActiveEmbargoNode` (6 tests including single-save assertion), `TestResetParticipantConsentNode` (3 tests) (AC-4).
- **`test/core/behaviors/embargo/nodes/test_lifecycle.py`**: Added `TestSetEmbargoActiveNode` (5 tests including ReadEmStateNode delegation check) (AC-4).

## Verification

- 6108 unit tests pass (18 new test methods in 4 new test classes targeting new nodes and AC-1 change)
- Black, flake8, mypy, pyright all clean