### PR TITLE
feat(emb-15): inbound embargo-response decision seam

### DIFF
--- a/notes/bt-fuzzer-nodes-embargo.md
+++ b/notes/bt-fuzzer-nodes-embargo.md
@@ -411,6 +411,35 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
   (`reject_embargo_trigger_bt` for Flow A; `reject_invite_to_embargo_tree`
   for Flow B). Not a monolithic `create_propose_embargo_decision_tree`.
 
+### `CaseOwnerApprovesEmbargoResponse`
+
+- **Node name**: `CaseOwnerApprovesEmbargoResponse`
+- **btz type**: `AlwaysSucceed` (p=1.00)
+- **Source file**: `vultron/demo/fuzzer/embargo.py`
+- **Parent tree**: `AuthorizeSelector` (within `create_embargo_response_decision_tree`,
+  as the second child of the `AuthorizeSelector` Selector — reached only when
+  the deciding actor is NOT a `CVDRole.CASE_OWNER`)
+- **Semantic function**: Condition — a non-CASE_OWNER actor (e.g. a CaseActor
+  processing an inbound overture on the owner's behalf) requests authorization
+  from the case owner before accepting or countering. Defaults to approval in
+  simulation (owner approval assumed).
+- **Input dependency**: Human approval / adjudication — final authority rests
+  with the case owner (a human or configured policy agent)
+- **Notes**: Gate only; no content artifact placed on the blackboard. In
+  production this seam would be fulfilled by an Evaluator-type Coordination
+  Agent (UI prompt, LLM adjudicator, or policy rule) returning the owner's
+  decision.
+- **Automation potential**: **Low** — final authority rests with the case
+  owner; not auto-approvable by default.
+- **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.CaseOwnerApprovesEmbargoResponse`
+- **Call-out point shape**: Evaluator — records an adjudication decision
+  (approve/deny); no blackboard output_keys (pass/fail gate only per BT-18-006).
+- **Factory-fn placement**: Implemented in PR #1983 (issue #1942) —
+  `vultron.core.behaviors.embargo.response_decision_tree.create_embargo_response_decision_tree`
+  (`case_owner_approves_embargo_response_factory` param in
+  `EmbargoCallOutBundle`) — second child of the `AuthorizeSelector`,
+  reached when `CheckIsCaseOwnerNode` returns FAILURE (EMB-15-002).
+
 ### `CurrentEmbargoAcceptable`
 
 - **Node name**: `CurrentEmbargoAcceptable`

--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -226,7 +226,7 @@ When implementing any code that transitions embargo state:
 
 ## Inbound Embargo-Response Decision (EMB-15)
 
-**Status**: Planned — issue #1257 (plan/1257). Spec group `EMB-15` in
+**Status**: Implemented — PR #1983 / issue #1942. Spec group `EMB-15` in
 `specs/em-behavior.yaml`; call-out catalog in
 `notes/bt-fuzzer-nodes-embargo.md`.
 

--- a/plan/history/2608/implementation/ISSUE-1942.md
+++ b/plan/history/2608/implementation/ISSUE-1942.md
@@ -1,0 +1,26 @@
+---
+source: ISSUE-1942
+timestamp: '2026-08-05T17:18:49.158164+00:00'
+title: EMB-15 inbound embargo-response decision seam
+type: implementation
+---
+
+## Issue #1942 — Implement inbound embargo-response decision seam (EMB-15)
+
+Implemented `create_embargo_response_decision_tree` in
+`vultron/core/behaviors/embargo/response_decision_tree.py`.
+
+Tree structure:
+
+- ResponseDecisionSelector (Selector, memory=False)
+  - AcceptArm (Sequence): AuthorizeSelector (CheckIsCaseOwnerNode gospel bypass + CaseOwnerApprovesEmbargoResponse call-out) → EvaluateEmbargoProposal → accept_bt
+  - CounterArm (Sequence, Flow A only, when counter_bt supplied): WillingToCounterEmbargoProposal → counter_bt
+  - reject_bt (always last fallback)
+
+Key fix from code review: parameter was renamed from `sender_actor_id` to `deciding_actor_id` — the gospel bypass checks whether the LOCAL deciding actor is CASE_OWNER, not whether the remote proposer is.
+
+Also added `case_owner_approves_embargo_response_factory` to `EmbargoCallOutBundle` (default AlwaysSucceed) and `CaseOwnerApprovesEmbargoResponse` fuzzer class in demo layer.
+
+36 structural unit tests added. Integration tests (runtime DataLayer tick) deferred to #1982.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1983>

--- a/test/core/behaviors/embargo/test_response_decision_tree.py
+++ b/test/core/behaviors/embargo/test_response_decision_tree.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for create_embargo_response_decision_tree (EMB-15).
+
+AC-6: verify tree structure, CASE_OWNER bypass vs call-out routing, and
+both flows' accept/reject/counter delegation.
+
+Covers:
+  - EMB-15-001: default-accept (EvaluateEmbargoProposal → SUCCESS)
+  - EMB-15-002: CASE_OWNER gospel-bypass seam
+  - EMB-15-003: counter arm present/absent (Flow A vs Flow B)
+  - EMB-15-004: reject arm always present as fallback
+  - BT-18-004: factory parameter wired + deterministic default
+  - BT-23-002: DETERMINISTIC bundle uses AlwaysSucceed/AlwaysFail
+"""
+
+import py_trees
+
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckIsCaseOwnerNode,
+)
+from vultron.core.behaviors.embargo.response_decision_tree import (
+    create_embargo_response_decision_tree,
+)
+from vultron.core.behaviors.call_out.bundles.embargo import (
+    EMBARGO_DETERMINISTIC,
+    EmbargoCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.embargo import EMBARGO_STOCHASTIC
+from vultron.demo.fuzzer.embargo import (
+    CaseOwnerApprovesEmbargoResponse,
+    EvaluateEmbargoProposal,
+    WillingToCounterEmbargoProposal,
+)
+
+CASE_ID = "https://example.org/cases/emb15-test"
+DECIDING_ACTOR_ID = "https://example.org/actors/local-deciding-actor"
+
+
+def _stub(name: str = "stub") -> py_trees.behaviour.Behaviour:
+    """Return a no-op stub behaviour."""
+
+    class _Stub(py_trees.behaviour.Behaviour):
+        def update(self) -> py_trees.common.Status:
+            return py_trees.common.Status.SUCCESS
+
+    return _Stub(name=name)
+
+
+def _make_tree(
+    *,
+    counter: bool = False,
+    call_out: EmbargoCallOutBundle = EMBARGO_DETERMINISTIC,
+) -> py_trees.behaviour.Behaviour:
+    return create_embargo_response_decision_tree(
+        case_id=CASE_ID,
+        deciding_actor_id=DECIDING_ACTOR_ID,
+        accept_bt=_stub("AcceptDelegate"),
+        reject_bt=_stub("RejectDelegate"),
+        counter_bt=_stub("CounterDelegate") if counter else None,
+        call_out=call_out,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Root structure
+# ---------------------------------------------------------------------------
+
+
+class TestRootStructure:
+    def test_returns_behaviour(self):
+        tree = _make_tree()
+        assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+    def test_root_name(self):
+        tree = _make_tree()
+        assert tree.name == "ResponseDecisionSelector"
+
+    def test_root_is_selector(self):
+        tree = _make_tree()
+        assert isinstance(tree, py_trees.composites.Selector)
+
+    def test_root_memory_false(self):
+        tree = _make_tree()
+        assert tree.memory is False  # type: ignore[attr-defined]
+
+    def test_two_arms_without_counter(self):
+        """Flow B (no counter): accept + reject = 2 arms."""
+        tree = _make_tree(counter=False)
+        assert len(tree.children) == 2
+
+    def test_three_arms_with_counter(self):
+        """Flow A (with counter): accept + counter + reject = 3 arms."""
+        tree = _make_tree(counter=True)
+        assert len(tree.children) == 3
+
+
+# ---------------------------------------------------------------------------
+# Accept arm (child 0)
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptArm:
+    def test_accept_arm_is_sequence(self):
+        tree = _make_tree()
+        accept_arm = tree.children[0]
+        assert isinstance(accept_arm, py_trees.composites.Sequence)
+
+    def test_accept_arm_memory_false(self):
+        tree = _make_tree()
+        assert tree.children[0].memory is False  # type: ignore[attr-defined]
+
+    def test_accept_arm_name(self):
+        tree = _make_tree()
+        assert tree.children[0].name == "AcceptArm"
+
+    def test_accept_arm_has_three_children(self):
+        """AcceptArm: AuthorizeSelector + EvaluateEmbargoProposal + delegate."""
+        tree = _make_tree()
+        accept_arm = tree.children[0]
+        assert len(accept_arm.children) == 3
+
+    def test_accept_arm_first_child_is_authorize_selector(self):
+        tree = _make_tree()
+        auth = tree.children[0].children[0]
+        assert isinstance(auth, py_trees.composites.Selector)
+        assert auth.name == "AuthorizeSelector"
+
+    def test_authorize_selector_memory_false(self):
+        tree = _make_tree()
+        auth = tree.children[0].children[0]
+        assert auth.memory is False  # type: ignore[attr-defined]
+
+    def test_authorize_selector_has_two_children(self):
+        tree = _make_tree()
+        auth = tree.children[0].children[0]
+        assert len(auth.children) == 2
+
+    def test_authorize_first_child_is_check_is_case_owner(self):
+        """EMB-15-002: gospel-bypass guard is CheckIsCaseOwnerNode."""
+        tree = _make_tree()
+        auth = tree.children[0].children[0]
+        assert isinstance(auth.children[0], CheckIsCaseOwnerNode)
+
+    def test_authorize_first_child_name(self):
+        tree = _make_tree()
+        auth = tree.children[0].children[0]
+        assert auth.children[0].name == "CheckIsCaseOwner"
+
+    def test_accept_arm_second_child_is_evaluate_embargo_proposal_deterministic(
+        self,
+    ):
+        """EMB-15-001: EvaluateEmbargoProposal defaults to AlwaysSucceed."""
+        tree = _make_tree()
+        evaluate_node = tree.children[0].children[1]
+        assert isinstance(evaluate_node, AlwaysSucceed)
+
+    def test_accept_arm_second_child_name(self):
+        tree = _make_tree()
+        evaluate_node = tree.children[0].children[1]
+        assert evaluate_node.name == "EvaluateEmbargoProposal"
+
+    def test_accept_arm_third_child_is_delegate(self):
+        tree = _make_tree()
+        delegate = tree.children[0].children[2]
+        assert delegate.name == "AcceptDelegate"
+
+
+# ---------------------------------------------------------------------------
+# CASE_OWNER authorization seam (EMB-15-002)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorizeSeam:
+    def test_non_owner_seam_deterministic_is_always_succeed(self):
+        """DETERMINISTIC bundle: CaseOwnerApprovesEmbargoResponse → AlwaysSucceed."""
+        tree = _make_tree()
+        auth = tree.children[0].children[0]
+        non_owner_node = auth.children[1]
+        assert isinstance(non_owner_node, AlwaysSucceed)
+
+    def test_non_owner_seam_name(self):
+        tree = _make_tree()
+        auth = tree.children[0].children[0]
+        non_owner_node = auth.children[1]
+        assert non_owner_node.name == "CaseOwnerApprovesEmbargoResponse"
+
+    def test_non_owner_seam_stochastic_is_correct_fuzzer_class(self):
+        """STOCHASTIC bundle: CaseOwnerApprovesEmbargoResponse → fuzzer class."""
+        tree = _make_tree(call_out=EMBARGO_STOCHASTIC)
+        auth = tree.children[0].children[0]
+        non_owner_node = auth.children[1]
+        assert isinstance(non_owner_node, CaseOwnerApprovesEmbargoResponse)
+
+    def test_custom_case_owner_approves_factory_wired(self):
+        """BT-18-004: custom factory is injected into the authorize seam."""
+        called = {"flag": False}
+
+        def custom_factory(name: str) -> py_trees.behaviour.Behaviour:
+            called["flag"] = True
+
+            class _Custom(py_trees.behaviour.Behaviour):
+                def update(self):
+                    return py_trees.common.Status.SUCCESS
+
+            return _Custom(name="CustomApproval")
+
+        bundle = EmbargoCallOutBundle(
+            case_owner_approves_embargo_response_factory=custom_factory  # type: ignore[arg-type]
+        )
+        tree = _make_tree(call_out=bundle)
+        assert called["flag"]
+        auth = tree.children[0].children[0]
+        assert auth.children[1].name == "CustomApproval"
+
+
+# ---------------------------------------------------------------------------
+# EvaluateEmbargoProposal call-out (EMB-15-001)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateEmbargoProposalCallOut:
+    def test_stochastic_evaluate_is_correct_fuzzer_class(self):
+        """STOCHASTIC bundle: EvaluateEmbargoProposal → fuzzer class."""
+        tree = _make_tree(call_out=EMBARGO_STOCHASTIC)
+        evaluate_node = tree.children[0].children[1]
+        assert isinstance(evaluate_node, EvaluateEmbargoProposal)
+
+    def test_custom_evaluate_factory_wired(self):
+        """Custom evaluate_embargo_proposal_factory is injected."""
+        called = {"flag": False}
+
+        def custom_factory(name: str) -> py_trees.behaviour.Behaviour:
+            called["flag"] = True
+
+            class _Custom(py_trees.behaviour.Behaviour):
+                def update(self):
+                    return py_trees.common.Status.SUCCESS
+
+            return _Custom(name="CustomEvaluate")
+
+        bundle = EmbargoCallOutBundle(
+            evaluate_embargo_proposal_factory=custom_factory  # type: ignore[arg-type]
+        )
+        tree = _make_tree(call_out=bundle)
+        assert called["flag"]
+        assert tree.children[0].children[1].name == "CustomEvaluate"
+
+
+# ---------------------------------------------------------------------------
+# Counter arm (EMB-15-003, Flow A only)
+# ---------------------------------------------------------------------------
+
+
+class TestCounterArm:
+    def test_counter_arm_absent_when_no_counter_bt(self):
+        """Flow B: no counter_bt → only 2 arms (no CounterArm)."""
+        tree = _make_tree(counter=False)
+        names = [c.name for c in tree.children]
+        assert "CounterArm" not in names
+
+    def test_counter_arm_present_when_counter_bt_supplied(self):
+        """Flow A: counter_bt supplied → CounterArm is child[1]."""
+        tree = _make_tree(counter=True)
+        assert tree.children[1].name == "CounterArm"
+
+    def test_counter_arm_is_sequence(self):
+        tree = _make_tree(counter=True)
+        assert isinstance(tree.children[1], py_trees.composites.Sequence)
+
+    def test_counter_arm_memory_false(self):
+        tree = _make_tree(counter=True)
+        assert tree.children[1].memory is False  # type: ignore[attr-defined]
+
+    def test_counter_arm_has_two_children(self):
+        tree = _make_tree(counter=True)
+        counter_arm = tree.children[1]
+        assert len(counter_arm.children) == 2
+
+    def test_counter_arm_first_child_is_willing_to_counter_deterministic(self):
+        """EMB-15-003: WillingToCounterEmbargoProposal defaults to AlwaysFail."""
+        tree = _make_tree(counter=True)
+        willing = tree.children[1].children[0]
+        assert isinstance(willing, AlwaysFail)
+
+    def test_counter_arm_first_child_name(self):
+        tree = _make_tree(counter=True)
+        willing = tree.children[1].children[0]
+        assert willing.name == "WillingToCounterEmbargoProposal"
+
+    def test_counter_arm_second_child_is_delegate(self):
+        tree = _make_tree(counter=True)
+        delegate = tree.children[1].children[1]
+        assert delegate.name == "CounterDelegate"
+
+    def test_counter_arm_first_child_stochastic(self):
+        """STOCHASTIC bundle: WillingToCounterEmbargoProposal → fuzzer class."""
+        tree = _make_tree(counter=True, call_out=EMBARGO_STOCHASTIC)
+        willing = tree.children[1].children[0]
+        assert isinstance(willing, WillingToCounterEmbargoProposal)
+
+    def test_custom_willing_to_counter_factory_wired(self):
+        """Custom willing_to_counter_factory is injected into the counter arm."""
+        called = {"flag": False}
+
+        def custom_factory(name: str) -> py_trees.behaviour.Behaviour:
+            called["flag"] = True
+
+            class _Custom(py_trees.behaviour.Behaviour):
+                def update(self):
+                    return py_trees.common.Status.FAILURE
+
+            return _Custom(name="CustomCounter")
+
+        bundle = EmbargoCallOutBundle(
+            willing_to_counter_factory=custom_factory  # type: ignore[arg-type]
+        )
+        tree = _make_tree(counter=True, call_out=bundle)
+        assert called["flag"]
+        assert tree.children[1].children[0].name == "CustomCounter"
+
+
+# ---------------------------------------------------------------------------
+# Reject arm (EMB-15-004)
+# ---------------------------------------------------------------------------
+
+
+class TestRejectArm:
+    def test_reject_arm_is_last_child_without_counter(self):
+        """Flow B: reject arm is child[1] (last, index 1)."""
+        tree = _make_tree(counter=False)
+        assert tree.children[1].name == "RejectDelegate"
+
+    def test_reject_arm_is_last_child_with_counter(self):
+        """Flow A: reject arm is child[2] (last, index 2)."""
+        tree = _make_tree(counter=True)
+        assert tree.children[2].name == "RejectDelegate"

--- a/vultron/core/behaviors/call_out/bundles/embargo.py
+++ b/vultron/core/behaviors/call_out/bundles/embargo.py
@@ -20,21 +20,22 @@ lives in the simulation layer
 
 Ceiling/floor mapping (BT-23-002):
 
-- ``exit_embargo_when_deployed_factory``       — ExitEmbargoWhenDeployed       (p=0.33) → AlwaysFail
-- ``exit_embargo_when_fix_ready_factory``      — ExitEmbargoWhenFixReady       (p=0.25) → AlwaysFail
-- ``exit_embargo_for_other_reason_factory``    — ExitEmbargoForOtherReason     (p=0.005) → AlwaysFail
-- ``stop_proposing_embargo_factory``           — StopProposingEmbargo          (p=0.25) → AlwaysFail
-- ``select_embargo_offer_terms_factory``       — SelectEmbargoOfferTerms       (p=1.0) → AlwaysSucceed
-- ``want_to_propose_embargo_factory``          — WantToProposeEmbargo          (p=0.50) → AlwaysSucceed (tie-break)
-- ``willing_to_counter_factory``               — WillingToCounterEmbargoProposal (p=0.25) → AlwaysFail
-- ``reason_to_propose_when_deployed_factory``  — ReasonToProposeEmbargoWhenDeployed (p=0.07) → AlwaysFail
-- ``evaluate_embargo_proposal_factory``        — EvaluateEmbargoProposal       (p=0.75) → AlwaysSucceed
-- ``current_embargo_acceptable_factory``       — CurrentEmbargoAcceptable      (p=0.90) → AlwaysSucceed
-- ``on_embargo_exit_factory``                  — OnEmbargoExit                 (p=1.0) → AlwaysSucceed
-- ``on_embargo_accept_factory``                — OnEmbargoAccept               (p=1.0) → AlwaysSucceed
-- ``on_embargo_reject_factory``                — OnEmbargoReject               (p=1.0) → AlwaysSucceed
-- ``embargo_exit_policy_guard_factory``        — EmbargoExitPolicyGuard        (p=1.0) → AlwaysSucceed
-- ``embargo_exit_override_factory``            — EmbargoExitOverride           (p=0.0) → AlwaysFail
+- ``exit_embargo_when_deployed_factory``              — ExitEmbargoWhenDeployed             (p=0.33) → AlwaysFail
+- ``exit_embargo_when_fix_ready_factory``             — ExitEmbargoWhenFixReady             (p=0.25) → AlwaysFail
+- ``exit_embargo_for_other_reason_factory``           — ExitEmbargoForOtherReason           (p=0.005) → AlwaysFail
+- ``stop_proposing_embargo_factory``                  — StopProposingEmbargo                (p=0.25) → AlwaysFail
+- ``select_embargo_offer_terms_factory``              — SelectEmbargoOfferTerms             (p=1.0) → AlwaysSucceed
+- ``want_to_propose_embargo_factory``                 — WantToProposeEmbargo                (p=0.50) → AlwaysSucceed (tie-break)
+- ``willing_to_counter_factory``                      — WillingToCounterEmbargoProposal     (p=0.25) → AlwaysFail
+- ``reason_to_propose_when_deployed_factory``         — ReasonToProposeEmbargoWhenDeployed  (p=0.07) → AlwaysFail
+- ``evaluate_embargo_proposal_factory``               — EvaluateEmbargoProposal             (p=0.75) → AlwaysSucceed
+- ``current_embargo_acceptable_factory``              — CurrentEmbargoAcceptable            (p=0.90) → AlwaysSucceed
+- ``on_embargo_exit_factory``                         — OnEmbargoExit                       (p=1.0) → AlwaysSucceed
+- ``on_embargo_accept_factory``                       — OnEmbargoAccept                     (p=1.0) → AlwaysSucceed
+- ``on_embargo_reject_factory``                       — OnEmbargoReject                     (p=1.0) → AlwaysSucceed
+- ``case_owner_approves_embargo_response_factory``    — CaseOwnerApprovesEmbargoResponse    (p=1.0) → AlwaysSucceed
+- ``embargo_exit_policy_guard_factory``               — EmbargoExitPolicyGuard              (p=1.0) → AlwaysSucceed
+- ``embargo_exit_override_factory``                   — EmbargoExitOverride                 (p=0.0) → AlwaysFail
 """
 
 from __future__ import annotations
@@ -103,6 +104,11 @@ class EmbargoCallOutBundle:
         default=_always_succeed  # type: ignore[assignment]
     )
     on_embargo_reject_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    case_owner_approves_embargo_response_factory: (
+        CallOutBackendFactory
+    ) = field(
         default=_always_succeed  # type: ignore[assignment]
     )
     embargo_exit_policy_guard_factory: CallOutBackendFactory = field(

--- a/vultron/core/behaviors/embargo/response_decision_tree.py
+++ b/vultron/core/behaviors/embargo/response_decision_tree.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Inbound embargo-response decision seam (EMB-15).
+
+Factory function :func:`create_embargo_response_decision_tree` builds a
+three-arm response Selector that chooses *how* to respond to an inbound
+embargo overture, then delegates to the appropriate mechanical BT.
+
+Two overture flows are supported via caller-supplied delegate trees:
+
+- **Flow A** — EM-level embargo proposal (EP).  The caller passes the
+  result of :func:`~vultron.core.behaviors.embargo.trigger_tree.accept_embargo_trigger_bt`
+  as ``accept_bt``,
+  :func:`~vultron.core.behaviors.embargo.trigger_tree.reject_embargo_trigger_bt`
+  as ``reject_bt``, and optionally
+  :func:`~vultron.core.behaviors.embargo.trigger_tree.propose_embargo_trigger_bt`
+  as ``counter_bt`` (counter = re-propose, no new mechanism, EMB-15-003).
+
+- **Flow B** — PEC-level invitation (InviteToEmbargoOnCase).  The caller
+  passes the result of
+  :func:`~vultron.core.behaviors.embargo.announce_teardown_tree.accept_invite_to_embargo_tree`
+  as ``accept_bt`` and
+  :func:`~vultron.core.behaviors.embargo.announce_teardown_tree.reject_invite_to_embargo_tree`
+  as ``reject_bt``.  No counter arm; pass ``counter_bt=None`` (the default).
+
+Tree structure (EMB-15, ADR-0046)::
+
+    ResponseDecisionSelector (Selector)
+    ├─ AcceptArm (Sequence)
+    │  ├─ AuthorizeSelector (Selector)
+    │  │  ├─ CheckIsCaseOwner          # EMB-15-002: gospel bypass
+    │  │  └─ CaseOwnerApprovesEmbargoResponse  # call-out; default SUCCESS
+    │  ├─ EvaluateEmbargoProposal      # call-out; default SUCCESS (EMB-15-001)
+    │  └─ <accept_bt>                  # caller-supplied accept delegate
+    ├─ CounterArm (Sequence) — Flow A only, omitted when counter_bt is None
+    │  ├─ WillingToCounterEmbargoProposal  # call-out; default FAILURE (EMB-15-003)
+    │  └─ <counter_bt>                 # caller-supplied propose delegate
+    └─ <reject_bt>                     # EMB-15-004: always present as fallback
+
+Spec: ``specs/em-behavior.yaml`` EMB-15 through EMB-15-004.
+Per: ``docs/adr/0025-call-out-point-abstraction-layer.md`` (call-out injection),
+     ``docs/adr/0046-received-status-authorization.md`` (two-seam authorization).
+"""
+
+import logging
+
+import py_trees
+
+__all__ = ["create_embargo_response_decision_tree"]
+
+from vultron.core.behaviors.call_out.bundles.embargo import (
+    EMBARGO_DETERMINISTIC,
+    EmbargoCallOutBundle,
+)
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckIsCaseOwnerNode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_embargo_response_decision_tree(
+    *,
+    case_id: str,
+    deciding_actor_id: str,
+    accept_bt: py_trees.behaviour.Behaviour,
+    reject_bt: py_trees.behaviour.Behaviour,
+    counter_bt: py_trees.behaviour.Behaviour | None = None,
+    call_out: EmbargoCallOutBundle = EMBARGO_DETERMINISTIC,
+) -> py_trees.behaviour.Behaviour:
+    """Build the inbound embargo-response decision seam (EMB-15).
+
+    Constructs a three-arm ``ResponseDecisionSelector`` that chooses how to
+    respond to an inbound embargo overture (Flow A: EP; Flow B:
+    InviteToEmbargoOnCase) and delegates to the caller-supplied mechanical BTs.
+
+    **Authorization (EMB-15-002)**: a ``AuthorizeSelector`` (Fallback) puts
+    ``CheckIsCaseOwnerNode`` first — when the **deciding** actor (the local
+    actor processing the inbound overture and choosing how to respond) holds
+    ``CVDRole.CASE_OWNER``, the response is gospel and no approval call-out
+    is invoked.  Non-owners route through
+    ``CaseOwnerApprovesEmbargoResponse`` (default SUCCESS).
+
+    **Default-accept (EMB-15-001)**: ``EvaluateEmbargoProposal`` defaults to
+    SUCCESS under :data:`EMBARGO_DETERMINISTIC`, so the accept arm is taken
+    when no external adjudication backend is injected.
+
+    **Counter arm (EMB-15-003, Flow A only)**: present when ``counter_bt`` is
+    supplied.  Gated by ``WillingToCounterEmbargoProposal`` (default FAILURE),
+    which is off-by-default.  Counter is implemented as re-propose — the caller
+    supplies a ``propose_embargo_trigger_bt`` result.
+
+    **Reject arm (EMB-15-004)**: the third child of the outer Selector, always
+    present.  The caller supplies the flow-appropriate reject BT
+    (``reject_embargo_trigger_bt`` for Flow A; ``reject_invite_to_embargo_tree``
+    for Flow B).
+
+    Args:
+        case_id: ID of the VulnerabilityCase.  Used to resolve CASE_OWNER
+            status for the gospel-bypass guard.
+        deciding_actor_id: Actor ID of the LOCAL actor that is processing the
+            inbound overture and making the accept/counter/reject decision.
+            Passed to ``CheckIsCaseOwnerNode`` — gospel bypass fires when THIS
+            actor holds ``CVDRole.CASE_OWNER``, not when the remote proposer does.
+        accept_bt: Pre-built BT to execute when the accept arm is taken.
+            For Flow A: ``accept_embargo_trigger_bt(...)``.
+            For Flow B: ``accept_invite_to_embargo_tree(...)``.
+        reject_bt: Pre-built BT to execute when the reject arm is taken.
+            For Flow A: ``reject_embargo_trigger_bt(...)``.
+            For Flow B: ``reject_invite_to_embargo_tree(...)``.
+        counter_bt: Pre-built BT to execute when the counter arm is taken.
+            Supply ``propose_embargo_trigger_bt(...)`` for Flow A.
+            Pass ``None`` (the default) for Flow B — omits the counter arm.
+        call_out: Call-out backend bundle.  Defaults to
+            :data:`EMBARGO_DETERMINISTIC` (accept by default, no counter).
+
+    Returns:
+        Root node of the ``ResponseDecisionSelector`` Selector.
+    """
+    # EMB-15-002: CASE_OWNER gospel bypass → non-owner adjudication call-out
+    authorize_selector = py_trees.composites.Selector(
+        name="AuthorizeSelector",
+        memory=False,
+        children=[
+            CheckIsCaseOwnerNode(
+                sender_actor_id=deciding_actor_id,
+                case_id=case_id,
+                name="CheckIsCaseOwner",
+            ),
+            call_out.case_owner_approves_embargo_response_factory(
+                "CaseOwnerApprovesEmbargoResponse"
+            ),
+        ],
+    )
+
+    # EMB-15-001: default-accept arm
+    accept_arm = py_trees.composites.Sequence(
+        name="AcceptArm",
+        memory=False,
+        children=[
+            authorize_selector,
+            call_out.evaluate_embargo_proposal_factory(
+                "EvaluateEmbargoProposal"
+            ),
+            accept_bt,
+        ],
+    )
+
+    outer_children: list[py_trees.behaviour.Behaviour] = [accept_arm]
+
+    # EMB-15-003: counter arm (Flow A only, off by default)
+    if counter_bt is not None:
+        counter_arm = py_trees.composites.Sequence(
+            name="CounterArm",
+            memory=False,
+            children=[
+                call_out.willing_to_counter_factory(
+                    "WillingToCounterEmbargoProposal"
+                ),
+                counter_bt,
+            ],
+        )
+        outer_children.append(counter_arm)
+
+    # EMB-15-004: reject arm (always present as fallback)
+    outer_children.append(reject_bt)
+
+    logger.info(
+        "Created ResponseDecisionSelector for case=%s deciding_actor=%s counter=%s",
+        case_id,
+        deciding_actor_id,
+        "present" if counter_bt is not None else "absent",
+    )
+
+    return py_trees.composites.Selector(
+        name="ResponseDecisionSelector",
+        memory=False,
+        children=outer_children,
+    )

--- a/vultron/core/behaviors/embargo/response_decision_tree.py
+++ b/vultron/core/behaviors/embargo/response_decision_tree.py
@@ -108,6 +108,12 @@ def create_embargo_response_decision_tree(
     (``reject_embargo_trigger_bt`` for Flow A; ``reject_invite_to_embargo_tree``
     for Flow B).
 
+    .. note::
+        This tree does **not** enforce EMB-01-002 (mandatory rejection when
+        CS is public/exploit/attacks).  Callers MUST check EMB-01-002 before
+        invoking this tree and route directly to the flow-appropriate
+        ``reject_bt`` (or skip the tree entirely) when that condition holds.
+
     Args:
         case_id: ID of the VulnerabilityCase.  Used to resolve CASE_OWNER
             status for the gospel-bypass guard.

--- a/vultron/demo/fuzzer/bundles/embargo.py
+++ b/vultron/demo/fuzzer/bundles/embargo.py
@@ -20,21 +20,22 @@ for backward-compatible import paths.
 
 Ceiling/floor mapping for the DETERMINISTIC counterpart (BT-23-002):
 
-- ``exit_embargo_when_deployed_factory``       — ExitEmbargoWhenDeployed       (p=0.33) → AlwaysFail
-- ``exit_embargo_when_fix_ready_factory``      — ExitEmbargoWhenFixReady       (p=0.25) → AlwaysFail
-- ``exit_embargo_for_other_reason_factory``    — ExitEmbargoForOtherReason     (p=0.005) → AlwaysFail
-- ``stop_proposing_embargo_factory``           — StopProposingEmbargo          (p=0.25) → AlwaysFail
-- ``select_embargo_offer_terms_factory``       — SelectEmbargoOfferTerms       (p=1.0) → AlwaysSucceed
-- ``want_to_propose_embargo_factory``          — WantToProposeEmbargo          (p=0.50) → AlwaysSucceed (tie-break)
-- ``willing_to_counter_factory``               — WillingToCounterEmbargoProposal (p=0.25) → AlwaysFail
-- ``reason_to_propose_when_deployed_factory``  — ReasonToProposeEmbargoWhenDeployed (p=0.07) → AlwaysFail
-- ``evaluate_embargo_proposal_factory``        — EvaluateEmbargoProposal       (p=0.75) → AlwaysSucceed
-- ``current_embargo_acceptable_factory``       — CurrentEmbargoAcceptable      (p=0.90) → AlwaysSucceed
-- ``on_embargo_exit_factory``                  — OnEmbargoExit                 (p=1.0) → AlwaysSucceed
-- ``on_embargo_accept_factory``                — OnEmbargoAccept               (p=1.0) → AlwaysSucceed
-- ``on_embargo_reject_factory``                — OnEmbargoReject               (p=1.0) → AlwaysSucceed
-- ``embargo_exit_policy_guard_factory``        — EmbargoExitPolicyGuard        (p=1.0) → AlwaysSucceed
-- ``embargo_exit_override_factory``            — EmbargoExitOverride           (p=0.0) → AlwaysFail
+- ``exit_embargo_when_deployed_factory``              — ExitEmbargoWhenDeployed             (p=0.33) → AlwaysFail
+- ``exit_embargo_when_fix_ready_factory``             — ExitEmbargoWhenFixReady             (p=0.25) → AlwaysFail
+- ``exit_embargo_for_other_reason_factory``           — ExitEmbargoForOtherReason           (p=0.005) → AlwaysFail
+- ``stop_proposing_embargo_factory``                  — StopProposingEmbargo                (p=0.25) → AlwaysFail
+- ``select_embargo_offer_terms_factory``              — SelectEmbargoOfferTerms             (p=1.0) → AlwaysSucceed
+- ``want_to_propose_embargo_factory``                 — WantToProposeEmbargo                (p=0.50) → AlwaysSucceed (tie-break)
+- ``willing_to_counter_factory``                      — WillingToCounterEmbargoProposal     (p=0.25) → AlwaysFail
+- ``reason_to_propose_when_deployed_factory``         — ReasonToProposeEmbargoWhenDeployed  (p=0.07) → AlwaysFail
+- ``evaluate_embargo_proposal_factory``               — EvaluateEmbargoProposal             (p=0.75) → AlwaysSucceed
+- ``current_embargo_acceptable_factory``              — CurrentEmbargoAcceptable            (p=0.90) → AlwaysSucceed
+- ``on_embargo_exit_factory``                         — OnEmbargoExit                       (p=1.0) → AlwaysSucceed
+- ``on_embargo_accept_factory``                       — OnEmbargoAccept                     (p=1.0) → AlwaysSucceed
+- ``on_embargo_reject_factory``                       — OnEmbargoReject                     (p=1.0) → AlwaysSucceed
+- ``case_owner_approves_embargo_response_factory``    — CaseOwnerApprovesEmbargoResponse    (p=1.0) → AlwaysSucceed
+- ``embargo_exit_policy_guard_factory``               — EmbargoExitPolicyGuard              (p=1.0) → AlwaysSucceed
+- ``embargo_exit_override_factory``                   — EmbargoExitOverride                 (p=0.0) → AlwaysFail
 """
 
 from __future__ import annotations
@@ -129,6 +130,14 @@ def _stochastic_on_reject(name: str) -> py_trees.behaviour.Behaviour:
     return OnEmbargoReject(name)
 
 
+def _stochastic_case_owner_approves_embargo_response(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import CaseOwnerApprovesEmbargoResponse
+
+    return CaseOwnerApprovesEmbargoResponse(name)
+
+
 def _stochastic_embargo_exit_policy_guard(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
@@ -159,6 +168,7 @@ EMBARGO_STOCHASTIC = EmbargoCallOutBundle(
     on_embargo_exit_factory=_stochastic_on_exit,  # type: ignore[arg-type]
     on_embargo_accept_factory=_stochastic_on_accept,  # type: ignore[arg-type]
     on_embargo_reject_factory=_stochastic_on_reject,  # type: ignore[arg-type]
+    case_owner_approves_embargo_response_factory=_stochastic_case_owner_approves_embargo_response,  # type: ignore[arg-type]
     embargo_exit_policy_guard_factory=_stochastic_embargo_exit_policy_guard,  # type: ignore[arg-type]
     embargo_exit_override_factory=_stochastic_embargo_exit_override,  # type: ignore[arg-type]
 )

--- a/vultron/demo/fuzzer/embargo.py
+++ b/vultron/demo/fuzzer/embargo.py
@@ -402,6 +402,33 @@ class OnEmbargoReject(ActuatorCallOutPoint, AlwaysSucceed):
 
 
 # ---------------------------------------------------------------------------
+# Inbound embargo-response decision nodes (EMB-15)
+# ---------------------------------------------------------------------------
+
+
+class CaseOwnerApprovesEmbargoResponse(EvaluatorCallOutPoint, AlwaysSucceed):
+    """Adjudication call-out: non-owner actor requests CASE_OWNER approval.
+
+    Semantic function:
+        Condition — a non-CASE_OWNER actor (e.g. a CaseActor processing an
+        inbound overture on the owner's behalf) requests authorization from the
+        case owner before accepting or countering.  Defaults to approval in
+        simulation (owner approval assumed).
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — reads actor/case context from construction time)
+      Output keys: (none — pass/fail gate only)
+
+    Input category: Human approval / adjudication.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Low** — final authority rests with the case owner
+    (a human or a configured policy agent).
+    """
+
+
+# ---------------------------------------------------------------------------
 # Embargo exit authorization nodes
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
- Closes #1942

## Summary

Implements `create_embargo_response_decision_tree`, the three-arm response
Selector decision layer for inbound embargo overtures (EMB-15). Adds a new
`case_owner_approves_embargo_response_factory` call-out field to
`EmbargoCallOutBundle` and the matching stochastic fuzzer class.

## Changes

- **`vultron/core/behaviors/embargo/response_decision_tree.py`** *(new)*:
  Factory `create_embargo_response_decision_tree` — builds a
  `ResponseDecisionSelector` with AcceptArm (AuthorizeSelector + EvaluateEmbargoProposal
  + accept delegate), optional CounterArm (WillingToCounterEmbargoProposal + counter
  delegate), and reject delegate fallback. `deciding_actor_id` (local actor) drives
  the CASE_OWNER gospel bypass per EMB-15-002.
- **`vultron/core/behaviors/call_out/bundles/embargo.py`**: New
  `case_owner_approves_embargo_response_factory` field in `EmbargoCallOutBundle`
  (default `AlwaysSucceed`). Updated ceiling/floor docstring.
- **`vultron/demo/fuzzer/embargo.py`**: New
  `CaseOwnerApprovesEmbargoResponse(EvaluatorCallOutPoint, AlwaysSucceed)` fuzzer
  class.
- **`vultron/demo/fuzzer/bundles/embargo.py`**: Lazy-import stochastic factory
  wired into `EMBARGO_STOCHASTIC`. Updated docstring.
- **`test/core/behaviors/embargo/test_response_decision_tree.py`** *(new)*:
  36 structural unit tests covering root shape, `memory=False` on all composites,
  CASE_OWNER bypass vs call-out seam, DETERMINISTIC/STOCHASTIC factory injection,
  and accept/counter/reject arm delegation for both flows.

## DEFER findings

- **#1982** — EMB-15 integration tests: tick tree with real DataLayer/CaseParticipant
  to exercise `CheckIsCaseOwnerNode.update()` at runtime.

## Verification

- 36 new unit tests pass; `test/core/ + test/demo/` — 2993 passed, 0 failures
- `black`, `flake8`, `mypy`, `pyright` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)