### PR TITLE
fix: RejectInviteActorToCase — resolve case_id from inner_target_id

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1973.md
+++ b/plan/history/2608/implementation/ISSUE-1973.md
@@ -1,0 +1,20 @@
+---
+source: ISSUE-1973
+timestamp: '2026-08-05T17:51:42.373539+00:00'
+title: 'fix: RejectInviteActorToCase — resolve case_id from inner_target_id'
+type: implementation
+---
+
+## Issue #1973 — fix: RejectInviteActorToCase — resolve case_id from inner_target_id
+
+Fixed a silent bug where `RejectInviteActorToCaseReceivedUseCase.execute()` was reading `request.target_id` (always `None` for `Reject(Invite(actor, case))`) instead of `request.inner_target_id`. The use case was early-returning without committing the canonical `Reject(Invite)` ledger entry.
+
+Changes:
+
+- Added `case_id` property to `RejectInviteActorToCaseReceivedEvent` returning `self.inner_target_id`
+- Fixed `execute()` to use `request.case_id` instead of `request.target_id`
+- Added `include_activity=True` to the semantic registry entry so the wire activity is populated (required for `payloadSnapshot.actor` validation)
+- Narrowed `activity` field to required on the event class
+- Replaced "skips ledger" test with real integration test confirming CaseLedgerEntry is committed
+
+PR: <https://github.com/CERTCC/Vultron/pull/1998>

