### PR TITLE
docs: fix DEMOMA-19-008 phantom conftest ref; add MS-15 path-existence lint

### DIFF
--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -39,6 +39,44 @@ invariant-harness (matrix: fv) → downloads artifact → runs pytest
 
 ---
 
+## Harness File Conventions
+
+Each scenario gets **one self-contained harness file**,
+`test/ci/invariants/test_<scenario>_invariants.py`. There is no shared
+per-scenario base class and no registry module. A new harness follows the
+existing eight:
+
+1. Declare `_DEMO_NAME = "<scenario>"` at module scope.
+2. Load replicas with `load_devlogs(demo_name=_DEMO_NAME)`, imported from
+   `test/ci/invariants/common.py`.
+3. Declare `_CHAIN_ACTORS` (scenario-role names, not docker service names) and
+   `_<SCENARIO>_EXPECTED_EVENT_TYPES`.
+4. Call the shared check functions from `common.py`; keep scenario-specific
+   assertions in the scenario file.
+
+**The scenario→harness registry is the CI matrix**, not a Python module. The
+`demo:` / `test_file:` pairs in `.github/workflows/demo-integration.yml` are the
+sole mapping from a scenario name to its harness file; the pairs appear in both
+the `demo` and `invariant-harness` jobs and must be kept in step.
+
+> **Do not add a `conftest.py` scenario registry.** DEMOMA-19-008 originally
+> required registering the FCVCV harness in `test/ci/invariants/conftest.py`
+> "under the `fcvcv` scenario key". No such registry has ever existed, and the
+> clause was written spec-first with no implementation to check against
+> (CONCERN-2004). It has been amended to describe the pattern above.
+>
+> A `test/ci/invariants/conftest.py` *does* exist as of issue #1976, but it
+> holds synthetic in-memory JSONL fixtures for unit-testing the check functions
+> in `common.py` — it carries no scenario mapping. Do not bolt scenario routing
+> onto it.
+
+Known duplication: all eight harnesses re-implement the same ~14 universal
+invariant tests as near-identical thin wrappers over `common.py`. Extracting
+them is tracked separately; the per-file `_DEMO_NAME` + `load_devlogs` idiom is
+not the duplication worth fixing.
+
+---
+
 ## Per-Scenario Expected Event Types (DEMOMA-16)
 
 **Problem**: All per-scenario `_XXX_EXPECTED_EVENT_TYPES` lists historically

