### PR TITLE
docs: plan issue #1968 — actor INFO log narrative standard

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -113,6 +113,16 @@ AKM-08).
 **Load when**: implementing actor knowledge queries, designing inter-actor
 trust or awareness logic, or working on AKM spec requirements.
 
+**`structured-logging.md`**
+Narrative log template (SL-04-006), infrastructure demotion list (SL-04-007),
+and per-module guidance for keeping actor INFO logs readable as a CVD protocol
+story. Documents the approved verb–template inventory (`Actor '<id>' RM: A → B
+for case '<id>'`), the ~10 infrastructure patterns that MUST be at DEBUG, and
+the ~8 missing INFO messages required by SL-04-001. Source: CONCERN-1968.
+**Load when**: adding a new BT node that writes RM/CS/EM state (must add INFO
+log), auditing logging levels in actor container output, or implementing
+CONCERN-1968 logging remediation.
+
 **`configuration.md`**
 Design decisions for YAML-backed Pydantic configuration loading in Vultron:
 `ActorConfig` neutral model, `LocalActorConfig` composition, default embargo

--- a/notes/structured-logging.md
+++ b/notes/structured-logging.md
@@ -1,0 +1,140 @@
+---
+title: Structured Logging — Narrative Standard and Infrastructure Demotion Guide
+status: active
+tags: [logging, observability, debugging]
+description: >
+  Narrative log template (SL-04-006), infrastructure demotion list (SL-04-007),
+  and per-module guidance for keeping INFO logs readable as a CVD protocol story.
+related_specs:
+  - specs/structured-logging.yaml
+related_notes:
+  - notes/codebase-structure.md
+  - notes/bt-integration.md
+---
+
+# Structured Logging — Narrative Standard and Infrastructure Demotion Guide
+
+## Motivation
+
+Actor container INFO logs serve two audiences simultaneously: developers
+debugging a live run, and contributors reading a CI transcript to verify
+protocol correctness. Both audiences need the INFO log to read as a coherent
+story of what the protocol did — not a stream of persistence bookkeeping.
+
+The underlying requirement is SL-04-001: all state transitions MUST be logged
+at INFO. The concrete gap is that many state transitions are only visible at
+DEBUG (or not at all), while the INFO channel is dominated by infrastructure
+noise.
+
+---
+
+## Narrative Template (SL-04-006)
+
+All BT leaf nodes and service-layer methods that write a protocol-visible state
+change SHOULD emit an INFO log following this template:
+
+```text
+Actor '<actor_id>' <verb> '<object_id>' (<STATE_A> → <STATE_B>)
+```
+
+### Approved verbs by domain
+
+| Domain | Verb | Example |
+|---|---|---|
+| RM | `RM:` | `Actor 'finder' RM: RECEIVED → ACCEPTED for case 'case-uuid'` |
+| CS/VFD | `CS:` | `Actor 'vendor' CS: vfd → Vfd (fix ready) for case 'case-uuid'` |
+| CS/VFD | `CS:` | `Actor 'vendor' CS: Vfd → VFd (fix deployed) for case 'case-uuid'` |
+| CS/PXA | `CS:` | `Actor 'finder' CS: pxa → Pxa (publicly known) for case 'case-uuid'` |
+| EM | `embargo:` | `Actor 'finder' proposed embargo 'embargo-uuid' (EM NONE → PROPOSED)` |
+| EM | `embargo:` | `Actor 'finder' embargo PROPOSED → ACTIVE for case 'case-uuid'` |
+| EM | `embargo:` | `Actor 'finder' embargo ACTIVE → TERMINATED for case 'case-uuid'` |
+| Case | `case:` | `Actor 'finder' engaged case 'case-uuid' (RM VALID → ACCEPTED)` |
+| Invite | `invite:` | `Actor 'finder' received case invite for 'case-uuid' from 'coordinator'` |
+| BT failure | `BT:` | `Actor 'vendor' BT execution FAILURE for case 'case-uuid': <reason>` |
+
+The existing embargo-propose messages (`Actor X proposed embargo Y (EM NONE → PROPOSED)`)
+and demo-step emoji markers (`demo_step` / `demo_check`) already follow this
+pattern and MUST NOT be changed.
+
+---
+
+## Infrastructure Patterns to Demote to DEBUG (SL-04-007)
+
+The following patterns appeared at INFO as of the concern CONCERN-1968. Each
+MUST be at DEBUG or lower. Verify with a grep after any bulk refactor.
+
+| Pattern | File(s) | Why DEBUG |
+|---|---|---|
+| `BT structure:\n<tree>` (before every execution) | `vultron/core/behaviors/bridge.py:209` | BT scaffolding, not story |
+| `DataLayer stored/saved/updated X 'ID'` | `vultron/adapters/driven/datalayer_sqlite/crud.py:70,152,195,301` | Persistence internals; higher-level "Created X" messages above them are fine |
+| `Parsing activity from request body` / `Parsing activity from body` | `vultron/adapters/driving/fastapi/routers/actors/_inbox.py:62`, `vultron/wire/as2/parser.py:113` | HTTP handler internals; duplicate pair |
+| `Processing outbox for actor ...` | `vultron/adapters/driving/fastapi/outbox_handler.py:242` | Preamble; delivery result is the meaningful line |
+| `Dispatch: dispatched X activity_id=...` / `process_payload: outcome status=processed` / `run_inbox_pipeline: status=processed` | `vultron/core/behaviors/inbox/_process_payload.py:214`, `vultron/adapters/driving/fastapi/inbox_orchestration.py:370,386` | Mechanical pipeline completion repeats |
+| `EM FSM: Finished processing state X exit/enter callbacks` | `vultron/core/states/em.py` (transitions callback) | FSM internals; the `Actor X proposed embargo Y (EM A → B)` already captures this |
+| `sync adapter: queued Announce(CaseLedgerEntry) 'UUID' → ['actor']` | `vultron/adapters/driven/sync_activity_adapter.py:116` | Fires per recipient per entry |
+| `store_embedded_participants: stored participant 'UUID'` | `vultron/core/use_cases/received/case/_helpers.py:92` | Fires per participant on every case announcement |
+| `SeedAnnouncedCaseNode: case already exists locally — skipping save` | `vultron/core/behaviors/case/nodes/announce.py:78` | Routine idempotency skip |
+| `Activity UUID already received by actor; ignoring duplicate submission` | `vultron/adapters/driving/fastapi/routers/actors/_routes.py:365` | Normal sync protocol behaviour |
+| `discover_actors()` full actor JSON at INFO | `vultron/demo/utils.py:280,283,286` | Only the ID is useful; full dump → DEBUG |
+
+---
+
+## Missing INFO Messages to Add (SL-04-001 violations)
+
+These state transitions happened with no INFO output as of CONCERN-1968.
+
+| Domain | Message to add | Location |
+|---|---|---|
+| RM per-participant | `Actor '<id>' RM: <A> → <B> for case '<case_id>'` | BT nodes that write `ParticipantStatus` with a new RM state |
+| CS/VFD | `Actor '<id>' CS: <vfd_before> → <vfd_after> (<event>) for case '<case_id>'` | BT nodes for fix-ready, fix-deployed |
+| CS/PXA | `Actor '<id>' CS: <pxa_before> → <pxa_after> (<event>) for case '<case_id>'` | BT nodes for publish |
+| Case engagement | `Actor '<id>' engaged case '<case_id>' (RM VALID → ACCEPTED)` | engage-case trigger BT |
+| EM PROPOSED→ACTIVE | `Actor '<id>' embargo PROPOSED → ACTIVE for case '<case_id>'` | embargo-accept BT when all signatories have accepted |
+| EM ACTIVE→TERMINATED | `Actor '<id>' embargo ACTIVE → TERMINATED for case '<case_id>'` | embargo-terminate BT |
+| Invite receipt | `Actor '<id>' received case invite for '<case_id>' from '<sender>'` | received-invite use case / BT |
+| BT FAILURE reason | `Actor '<id>' BT execution FAILURE for case '<case_id>': <reason>` | `BTBridge.execute_with_setup` (non-SUCCESS path) |
+
+---
+
+## Implementation Guidance
+
+### Where to add new log lines
+
+Add them in the **BT leaf node** that performs the state write, not in the
+use-case `execute()` wrapper. This mirrors the existing embargo proposal
+pattern (`AdvanceEMStateToProposedNode` etc.) and keeps protocol-significant
+logging co-located with the protocol-significant action.
+
+Use `self.logger.info(...)` (on `DataLayerAction`) or `logger.info(...)` from
+a module-level logger. Include `actor_id` and `case_id` in every message.
+
+### Grep check after refactor
+
+After any bulk logging-level change, always run:
+
+```bash
+grep -rn "logger\.info.*DataLayer stored\|logger\.info.*DataLayer saved\|logger\.info.*BT structure\|logger\.info.*Processing outbox" vultron/
+```
+
+If any hits remain, they are regressions.
+
+### `discover_actors()` — trim to ID only
+
+```python
+# Before
+logger.info(f"Found finder actor: {logfmt(finder)}")
+# After
+logger.info("Found finder actor: %s", finder.get("id", "<unknown>"))
+```
+
+Full actor JSON (all fields) belongs at DEBUG.
+
+---
+
+## Relationship to SL specs
+
+| Spec | Rule |
+|---|---|
+| SL-04-001 | All state transitions MUST be logged at INFO — the missing messages above violate this |
+| SL-04-006 | Narrative template SHOULD; see table above |
+| SL-04-007 | Infrastructure patterns MUST NOT be at INFO; see demotion list above |

