### PR TITLE
docs: plan issue #1967 — demo CI barrier decision and DEMOCI-06 coverage spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ plan/data/
 
 # graphify knowledge graph output
 graphify-out/
+.DS_Store

--- a/docs/adr/0052-demo-ci-job-structure-barrier-accepted.md
+++ b/docs/adr/0052-demo-ci-job-structure-barrier-accepted.md
@@ -1,0 +1,103 @@
+---
+status: accepted-provisional
+date: 2026-08-05
+deciders: Allen D. Householder
+consulted: []
+informed: []
+---
+
+# Demo CI Job Structure: Accept Barrier + Concurrency Group Over Job Consolidation
+
+## Context and Problem Statement
+
+`demo-integration.yml` runs 7 demo scenarios and 7 invariant-harness jobs as
+two GitHub Actions matrix blocks. The invariant-harness job declares
+`needs: demo`, which — per GitHub Actions semantics — creates a **full fan-in
+barrier**: every invariant job must wait for the slowest of all 7 demo jobs
+before any invariant job can start. The actual logical dependency is pairwise
+(fv-invariant depends only on fv-demo, not on fvcv-handoff-demo), so the
+barrier introduces systematic lag proportional to the variance in demo scenario
+runtimes.
+
+Three structural options were evaluated for eliminating or reducing this lag.
+
+## Decision Drivers
+
+- DEMOCI-04-001: invariant failures MUST produce a **separate, independent
+  pass/fail status** on the PR, visible even when the demo job fails.
+- DEMOCI-02-011: the workflow MUST define a `concurrency` group to cancel
+  superseded PR runs — this is an unimplemented MUST already in spec.
+- Workflow maintainability: the YAML must remain easy to add new scenarios to.
+- GitHub Actions platform constraints: `needs:` on a matrix job name waits for
+  **all** entries of that matrix, with no native pairwise-dependency syntax.
+
+## Considered Options
+
+- **Option A — Merge demo + invariant into one job per matrix entry** (single
+  13-step matrix job that runs both the demo and pytest inline)
+- **Option B — Expand to 14 named jobs** (replace both matrix blocks with 14
+  individually-named jobs so each invariant job can `needs:` its specific demo
+  job by name)
+- **Option C — Accept barrier, add concurrency group** (keep the current
+  two-matrix structure; implement the already-specified DEMOCI-02-011
+  concurrency block that was never wired in; eliminate the pairwise ordering
+  problem by cancelling superseded PR runs early)
+
+## Decision Outcome
+
+Chosen option: **Option C — Accept barrier, add concurrency group**, because:
+
+- Option A violates DEMOCI-04-001: merging both steps into one job collapses
+  the two independent pass/fail statuses into one. A reviewer can no longer
+  distinguish "demo passed, invariant failed" from "demo failed" — exactly the
+  failure mode that motivated the separate-job design.
+- Option B achieves pairwise ordering but multiplies YAML maintenance cost
+  14×. Every new scenario requires two new named jobs; the YAML grows
+  non-linearly and there is no matrix inheritance to DRY it. Additionally,
+  even with named pairwise `needs:`, GitHub Actions does not guarantee that
+  artifact uploads from a named job are visible to its dependent before the
+  dependent starts; the download-artifact step already handles this correctly.
+- Option C recovers the most impactful practical improvement: on active PR
+  branches, every push cancels the prior queued run, so the accumulated
+  "all 7 demo jobs must finish before any invariant job starts" wall-clock cost
+  only occurs **once per PR commit**, not for every intermediate push. The
+  `cancel-in-progress: false` on main-branch runs preserves per-commit signals.
+
+This decision is **accepted-provisional** because the scenario coverage split
+(minimum PR validation set vs. full post-merge set) is not yet designed or
+validated. When DEMOCI-06 is implemented — defining a minimum PR set and a
+full post-merge set — this ADR should be revised to reflect whether the reduced
+PR scenario set further mitigates the barrier impact.
+
+### Consequences
+
+- Good, because DEMOCI-02-011 (a MUST that was never implemented) is closed.
+- Good, because superseded PR runs are cancelled, recovering CI minutes on
+  active branches and giving faster per-commit feedback.
+- Good, because the two-matrix structure is preserved and new scenarios require
+  only two new matrix entries (one per block) per DEMOCI-03-004.
+- Good, because DEMOCI-04-001's separate pass/fail signals are fully preserved.
+- Neutral, because the fan-in barrier persists structurally on individual
+  commits; it only manifests as lag when a PR push is not superseded by a
+  later push.
+- Bad, because genuinely pairwise dependency cannot be expressed in GitHub
+  Actions without Option B's YAML explosion.
+
+## Validation
+
+The concurrency block (DEMOCI-02-011) is verifiable by inspection of
+`demo-integration.yml`. The behaviour (cancel superseded PR runs, never cancel
+main-branch runs) is validated by observing CI behaviour on a PR with multiple
+rapid pushes.
+
+## More Information
+
+- Source concern: CERTCC/Vultron#1967
+- Related implementation issue: CERTCC/Vultron#1862
+  (push-to-main trigger + concurrency + cache-warm removal)
+- DEMOCI spec: `specs/demo-ci.yaml` DEMOCI-02-011, DEMOCI-05
+- Follow-on: CERTCC/Vultron#1794 epic — scenario coverage analysis will
+  determine whether a minimum PR validation set can reduce the number of matrix
+  entries that participate in the barrier, further reducing worst-case lag.
+- Generated spec requirements: `specs/demo-ci.yaml` DEMOCI-06 (to be added
+  when the scenario coverage split is designed).