--- a/plan/history/2608/learning/CONCERN-2004.md
+++ b/plan/history/2608/learning/CONCERN-2004.md
@@ -1,0 +1,106 @@
+---
+source: CONCERN-2004
+timestamp: '2026-08-05T20:31:36.136682+00:00'
+title: DEMOMA-19-008 phantom conftest.py reference; spec path-existence lint
+type: learning
+---
+
+## Original concern
+
+`DEMOMA-19-008` (MUST) ended with: "The harness MUST be added to
+`test/ci/invariants/conftest.py` under the `fcvcv` scenario key." No such file
+existed, and no prior scenario harness registered anywhere — each of the eight
+harnesses hardcoded its own `devlogs/<scenario>/` path. So the clause could not
+be satisfied as written. `test_fcvcv_invariants.py` (PR #1962) followed the
+established pattern instead, satisfying the spec's intent while formally
+violating its letter.
+
+Found during `/pr-ship` triage of PR #1962 (finding
+`phase5-demoma-19-008-conftest-stale-0`). Not a defect in that PR.
+
+## Verdict: the spec was wrong, not misled
+
+The framing question that unlocked this was "is the spec just wrong, or was it
+misled?" Provenance answered it:
+
+- The clause was authored in `439cead6` ("docs: plan issue #1217"), a *planning*
+  commit that wrote all 9 DEMOMA-19 entries spec-first, before any FCVCV code
+  existed. There was no implementation to describe.
+- `test/ci/invariants/conftest.py` has never existed on `main` —
+  `git log --all --diff-filter=A` finds one adding commit, not an ancestor of
+  `origin/main`.
+- No scenario-keyed registry exists anywhere under `test/`.
+- The three prior harness clauses (`multi-actor-demo.yaml:1241`, `1534`, `1761`)
+  name the test file and stop. The generic clauses (DEMOMA-16-008, DEMOCI-04-004)
+  say `test/ci/invariants/test_XXX_invariants.py` — the per-file pattern.
+
+So this was not a premise that drifted. It was never true, and the surrounding
+spec text pointed the other way. "Build the registry to make the spec true" was
+only attractive while the clause looked like it might encode real intent.
+
+## What the audit found
+
+DEMOMA-19-008 was not isolated. A path-existence scan over all spec statements
+found **18 clauses across 13 phantom paths**, most stale after a file move or a
+module-to-package refactor: `vultron/config.py` (now a package),
+`sync_activity_port.py` (renamed), `specs/architecture.md` (wrong extension),
+`.github/skills/` (moved to `.claude/skills/`), and others.
+
+Three needed semantic rewrites rather than path fixes, because the referenced
+*concept* was gone: UCORG-02-001/002 (`USE_CASE_MAP` replaced by
+`SEMANTIC_REGISTRY`), PD-06-004/005 (`plan/PRIORITIES.md` deliberately archived
+in `51fa5aee4`, migrated to the Project #24 `Schedule` field).
+
+## Key distinction: statement vs. rationale
+
+A scan of `rationale` found 5 more hits, but **2 were correct as written** —
+rationale narrates history by design ("`specs/meta-specifications.md` has been
+converted to `.yaml`", "if `CVDRole` stays in `vultron/core/states/roles.py`...").
+Enforcing path existence on `rationale` would be wrong. The lint check scans
+`statement` only. The 3 genuinely-stale rationale refs to the dead aggregate
+invariant file were fixed by hand.
+
+## The registry that does exist
+
+The scenario-to-harness registry is the `demo`/`test_file` matrix in
+`.github/workflows/demo-integration.yml`, duplicated verbatim across both the
+`demo` and `invariant-harness` jobs. A `conftest.py` registry would have been a
+*second* one.
+
+## Resolution
+
+Deviated from plan-only: the fix is docs + a lint check, which is what Phase 5
+writes anyway, so routing it through an impl issue would be ceremony. The
+universal-test dedup stayed an issue because it is a real code change across the
+CI gate for all 8 scenarios.
+
+- Amended DEMOMA-19-008 to describe the actual pattern and record that the CI
+  matrix is the sole registry.
+- Retargeted 15 stale path references; rewrote 3 clause groups semantically.
+- Added MS-15-001 and `_check_phantom_paths` as a **hard error** — an advisory
+  warning would have been the same failure mode being fixed. Escape hatch is
+  `lint_suppress: [phantom_path_ref]`; placeholder forms and package-relative
+  illustrations are exempt automatically.
+- 6 regression tests: fires, passes on real path, both exemptions, rationale
+  non-scanning, suppression. Verified by negative test that the check exits 1
+  and names the path, and 0 once suppressed.
+
+## Downstream: the clause had already propagated
+
+Issue #1926 was open *only* because its AC-4f was this same phantom requirement,
+copied verbatim out of DEMOMA-19-008 by `plan-issue`. AC-4a–4e were all already
+shipped in #1962. The unbuildable AC was the sole reason the issue could not
+close — a work item that could never be completed as written. AC-4f struck with
+a triage comment. This is the landmine reproducing one level up from the spec,
+which is the strongest argument for the lint gate.
+
+Also noted: `test/ci/invariants/conftest.py` *is* added by #1976, holding
+synthetic in-memory JSONL fixtures for unit-testing `common.py` — no scenario
+mapping. After #1976 lands the filename resolves, making the phantom clause
+*more* inviting, not less. Documented in `notes/demo-ci-invariants.md` so nobody
+bolts scenario routing onto a fixtures module.
+
+**Resolved**: 2026-08-05 — implementation tracked in #2007.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2006>.
+Spec: `specs/meta-specifications.yaml` (MS-15), `specs/multi-actor-demo.yaml`.
+Notes: `notes/demo-ci-invariants.md`.

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -103,7 +103,7 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      `SyncActivityPort` MUST be defined as a `typing.Protocol` in `vultron/core/ports/sync_activity_port.py`
+      `SyncActivityPort` MUST be defined as a `typing.Protocol` in `vultron/core/ports/sync_activity.py`
       with two fire-and-forget methods: `send_reject_log_entry(entry, tail_hash, actor_id, to)` and
       `send_announce_log_entry(entry, actor_id, to)`. The concrete adapter (`SyncActivityAdapter`)
       MUST be implemented in `vultron/adapters/driven/sync_activity_adapter.py` and own the full

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -370,7 +370,7 @@ groups:
     priority: MUST_NOT
     kind: protocol
     statement: Domain objects MUST NOT directly inherit from ActivityStreams base types; explicit `from_core()` / `to_core()`
-      translation methods MUST be provided at the wire boundary (see `specs/architecture.md` ARCH-12-001 through ARCH-12-007
+      translation methods MUST be provided at the wire boundary (see `specs/architecture.yaml` ARCH-12-001 through ARCH-12-007
       and `notes/domain-model-separation.md`)
 - id: CM-09
   title: Redacted Case View

--- a/specs/code-style.yaml
+++ b/specs/code-style.yaml
@@ -394,7 +394,7 @@ groups:
     statement: A test fixture or constant that enumerates the same value set as a production enum (e.g., a list of expected
       event-type strings mirroring `MessageSemantics`) MUST derive its values from the enum at import/collection time rather
       than duplicating them as separately-maintained literals.
-    rationale: '`EXPECTED_EVENT_TYPES` in `test/ci/test_case_ledger_invariants.py` hardcoded values that silently diverged
+    rationale: '`EXPECTED_EVENT_TYPES` in the case-ledger invariant harness (now `test/ci/invariants/`) hardcoded values that silently diverged
       from `MessageSemantics` (issue #998/#1020): five of ten values used legacy names that no longer matched the enum. The
       mismatch produced no failure on its own — it only surfaced when the invariant using it was audited by hand. Deriving
       the fixture from the enum makes the two sets impossible to drift apart; a rename in the enum either propagates automatically

--- a/specs/configuration.yaml
+++ b/specs/configuration.yaml
@@ -15,7 +15,7 @@ groups:
   - id: CFG-01-001
     priority: MUST
     kind: project
-    statement: The application MUST provide a top-level neutral module `vultron/config.py` containing `AppConfig`, `get_config()`,
+    statement: The application MUST provide a top-level neutral package `vultron/config/` whose `app.py` module contains `AppConfig`, `get_config()`,
       and `reload_config()`.
   - id: CFG-01-002
     priority: MUST
@@ -39,7 +39,7 @@ groups:
   - id: CFG-01-006
     priority: MUST_NOT
     kind: project
-    statement: '`vultron/config.py` MUST NOT import from adapter-layer or FastAPI modules; it is a neutral shared module usable
+    statement: '`vultron/config/` MUST NOT import from adapter-layer or FastAPI modules; it is a neutral shared module usable
       by all layers.'
     relationships:
     - rel_type: refines
@@ -190,7 +190,7 @@ groups:
     priority: MUST
     kind: project
     statement: A neutral `ActorConfig` Pydantic model MUST be defined outside the demo layer (e.g., in `vultron/core/models/`
-      or `vultron/config.py`) so it can be used by BT nodes, API adapters, and CLI entry points without importing from `vultron/demo/`.
+      or `vultron/config/actor.py`) so it can be used by BT nodes, API adapters, and CLI entry points without importing from `vultron/demo/`.
     rationale: '`LocalActorConfig` (in `vultron/demo/seed_config.py`) is demo scaffolding. BT nodes that need actor role information
       MUST NOT import from the demo layer (BTND-04-002). A neutral `ActorConfig` provides the same information without the
       layering violation.'

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -38,7 +38,7 @@ groups:
     rationale: >-
       This mirrors the layout written by `fv_demo._phase_dump_case_ledgers`
       (`{DEVLOGS_DIR}/{demo_name}/{actor_name}/{case_id_slug}-case-ledger.jsonl`)
-      and read by `test/ci/test_case_ledger_invariants.py`.
+      and read by the invariant harnesses in `test/ci/invariants/`.
   - id: DRPT-01-003
     priority: MUST
     kind: project
@@ -101,7 +101,7 @@ groups:
       The parser MUST tolerate both camelCase and snake_case field spellings in
       source entries (e.g. `logIndex`/`log_index`, `entryHash`/`entry_hash`,
       `payloadSnapshot`/`payload_snapshot`), consistent with the tolerance
-      already present in `test/ci/test_case_ledger_invariants.py`.
+      already present in `test/ci/invariants/common.py`.
   - id: DRPT-02-004
     priority: MUST
     kind: project

--- a/specs/duration.yaml
+++ b/specs/duration.yaml
@@ -139,7 +139,7 @@ groups:
     statement: >-
       When a default embargo duration is applied at case creation, this application MUST be
       logged at INFO level to ensure visibility in logs. The resulting `CaseStatus.em_state`
-      MUST be `EM.ACTIVE` (not `EM.PROPOSED`); see `specs/embargo-policy.md` EP-04-001.
+      MUST be `EM.ACTIVE` (not `EM.PROPOSED`); see `specs/embargo-policy.yaml` EP-04-001.
   - id: DUR-07-004
     priority: MUST
     kind: protocol

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -547,21 +547,23 @@ groups:
     priority: MUST
     kind: process
     statement: >-
-      A spec item's `statement` MUST NOT reference a repo-relative file path that
-      does not exist. A spec-first requirement that deliberately names a file yet
-      to be created MUST either use a placeholder form (e.g.
-      `test_XXX_invariants.py`) or opt out with
-      `lint_suppress: [phantom_path_ref]`. Enforced as a hard error by spec-lint.
+      A spec item's `statement` MUST NOT reference a file path that does not
+      exist, and MUST NOT use an absolute path or a `..` segment. A path rooted
+      at a top-level repo directory is resolved repo-relatively; any other path
+      is resolved as a suffix of some file in the tree, so a package-relative
+      illustration is permitted but a mistyped leading segment is not. A
+      spec-first requirement that deliberately names a file yet to be created
+      MUST either use a placeholder form (e.g. `test_XXX_invariants.py`) or opt
+      out with `lint_suppress: [phantom_path_ref]`. Enforced as a hard error by
+      spec-lint.
     rationale: >-
       A normative statement naming non-existent infrastructure is a stale-premise
-      landmine: the agent implementing it either invents something inconsistent
-      with the rest of the codebase or silently ignores a MUST, and either way the
-      spec stops describing the system. DEMOMA-19-008 required registering an
-      invariant harness in a `test/ci/invariants/conftest.py` that had never
-      existed on any branch (CONCERN-2004); an audit found 18 such clauses across
-      13 phantom paths, most stale after a file move or a module-to-package
-      refactor. Only `statement` is checked — `rationale` narrates history by
-      design and legitimately cites paths that are gone.
+      landmine: the implementing agent either invents something inconsistent with
+      the codebase or silently ignores a MUST, and the spec stops describing the
+      system. DEMOMA-19-008 named a `conftest.py` registry that had never existed
+      (CONCERN-2004); an audit found 18 such clauses across 13 phantom paths.
+      Only `statement` is checked — `rationale` narrates history by design and
+      legitimately cites paths that are gone.
     relationships:
     - rel_type: derives_from
       spec_id: MS-04-001

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -540,3 +540,32 @@ groups:
     - tooling
     adr:
     - ADR-0027
+- id: MS-15
+  title: Spec Statements Must Not Reference Phantom Paths
+  specs:
+  - id: MS-15-001
+    priority: MUST
+    kind: process
+    statement: >-
+      A spec item's `statement` MUST NOT reference a repo-relative file path that
+      does not exist. A spec-first requirement that deliberately names a file yet
+      to be created MUST either use a placeholder form (e.g.
+      `test_XXX_invariants.py`) or opt out with
+      `lint_suppress: [phantom_path_ref]`. Enforced as a hard error by spec-lint.
+    rationale: >-
+      A normative statement naming non-existent infrastructure is a stale-premise
+      landmine: the agent implementing it either invents something inconsistent
+      with the rest of the codebase or silently ignores a MUST, and either way the
+      spec stops describing the system. DEMOMA-19-008 required registering an
+      invariant harness in a `test/ci/invariants/conftest.py` that had never
+      existed on any branch (CONCERN-2004); an audit found 18 such clauses across
+      13 phantom paths, most stale after a file move or a module-to-package
+      refactor. Only `statement` is checked — `rationale` narrates history by
+      design and legitimately cites paths that are gone.
+    relationships:
+    - rel_type: derives_from
+      spec_id: MS-04-001
+      note: extends spec-authoring rules with a path-existence guarantee
+    tags:
+    - documentation
+    - tooling

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -2307,9 +2307,15 @@ groups:
       `invite_actor_to_case` appears at least three times (C1→V1, C1→C2,
       CaseActor→V2); (b) `offer_case_participant` appears at least once (C2
       suggests V2 via ADR-0026); (c) `accept_invite_actor_to_case` appears
-      at least three times (V1, C2, V2 each accept). The harness MUST be
-      added to `test/ci/invariants/conftest.py` under the `fcvcv` scenario
-      key.
+      at least three times (V1, C2, V2 each accept). The harness MUST set
+      `_DEMO_NAME = "fcvcv"` and load its replicas via
+      `load_devlogs(demo_name=_DEMO_NAME)` from
+      `test/ci/invariants/common.py`, following the same self-contained
+      pattern as every prior scenario harness. The scenario MUST be routed to
+      this file by the `demo`/`test_file` matrix in
+      `.github/workflows/demo-integration.yml`, which is the sole
+      scenario-to-harness registry; harnesses MUST NOT be registered via a
+      `conftest.py` scenario mapping.
     rationale: >-
       The invariant harness is the CI-level acceptance test for the scenario.
       The three scenario-specific count checks verify that the multi-party

--- a/specs/project-documentation.yaml
+++ b/specs/project-documentation.yaml
@@ -82,8 +82,8 @@ groups:
   - id: PD-04-002
     priority: MUST
     kind: project
-    statement: Validation MUST occur after markdown linting (via `.github/skills/format-markdown/SKILL.md`) and before test
-      runs, in the build-and-test workflow documented in `.github/skills/build-docs/SKILL.md`
+    statement: Validation MUST occur after markdown linting (via `.claude/skills/format-markdown/SKILL.md`) and before test
+      runs, in the build-and-test workflow documented in `.claude/skills/build-docs/SKILL.md`
   - id: PD-04-003
     priority: SHOULD
     kind: project
@@ -129,15 +129,27 @@ groups:
   - id: PD-06-004
     priority: MUST_NOT
     kind: process
-    statement: Priority ordering is the sole responsibility of `plan/PRIORITIES.md`. GitHub Issue
-      titles and `plan/PRIORITIES.md` headings MUST NOT encode priority information as numeric
-      prefixes or rely on ordering to imply priority.
+    statement: >-
+      Priority ordering is the sole responsibility of the `Schedule` field
+      (Now/Next/Later/Someday) on GitHub Project #24. GitHub Issue titles MUST NOT
+      encode priority information as numeric prefixes or rely on ordering to imply
+      priority.
+    rationale: >-
+      Priority lived in `plan/PRIORITIES.md` until it was archived in favour of the
+      GitHub Project board (#693); the board's `Schedule` field is now the single
+      source of ordering. Encoding priority in issue titles would reintroduce a
+      second, silently-drifting ranking.
   - id: PD-06-005
     priority: SHOULD
     kind: process
-    statement: '`plan/PRIORITIES.md` entries SHOULD reference the relevant GitHub Issue numbers to link
-      priority assignments to implementation work. No rigid format is required because PRIORITIES.md is primarily human-edited;
-      a brief reference to the issue number or topic is sufficient.'
+    statement: >-
+      Every issue carrying a `Schedule` value on GitHub Project #24 SHOULD also be
+      wired to the Epic it belongs to (as a sub-issue), so a priority assignment is
+      traceable to the thematic group it advances.
+    rationale: >-
+      Replaces the former requirement that `plan/PRIORITIES.md` entries cite issue
+      numbers; with priorities held on the board, the equivalent linkage is the
+      issue-to-Epic relationship rather than a hand-maintained list.
 - id: PD-09
   title: Task Granularity and GitHub Issues Coordination
   specs:
@@ -184,7 +196,7 @@ groups:
       or `create_commit_log_entry_tree` in `vultron/core/behaviors/`, or any call site that invokes
       these directly.
     rationale: >-
-      The aggregate invariant suite (`test/ci/test_case_ledger_invariants.py`) can pass on `main`
+      The aggregate invariant suite (the per-scenario harnesses in `test/ci/invariants/`) can pass on `main`
       throughout a ledger-path Epic while protocol-correctness bugs — such as hash-chain forks and
       RM oscillation loops — remain invisible. Such bugs are only detectable from a direct
       side-by-side review of each actor's JSONL log. Without a standing rule requiring this review

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -115,7 +115,7 @@ groups:
   - id: SR-02-007
     priority: MUST
     kind: project
-    statement: '`SpecTag` MUST be a controlled vocabulary StrEnum; initial values are defined in `notes/spec-registry.md`.'
+    statement: '`SpecTag` MUST be a controlled vocabulary StrEnum, defined in `vultron/metadata/specs/schema.py`.'
   - id: SR-02-008
     priority: MUST
     kind: project

--- a/specs/sync-behavior-trees.yaml
+++ b/specs/sync-behavior-trees.yaml
@@ -220,7 +220,8 @@ groups:
         priority: MUST
         kind: project
         statement: >-
-          The existing `CommitCaseLedgerEntryNode` in `case/nodes.py` MUST be
+          The existing `CommitCaseLedgerEntryNode` in
+          `vultron/core/behaviors/case/nodes/lifecycle.py` MUST be
           refactored to invoke CommitLogEntryBT as a subtree rather than
           calling `commit_log_entry_trigger()` procedurally.
 

--- a/specs/testability.yaml
+++ b/specs/testability.yaml
@@ -241,7 +241,7 @@ groups:
     priority: SHOULD
     kind: process
     statement: >-
-      Once the `core` and `wire` packages are fully separated (see `specs/architecture.md`
+      Once the `core` and `wire` packages are fully separated (see `specs/architecture.yaml`
       and `archived_notes/architecture-review.md`), architecture boundary tests SHOULD be
       added to enforce layer separation rules
     rationale: >-

--- a/specs/traceability.yaml
+++ b/specs/traceability.yaml
@@ -19,7 +19,7 @@ groups:
     kind: project
     statement: >-
       A traceability file MUST exist at `docs/reference/user_stories/traceability.md` mapping each user story
-      in `docs/topics/user_stories/` to the implementing specification(s) and specific requirement
+      in `docs/reference/user_stories/` to the implementing specification(s) and specific requirement
       ID(s)
   - id: TRACE-01-002
     priority: MUST

--- a/specs/traceability.yaml
+++ b/specs/traceability.yaml
@@ -18,7 +18,7 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      A traceability file MUST exist at `notes/user-stories-trace.md` mapping each user story
+      A traceability file MUST exist at `docs/reference/user_stories/traceability.md` mapping each user story
       in `docs/topics/user_stories/` to the implementing specification(s) and specific requirement
       ID(s)
   - id: TRACE-01-002

--- a/specs/use-case-organization.yaml
+++ b/specs/use-case-organization.yaml
@@ -47,15 +47,18 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      Any relocation or rename of a use-case class MUST update `USE_CASE_MAP` in `vultron/core/use_cases/use_case_map.py`
-      in the same commit
+      Any relocation or rename of a use-case class MUST update its
+      `SEMANTIC_REGISTRY` entry in `vultron/semantic_registry/` in the same commit.
+      The registry is the single source of the `MessageSemantics` → use-case-class
+      mapping, projected by `use_case_map()` in
+      `vultron/semantic_registry/__init__.py`
   - id: UCORG-02-002
     priority: MUST
     kind: project
     statement: >-
-      A dispatch coverage test MUST verify that every `MessageSemantics` value registered
-      in `USE_CASE_MAP` resolves to a callable class and that dispatch succeeds for a representative
-      event
+      A dispatch coverage test MUST verify that every `MessageSemantics` value
+      registered in `SEMANTIC_REGISTRY` resolves to a callable class and that
+      dispatch succeeds for a representative event
 - id: UCORG-03
   title: Test Layout
   specs:

--- a/specs/vultron-as2-mapping.yaml
+++ b/specs/vultron-as2-mapping.yaml
@@ -22,7 +22,7 @@ groups:
   - id: VAM-01-002
     priority: MUST_NOT
     kind: project
-    statement: The AS2 activity patterns defined in this document MUST be implemented in `vultron/wire/as2/extractor.py` as
+    statement: The AS2 activity patterns defined in this document MUST be implemented in `vultron/wire/as2/extractor/` (pattern instances in `_instances.py`) as
       `ActivityPattern` objects and MUST NOT be duplicated in any other module
   - id: VAM-01-003
     priority: MUST

--- a/test/metadata/specs/test_lint.py
+++ b/test/metadata/specs/test_lint.py
@@ -595,3 +595,90 @@ def test_lint_adr_status_prose_suppress(tmp_path, capsys):
     captured = capsys.readouterr()
     assert result == 0
     assert "MS-14-002" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# MS-15-001: phantom path references in spec statements
+# ---------------------------------------------------------------------------
+
+
+def _repo_with_specs(tmp_path):
+    """Return (repo_root, spec_dir) — lint() treats spec_dir.parent as the root."""
+    spec_dir = tmp_path / "specs"
+    spec_dir.mkdir()
+    (tmp_path / "vultron").mkdir()
+    return tmp_path, spec_dir
+
+
+def test_lint_phantom_path_is_hard_error(tmp_path, capsys):
+    """A statement naming a non-existent repo-relative path fails (MS-15-001)."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "The harness MUST be registered in `vultron/nope.py`"
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "MS-15-001" in captured.err
+    assert "vultron/nope.py" in captured.err
+
+
+def test_lint_phantom_path_existing_file_passes(tmp_path):
+    """A statement naming a path that exists is accepted."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    (repo / "vultron" / "real.py").write_text("x = 1\n")
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "The thing MUST live in `vultron/real.py`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_path_placeholder_exempt(tmp_path):
+    """Placeholder path forms describe a shape, not a file, and are exempt."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Each scenario MUST have a `test/ci/invariants/test_XXX_invariants.py`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_path_package_relative_exempt(tmp_path):
+    """A path whose first segment is not a top-level repo dir is an illustration."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Patterns MUST be defined in `received/sync.py`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_path_rationale_not_scanned(tmp_path):
+    """rationale narrates history and may cite paths that no longer exist."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "rationale"
+    ] = "`vultron/old_config.py` has been converted to a package."
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_path_suppress(tmp_path, capsys):
+    """lint_suppress: [phantom_path_ref] allows a deliberate forward reference."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec(extra={"lint_suppress": ["phantom_path_ref"]})
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "A new module MUST be created at `vultron/planned.py`"
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "MS-15-001" not in captured.err

--- a/test/metadata/specs/test_lint.py
+++ b/test/metadata/specs/test_lint.py
@@ -603,16 +603,22 @@ def test_lint_adr_status_prose_suppress(tmp_path, capsys):
 
 
 def _repo_with_specs(tmp_path):
-    """Return (repo_root, spec_dir) — lint() treats spec_dir.parent as the root."""
+    """Return (repo_root, spec_dir) — lint() treats spec_dir.parent as the root.
+
+    Creates the top-level directories the phantom-path tests reference, so a
+    match is exercised against the existence check rather than being skipped as
+    a package-relative illustration.
+    """
     spec_dir = tmp_path / "specs"
     spec_dir.mkdir()
-    (tmp_path / "vultron").mkdir()
+    for name in ("vultron", "test", ".claude", "docs"):
+        (tmp_path / name).mkdir()
     return tmp_path, spec_dir
 
 
 def test_lint_phantom_path_is_hard_error(tmp_path, capsys):
     """A statement naming a non-existent repo-relative path fails (MS-15-001)."""
-    repo, spec_dir = _repo_with_specs(tmp_path)
+    _, spec_dir = _repo_with_specs(tmp_path)
     data = _minimal_spec()
     data["groups"][0]["specs"][0][
         "statement"
@@ -639,7 +645,7 @@ def test_lint_phantom_path_existing_file_passes(tmp_path):
 
 def test_lint_phantom_path_placeholder_exempt(tmp_path):
     """Placeholder path forms describe a shape, not a file, and are exempt."""
-    repo, spec_dir = _repo_with_specs(tmp_path)
+    _, spec_dir = _repo_with_specs(tmp_path)
     data = _minimal_spec()
     data["groups"][0]["specs"][0][
         "statement"
@@ -648,9 +654,79 @@ def test_lint_phantom_path_placeholder_exempt(tmp_path):
     assert lint(spec_dir) == 0
 
 
-def test_lint_phantom_path_package_relative_exempt(tmp_path):
-    """A path whose first segment is not a top-level repo dir is an illustration."""
+def test_lint_phantom_path_without_placeholder_token_fails(tmp_path):
+    """The same path minus the placeholder token is checked and fails.
+
+    Guards the exemption above against becoming vacuous: `test/` exists in the
+    fixture repo, so this path reaches the existence check.
+    """
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Each scenario MUST have a `test/ci/invariants/test_fv_invariants.py`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 1
+
+
+def test_lint_phantom_path_placeholder_basename_exempt(tmp_path):
+    """Placeholder basenames are exempt, but only as a whole path segment."""
     repo, spec_dir = _repo_with_specs(tmp_path)
+    (repo / "notes").mkdir()
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "A new note MUST be created at `notes/new-topic.md`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_path_placeholder_basename_not_a_substring(tmp_path):
+    """A real path merely *starting* with a placeholder name is still checked."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    (repo / "notes").mkdir()
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "The workflow MUST be documented in `notes/new-topic-workflow.md`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 1
+
+
+def test_lint_phantom_path_dot_directory_is_checked(tmp_path, capsys):
+    """Dot-directories such as `.claude/` are enforced, not silently skipped."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Linting MUST run via `.claude/skills/format-markdown/SKILL.md`"
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert ".claude/skills/format-markdown/SKILL.md" in captured.err
+
+
+def test_lint_phantom_path_dot_directory_existing_passes(tmp_path):
+    """A dot-directory path that does exist is accepted."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    skill = repo / ".claude" / "skills" / "format-markdown"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# skill\n")
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Linting MUST run via `.claude/skills/format-markdown/SKILL.md`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_path_package_relative_resolves_as_suffix(tmp_path):
+    """A package-relative illustration resolves against a real file's suffix."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    pkg = repo / "vultron" / "wire" / "received"
+    pkg.mkdir(parents=True)
+    (pkg / "sync.py").write_text("x = 1\n")
     data = _minimal_spec()
     data["groups"][0]["specs"][0][
         "statement"
@@ -659,9 +735,84 @@ def test_lint_phantom_path_package_relative_exempt(tmp_path):
     assert lint(spec_dir) == 0
 
 
+def test_lint_phantom_path_package_relative_unresolvable_fails(tmp_path):
+    """A package-relative path matching nothing in the tree is still an error."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Patterns MUST be defined in `received/sync.py`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 1
+
+
+def test_lint_phantom_path_mistyped_leading_segment_fails(tmp_path, capsys):
+    """A mistyped first segment does not escape via the suffix path.
+
+    `tests/` (plural) is not a top-level dir, so the match is resolved as a
+    suffix — and no file ends with `tests/ci/common.py`, so it errors.
+    """
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    real = repo / "test" / "ci"
+    real.mkdir(parents=True)
+    (real / "common.py").write_text("x = 1\n")
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Checks MUST live in `tests/ci/common.py`"
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "tests/ci/common.py" in captured.err
+
+
+def test_lint_phantom_path_suffix_ignores_build_artifacts(tmp_path):
+    """A path satisfied only inside `.venv/` or `__pycache__/` is not resolved."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    vendored = repo / ".venv" / "lib" / "received"
+    vendored.mkdir(parents=True)
+    (vendored / "sync.py").write_text("x = 1\n")
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Patterns MUST be defined in `received/sync.py`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 1
+
+
+def test_lint_phantom_path_absolute_rejected(tmp_path, capsys):
+    """An absolute path is rejected outright, not exempted."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Config MUST be read from `/etc/vultron/settings.yaml`"
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "not a valid repo-relative path" in captured.err
+
+
+def test_lint_phantom_path_parent_traversal_rejected(tmp_path, capsys):
+    """A `..` segment is rejected even when it resolves on the filesystem."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    (repo / "vultron" / "real.py").write_text("x = 1\n")
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "The thing MUST live in `test/../vultron/real.py`"
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "not a valid repo-relative path" in captured.err
+
+
 def test_lint_phantom_path_rationale_not_scanned(tmp_path):
     """rationale narrates history and may cite paths that no longer exist."""
-    repo, spec_dir = _repo_with_specs(tmp_path)
+    _, spec_dir = _repo_with_specs(tmp_path)
     data = _minimal_spec()
     data["groups"][0]["specs"][0][
         "rationale"
@@ -672,7 +823,7 @@ def test_lint_phantom_path_rationale_not_scanned(tmp_path):
 
 def test_lint_phantom_path_suppress(tmp_path, capsys):
     """lint_suppress: [phantom_path_ref] allows a deliberate forward reference."""
-    repo, spec_dir = _repo_with_specs(tmp_path)
+    _, spec_dir = _repo_with_specs(tmp_path)
     data = _minimal_spec(extra={"lint_suppress": ["phantom_path_ref"]})
     data["groups"][0]["specs"][0][
         "statement"

--- a/vultron/metadata/specs/lint.py
+++ b/vultron/metadata/specs/lint.py
@@ -9,6 +9,7 @@ Usage::
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path
@@ -113,11 +114,62 @@ _SPEC_PATH_RE = re.compile(
     r"`([A-Za-z0-9_./-]+/[A-Za-z0-9_.-]+\.(?:py|ya?ml|md|json|toml))`"
 )
 
-#: Placeholder forms that name a *shape* of path rather than a real one
-#: (e.g. `test_XXX_invariants.py`, `plan/history/YYMM/README.md`). These are
-#: intentionally generic and are exempt from the existence check.
-_PATH_PLACEHOLDER_RE = re.compile(
-    r"XXX|YYMM|NNNN|new-topic|new-spec|<|\{",
+#: Placeholder tokens that name a *shape* of path rather than a real one
+#: (e.g. `test_XXX_invariants.py`, `plan/history/YYMM/README.md`,
+#: `docs/adr/ADR-XXXX-foo.md`). Uppercase by convention, so a collision with a
+#: real path segment is implausible. Bracketed forms (`{YYMM}`, `<repo>`) need
+#: no entry here — :data:`_SPEC_PATH_RE` cannot match them in the first place.
+_PATH_PLACEHOLDER_RE = re.compile(r"XXX|YYMM|NNNN")
+
+#: Placeholder *basenames* used in spec prose to illustrate a new file being
+#: created. Matched whole-segment, not as substrings: `notes/new-spec.md` is
+#: exempt but `notes/new-spec-workflow.md` is a real path and is checked.
+_PLACEHOLDER_BASENAMES = frozenset({"new-topic.md", "new-spec.md"})
+
+#: Top-level repository directories that a spec statement may reference
+#: repo-relatively. Enumerated explicitly rather than read from the working
+#: tree so the check behaves identically in a developer checkout (where
+#: gitignored directories such as ``devlogs/`` and ``site/`` exist) and in a
+#: fresh CI clone (where they do not). Add a directory here when the repo grows
+#: one that specs cite.
+_REPO_TOP_LEVEL_DIRS = frozenset(
+    {
+        ".agents",
+        ".claude",
+        ".devcontainer",
+        ".github",
+        "archived_notes",
+        "doc",
+        "docker",
+        "docs",
+        "integration_tests",
+        "notes",
+        "ontology",
+        "overrides",
+        "plan",
+        "prompts",
+        "scripts",
+        "specs",
+        "test",
+        "vultron",
+    }
+)
+
+#: Directories skipped when resolving a package-relative path suffix — build
+#: artifacts and virtualenvs would otherwise satisfy a reference that no
+#: tracked file does.
+_IGNORED_TREE_DIRS = frozenset(
+    {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".venv",
+        "__pycache__",
+        "devlogs",
+        "node_modules",
+        "site",
+        "vultron.egg-info",
+    }
 )
 
 
@@ -134,39 +186,115 @@ def _check_phantom_paths(registry: SpecRegistry, repo_root: Path) -> list[str]:
     ("X has been converted to Y", "if X stays in Z...") and legitimately
     references paths that no longer exist.
 
+    A match whose first segment is a known top-level directory
+    (:data:`_REPO_TOP_LEVEL_DIRS`) is resolved repo-relatively. Any other match
+    is a package-relative illustration such as ``vocab/activities/embargo.py``
+    and is resolved as a path *suffix* anywhere in the tree. Suffix resolution
+    is deliberate rather than a blanket exemption: it is what catches a
+    mistyped leading segment (``tests/ci/...`` for ``test/ci/...``), which is
+    the most common shape of a stale reference.
+
     Exemptions:
 
-    - Placeholder forms (:data:`_PATH_PLACEHOLDER_RE`) that describe a path
-      shape rather than a specific file.
-    - Paths whose first segment is not a real top-level repo directory, which
-      are package-relative illustrations rather than repo-relative references.
+    - Placeholder forms (:data:`_PATH_PLACEHOLDER_RE`,
+      :data:`_PLACEHOLDER_BASENAMES`) that describe a path shape rather than a
+      specific file.
     - Per-spec opt-out via ``lint_suppress: [phantom_path_ref]``, for a
       spec-first requirement that deliberately names a file yet to be created.
+
+    Absolute paths and paths containing a ``..`` segment are rejected outright
+    rather than exempted: neither is a valid repo-relative reference, and
+    ``..`` would otherwise resolve outside the repository.
     """
-    top_level = {
-        p.name
-        for p in repo_root.iterdir()
-        if p.is_dir() and not p.name.startswith(".")
-    } | {".github"}
+    resolver = _PathResolver(repo_root)
 
     errors: list[str] = []
     for spec_id, spec in registry.all_specs.items():
         if LintWarningCode.PHANTOM_PATH_REF in set(spec.lint_suppress or []):
             continue
         for match in _SPEC_PATH_RE.findall(spec.statement or ""):
-            if _PATH_PLACEHOLDER_RE.search(match):
-                continue
-            if match.split("/")[0] not in top_level:
-                continue
-            if (repo_root / match).exists():
-                continue
-            errors.append(
-                f"{spec_id}: statement references '{match}' which does not "
-                f"exist (MS-15-001). Point at the real path, or — if the file "
-                f"is intentionally yet to be created — suppress with "
-                f"lint_suppress: [phantom_path_ref]."
-            )
+            problem = resolver.problem_with(match)
+            if problem is not None:
+                errors.append(f"{spec_id}: statement references {problem}")
     return errors
+
+
+class _PathResolver:
+    """Classifies a single backticked path match for :func:`_check_phantom_paths`.
+
+    Holds the lazily-built tree-path index so it is walked at most once per
+    lint run rather than once per match.
+    """
+
+    def __init__(self, repo_root: Path) -> None:
+        self._repo_root = repo_root
+        self._tree_paths: set[str] | None = None
+
+    def problem_with(self, match: str) -> str | None:
+        """Return an error fragment for ``match``, or ``None`` if it resolves."""
+        segments = match.split("/")
+
+        if match.startswith("/") or ".." in segments:
+            return (
+                f"'{match}', which is not a valid repo-relative path "
+                f"(MS-15-001). Absolute paths and '..' segments are not "
+                f"permitted."
+            )
+
+        if _PATH_PLACEHOLDER_RE.search(match):
+            return None
+        if segments[-1] in _PLACEHOLDER_BASENAMES:
+            return None
+
+        if segments[0] in _REPO_TOP_LEVEL_DIRS:
+            if (self._repo_root / match).exists():
+                return None
+            hint = "Point at the real path"
+        else:
+            if self._resolves_as_suffix(match):
+                return None
+            hint = (
+                "Point at the real path (this is not a repo-relative path, "
+                "and no file in the tree ends with it)"
+            )
+
+        return (
+            f"'{match}' which does not exist (MS-15-001). {hint}, or — if the "
+            f"file is intentionally yet to be created — suppress with "
+            f"lint_suppress: [phantom_path_ref]."
+        )
+
+    def _resolves_as_suffix(self, match: str) -> bool:
+        """True when some file in the tree has ``match`` as a path suffix."""
+        if self._tree_paths is None:
+            self._tree_paths = _collect_tree_paths(self._repo_root)
+        suffix = "/" + match
+        return match in self._tree_paths or any(
+            p.endswith(suffix) for p in self._tree_paths
+        )
+
+
+def _collect_tree_paths(repo_root: Path) -> set[str]:
+    """Return every file path in the repo, repo-relative, as a POSIX string.
+
+    Specs illustrate package-relative paths (``vocab/activities/embargo.py`` for
+    ``vultron/wire/as2/vocab/activities/embargo.py``), so a match that is not
+    rooted at a top-level directory is resolved against this set as a path
+    suffix rather than exempted outright.
+
+    :data:`_IGNORED_TREE_DIRS` is pruned during the walk, not filtered
+    afterwards — descending into ``.venv/`` would dominate the runtime and let a
+    vendored file satisfy a reference that no repo file does. Built lazily and
+    at most once per lint run.
+    """
+    paths: set[str] = set()
+    for dirpath, dirnames, filenames in os.walk(repo_root):
+        dirnames[:] = [d for d in dirnames if d not in _IGNORED_TREE_DIRS]
+        rel_dir = Path(dirpath).relative_to(repo_root)
+        prefix = "" if rel_dir == Path(".") else rel_dir.as_posix() + "/"
+        for name in filenames:
+            paths.add(prefix + name)
+    return paths
 
 
 def _check_prefix_consistency(registry: SpecRegistry) -> list[str]:

--- a/vultron/metadata/specs/lint.py
+++ b/vultron/metadata/specs/lint.py
@@ -107,6 +107,68 @@ def _check_adr_status(
     return errors, warnings
 
 
+#: MS-15: a backticked token in a spec statement that looks like a
+#: repo-relative file path (has a directory separator and a known extension).
+_SPEC_PATH_RE = re.compile(
+    r"`([A-Za-z0-9_./-]+/[A-Za-z0-9_.-]+\.(?:py|ya?ml|md|json|toml))`"
+)
+
+#: Placeholder forms that name a *shape* of path rather than a real one
+#: (e.g. `test_XXX_invariants.py`, `plan/history/YYMM/README.md`). These are
+#: intentionally generic and are exempt from the existence check.
+_PATH_PLACEHOLDER_RE = re.compile(
+    r"XXX|YYMM|NNNN|new-topic|new-spec|<|\{",
+)
+
+
+def _check_phantom_paths(registry: SpecRegistry, repo_root: Path) -> list[str]:
+    """Hard error when a spec ``statement`` names a file that does not exist (MS-15-001).
+
+    A normative statement that points at a non-existent path is a stale-premise
+    landmine: an agent reads the MUST, cannot find the infrastructure, and
+    either invents something inconsistent or silently ignores the requirement.
+    DEMOMA-19-008 (issue #2004) named a ``test/ci/invariants/conftest.py`` that
+    had never existed on any branch.
+
+    Only ``statement`` is scanned. ``rationale`` narrates history by design
+    ("X has been converted to Y", "if X stays in Z...") and legitimately
+    references paths that no longer exist.
+
+    Exemptions:
+
+    - Placeholder forms (:data:`_PATH_PLACEHOLDER_RE`) that describe a path
+      shape rather than a specific file.
+    - Paths whose first segment is not a real top-level repo directory, which
+      are package-relative illustrations rather than repo-relative references.
+    - Per-spec opt-out via ``lint_suppress: [phantom_path_ref]``, for a
+      spec-first requirement that deliberately names a file yet to be created.
+    """
+    top_level = {
+        p.name
+        for p in repo_root.iterdir()
+        if p.is_dir() and not p.name.startswith(".")
+    } | {".github"}
+
+    errors: list[str] = []
+    for spec_id, spec in registry.all_specs.items():
+        if LintWarningCode.PHANTOM_PATH_REF in set(spec.lint_suppress or []):
+            continue
+        for match in _SPEC_PATH_RE.findall(spec.statement or ""):
+            if _PATH_PLACEHOLDER_RE.search(match):
+                continue
+            if match.split("/")[0] not in top_level:
+                continue
+            if (repo_root / match).exists():
+                continue
+            errors.append(
+                f"{spec_id}: statement references '{match}' which does not "
+                f"exist (MS-15-001). Point at the real path, or — if the file "
+                f"is intentionally yet to be created — suppress with "
+                f"lint_suppress: [phantom_path_ref]."
+            )
+    return errors
+
+
 def _check_prefix_consistency(registry: SpecRegistry) -> list[str]:
     """Verify each group ID prefix matches its containing file prefix
     (SR-01-007)."""
@@ -281,6 +343,7 @@ def lint(spec_dir: Path, adr_dir: Path | None = None) -> int:
     hard_errors.extend(_check_prefix_consistency(registry))
     hard_errors.extend(_check_spec_id_prefix_consistency(registry))
     hard_errors.extend(_check_scenario_start_groups(registry))
+    hard_errors.extend(_check_phantom_paths(registry, spec_dir.parent))
 
     for spec_id, spec in registry.all_specs.items():
         suppressed = set(spec.lint_suppress or [])

--- a/vultron/metadata/specs/schema.py
+++ b/vultron/metadata/specs/schema.py
@@ -191,6 +191,7 @@ class LintWarningCode(StrEnum):
     RATIONALE_TOO_LONG = "rationale_too_long"
     MISSING_TAGS = "missing_tags"
     DANGLING_ADR_REF = "dangling_adr_ref"
+    PHANTOM_PATH_REF = "phantom_path_ref"
 
 
 class Relationship(BaseModel):


### PR DESCRIPTION
- Closes #2004
<!-- ⚠️  MUST be first — before any ## header. -->

## Summary

`DEMOMA-19-008` (MUST) required registering the FCVCV invariant harness in a
`test/ci/invariants/conftest.py` "under the `fcvcv` scenario key". That file has
never existed on any branch, so the clause could not be satisfied.

**The spec is wrong, not stale.** Provenance: the clause was authored spec-first in
`439cead6` (planning issue #1217), before any FCVCV code existed, so there was no
implementation to check against. Nothing in the codebase ever pointed at it — no
scenario-keyed registry exists anywhere under `test/`, and the three prior harness
clauses (`multi-actor-demo.yaml:1241`, `1534`, `1761`) name the test file and stop.
This is not a premise that drifted; it was never true.

**DEMOMA-19-008 was not isolated.** An audit found **18 clauses across 13 phantom
paths** — most stale after a file move or a module-to-package refactor.

## Changes

### Amend DEMOMA-19-008

Describes what the harnesses actually do (`_DEMO_NAME` + `load_devlogs`), and records
that the `demo`/`test_file` matrix in `.github/workflows/demo-integration.yml` is the
**sole** scenario-to-harness registry.

### Retarget 15 stale path references

| Was | Now |
|---|---|
| `vultron/config.py` | `vultron/config/app.py` / `actor.py` (module → package) |
| `vultron/core/ports/sync_activity_port.py` | `vultron/core/ports/sync_activity.py` |
| `vultron/wire/as2/extractor.py` | `vultron/wire/as2/extractor/` |
| `specs/architecture.md`, `specs/embargo-policy.md` | `.yaml` |
| `.github/skills/*/SKILL.md` | `.claude/skills/*/SKILL.md` |
| `notes/user-stories-trace.md` | `docs/reference/user_stories/traceability.md` |
| `test/ci/test_case_ledger_invariants.py` | `test/ci/invariants/common.py` |
| `notes/spec-registry.md` | `vultron/metadata/specs/schema.py` (`SpecTag`) |

### Rewrite 3 clauses whose referenced concept is gone, not moved

- **UCORG-02-001/002** — `USE_CASE_MAP` was replaced by `SEMANTIC_REGISTRY`
  (projected via `use_case_map()`).
- **PD-06-004/005** — `plan/PRIORITIES.md` was deliberately archived in `51fa5aee4`
  and migrated to the Project #24 `Schedule` field.

### Add MS-15-001 + enforcement

`_check_phantom_paths` in `vultron/metadata/specs/lint.py` — a **hard error**, since
an advisory warning is the same failure mode this PR is fixing.

- Escape hatch: `lint_suppress: [phantom_path_ref]` for a deliberate forward reference.
- Placeholder forms (`test_XXX_invariants.py`, `YYMM`) exempt automatically.
- Package-relative illustrations (`received/sync.py`) exempt.
- **Only `statement` is scanned.** `rationale` narrates history by design
  ("X has been converted to Y") and legitimately cites paths that are gone — 2 of the
  5 rationale hits were correct as written.

## Verification

- `spec-lint` exits 0; negative test confirms it exits 1 and names the offending
  path when a phantom ref is introduced, and 0 once suppressed.
- 16 regression tests: fires, passes on real path, placeholder token both ways,
  placeholder basename vs. substring, dot-directory both ways, suffix resolution
  both ways, mistyped leading segment, build-artifact exclusion, absolute path,
  `..` traversal, rationale non-scanning, suppression.
- `test/metadata/ test/ci/`: **418 passed, 298 skipped** (skips are absent devlogs).
- Full suite green; black / flake8 / mypy / pyright / markdownlint clean.

## Related

Unblocks #1926, whose AC-4f was the same phantom requirement copied out of
DEMOMA-19-008 — the sole reason that issue could not close. AC-4f struck; AC-4a–4e
verified already satisfied by #1962.

Note `test/ci/invariants/conftest.py` *is* added by #1976, holding synthetic JSONL
fixtures for unit-testing `common.py` — no scenario mapping. Documented in
`notes/demo-ci-invariants.md` so the filename resolving later does not invite
bolting scenario routing onto it.

## Review Fixes (`/pr-ship` triage)

Triage found the first-cut lint had enforcement gaps of the same kind it was
added to prevent. Fixed in `3b6be41f`:

- **Dot-directories were exempt.** `top_level` came from `iterdir()` filtered by
  `not startswith(".")`, then re-added only `.github` — so `.claude/` and
  `.agents/` refs were never checked, *including the two
  `.claude/skills/*/SKILL.md` paths this PR retargeted*. Replaced with an
  explicit `_REPO_TOP_LEVEL_DIRS` allowlist, which also makes results
  independent of whether gitignored dirs (`devlogs/`, `site/`) happen to exist.
- **A mistyped leading segment escaped.** A non-top-level match was exempted
  outright, so `tests/ci/common.py` (plural) passed. Such matches now resolve as
  a path *suffix* against a pruned single tree walk: package-relative
  illustrations (`vocab/activities/embargo.py`) still pass, typos do not.
- **Absolute paths and `..` are now rejected**, not exempted — `..` previously
  resolved outside the repo.
- **Placeholder exemption narrowed.** `new-spec`/`new-topic` matched as bare
  substrings, exempting `notes/new-spec-workflow.md`; they are now whole-segment
  basenames. The `<`/`\{` alternatives were unreachable and are dropped.
- **The placeholder test was vacuous** — the fixture repo lacked `test/`, so the
  path was skipped by the first-segment rule before the placeholder branch ran;
  deleting that branch left the suite green. Fixture fixed, 10 tests added.
- `TRACE-01-001` cited a *second* phantom path in the same sentence,
  `docs/topics/user_stories/`; MS-15 cannot see directory refs (see #2012).
- MS-15-001's own rationale tripped spec-lint's 500-char warning.

The stricter check then found a 14th phantom path on its own: `SBT-04-003` named
`case/nodes.py`, now `vultron/core/behaviors/case/nodes/lifecycle.py`.

Two findings deferred:

- **#2011** — rewriting `PD-06` makes a latent contradiction live: `PAD-03` still
  declares the archived `plan/PRIORITIES.md` authoritative for priority
  ordering. 14 refs across `parallel-development.yaml`; reconciling them is a
  design pass over how `build` selects work, not a retarget.
- **#2012** — MS-15 structurally misses bare filenames (`PRIORITIES.md`,
  `conftest.py` — no separator), directory refs (no extension), and behavioral
  step fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Implementation Issues

- #2007 — extract the duplicated universal invariant tests (the real duplication DEMOMA-19-008 gestured at)