--- a/test/core/models/events/test_event_property_aliases.py
+++ b/test/core/models/events/test_event_property_aliases.py
@@ -260,8 +260,12 @@ _CASES = [
     (
         RejectInviteActorToCaseReceivedEvent,
         MessageSemantics.REJECT_INVITE_ACTOR_TO_CASE,
-        {"object_": _activity},
-        [("invite_id", "object_id"), ("invite", "object_")],
+        {"object_": _activity, "activity": _activity, "inner_target": _case},
+        [
+            ("invite_id", "object_id"),
+            ("invite", "object_"),
+            ("case_id", "inner_target_id"),
+        ],
     ),
     # ── case_participant.py ───────────────────────────────────────────────────
     (

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -124,61 +124,87 @@ class TestInviteActorUseCases:
         stored = dl.get(invite.type_.value, invite.id_)
         assert stored is not None
 
-    def test_reject_invite_actor_to_case_ledgers_rejection(self, make_payload):
-        """RejectInviteActorToCaseReceivedUseCase logs without raising."""
-        invite = rm_invite_to_case_activity(
-            as_Actor(id_="https://example.org/users/coordinator"),
-            target="https://example.org/cases/case1",
-            actor="https://example.org/users/owner",
-            id_="https://example.org/cases/case1/invitations/3",
-        )
-        reject = rm_reject_invite_to_case_activity(
-            invite,
-            actor="https://example.org/users/coordinator",
-        )
-
-        event = make_payload(reject)
-
-        result = RejectInviteActorToCaseReceivedUseCase(
-            MagicMock(), event
-        ).execute()
-        assert result is None
-
-    def test_reject_invite_skips_ledger_when_target_id_absent(
+    def test_reject_invite_actor_to_case_commits_ledger_entry(
         self, make_payload
     ):
-        """RejectInviteActorToCaseReceivedUseCase returns without error when case_id cannot be resolved.
+        """RejectInviteActorToCaseReceivedUseCase commits a CaseLedgerEntry (AC-3).
 
         Reject(Invite(actor, case)) carries the case reference in the nested
-        Invite's ``target`` field, not at the top-level ``target`` of the
-        Reject.  ``extract_event`` populates ``inner_target`` but not ``target``,
-        so ``request.target_id`` is None and the use case short-circuits.
-        This is tracked as a known gap to be addressed separately.
+        Invite's ``target`` field (``inner_target_id``), not the top-level
+        ``target`` of the Reject.  CM-11-003: use ``request.case_id`` which
+        reads ``inner_target_id``.
         """
-        from unittest.mock import MagicMock
-
-        invite = rm_invite_to_case_activity(
-            as_Actor(id_="https://example.org/users/coordinator"),
-            target=VulnerabilityCaseStub(
-                id_="https://example.org/cases/case-ri1"
-            ),
-            actor="https://example.org/users/owner",
-            id_="https://example.org/cases/case-ri1/invitations/3",
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.models.case_ledger_entry import (
+            CaseLedgerEntry as WireCaseLedgerEntry,
         )
+        from vultron.enums.roles import CVDRole
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            as_CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_id = "https://example.org/cases/case-reject-ri1"
+        case_actor_id = f"{case_id}/actor"
+        invitee_id = "https://example.org/users/coordinator"
+
+        case = as_VulnerabilityCase(
+            id_=case_id,
+            name="TEST-REJECT-INVITE",
+            attributed_to=case_actor_id,
+        )
+        case_manager_participant = as_CaseParticipant(
+            id_=f"{case_id}/participants/case-actor-p",
+            attributed_to=case_actor_id,
+            context=case_id,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        case.case_participants.append(case_manager_participant.id_)
+        case.actor_participant_index[case_actor_id] = (
+            case_manager_participant.id_
+        )
+        invite = rm_invite_to_case_activity(
+            as_Actor(id_=invitee_id),
+            target=VulnerabilityCaseStub(id_=case_id),
+            actor=case_actor_id,
+            id_=f"{case_id}/invitations/1",
+        )
+        dl.create(case_manager_participant)
+        dl.create(case)
+        dl.create(invite)
+
         reject = rm_reject_invite_to_case_activity(
             invite,
-            actor="https://example.org/users/coordinator",
+            actor=invitee_id,
         )
-
         event = make_payload(reject)
+
         assert (
             event.target_id is None
         ), "Precondition: Reject(Invite) has no top-level target"
+        assert (
+            event.case_id == case_id
+        ), "Precondition: case_id resolves via inner_target_id"
 
-        result = RejectInviteActorToCaseReceivedUseCase(
-            MagicMock(), event
+        RejectInviteActorToCaseReceivedUseCase(
+            dl,
+            event.model_copy(update={"receiving_actor_id": case_actor_id}),
         ).execute()
-        assert result is None
+
+        entries = [
+            e
+            for e in dl.list_objects("CaseLedgerEntry")
+            if isinstance(e, WireCaseLedgerEntry) and e.case_id == case_id
+        ]
+        assert (
+            len(entries) >= 1
+        ), "Expected at least one CaseLedgerEntry after reject-invite"
+        assert any(
+            "reject" in e.event_type for e in entries
+        ), f"Expected a reject-invite ledger entry; got: {[e.event_type for e in entries]}"
 
     def test_accept_invite_actor_to_case_adds_participant(
         self, monkeypatch, make_payload

--- a/vultron/core/models/events/actor.py
+++ b/vultron/core/models/events/actor.py
@@ -173,6 +173,7 @@ class RejectInviteActorToCaseReceivedEvent(VultronEvent):
     semantic_type: Literal[MessageSemantics.REJECT_INVITE_ACTOR_TO_CASE] = (
         MessageSemantics.REJECT_INVITE_ACTOR_TO_CASE
     )
+    activity: VultronActivity  # pyright: ignore[reportGeneralTypeIssues]
 
     @property
     def invite_id(self) -> str | None:
@@ -181,6 +182,10 @@ class RejectInviteActorToCaseReceivedEvent(VultronEvent):
     @property
     def invite(self) -> "VultronActivity | None":
         return cast("VultronActivity | None", self.object_)
+
+    @property
+    def case_id(self) -> str | None:
+        return self.inner_target_id
 
 
 class AnnounceVulnerabilityCaseReceivedEvent(VultronEvent):

--- a/vultron/core/use_cases/received/actor/invite.py
+++ b/vultron/core/use_cases/received/actor/invite.py
@@ -226,7 +226,7 @@ class RejectInviteActorToCaseReceivedUseCase:
             request.actor_id,
             request.invite_id,
         )
-        case_id = request.target_id or ""
+        case_id = request.case_id or ""
         if not case_id:
             logger.warning(
                 "RejectInviteActorToCase: missing case_id for invite '%s'"

--- a/vultron/semantic_registry/actor.py
+++ b/vultron/semantic_registry/actor.py
@@ -219,6 +219,7 @@ ENTRIES: list[SemanticEntry] = [
         use_case_class=RejectInviteActorToCaseReceivedUseCase,
         phrase="{actor} declined the case invitation",
         wire_activity_class=_RmRejectInviteToCaseActivity,
+        include_activity=True,
     ),
     SemanticEntry(
         semantics=MessageSemantics.ANNOUNCE_VULNERABILITY_CASE,


### PR DESCRIPTION
- Closes #1973

## Summary

Fixes `RejectInviteActorToCaseReceivedUseCase` which was silently skipping the
canonical ledger commit because it read `request.target_id` (always `None` for
`Reject(Invite(actor, case))`) instead of `request.inner_target_id` where the
case reference actually lives (CM-11-003).

## Changes

- **`vultron/core/models/events/actor.py`**: Add `case_id` property to `RejectInviteActorToCaseReceivedEvent` returning `self.inner_target_id` (parallel to `AcceptInviteActorToCaseReceivedEvent.case_id`). Narrow `activity` field to required so the payload snapshot has a valid `actor` URI for ledger validation.
- **`vultron/core/use_cases/received/actor/invite.py`**: Change `execute()` to use `request.case_id` instead of `request.target_id`.
- **`vultron/semantic_registry/actor.py`**: Add `include_activity=True` to the `REJECT_INVITE_ACTOR_TO_CASE` registry entry so the wire activity is populated on the event (required for `payloadSnapshot.actor` validation in `CreateLogEntryNode`).
- **`test/core/use_cases/received/actor/test_invite.py`**: Replace the old "skips ledger" test (which documented the broken behaviour) with a real integration test that seeds a case with a CASE_MANAGER participant and asserts a `CaseLedgerEntry` with `event_type` containing "reject" is committed.
- **`test/core/models/events/test_event_property_aliases.py`**: Extend `RejectInviteActorToCaseReceivedEvent` alias test to cover `case_id → inner_target_id` and supply the now-required `activity` field.

## Verification

- 54 targeted tests pass (1 new integration test replaces 2 old tests)
- Full suite passes (pre-commit hooks: black, flake8 — all clean)
- mypy: no issues in 1152 source files
- pyright: 0 errors, 0 warnings