--- a/docs/adr/0052-demo-ci-job-structure-barrier-accepted.md
+++ b/docs/adr/0052-demo-ci-job-structure-barrier-accepted.md
@@ -99,5 +99,4 @@ rapid pushes.
 - Follow-on: CERTCC/Vultron#1794 epic — scenario coverage analysis will
   determine whether a minimum PR validation set can reduce the number of matrix
   entries that participate in the barrier, further reducing worst-case lag.
-- Generated spec requirements: `specs/demo-ci.yaml` DEMOCI-06 (to be added
-  when the scenario coverage split is designed).
+- Generated spec requirements: `specs/demo-ci.yaml` DEMOCI-06-001 through DEMOCI-06-003.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -121,6 +121,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0049 Core Does Not Model Inbound Protocol Error Message Types; No `create_inbound_error_followup_tree`](0049-core-does-not-model-error-message-types.md)
 - [ADR-0050 Leave(VulnerabilityCase) Is the Canonical RM Case Closure Mechanism](0050-leave-vul-case-canonical-rm-closure.md)
 - [ADR-0051 CaseActor Has Its Own RM Lifecycle Tracked via CaseParticipant](0051-caseactor-rm-lifecycle.md)
+- [ADR-0052 Demo CI Job Structure: Accept Barrier + Concurrency Group Over Job Consolidation](0052-demo-ci-job-structure-barrier-accepted.md) *(provisional)*
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -269,6 +269,7 @@ nav:
       - No Core Error Message Types or Error-Followup Factory: 'adr/0049-core-does-not-model-error-message-types.md'
       - Leave(VulnerabilityCase) Is the Canonical RM Closure Mechanism: 'adr/0050-leave-vul-case-canonical-rm-closure.md'
       - CaseActor Has Its Own RM Lifecycle via CaseParticipant: 'adr/0051-caseactor-rm-lifecycle.md'