--- a/notes/structured-logging.md
+++ b/notes/structured-logging.md
@@ -75,7 +75,7 @@ MUST be at DEBUG or lower. Verify with a grep after any bulk refactor.
 | `store_embedded_participants: stored participant 'UUID'` | `vultron/core/use_cases/received/case/_helpers.py:92` | Fires per participant on every case announcement |
 | `SeedAnnouncedCaseNode: case already exists locally — skipping save` | `vultron/core/behaviors/case/nodes/announce.py:78` | Routine idempotency skip |
 | `Activity UUID already received by actor; ignoring duplicate submission` | `vultron/adapters/driving/fastapi/routers/actors/_routes.py:365` | Normal sync protocol behaviour |
-| `discover_actors()` full actor JSON at INFO | `vultron/demo/utils.py:280,283,286` | Only the ID is useful; full dump → DEBUG |
+| `discover_actors()` full logfmt() actor object at INFO | `vultron/demo/utils.py:280,283,286` | logfmt() actor object output at INFO; only the ID is meaningful — full formatted object → DEBUG |
 
 ---
 
@@ -127,7 +127,8 @@ logger.info(f"Found finder actor: {logfmt(finder)}")
 logger.info("Found finder actor: %s", finder.get("id", "<unknown>"))
 ```
 
-Full actor JSON (all fields) belongs at DEBUG.
+Full `logfmt()` actor object output belongs at DEBUG; only the actor ID is
+meaningful at INFO.
 
 ---
 

--- a/plan/history/2608/learning/CONCERN-1968.md
+++ b/plan/history/2608/learning/CONCERN-1968.md
@@ -1,0 +1,42 @@
+---
+source: CONCERN-1968
+timestamp: '2026-08-05T17:34:11.513526+00:00'
+title: Actor container INFO logs are too noisy to narrate the case story; key CVD
+  state transitions are missing or buried
+type: learning
+---
+
+## Summary
+
+At INFO level, actor container logs are dominated by persistence plumbing
+(`DataLayer stored/saved`), BT scaffolding (BT structure printout on every
+execution), and protocol bookkeeping echoes (pipeline outcome, outbox
+preambles, EM FSM callback lifecycle lines), making it impossible to "get
+the story of the case from the actor's perspective." Simultaneously, the
+most meaningful CVD milestones — RM state transitions per participant,
+CS/VFD state changes (fix, deploy, publish), embargo lifecycle beyond
+initial proposal, and case engagement — are either absent at INFO or only
+visible buried inside DEBUG-level `PersistLogEntry` JSON payloads.
+
+## Root Cause
+
+INFO and DEBUG levels were assigned based on where code is convenient to
+instrument, not based on "what would a reader need to follow the protocol
+story." The result is two failures: high-volume infrastructure lines at
+INFO that a reader must filter mentally, and missing narrative lines for
+the exact events that matter most to understanding what the protocol is
+doing.
+
+## Resolution
+
+Two-pass remediation tracked in #1988:
+
+1. Demote ~10 infrastructure INFO patterns to DEBUG (SL-04-007)
+2. Add ~8 missing INFO messages for CVD milestones following the
+   `"Actor X did Y on case Z (STATE_A → STATE_B)"` template (SL-04-001,
+   SL-04-006)
+
+**Resolved**: 2026-08-05 — implementation tracked in #1988.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1987>.
+Spec: `specs/structured-logging.yaml` (SL-04-006, SL-04-007).
+Notes: `notes/structured-logging.md`.

--- a/specs/structured-logging.yaml
+++ b/specs/structured-logging.yaml
@@ -3,7 +3,7 @@ title: Structured Logging Requirements
 description: >-
   Logging requirements for the Vultron API, covering log format, correlation IDs, log levels,
   state transition logging, error context, and authorization and data-access audit records.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -85,6 +85,24 @@ groups:
     kind: project
     statement: >-
       Demo scripts and stepwise workflows SHOULD use structured, consistent lifecycle logs
+  - id: SL-04-006
+    priority: SHOULD
+    kind: project
+    statement: >-
+      State transition log messages SHOULD follow the narrative template
+      "Actor '<actor_id>' <verb> '<object_id>' (<STATE_A> → <STATE_B>)" so
+      that reading an actor's INFO log tells the complete protocol story
+      without requiring DEBUG. See notes/structured-logging.md for the
+      full template inventory and the list of infrastructure patterns that
+      MUST be demoted to DEBUG.
+  - id: SL-04-007
+    priority: MUST
+    kind: project
+    statement: >-
+      Infrastructure log lines (persistence store/save/update, BT scaffolding,
+      HTTP handler parsing echoes, pipeline completion repeats, FSM internal
+      callbacks, per-recipient sync queue entries) MUST NOT be logged at INFO;
+      they MUST be logged at DEBUG or lower.
 - id: SL-05
   title: Error Context
   specs:


### PR DESCRIPTION
- Closes #1968

## Summary

Plans CONCERN-1968: actor container INFO logs are dominated by infrastructure
noise while key CVD state transitions (RM/CS/EM) emit no INFO output. Adds a
spec contract and durable notes so the implementation issue has a clear target.

## Changes

- **`specs/structured-logging.yaml`**: added SL-04-006 (narrative template
  SHOULD: `Actor '<id>' <verb> '<object_id>' (A → B)`) and SL-04-007
  (infrastructure patterns MUST NOT be at INFO); bumped version 1.0.0 → 1.1.0
- **`notes/structured-logging.md`**: new file — full demotion list (~10
  infrastructure patterns with file/line refs), missing INFO message inventory
  (~8 state transitions violating SL-04-001), approved verb-template table,
  grep-check guidance
- **`notes/README.md`**: added load-when entry for the new notes file

## Implementation Issues

- #1988