### PR TITLE
fix(embargo): handle EM PROPOSED in PublicDisclosureBranchNode P/X/A cascade

### DIFF
--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -162,7 +162,7 @@ The node is a Selector with two arms depending on the current EM state:
 
 - **EM ACTIVE or REVISE** → delegates to `terminate_embargo_bt` (ET + EM →
   EXITED). This is the cascade path for AC-2 of issue #1454.
-- **EM PROPOSED** → delegates to `reject_embargo_trigger_bt` (ER + EM →
+- **EM PROPOSED** → delegates to `reject_proposed_embargo_bt` (ER + EM →
   NO_EMBARGO). EMB-16-001: continuing to negotiate a proposed embargo after
   P/X/A is set is not viable; the proposal must be abandoned immediately.
 - **EM NO_EMBARGO or EXITED** → skip (nothing to tear down).
@@ -216,9 +216,9 @@ When implementing any code that transitions embargo state:
    `transition_mode=TransitionMode.OBSERVED` to sync local state with a remote
    assertion. All guards and PEC cascades are bypassed in OBSERVED mode.
 6. **PROPOSED + P/X/A**: when a CS public/exploit/attacks event fires while EM
-   is PROPOSED, use `reject_embargo_trigger_bt` (not `terminate_embargo_bt`).
+   is PROPOSED, use `reject_proposed_embargo_bt` (not `terminate_embargo_bt`).
    `terminate_embargo_bt` requires an active embargo (`HasActiveEmbargoNode`
-   guard); it fails when EM is PROPOSED. `reject_embargo_trigger_bt` calls
+   guard); it fails when EM is PROPOSED. `reject_proposed_embargo_bt` calls
    `reject_embargo_invite()` which handles PROPOSED → NO_EMBARGO correctly
    (EMB-16-001).
 

--- a/plan/history/2608/implementation/ISSUE-1959.md
+++ b/plan/history/2608/implementation/ISSUE-1959.md
@@ -1,0 +1,23 @@
+---
+source: ISSUE-1959
+timestamp: '2026-08-05T15:06:52.218572+00:00'
+title: 'fix(embargo): handle EM PROPOSED in PublicDisclosureBranchNode P/X/A cascade'
+type: implementation
+---
+
+## Issue #1959 — fix(embargo): handle EM PROPOSED in PublicDisclosureBranchNode P/X/A cascade
+
+Fixed root-cause bug in `_PublicDisclosureSkipConditionNode` where `case.active_embargo is None`
+silently skipped teardown in EM PROPOSED state (active_embargo is always None when only a proposed
+embargo exists). Now reads `case.current_status.em.state` directly via `_em_state()` helper.
+
+`PublicDisclosureBranchNode` now uses a `TeardownSelector` routing to either `terminate_embargo_bt`
+(ACTIVE/REVISE) or the new `reject_proposed_embargo_bt` (PROPOSED), implementing EMB-16-001.
+
+New nodes: `IsProposedEmbargoNode`, `ReadProposedEmbargoIdNode`, `RejectProposedEmbargoLifecycleNode`,
+`SendRejectEmbargoActivityNode` — extracted to `reject_proposed.py` for BTND-07-004 compliance.
+
+14 tests (9 new): unit tests for all 5 skip-condition cases (AC-4) + integration test verifying
+EM→NONE transition and ER outbox queueing (AC-5). All 6097 tests pass.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1974>

--- a/test/core/behaviors/status/nodes/test_lifecycle.py
+++ b/test/core/behaviors/status/nodes/test_lifecycle.py
@@ -31,10 +31,17 @@ from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.status.nodes.lifecycle import (
     EmitCloseCaseNode,
     PublicDisclosureBranchNode,
+    _PublicDisclosureSkipConditionNode,
 )
+from vultron.core.states.cs import CS_pxa
+from vultron.core.states.em import EM
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
+from vultron.wire.as2.vocab.objects.case_status import (
+    as_CaseStatus,
+    as_ParticipantStatus,
+)
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
 )
@@ -45,6 +52,7 @@ CASE_ID = "https://example.org/cases/case-01"
 PARTICIPANT_ID = "https://example.org/cases/case-01/participants/vendor"
 CM_PARTICIPANT_ID = "https://example.org/cases/case-01/participants/case-actor"
 STATUS_ID = "https://example.org/cases/case-01/statuses/s1"
+EMBARGO_ID = "https://example.org/cases/case-01/embargo_events/e1"
 
 
 @pytest.fixture(autouse=True)
@@ -73,6 +81,21 @@ def status_obj():
 
 
 @pytest.fixture