+      - Demo CI Job Structure — Accept Barrier and Concurrency Group: 'adr/0052-demo-ci-job-structure-barrier-accepted.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/plan/history/2608/learning/CONCERN-1967.md
+++ b/plan/history/2608/learning/CONCERN-1967.md
@@ -1,0 +1,47 @@
+---
+source: CONCERN-1967
+timestamp: '2026-08-05T17:52:33.643926+00:00'
+title: 'Demo CI pipeline is structurally inefficient: forced barrier between demo
+  and invariant-harness jobs inflates PR wait time'
+type: learning
+---
+
+## Summary
+
+The demo CI pipeline (`demo-integration.yml`) imposes a full fan-in barrier
+between the `demo` matrix and the `invariant-harness` matrix (`needs: demo`),
+forcing every invariant job to wait for the slowest demo job before any
+invariant job can start. The actual dependency is pairwise (fv→fv,
+fvcv-handoff→fvcv-handoff, etc.), so the barrier introduces systematic lag
+proportional to the variance in demo scenario runtimes. Beyond the structural
+issue, the demo set may contain redundant coverage (simpler scenarios
+exercising subsets of more complex ones), and unconditional triggering means
+every PR touching `vultron/**` pays the full matrix cost regardless of whether
+the change could affect demo scenarios at all.
+
+Three independent inefficiency sources were identified and resolved to separate
+implementation tracks:
+
+1. **Fan-in barrier** — GitHub Actions has no native pairwise
+   matrix-to-matrix `needs:` syntax. Merging jobs into one (Option A) was
+   rejected because it loses the independent DEMOCI-04 pass/fail status
+   signals. Expanding to 14 named jobs (Option B) was rejected because YAML
+   maintenance cost grows 14× with no pairwise artifact ordering guarantee.
+   The chosen approach (Option C) accepts the structural barrier and
+   implements the missing DEMOCI-02-011 concurrency group, so superseded PR
+   runs are cancelled — recovering the most common wasted-wait scenario.
+   See ADR-0052.
+
+2. **Scenario coverage redundancy** — A coverage matrix analysis is required
+   to determine the minimum PR validation set vs. the full post-merge set.
+   Milestone sets may have been copied across scenarios and may under-report
+   what each scenario actually exercises. Tracked in #1996.
+
+3. **Path filter over-triggering** — The `vultron/**` path filter may trigger
+   the full matrix on type-annotation or docstring-only changes. Tracked in
+   #1997.
+
+**Resolved**: 2026-08-05 — implementation tracked in #1862, #1996, #1997.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1995>.
+Spec: `specs/demo-ci.yaml` DEMOCI-06-001 through DEMOCI-06-003.
+ADR: `docs/adr/0052-demo-ci-job-structure-barrier-accepted.md`.

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -480,3 +480,67 @@ groups:
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-05-001
+
+  - id: DEMOCI-06
+    title: Demo Scenario Coverage Model — PR Validation Set vs. Full Post-Merge Set
+    specs:
+      - id: DEMOCI-06-001
+        priority: MUST
+        kind: project
+        statement: >-
+          A scenario coverage analysis MUST be performed that maps each of the
+          7 demo scenarios to the distinct Vultron protocol phases and
+          message-type milestones it exercises, producing a coverage matrix.
+          The analysis MUST inspect the actual milestone sets defined in each
+          scenario script (not assume they are complete), and MAY update
+          scenario milestone sets where copy-paste from simpler scenarios has
+          left them incomplete.
+        rationale: >-
+          The 7 scenarios share common helper phases but each exercises a
+          distinct set of protocol phases (e.g. invite_actor_to_case,
+          offer_case_participant, accept_invite_actor_to_case). Milestone sets
+          were often copied from simpler scenarios and may under-report what a
+          scenario actually exercises. A complete per-scenario coverage matrix
+          is prerequisite to designing a minimum PR validation set.
+        relationships:
+          - rel_type: implements
+            spec_id: DEMOCI-03-001
+          - rel_type: refines
+            spec_id: DEMOCI-04-004
+
+      - id: DEMOCI-06-002
+        priority: MUST
+        kind: project
+        statement: >-
+          Based on the coverage matrix (DEMOCI-06-001), a minimum PR validation
+          scenario set MUST be defined: the smallest subset of scenarios that
+          together covers all distinct protocol phases exercised by the full
+          scenario suite. Scenarios not in the minimum set SHOULD run only on
+          the post-merge (push-to-main) trigger, reducing the PR matrix size
+          and thus the fan-in barrier wall-clock cost.
+        rationale: >-
+          Running all scenarios on every PR commit incurs a fan-in barrier
+          proportional to the slowest scenario. A minimum set that preserves
+          full protocol coverage lets the PR run faster while the post-merge
+          run retains full coverage for regression detection. See ADR-0052.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-06-001
+
+      - id: DEMOCI-06-003
+        priority: MUST
+        kind: project
+        statement: >-
+          The full scenario suite MUST continue to run on push events to main
+          (DEMOCI-05-001), regardless of which subset runs for PR validation,
+          so that all scenario variants continue to generate case-log invariant
+          signals on the default branch.
+        rationale: >-
+          The post-merge run is the safety net for cross-PR regressions; it
+          must cover all scenarios to ensure no scenario silently degrades after
+          its covered phases are removed from the PR validation set.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-06-002
+          - rel_type: refines
+            spec_id: DEMOCI-05-001


### PR DESCRIPTION
- Closes #1967

## Summary

Documents the three-way architectural decision for the demo CI fan-in barrier
(ADR-0052) and adds DEMOCI-06 spec requirements for scenario coverage analysis
and a minimum PR validation set.

## Changes

- **`docs/adr/0052-demo-ci-job-structure-barrier-accepted.md`**: New ADR
  recording the decision to accept the GHA `needs:` fan-in barrier and add the
  missing DEMOCI-02-011 concurrency group, over the two rejected alternatives
  (merge jobs into one — loses DEMOCI-04 independent status signals; expand to
  14 named jobs — YAML explosion with no pairwise artifact ordering guarantee).
  Status: `accepted-provisional` pending DEMOCI-06 scenario coverage split.
- **`docs/adr/index.md`**: Add ADR-0052 entry under Accepted ADRs.
- **`mkdocs.yml`**: Add ADR-0052 to docs nav.
- **`specs/demo-ci.yaml`**: Add DEMOCI-06 spec group (DEMOCI-06-001..003)
  requiring a scenario coverage analysis, a minimum PR validation set, and
  preservation of the full scenario suite on post-merge (push-to-main) runs.

## Implementation Issues
- #1862 (re-parented to this epic — push-to-main trigger + concurrency group)
- #1996 (new — scenario coverage analysis and minimum PR validation set)
- #1997 (new — path filter audit and tightening)