### PR TITLE
docs: plan issue #1747 — Reject(Invite) inner_target case_id gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -514,6 +514,14 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   — check open issues before starting a session; an issue may be fully implemented
   but not closed. Use `git log -S "<fix string>" -- <file>` against `origin/main`
   to confirm. *Source: ISSUE-1787*
+- **`Reject(Invite(actor, case))` Carries the Case in `inner_target`, Not Top-Level `target`**
+  — `extract_event` does NOT populate `request.target` for the Reject; the case
+  reference is on the nested Invite's `target` field, exposed as `request.inner_target_id`.
+  Always read `request.inner_target_id or request.target_id` (or use a typed `case_id`
+  property on the event class) when resolving `case_id` for
+  `RejectInviteActorToCaseReceivedUseCase`. The same nesting applies to
+  `Accept(Invite(actor, case))` — `AcceptInviteActorToCaseReceivedEvent.case_id` already
+  follows this pattern. See CM-11-003. *Source: ISSUE-1747*
 
 ---
 

--- a/plan/history/2608/learning/CONCERN-1747.md
+++ b/plan/history/2608/learning/CONCERN-1747.md
@@ -1,0 +1,55 @@
+---
+source: CONCERN-1747
+timestamp: '2026-08-05T14:55:12.824047+00:00'
+title: 'concern: RejectInviteActorToCase ledger commit unreachable — Reject(Invite)
+  carries case_id in inner_target not target'
+type: learning
+---
+
+## Concern
+
+`RejectInviteActorToCaseReceivedUseCase.execute()` reads `request.target_id`
+(from `request.target`) to resolve the `case_id`. However,
+`Reject(Invite(actor, case))` carries the case reference in the nested
+Invite's `target` field (`inner_target`), not at the top-level `target` of
+the Reject activity.
+
+`extract_event` populates `inner_target` but not `target`, so
+`request.target_id` is always `None`.
+
+The use case early-returns with a warning log and **never reaches** the BT
+that would commit the canonical `Reject(Invite)` ledger entry.
+
+## Fix
+
+In `RejectInviteActorToCaseReceivedUseCase.execute()`
+(`vultron/core/use_cases/received/actor/invite.py`), change:
+
+```python
+case_id = request.target_id
+```
+
+to:
+
+```python
+case_id = request.inner_target_id or request.target_id
+```
+
+Also add a `case_id` convenience property to
+`RejectInviteActorToCaseReceivedEvent` (parallel to
+`AcceptInviteActorToCaseReceivedEvent.case_id`) returning `inner_target_id`.
+
+## Evidence
+
+Test `test_reject_invite_skips_ledger_when_target_id_absent` in
+`test/core/use_cases/received/actor/test_invite.py` documents and confirms
+the current (broken) behaviour.
+
+## History
+
+Pre-existing gap introduced in #1293. Discovered and documented during PR #1746
+(Issue #1689). Not introduced by #1746 — held out for separate design attention.
+
+**Resolved**: 2026-08-05 — implementation tracked in #1973.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1972>.
+Spec: `specs/case-management.yaml` CM-11-003.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -453,6 +453,25 @@ groups:
     relationships:
     - rel_type: depends_on
       spec_id: OX-02-001
+  - id: CM-11-003
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When processing a `Reject(Invite(actor, case))` activity, the use case MUST resolve
+      `case_id` from the nested Invite's `target` field (`inner_target_id`) rather than from
+      the top-level `target` of the Reject activity; the top-level `target` is not populated
+      by `extract_event` for this activity pattern and will always be `None`.
+    note: >-
+      `Accept(Invite(actor, case))` follows the same nesting — `AcceptInviteActorToCaseReceivedEvent`
+      already exposes a `case_id` property as `inner_target_id`. The symmetric property must
+      be present on `RejectInviteActorToCaseReceivedEvent` and used in
+      `RejectInviteActorToCaseReceivedUseCase.execute()`. Failure to read `inner_target_id`
+      causes the use case to early-return without committing the canonical `CaseLedgerEntry`
+      for the rejection (pre-existing gap introduced in #1293, documented in #1747).
+    rationale: >-
+      The `Reject(Invite(actor, case))` wire activity wraps the Invite as its `object_`; the
+      case reference is therefore on `object_.target`, which `extract_event` maps to
+      `inner_target`. There is no top-level `target` on the Reject itself.
 - id: CM-12
   title: Case Creation Timing
   specs:


### PR DESCRIPTION
- Closes #1747

## Summary

Plans the fix for `RejectInviteActorToCaseReceivedUseCase`: the use case
read `request.target_id` (always `None` for `Reject(Invite(actor, case))`)
causing an early-return before the BT ledger commit. The case reference
lives in `inner_target`, not the top-level `target` of the Reject.

## Changes

- **`specs/case-management.yaml`**: add CM-11-003 — MUST resolve `case_id`
  from `inner_target_id` when processing `Reject(Invite(actor, case))`
- **`AGENTS.md`**: add pitfall for `inner_target` vs `target` on nested
  Reject/Accept activities

## Implementation Issues

- #1973