### PR TITLE
feat(bt): create_deploy_tree combinator factory (BT-20-005)

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1985.md
+++ b/plan/history/2608/implementation/ISSUE-1985.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1985
+timestamp: '2026-08-05T18:50:01.586693+00:00'
+title: create_deploy_tree combinator factory (BT-20-005)
+type: implementation
+---
+
+## Issue #1985 — create_deploy_tree combinator factory (BT-20-005 SHOULD)
+
+Added `create_deploy_tree(case_id, actor_id, fix_call_out, mitigation_call_out)` in `vultron/core/behaviors/report/deploy_tree.py`. Composes `create_deploy_fix_tree` (preferred fix arm) and `create_deploy_mitigation_tree` (mitigation fallback) into a `DeployOrMitigateBT` Selector, satisfying spec requirement BT-20-005 SHOULD.
+
+14 unit tests added in `test/core/behaviors/report/test_deploy_tree.py` covering tree structure (AC-1), factory delegation (AC-2), bundle forwarding, and deterministic defaults (AC-3).
+
+Follow-up issue #2002 created for tick-level Fallback ordering integration tests (DataLayer fixture required).
+
+PR: <https://github.com/CERTCC/Vultron/pull/2003>

--- a/test/core/behaviors/report/test_deploy_tree.py
+++ b/test/core/behaviors/report/test_deploy_tree.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the deploy-tree combinator factory (issue #1985, BT-20-005).
+
+Covers all acceptance criteria:
+
+- AC-1: ``deploy_tree.py`` with ``create_deploy_tree(case_id, actor_id,
+  fix_call_out, mitigation_call_out)`` building a ``DeployOrMitigateBT``
+  Fallback with the fix arm first.
+- AC-2: Fix arm delegates to ``create_deploy_fix_tree``; mitigation arm
+  delegates to ``create_deploy_mitigation_tree``.
+- AC-3: Unit tests covering tree structure and factory delegation.
+"""
+
+import py_trees
+
+from vultron.core.behaviors.call_out.bundles.deploy_fix import (
+    DEPLOY_FIX_DETERMINISTIC,
+    DeployFixCallOutBundle,
+)
+from vultron.core.behaviors.call_out.bundles.deploy_mitigation import (
+    DEPLOY_MITIGATION_DETERMINISTIC,
+    DeployMitigationCallOutBundle,
+)
+from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.report.deploy_fix_tree import (
+    create_deploy_fix_tree,
+)
+from vultron.core.behaviors.report.deploy_mitigation_tree import (
+    create_deploy_mitigation_tree,
+)
+from vultron.core.behaviors.report.deploy_tree import create_deploy_tree
+
+CASE_ID = "https://example.org/cases/test-deploy-combinator-001"
+ACTOR_ID = "https://example.org/actors/deployer-combinator-001"
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Tree structure — root is Fallback named "DeployOrMitigateBT" with 2 arms
+# ---------------------------------------------------------------------------
+
+
+def test_create_deploy_tree_returns_behaviour():
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_create_deploy_tree_root_name():
+    """Root Fallback is named 'DeployOrMitigateBT' (AC-1)."""
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    assert tree.name == "DeployOrMitigateBT"
+
+
+def test_tree_root_is_fallback():
+    """Root node is a py_trees Selector (Fallback) (AC-1)."""
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    assert isinstance(tree, py_trees.composites.Selector)
+
+
+def test_tree_has_exactly_two_arms():
+    """DeployOrMitigateBT has exactly two children: fix arm then mitigation arm (AC-1)."""
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    assert len(tree.children) == 2
+
+
+def test_fix_arm_is_first():
+    """Fix arm (DeployFixBT) is child[0] — preferred over mitigation (AC-1)."""
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    assert tree.children[0].name == "DeployFixBT"
+
+
+def test_mitigation_arm_is_second():
+    """Mitigation arm (DeployMitigationBT) is child[1] — fallback (AC-1)."""
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    assert tree.children[1].name == "DeployMitigationBT"
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Fix arm delegates to create_deploy_fix_tree;
+#        mitigation arm delegates to create_deploy_mitigation_tree
+# ---------------------------------------------------------------------------
+
+
+def test_fix_arm_matches_standalone_deploy_fix_tree():
+    """Fix arm has the same structure as a standalone create_deploy_fix_tree (AC-2)."""
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    standalone = create_deploy_fix_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    assert tree.children[0].name == standalone.name
+    assert len(tree.children[0].children) == len(standalone.children)
+
+
+def test_mitigation_arm_matches_standalone_deploy_mitigation_tree():
+    """Mitigation arm has the same structure as a standalone create_deploy_mitigation_tree (AC-2)."""
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    standalone = create_deploy_mitigation_tree(
+        case_id=CASE_ID, actor_id=ACTOR_ID
+    )
+    assert tree.children[1].name == standalone.name
+    assert len(tree.children[1].children) == len(standalone.children)
+
+
+# ---------------------------------------------------------------------------
+# AC-2 / AC-3: Bundle injection — fix_call_out and mitigation_call_out are forwarded
+# ---------------------------------------------------------------------------
+
+
+def test_fix_call_out_bundle_forwarded_to_fix_arm():
+    """fix_call_out bundle is forwarded to the fix arm (AC-2)."""
+    sentinel = {"called": False}
+
+    def custom_deploy_fix(name: str) -> py_trees.behaviour.Behaviour:
+        sentinel["called"] = True
+        return AlwaysSucceed(name)
+
+    bundle = DeployFixCallOutBundle(
+        deploy_fix_factory=custom_deploy_fix,  # type: ignore[arg-type]
+    )
+    create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID, fix_call_out=bundle)
+    assert sentinel["called"]
+
+
+def test_mitigation_call_out_bundle_forwarded_to_mitigation_arm():
+    """mitigation_call_out bundle is forwarded to the mitigation arm (AC-2)."""
+    sentinel = {"called": False}
+
+    def custom_mitigation_deployed(name: str) -> py_trees.behaviour.Behaviour:
+        sentinel["called"] = True
+        return AlwaysFail(name)
+
+    bundle = DeployMitigationCallOutBundle(
+        mitigation_deployed_factory=custom_mitigation_deployed,  # type: ignore[arg-type]
+    )
+    create_deploy_tree(
+        case_id=CASE_ID, actor_id=ACTOR_ID, mitigation_call_out=bundle
+    )
+    assert sentinel["called"]
+
+
+def test_default_bundles_are_deterministic_singletons():
+    """Default call_out=None uses DETERMINISTIC singletons for both arms (AC-3).
+
+    Checks only what the combinator owns: that the fix arm contains a
+    "DeployFix" node backed by AlwaysFail (p=0.10 ceiling) and the mitigation
+    arm's first child is named "MitigationDeployed" and is AlwaysFail
+    (p=0.25 floor).  Uses name-based lookup so adding guards inside either
+    subtree does not silently misdirect the assertion.
+    """
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    fix_arm = tree.children[0]
+    mit_arm = tree.children[1]
+
+    # Fix arm: locate DeployFix call-out node by name, verify AlwaysFail
+    deploy_if_ready = next(
+        c for c in fix_arm.children if c.name == "_DeployFixIfReady"
+    )
+    deploy_fix_node = next(
+        c for c in deploy_if_ready.children if c.name == "DeployFix"
+    )
+    assert isinstance(deploy_fix_node, AlwaysFail)
+
+    # Mitigation arm: MitigationDeployed is arm's first child (direct Fallback child)
+    assert mit_arm.children[0].name == "MitigationDeployed"
+    assert isinstance(mit_arm.children[0], AlwaysFail)
+
+
+def test_explicit_deterministic_bundles_accepted():
+    """Passing DETERMINISTIC singletons explicitly produces the same tree (AC-3)."""
+    tree = create_deploy_tree(
+        case_id=CASE_ID,
+        actor_id=ACTOR_ID,
+        fix_call_out=DEPLOY_FIX_DETERMINISTIC,
+        mitigation_call_out=DEPLOY_MITIGATION_DETERMINISTIC,
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+    assert tree.name == "DeployOrMitigateBT"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Fallback ordering — fix arm is tried before mitigation arm
+# ---------------------------------------------------------------------------
+
+
+def test_both_bundles_are_invoked_during_construction():
+    """Both fix and mitigation bundles are called when the tree is built (AC-2/3).
+
+    Verifies that `fix_call_out` and `mitigation_call_out` are each forwarded
+    to their respective subtree factories during construction — confirmed by
+    sentinel dicts in custom factory functions.
+
+    Note: tick-level Fallback ordering (fix succeeds → mitigation skipped) is
+    deferred to a DataLayer integration test (see follow-up issue).
+    """
+    fix_invoked = {"called": False}
+    mit_invoked = {"called": False}
+
+    def tracking_deploy_fix(name: str) -> py_trees.behaviour.Behaviour:
+        fix_invoked["called"] = True
+        return AlwaysSucceed(name)
+
+    def tracking_mitigation_deployed(
+        name: str,
+    ) -> py_trees.behaviour.Behaviour:
+        mit_invoked["called"] = True
+        return AlwaysFail(name)
+
+    fix_bundle = DeployFixCallOutBundle(
+        deploy_fix_factory=tracking_deploy_fix,  # type: ignore[arg-type]
+    )
+    mit_bundle = DeployMitigationCallOutBundle(
+        mitigation_deployed_factory=tracking_mitigation_deployed,  # type: ignore[arg-type]
+    )
+
+    create_deploy_tree(
+        case_id=CASE_ID,
+        actor_id=ACTOR_ID,
+        fix_call_out=fix_bundle,
+        mitigation_call_out=mit_bundle,
+    )
+
+    assert fix_invoked["called"]
+    assert mit_invoked["called"]
+
+
+def test_tree_ascii_contains_both_arm_names():
+    """ASCII tree representation includes both subtree root names (AC-3)."""
+    tree = create_deploy_tree(case_id=CASE_ID, actor_id=ACTOR_ID)
+    tree_str = py_trees.display.ascii_tree(tree)
+    assert "DeployFixBT" in tree_str
+    assert "DeployMitigationBT" in tree_str

--- a/vultron/core/behaviors/report/deploy_tree.py
+++ b/vultron/core/behaviors/report/deploy_tree.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Deployment combinator behavior tree (BT-20-005 SHOULD).
+
+This module provides :func:`create_deploy_tree`, which composes the overarching
+deployment decision as a ``DeployOrMitigateBT`` Fallback:
+
+.. code-block:: text
+
+    DeployOrMitigateBT (Fallback)
+    ├─ create_deploy_fix_tree(...)        # fix arm — preferred
+    └─ create_deploy_mitigation_tree(...) # mitigation arm — fallback
+
+The fix arm is attempted first; if it fails the mitigation arm runs as a
+fallback.  Each arm is a fully independent subtree with its own call-out bundle.
+
+References
+----------
+- Issue: #1985
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-20-005
+- Notes: ``notes/bt-fuzzer-rm-fix.md`` § "Combinator tree"
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+import py_trees
+
+from vultron.core.behaviors.report.deploy_fix_tree import (
+    create_deploy_fix_tree,
+)
+from vultron.core.behaviors.report.deploy_mitigation_tree import (
+    create_deploy_mitigation_tree,
+)
+
+if TYPE_CHECKING:
+    from vultron.core.behaviors.call_out.bundles.deploy_fix import (
+        DeployFixCallOutBundle,
+    )
+    from vultron.core.behaviors.call_out.bundles.deploy_mitigation import (
+        DeployMitigationCallOutBundle,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+def create_deploy_tree(
+    case_id: str,
+    actor_id: str,
+    fix_call_out: "DeployFixCallOutBundle | None" = None,
+    mitigation_call_out: "DeployMitigationCallOutBundle | None" = None,
+) -> py_trees.behaviour.Behaviour:
+    """Create the deployment combinator behavior tree (BT-20-005).
+
+    Composes the fix and mitigation deployment subtrees into a single
+    ``DeployOrMitigateBT`` Fallback.  The fix arm is preferred; the mitigation
+    arm runs only when the fix arm fails.
+
+    Args:
+        case_id: ID of VulnerabilityCase being processed.
+        actor_id: ID of the actor running this tree.
+        fix_call_out: Call-out bundle for the fix deployment arm.  Defaults to
+            :data:`~vultron.core.behaviors.call_out.bundles.deploy_fix.DEPLOY_FIX_DETERMINISTIC`.
+        mitigation_call_out: Call-out bundle for the mitigation deployment arm.
+            Defaults to
+            :data:`~vultron.core.behaviors.call_out.bundles.deploy_mitigation.DEPLOY_MITIGATION_DETERMINISTIC`.
+
+    Returns:
+        Root node of the deploy-or-mitigate behavior tree (Fallback).
+    """
+    fix_arm = create_deploy_fix_tree(
+        case_id=case_id, actor_id=actor_id, call_out=fix_call_out
+    )
+    mitigation_arm = create_deploy_mitigation_tree(
+        case_id=case_id, actor_id=actor_id, call_out=mitigation_call_out
+    )
+
+    root = py_trees.composites.Selector(
+        name="DeployOrMitigateBT",
+        memory=False,
+        children=[fix_arm, mitigation_arm],
+    )
+
+    logger.info(
+        "Created DeployOrMitigateBT for case=%s actor=%s", case_id, actor_id
+    )
+    return root


### PR DESCRIPTION
- Closes #1985

## Summary

Adds `create_deploy_tree()` in `vultron/core/behaviors/report/deploy_tree.py` — a `DeployOrMitigateBT` Fallback that composes `create_deploy_fix_tree` (preferred) and `create_deploy_mitigation_tree` (fallback), satisfying spec requirement BT-20-005 (SHOULD).

## Changes

- **`vultron/core/behaviors/report/deploy_tree.py`**: new combinator factory; delegates both arms via their existing factories with independent call-out bundle injection seams
- **`test/core/behaviors/report/test_deploy_tree.py`**: 14 unit tests covering tree structure (AC-1), factory delegation (AC-2), bundle forwarding, and deterministic defaults (AC-3)

## Verification

- 14 new unit tests pass; full suite 6202 passed, 0 failures
- Black, flake8, mypy, pyright all clean

## DEFER

- [#2002](https://github.com/CERTCC/Vultron/issues/2002) — tick-level Fallback ordering integration tests (DataLayer fixture required; factory-only scope sufficient for AC-1–3)