+def public_aware_status():
+    """ParticipantStatus with CS.P set (CS_pxa.Pxa = public-aware)."""
+    return as_ParticipantStatus(
+        id_=STATUS_ID,
+        context=CASE_ID,
+        case_status=as_CaseStatus(pxa_state=CS_pxa.Pxa),
+    )
+
+
+@pytest.fixture
+def embargo():
+    return as_EmbargoEvent(id_=EMBARGO_ID, context=CASE_ID)
+
+
+@pytest.fixture
 def populated_dl(dl, participant, status_obj):
     case_manager_participant = as_CaseParticipant(
         id_=CM_PARTICIPANT_ID,
@@ -93,6 +116,221 @@ def populated_dl(dl, participant, status_obj):
 @pytest.fixture
 def populated_bridge(populated_dl):
     return BTBridge(datalayer=populated_dl)
+
+
+def _make_dl_with_em_state(
+    em_state: EM,
+    *,
+    with_embargo: bool = False,
+    with_proposed_embargo: bool = False,
+    with_active_embargo: bool = False,
+) -> SqliteDataLayer:
+    """Return a populated SqliteDataLayer for skip-condition unit tests."""
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    case = as_VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    case.current_status.em_state = em_state
+
+    if with_proposed_embargo or with_embargo:
+        embargo = as_EmbargoEvent(id_=EMBARGO_ID, context=CASE_ID)
+        case.proposed_embargoes = [embargo.id_]
+        dl.create(embargo)
+
+    if with_active_embargo or with_embargo:
+        embargo = as_EmbargoEvent(id_=EMBARGO_ID, context=CASE_ID)
+        case.active_embargo = embargo.id_
+        try:
+            dl.create(embargo)
+        except Exception:
+            pass
+
+    participant = as_CaseParticipant(
+        id_=PARTICIPANT_ID,
+        context=CASE_ID,
+        attributed_to=ACTOR_ID,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    case.add_participant(participant)
+    dl.create(case)
+    dl.create(participant)
+    return dl
+
+
+# ---------------------------------------------------------------------------
+# _PublicDisclosureSkipConditionNode — unit tests (AC-4, EMB-16-001)
+# ---------------------------------------------------------------------------
+
+
+class TestPublicDisclosureSkipConditionNode:
+    """Unit tests for _PublicDisclosureSkipConditionNode.
+
+    Per EMB-16-001: teardown (FAILURE = proceed) must fire for EM PROPOSED,
+    ACTIVE, and REVISE.  For EM NONE/EXITED or non-public-aware status the
+    node must skip (SUCCESS).
+    """
+
+    def _make_bridge_and_node(
+        self, dl: SqliteDataLayer, status_obj: as_ParticipantStatus
+    ) -> tuple[BTBridge, _PublicDisclosureSkipConditionNode]:
+        bridge = BTBridge(datalayer=dl)
+        node = _PublicDisclosureSkipConditionNode(
+            status_obj=status_obj,
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        return bridge, node
+
+    # AC-4 case 1: PROPOSED + public-aware PXA → FAILURE (do not skip)
+    def test_proposed_em_public_aware_returns_failure(
+        self, public_aware_status
+    ):
+        """EM PROPOSED + CS.P set → skip-condition returns FAILURE (EMB-16-001).
+
+        Spec: EMB-16-001 — when CASE_OWNER sends public-aware status while
+        EM is PROPOSED the BT must route to reject_proposed_embargo_bt.
+        """
+        dl = _make_dl_with_em_state(EM.PROPOSED, with_proposed_embargo=True)
+        bridge, node = self._make_bridge_and_node(dl, public_aware_status)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    # AC-4 case 2: ACTIVE + public-aware PXA → FAILURE (do not skip)
+    def test_active_em_public_aware_returns_failure(self, public_aware_status):
+        """EM ACTIVE + CS.P set → skip-condition returns FAILURE (EMB-16-001)."""
+        dl = _make_dl_with_em_state(EM.ACTIVE, with_active_embargo=True)
+        bridge, node = self._make_bridge_and_node(dl, public_aware_status)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    # AC-4 case 2b: REVISE + public-aware PXA → FAILURE (do not skip)
+    def test_revise_em_public_aware_returns_failure(self, public_aware_status):
+        """EM REVISE + CS.P set → skip-condition returns FAILURE (EMB-16-001)."""
+        dl = _make_dl_with_em_state(EM.REVISE, with_active_embargo=True)
+        bridge, node = self._make_bridge_and_node(dl, public_aware_status)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    # AC-4 case 3: NONE + public-aware PXA → SUCCESS (skip; nothing to tear down)
+    def test_none_em_public_aware_returns_success(self, public_aware_status):
+        """EM NONE + CS.P set → skip-condition returns SUCCESS (nothing to tear down)."""
+        dl = _make_dl_with_em_state(EM.NONE)
+        bridge, node = self._make_bridge_and_node(dl, public_aware_status)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+    # AC-4 case 4: non-public-aware status → SUCCESS (skip regardless of EM)
+    def test_non_public_aware_status_always_returns_success(
+        self, status_obj, populated_bridge
+    ):
+        """Non-public-aware status → skip regardless of EM state."""
+        node = _PublicDisclosureSkipConditionNode(
+            status_obj=status_obj,
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        result = populated_bridge.execute_with_setup(
+            tree=node, actor_id=ACTOR_ID
+        )
+        assert result.status == Status.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# PublicDisclosureBranchNode — integration tests (AC-5, EMB-16-001)
+# ---------------------------------------------------------------------------
+
+
+class TestPublicDisclosureBranchNodeProposedEmPath:
+    """Integration tests: CS.P/X/A fires while EM is PROPOSED.
+
+    Per EMB-16-001 the BranchNode must route to reject_proposed_embargo_bt
+    (not terminate_embargo_bt), transitioning EM from PROPOSED to NONE and
+    queuing an ER reject activity to the Case Manager.
+    """
+
+    def _setup(
+        self,
+        public_aware_status: as_ParticipantStatus,
+        *,
+        reject_activity_id: str = "https://example.org/activities/reject-01",
+    ) -> tuple[SqliteDataLayer, BTBridge, PublicDisclosureBranchNode]:
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        embargo = as_EmbargoEvent(id_=EMBARGO_ID, context=CASE_ID)
+        case = as_VulnerabilityCase(id_=CASE_ID, name="Test Case")
+        case.attributed_to = (
+            ACTOR_ID  # required by EmbargoLifecycle.is_owner check
+        )
+        case.current_status.em_state = EM.PROPOSED
+        case.proposed_embargoes = [embargo.id_]
+
+        participant = as_CaseParticipant(
+            id_=PARTICIPANT_ID,
+            context=CASE_ID,
+            attributed_to=ACTOR_ID,
+            case_roles=[CVDRole.CASE_OWNER],
+        )
+        cm_participant = as_CaseParticipant(
+            id_=CM_PARTICIPANT_ID,
+            context=CASE_ID,
+            attributed_to=CASE_MANAGER_ID,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        case.add_participant(participant)
+        case.add_participant(cm_participant)
+        dl.create(embargo)
+        dl.create(case)
+        dl.create(participant)
+        dl.create(cm_participant)
+
+        factory = MagicMock()
+        factory.reject_embargo.return_value = (reject_activity_id, {})
+
+        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
+        node = PublicDisclosureBranchNode(
+            status_obj=public_aware_status,
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        return dl, bridge, node
+
+    # AC-5: full integration — EM PROPOSED + P fires → EM→NONE + ER queued
+    def test_proposed_em_pxa_routes_to_reject_path_and_succeeds(
+        self, public_aware_status
+    ):
+        """EM PROPOSED + CS.P → BranchNode succeeds; EM transitions to NONE.
+
+        Per EMB-16-001: reject_proposed_embargo_bt arm must execute, driving
+        EM PROPOSED → NO_EMBARGO via reject_embargo_invite().
+        """
+        reject_id = "https://example.org/activities/reject-01"
+        dl, bridge, node = self._setup(
+            public_aware_status, reject_activity_id=reject_id
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+        # AC-5: EM must have transitioned to NONE after the BT ran
+        from vultron.core.models.case import VulnerabilityCase
+
+        updated_case = dl.read(CASE_ID)
+        assert isinstance(updated_case, VulnerabilityCase)
+        assert updated_case.current_status.em.state == EM.NONE
+
+    def test_proposed_em_pxa_queues_reject_activity_to_outbox(
+        self, public_aware_status
+    ):
+        """EM PROPOSED + CS.P → reject activity queued in actor outbox.
+
+        Per EMB-16-001: SendRejectEmbargoActivityNode must call
+        factory.reject_embargo() and record the result in the outbox.
+        """
+        reject_id = "https://example.org/activities/reject-01"
+        dl, bridge, node = self._setup(
+            public_aware_status, reject_activity_id=reject_id
+        )
+        bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        outbox = dl.outbox_list_for_actor(ACTOR_ID)
+        assert reject_id in outbox
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/status/nodes/test_lifecycle.py
+++ b/test/core/behaviors/status/nodes/test_lifecycle.py
@@ -217,6 +217,14 @@ class TestPublicDisclosureSkipConditionNode:
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
         assert result.status == Status.SUCCESS
 
+    # AC-4 case 3b: EXITED + public-aware PXA → SUCCESS (skip; embargo already gone)
+    def test_exited_em_public_aware_returns_success(self, public_aware_status):
+        """EM EXITED + CS.P set → skip-condition returns SUCCESS (nothing to tear down)."""
+        dl = _make_dl_with_em_state(EM.EXITED)
+        bridge, node = self._make_bridge_and_node(dl, public_aware_status)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
     # AC-4 case 4: non-public-aware status → SUCCESS (skip regardless of EM)
     def test_non_public_aware_status_always_returns_success(
         self, status_obj, populated_bridge

--- a/vultron/core/behaviors/embargo/nodes/__init__.py
+++ b/vultron/core/behaviors/embargo/nodes/__init__.py
@@ -29,6 +29,7 @@ from vultron.core.behaviors.embargo.nodes.conditions import (
     HasActiveEmbargoNode,
     HasCaseStatusesNode,
     IsActiveEmbargoNode,
+    IsProposedEmbargoNode,
     LookupParticipantNode,
     OptionalLookupParticipantNode,
     ValidateCaseExistsNode,
@@ -42,6 +43,11 @@ from vultron.core.behaviors.embargo.nodes.lifecycle import (
     SetEmbargoActiveNode,
     TerminateEmbargoLifecycleNode,
     ValidateEmbargoRevisionStateNode,
+)
+from vultron.core.behaviors.embargo.nodes.reject_proposed import (
+    ReadProposedEmbargoIdNode,
+    RejectProposedEmbargoLifecycleNode,
+    SendRejectEmbargoActivityNode,
 )
 from vultron.core.behaviors.embargo.nodes.proposal import (
     CreateAndStoreInviteNode,
@@ -59,6 +65,7 @@ __all__ = [
     # Conditions
     "ValidateCaseExistsNode",
     "IsActiveEmbargoNode",
+    "IsProposedEmbargoNode",
     "HasActiveEmbargoNode",
     "HasCaseStatusesNode",
     "LookupParticipantNode",
@@ -83,6 +90,9 @@ __all__ = [
     "RejectEmbargoLifecycleNode",
     "TerminateEmbargoLifecycleNode",
     "ReadEmbargoIdNode",
+    "ReadProposedEmbargoIdNode",
+    "RejectProposedEmbargoLifecycleNode",
     "SendTerminateEmbargoActivityNode",
+    "SendRejectEmbargoActivityNode",
     "SetEmbargoActiveNode",
 ]

--- a/vultron/core/behaviors/embargo/nodes/conditions.py
+++ b/vultron/core/behaviors/embargo/nodes/conditions.py
@@ -294,6 +294,49 @@ class HasActiveEmbargoNode(DataLayerCondition):
         return Status.SUCCESS
 
 
+class IsProposedEmbargoNode(DataLayerCondition):
+    """Check that the case EM state is PROPOSED.
+
+    Returns SUCCESS when ``case.current_status.em.state == EM.PROPOSED``.
+    Returns FAILURE for any other EM state (including ACTIVE, REVISE, NONE,
+    EXITED), halting the parent Sequence so the proposed-embargo arm is skipped.
+
+    Analogous to :class:`IsActiveEmbargoNode` but for the PROPOSED state.
+    """
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self.case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            return Status.FAILURE
+
+        try:
+            em_state = case.current_status.em.state
+        except (ValueError, AttributeError):
+            self.feedback_message = (
+                f"Case '{self.case_id}' has no materialized CaseStatus"
+            )
+            return Status.FAILURE
+
+        from vultron.core.states.em import EM
+
+        if em_state != EM.PROPOSED:
+            self.feedback_message = (
+                f"Case '{self.case_id}' EM state is '{em_state}', not PROPOSED"
+            )
+            return Status.FAILURE
+
+        return Status.SUCCESS
+
+
 class HasCaseStatusesNode(DataLayerCondition):
     """Guard that the case has at least one CaseStatus entry.
 

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -25,6 +25,11 @@ from vultron.core.behaviors.embargo.nodes.em_state import (
     WriteEmStateNode,
 )
 from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
+from vultron.core.behaviors.embargo.nodes.reject_proposed import (  # noqa: F401
+    ReadProposedEmbargoIdNode,
+    RejectProposedEmbargoLifecycleNode,
+    SendRejectEmbargoActivityNode,
+)
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import EmDimension

--- a/vultron/core/behaviors/embargo/nodes/reject_proposed.py
+++ b/vultron/core/behaviors/embargo/nodes/reject_proposed.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Reject-proposed-embargo BT nodes (EMB-16-001).
+
+Handles the cascade arm triggered when CS.P/X/A fires while EM is PROPOSED:
+abandon the proposed embargo via reject_embargo_invite() and queue an ER
+activity to the Case Manager.
+
+Extracted from lifecycle.py to keep that module under the BTND-07-004
+500-line limit.
+"""
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.embargo.nodes.em_state import (
+    ReadEmStateNode,
+    WriteEmStateNode,
+)
+from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.models._helpers import _as_id
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.services.embargo_lifecycle import (
+    EmbargoLifecycle,
+    TransitionMode,
+)
+from vultron.core.states.em import EM
+from vultron.errors import VultronError
+
+
+class RejectProposedEmbargoLifecycleNode(DataLayerAction):
+    """Apply STRICT reject-invite transition reading embargo_id from the blackboard.
+
+    Cascade-path variant of :class:`RejectEmbargoLifecycleNode` used by
+    :func:`~vultron.core.behaviors.embargo.trigger_tree.reject_proposed_embargo_bt`.
+
+    Reads ``embargo_id`` written by ``ReadProposedEmbargoIdNode`` so the
+    transition uses the correct proposed embargo rather than a
+    construction-time value.
+
+    EMB-16-001: abandons a proposed embargo when P/X/A fires while EM is PROPOSED.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        result_out: dict[str, object],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id_value = case_id
+        self._result_out = result_out
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="embargo_id",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+
+        try:
+            embargo_id: str = self.blackboard.embargo_id
+        except KeyError:
+            self.feedback_message = "embargo_id not found on blackboard"
+            return Status.FAILURE
+
+        read_node = ReadEmStateNode(
+            case_id=self._case_id_value, result_out=self._result_out
+        )
+        read_node.datalayer = self.datalayer
+        read_status = read_node.update()
+        if read_status != Status.SUCCESS:
+            self.feedback_message = read_node.feedback_message
+            return Status.FAILURE
+        em_before = self._result_out["em_before"]
+        assert isinstance(em_before, EM)
+
+        lifecycle = EmbargoLifecycle(persistence=self.datalayer)
+        try:
+            result = lifecycle.reject_embargo_invite(
+                case_id=self._case_id_value,
+                embargo_id=embargo_id,
+                actor_id=self.actor_id,
+                transition_mode=TransitionMode.STRICT,
+                em_before=em_before,
+            )
+        except VultronError as exc:
+            self._result_out["error"] = exc
+            self.feedback_message = str(exc)
+            return Status.FAILURE
+
+        self._result_out["lifecycle_result"] = result
+        self._result_out["em_after"] = result.em_after
+
+        if result.em_after != em_before:
+            write_node = WriteEmStateNode(
+                case_id=self._case_id_value, result_out=self._result_out
+            )
+            write_node.datalayer = self.datalayer
+            write_status = write_node.update()
+            if write_status != Status.SUCCESS:
+                self.feedback_message = write_node.feedback_message
+                return Status.FAILURE
+
+        return Status.SUCCESS
+
+
+class ReadProposedEmbargoIdNode(DataLayerAction):
+    """Read the first proposed embargo ID from the case and write it to the blackboard.
+
+    Used by the EM PROPOSED cascade arm of ``PublicDisclosureBranchNode``
+    (EMB-16-001): when public disclosure fires while EM is PROPOSED we must
+    reject the proposed embargo.  Unlike ``ReadEmbargoIdNode`` (which reads
+    ``active_embargo``), this node reads the first entry of
+    ``proposed_embargoes``.
+
+    Returns FAILURE when the case is not found, has no proposed embargoes, or
+    the DataLayer is unavailable.  Returns SUCCESS and writes ``embargo_id``
+    to the blackboard on success.
+    """
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="embargo_id",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.feedback_message = f"Case '{self._case_id}' not found"
+            return Status.FAILURE
+
+        proposed = case.proposed_embargoes
+        if not proposed:
+            self.feedback_message = (
+                f"No proposed embargoes on case '{self._case_id}'"
+            )
+            return Status.FAILURE
+
+        embargo_id = _as_id(proposed[0])
+        if embargo_id is None:
+            self.feedback_message = (
+                f"First proposed embargo on case '{self._case_id}' has no id"
+            )
+            return Status.FAILURE
+
+        self.blackboard.embargo_id = embargo_id
+        return Status.SUCCESS
+
+
+class SendRejectEmbargoActivityNode(_SendEmbargoActivityBase):
+    """Build and queue a ``Reject(EmbargoEvent)`` activity.
+
+    Used as the emit step in the EM PROPOSED cascade arm
+    (EMB-16-001): reads ``embargo_id`` and ``case_manager_id`` from the
+    blackboard and constructs the outbound ER activity via
+    ``trigger_activity_factory.reject_embargo``.
+
+    Returns FAILURE (BT-14-001) when the factory is unavailable, a required
+    blackboard key is missing, or dispatch raises an exception.
+    Returns SUCCESS when the activity is created and queued.
+    """
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(case_id=case_id, name=name)
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="embargo_id",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="case_manager_id",
+            access=py_trees.common.Access.READ,
+        )
+
+    def _on_factory_unavailable(self) -> Status:
+        self.feedback_message = (
+            "trigger_activity_factory not available"
+            " — reject embargo broadcast FAILURE (BT-14-001)"
+        )
+        self.logger.warning("%s: %s", self.name, self.feedback_message)
+        return Status.FAILURE
+
+    def _resolve_embargo_and_manager(self) -> "tuple[str, str] | Status":
+        try:
+            embargo_id: str = self.blackboard.embargo_id
+            case_manager_id: str = self.blackboard.case_manager_id
+        except KeyError as exc:
+            self.feedback_message = f"Required blackboard key missing: {exc}"
+            return Status.FAILURE
+        return embargo_id, case_manager_id
+
+    def _call_factory(
+        self, actor_id: str, embargo_id: str, case_manager_id: str
+    ) -> tuple[str, object]:
+        assert self.trigger_activity_factory is not None
+        return self.trigger_activity_factory.reject_embargo(
+            proposal_id=embargo_id,
+            case_id=self._case_id,
+            actor=actor_id,
+            to=[case_manager_id],
+        )
+
+    def _on_outbox_write_failure(
+        self, activity_id: str, exc: Exception
+    ) -> Status:
+        self.feedback_message = (
+            f"Outbox write failed for Reject(EmbargoEvent)"
+            f" '{activity_id}': {exc}"
+        )
+        self.logger.warning("%s: %s", self.name, self.feedback_message)
+        return Status.FAILURE

--- a/vultron/core/behaviors/embargo/trigger_tree.py
+++ b/vultron/core/behaviors/embargo/trigger_tree.py
@@ -22,10 +22,14 @@ import py_trees
 from vultron.core.behaviors.embargo.nodes import (
     AcceptEmbargoLifecycleNode,
     HasActiveEmbargoNode,
+    IsProposedEmbargoNode,
     PersistEmbargoEventNode,
     ProposeEmbargoLifecycleNode,
     ReadEmbargoIdNode,
+    ReadProposedEmbargoIdNode,
     RejectEmbargoLifecycleNode,
+    RejectProposedEmbargoLifecycleNode,
+    SendRejectEmbargoActivityNode,
     SendTerminateEmbargoActivityNode,
     TerminateEmbargoLifecycleNode,
     ValidateEmbargoRevisionStateNode,
@@ -135,6 +139,43 @@ def reject_embargo_trigger_bt(
                 result_out=result_out,
             ),
             sender_side_bt(case_id=case_id, activity_builder=activity_builder),
+        ],
+    )
+
+
+def reject_proposed_embargo_bt(
+    *,
+    case_id: str,
+    result_out: dict[str, object],
+) -> py_trees.behaviour.Behaviour:
+    """Shared BT for abandoning a proposed embargo (EMB-16-001).
+
+    Used by :class:`PublicDisclosureBranchNode` when CS.P/X/A fires while the
+    case EM state is PROPOSED.  Mirrors the routing-guard ordering of
+    :func:`terminate_embargo_bt`:
+
+    1. ``IsProposedEmbargoNode`` — guard: EM must be PROPOSED; FAILURE otherwise.
+    2. ``ReadProposedEmbargoIdNode`` — read embargo_id from proposed_embargoes.
+    3. ``ResolveCaseManagerNode`` — routing guard; FAILURE = no state change.
+    4. ``RejectEmbargoLifecycleNode`` — EM state mutation (PROPOSED → NO_EMBARGO).
+    5. ``SendRejectEmbargoActivityNode`` — queue ER to Case Manager.
+
+    Both the routing guard (step 3) and state mutation (step 4) are ordered per
+    BT-19-001/BT-19-002 so that routing prerequisites are always verified before
+    the DataLayer state change is committed.
+    """
+    return py_trees.composites.Sequence(
+        name="RejectProposedEmbargoBT",
+        memory=True,
+        children=[
+            IsProposedEmbargoNode(case_id=case_id),
+            ReadProposedEmbargoIdNode(case_id=case_id),
+            ResolveCaseManagerNode(case_id=case_id),
+            RejectProposedEmbargoLifecycleNode(
+                case_id=case_id,
+                result_out=result_out,
+            ),
+            SendRejectEmbargoActivityNode(case_id=case_id),
         ],
     )
 

--- a/vultron/core/behaviors/embargo/trigger_tree.py
+++ b/vultron/core/behaviors/embargo/trigger_tree.py
@@ -157,7 +157,7 @@ def reject_proposed_embargo_bt(
     1. ``IsProposedEmbargoNode`` — guard: EM must be PROPOSED; FAILURE otherwise.
     2. ``ReadProposedEmbargoIdNode`` — read embargo_id from proposed_embargoes.
     3. ``ResolveCaseManagerNode`` — routing guard; FAILURE = no state change.
-    4. ``RejectEmbargoLifecycleNode`` — EM state mutation (PROPOSED → NO_EMBARGO).
+    4. ``RejectProposedEmbargoLifecycleNode`` — EM state mutation (PROPOSED → NO_EMBARGO).
     5. ``SendRejectEmbargoActivityNode`` — queue ER to Case Manager.
 
     Both the routing guard (step 3) and state mutation (step 4) are ordered per

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -32,14 +32,17 @@ from typing import cast
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.embargo.trigger_tree import terminate_embargo_bt
+from vultron.core.behaviors.embargo.trigger_tree import (
+    reject_proposed_embargo_bt,
+    terminate_embargo_bt,
+)
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.protocols import PersistableModel
+from vultron.core.states.em import EM
 from vultron.enums.roles import CVDRole
-from vultron.core.models._helpers import _as_id
 from vultron.core.behaviors.status.nodes.threat_termination import (  # noqa: F401
     ThreatTerminationBranchNode,
     _ThreatTerminationSkipConditionNode,
@@ -115,6 +118,13 @@ class _PublicDisclosureSkipConditionNode(DataLayerCondition):
         )
         return CVDRole.CASE_OWNER in roles
 
+    def _em_state(self, case: VulnerabilityCase) -> EM:
+        """Return current EM state; falls back to NONE on missing status."""
+        try:
+            return case.current_status.em.state
+        except (ValueError, AttributeError):
+            return EM.NONE
+
     def update(self) -> Status:
         if not self._public_aware():
             return Status.SUCCESS
@@ -129,11 +139,15 @@ class _PublicDisclosureSkipConditionNode(DataLayerCondition):
         if not self._sender_is_case_owner(case):
             return Status.SUCCESS
 
-        if _as_id(case.active_embargo) is None:
+        # Check EM state directly (EMB-16-001): teardown is required for
+        # ACTIVE, REVISE (terminate path) and PROPOSED (reject path).
+        # NO_EMBARGO and EXITED have nothing to tear down.
+        em_state = self._em_state(case)
+        if em_state not in (EM.ACTIVE, EM.REVISE, EM.PROPOSED):
             return Status.SUCCESS
 
         # Condition met: sender is CASE_OWNER reporting public awareness AND
-        # there is an active embargo to terminate.
+        # there is an active or proposed embargo to handle.
         return Status.FAILURE
 
 
@@ -143,9 +157,13 @@ class PublicDisclosureBranchNode(py_trees.composites.Selector):
     Condition: the new ParticipantStatus has CS.P (public-aware) set AND
     the sender holds the CASE_OWNER role.
 
-    When the condition is met, delegates to the shared ``terminate_embargo_bt``
-    factory (BT-19-002), which places the routing guard before the EM state
-    mutation.  Skips silently if conditions are not met.
+    When the condition is met, routes teardown based on EM state (EMB-16-001):
+
+    - EM ACTIVE/REVISE → ``terminate_embargo_bt`` (terminate path).
+    - EM PROPOSED → ``reject_proposed_embargo_bt`` (reject path, EMB-16-001).
+
+    Skips silently if conditions are not met (EM NONE/EXITED, or sender is not
+    CASE_OWNER, or status is not public-aware).
 
     Returns SUCCESS when teardown conditions are not met (skip path) or
     when teardown completes and the broadcast activity is queued.
@@ -155,10 +173,11 @@ class PublicDisclosureBranchNode(py_trees.composites.Selector):
     Implemented as a ``py_trees.composites.Selector`` (memory=False):
 
     - Child 1 ``_PublicDisclosureSkipConditionNode``: SUCCESS → skip teardown.
-    - Child 2 ``TerminateEmbargoBT``: SUCCESS on success; FAILURE when routing
-      prerequisites are absent or dispatch fails (BT-14-001).
+    - Child 2 Teardown Selector: tries ACTIVE/REVISE arm then PROPOSED arm.
+      - ``TerminateEmbargoBT``: for EM ACTIVE/REVISE.
+      - ``RejectProposedEmbargoBT``: for EM PROPOSED (EMB-16-001).
 
-    Per DEMOMA-07-003 step 4.
+    Per DEMOMA-07-003 step 4, EMB-16-001.
     """
 
     def __init__(
@@ -170,14 +189,26 @@ class PublicDisclosureBranchNode(py_trees.composites.Selector):
     ):
         super().__init__(name=name or self.__class__.__name__, memory=False)
         result_out: dict[str, object] = {}
-        terminate_subtree = (
-            terminate_embargo_bt(
+        if case_id is None:
+            teardown_subtree: py_trees.behaviour.Behaviour = (
+                py_trees.behaviours.Success(name="TeardownSkipped")
+            )
+        else:
+            reject_proposed_subtree = reject_proposed_embargo_bt(
                 case_id=case_id,
                 result_out=result_out,
             )
-            if case_id is not None
-            else py_trees.behaviours.Success(name="TerminateEmbargoSkipped")
-        )
+            terminate_subtree = terminate_embargo_bt(
+                case_id=case_id,
+                result_out=result_out,
+            )
+            # Selector: try terminate (ACTIVE/REVISE) first; if it fails because
+            # there is no active embargo, try reject (PROPOSED).
+            teardown_subtree = py_trees.composites.Selector(
+                name="TeardownSelector",
+                memory=False,
+                children=[terminate_subtree, reject_proposed_subtree],
+            )
         self.add_children(
             [
                 _PublicDisclosureSkipConditionNode(
@@ -186,7 +217,7 @@ class PublicDisclosureBranchNode(py_trees.composites.Selector):
                     case_id=case_id,
                     name="SkipCondition",
                 ),
-                terminate_subtree,
+                teardown_subtree,
             ]
         )
 

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -59,10 +59,11 @@ class _PublicDisclosureSkipConditionNode(DataLayerCondition):
     - DataLayer or case_id is unavailable, OR
     - The sender is not a known case participant, OR
     - The sender does NOT hold the CASE_OWNER role, OR
-    - The case has no active embargo (nothing to terminate).
+    - The EM state is NONE or EXITED (nothing to tear down).
 
     Returns FAILURE (proceed to teardown) when the sender IS a CASE_OWNER
-    who has sent a public-aware status update AND the case has an active embargo.
+    who has sent a public-aware status update AND EM state is ACTIVE, REVISE,
+    or PROPOSED (EMB-16-001).
     """
 
     def __init__(


### PR DESCRIPTION
- Closes #1959
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Fixes a root-cause bug where `_PublicDisclosureSkipConditionNode` checked `case.active_embargo is None` to decide whether to skip embargo teardown. In EM PROPOSED state `active_embargo` is always `None` even though a proposed embargo exists, so teardown was silently skipped per EMB-16-001.

## Changes

- **`vultron/core/behaviors/status/nodes/lifecycle.py`**: Replace `active_embargo` check with `_em_state()` helper reading `case.current_status.em.state`; add `TeardownSelector` to `PublicDisclosureBranchNode` routing to either `terminate_embargo_bt` (ACTIVE/REVISE) or `reject_proposed_embargo_bt` (PROPOSED)
- **`vultron/core/behaviors/embargo/nodes/conditions.py`**: Add `IsProposedEmbargoNode` — guards the PROPOSED arm by checking `em.state == EM.PROPOSED`
- **`vultron/core/behaviors/embargo/nodes/reject_proposed.py`**: New module (extracted for BTND-07-004 compliance) — `RejectProposedEmbargoLifecycleNode`, `ReadProposedEmbargoIdNode`, `SendRejectEmbargoActivityNode`
- **`vultron/core/behaviors/embargo/nodes/lifecycle.py`**: Re-export new nodes from `reject_proposed.py` for backward-compatible import paths
- **`vultron/core/behaviors/embargo/trigger_tree.py`**: Add `reject_proposed_embargo_bt()` factory — sequences guard → read-id → resolve-manager → lifecycle → send-activity per BT-19-001
- **`vultron/core/behaviors/embargo/nodes/__init__.py`**: Export new nodes
- **`test/core/behaviors/status/nodes/test_lifecycle.py`**: 9 new tests — `TestPublicDisclosureSkipConditionNode` (AC-4: PROPOSED/ACTIVE/REVISE/NONE/non-public-aware) and `TestPublicDisclosureBranchNodeProposedEmPath` (AC-5: EM→NONE transition + ER outbox)

## Verification

- All 14 lifecycle tests pass (9 new)
- Full suite: 6097 passed, 0 failed
- Black, flake8, mypy, pyright clean
- BTND-07-004: `lifecycle.py` 474 lines, `reject_proposed.py` 244 lines