### PR TITLE
fix(logging): demote infrastructure INFO lines; add RM/CS/EM narrative messages

### DIFF
--- a/notes/structured-logging.md
+++ b/notes/structured-logging.md
@@ -70,7 +70,8 @@ MUST be at DEBUG or lower. Verify with a grep after any bulk refactor.
 | `Parsing activity from request body` / `Parsing activity from body` | `vultron/adapters/driving/fastapi/routers/actors/_inbox.py:62`, `vultron/wire/as2/parser.py:113` | HTTP handler internals; duplicate pair |
 | `Processing outbox for actor ...` | `vultron/adapters/driving/fastapi/outbox_handler.py:242` | Preamble; delivery result is the meaningful line |
 | `Dispatch: dispatched X activity_id=...` / `process_payload: outcome status=processed` / `run_inbox_pipeline: status=processed` | `vultron/core/behaviors/inbox/_process_payload.py:214`, `vultron/adapters/driving/fastapi/inbox_orchestration.py:370,386` | Mechanical pipeline completion repeats |
-| `EM FSM: Finished processing state X exit/enter callbacks` | `vultron/core/states/em.py` (transitions callback) | FSM internals; the `Actor X proposed embargo Y (EM A → B)` already captures this |
+| `EM FSM: Finished processing state X exit/enter callbacks` | `transitions` library logger (see below) | FSM internals; the `Actor X proposed embargo Y (EM A → B)` already captures this |
+| `Final BT state:\n<tree>` (after every execution) | `vultron/core/behaviors/bridge.py` | Same scaffolding as `BT structure` |
 | `sync adapter: queued Announce(CaseLedgerEntry) 'UUID' → ['actor']` | `vultron/adapters/driven/sync_activity_adapter.py:116` | Fires per recipient per entry |
 | `store_embedded_participants: stored participant 'UUID'` | `vultron/core/use_cases/received/case/_helpers.py:92` | Fires per participant on every case announcement |
 | `SeedAnnouncedCaseNode: case already exists locally — skipping save` | `vultron/core/behaviors/case/nodes/announce.py:78` | Routine idempotency skip |
@@ -82,21 +83,48 @@ MUST be at DEBUG or lower. Verify with a grep after any bulk refactor.
 ## Missing INFO Messages to Add (SL-04-001 violations)
 
 These state transitions happened with no INFO output as of CONCERN-1968.
+All of these are implemented as of #1988; the "Location" column records where
+each line is emitted from.
 
 | Domain | Message to add | Location |
 |---|---|---|
-| RM per-participant | `Actor '<id>' RM: <A> → <B> for case '<case_id>'` | BT nodes that write `ParticipantStatus` with a new RM state |
-| CS/VFD | `Actor '<id>' CS: <vfd_before> → <vfd_after> (<event>) for case '<case_id>'` | BT nodes for fix-ready, fix-deployed |
-| CS/PXA | `Actor '<id>' CS: <pxa_before> → <pxa_after> (<event>) for case '<case_id>'` | BT nodes for publish |
-| Case engagement | `Actor '<id>' engaged case '<case_id>' (RM VALID → ACCEPTED)` | engage-case trigger BT |
-| EM PROPOSED→ACTIVE | `Actor '<id>' embargo PROPOSED → ACTIVE for case '<case_id>'` | embargo-accept BT when all signatories have accepted |
-| EM ACTIVE→TERMINATED | `Actor '<id>' embargo ACTIVE → TERMINATED for case '<case_id>'` | embargo-terminate BT |
-| Invite receipt | `Actor '<id>' received case invite for '<case_id>' from '<sender>'` | received-invite use case / BT |
+| RM per-participant | `Actor '<id>' RM: <A> → <B> for case '<case_id>'` | `update_participant_rm_state()` — the single per-participant RM write path |
+| CS/VFD | `Actor '<id>' CS: <vfd_before> → <vfd_after> (<event>) for case '<case_id>'` | `CreateParticipantStatusNode` (shared writer for fix-ready / fix-deployed) |
+| CS/PXA | `Actor '<id>' CS: <pxa_before> → <pxa_after> (<event>) for case '<case_id>'` | `CreateParticipantStatusNode` (same node, PXA branch) |
+| Case engagement | `Actor '<id>' engaged case '<case_id>' (RM VALID → ACCEPTED)` | `SvcEngageCaseUseCase._handle_result()` |
+| EM PROPOSED→ACTIVE | `Actor '<id>' embargo PROPOSED → ACTIVE for case '<case_id>'` | `SetEmbargoActiveNode._apply_transition()` |
+| EM ACTIVE→EXITED | `Actor '<id>' embargo ACTIVE → EXITED for case '<case_id>'` | `ClearActiveEmbargoNode`, `ApplyEmbargoTeardownNode` |
+| Invite receipt | `Actor '<id>' received case invite for '<case_id>' from '<sender>'` | `InviteActorToCaseReceivedUseCase` (invitee path) |
 | BT FAILURE reason | `Actor '<id>' BT execution FAILURE for case '<case_id>': <reason>` | `BTBridge.execute_with_setup` (non-SUCCESS path) |
+
+The EM terminal state is spelled **EXITED** (`EM.EXITED`), not "TERMINATED":
+the trigger is named `terminate` but the resulting state is `EXITED`.
 
 ---
 
 ## Implementation Guidance
+
+### Use the shared helpers — do not hand-format the template
+
+`vultron/core/behaviors/narrative_log.py` owns the SL-04-006 template. Call the
+helper for the domain instead of formatting the string at the call site, so the
+wording cannot drift (CS-22-001):
+
+| Helper | Emits |
+|---|---|
+| `log_cs_transition()` | `Actor '<id>' CS: <A> → <B> (<event>) for case '<id>'` |
+| `log_em_transition()` | `Actor '<id>' embargo <A> → <B> for case '<id>'` |
+| `log_case_engagement()` | `Actor '<id>' engaged case '<id>' (RM <A> → <B>)` |
+| `log_invite_received()` | `Actor '<id>' received case invite for '<id>' from '<id>'` |
+| `log_bt_failure()` | `Actor '<id>' BT execution FAILURE for case '<id>': <reason>` |
+
+`cs_event_label()` derives the event name (`fix ready`, `publicly known`, …) by
+diffing the `CS_vfd`/`CS_pxa` sub-dimensions, so a multi-step transition names
+every dimension that advanced.
+
+**No-op writes emit nothing.** `log_cs_transition()` and `log_em_transition()`
+return early when before == after: re-asserting the current state is not a
+protocol event and would reintroduce noise (SL-04-007).
 
 ### Where to add new log lines
 
@@ -105,12 +133,40 @@ use-case `execute()` wrapper. This mirrors the existing embargo proposal
 pattern (`AdvanceEMStateToProposedNode` etc.) and keeps protocol-significant
 logging co-located with the protocol-significant action.
 
-Use `self.logger.info(...)` (on `DataLayerAction`) or `logger.info(...)` from
-a module-level logger. Include `actor_id` and `case_id` in every message.
+Prefer the **narrowest choke point that knows the before-state**. Two examples
+from the #1988 implementation:
+
+- RM: `update_participant_rm_state()` in `vultron/core/use_cases/_helpers.py`
+  is the single write path for per-participant RM state, so one call there
+  covers every RM transition node. It reads the before-state from the latest
+  `ParticipantStatus` (falling back to `RM.START`).
+- CS: `CreateParticipantStatusNode` is the shared writer for both VFD and PXA
+  snapshots. `TransitionCStoFixReady` / `TransitionCStoFixDeployed` delegate to
+  it and log only at DEBUG — they know the target state but not the origin.
+
+When a trigger use case needs the before-state, capture it in `_prepare()`
+**before** the BT mutates anything (see `SvcEngageCaseUseCase` and
+`current_participant_rm_state()`).
+
+### Third-party FSM noise
+
+The `transitions` library logs `Finished processing state X enter/exit
+callbacks.` and `Executed callback '<f>'` at INFO on every RM/EM/CS/PEC step.
+Because the messages come from library code, they cannot be demoted at the call
+site. `vultron/logging_setup.suppress_third_party_info_noise()` pins those
+loggers to `WARNING` whenever the app level is above DEBUG; it is called from
+both `configure_logging()` (server) and the demo CLI's `main()`. Add any future
+noisy library to `NOISY_INFO_LOGGERS` there.
 
 ### Grep check after refactor
 
-After any bulk logging-level change, always run:
+This check is automated as
+`test/architecture/test_infrastructure_logs_not_at_info.py`, which walks
+`vultron/` with `ast` and fails when any demoted fragment appears in a
+`logger.info(...)` format string. Add new demoted patterns to its
+`DEMOTED_FRAGMENTS` tuple rather than relying on a manual grep.
+
+For a quick manual spot-check:
 
 ```bash
 grep -rn "logger\.info.*DataLayer stored\|logger\.info.*DataLayer saved\|logger\.info.*BT structure\|logger\.info.*Processing outbox" vultron/

--- a/notes/structured-logging.md
+++ b/notes/structured-logging.md
@@ -88,17 +88,24 @@ each line is emitted from.
 
 | Domain | Message to add | Location |
 |---|---|---|
-| RM per-participant | `Actor '<id>' RM: <A> → <B> for case '<case_id>'` | `update_participant_rm_state()` — the single per-participant RM write path |
+| RM per-participant | `Actor '<id>' RM: <A> → <B> for case '<case_id>'` | `update_participant_rm_state()` **and** `CreateParticipantStatusNode` — the two per-participant RM write paths |
 | CS/VFD | `Actor '<id>' CS: <vfd_before> → <vfd_after> (<event>) for case '<case_id>'` | `CreateParticipantStatusNode` (shared writer for fix-ready / fix-deployed) |
 | CS/PXA | `Actor '<id>' CS: <pxa_before> → <pxa_after> (<event>) for case '<case_id>'` | `CreateParticipantStatusNode` (same node, PXA branch) |
 | Case engagement | `Actor '<id>' engaged case '<case_id>' (RM VALID → ACCEPTED)` | `SvcEngageCaseUseCase._handle_result()` |
 | EM PROPOSED→ACTIVE | `Actor '<id>' embargo PROPOSED → ACTIVE for case '<case_id>'` | `SetEmbargoActiveNode._apply_transition()` |
 | EM ACTIVE→EXITED | `Actor '<id>' embargo ACTIVE → EXITED for case '<case_id>'` | `ClearActiveEmbargoNode`, `ApplyEmbargoTeardownNode` |
 | Invite receipt | `Actor '<id>' received case invite for '<case_id>' from '<sender>'` | `InviteActorToCaseReceivedUseCase` (invitee path) |
-| BT FAILURE reason | `Actor '<id>' BT execution FAILURE for case '<case_id>': <reason>` | `BTBridge.execute_with_setup` (non-SUCCESS path) |
+| BT FAILURE reason | folded into the existing `BT execution completed: <status> after <N> ticks - <reason>` line | `BTBridge.execute_tree` (FAILURE path) |
 
 The EM terminal state is spelled **EXITED** (`EM.EXITED`), not "TERMINATED":
 the trigger is named `terminate` but the resulting state is `EXITED`.
+
+The BT-failure row is deliberately *not* a separate narrative line. `BTBridge`
+folds `get_failure_reason()` into the record it already emits, because a second
+line would double-log, would fire for the many callers that treat `FAILURE` as
+an expected idempotent skip (and log their own reason at DEBUG), and has no
+reliable `case_id`: no production `execute_with_setup` call site passes one.
+See the closing `NOTE` in `narrative_log.py`.
 
 ---
 
@@ -116,7 +123,10 @@ wording cannot drift (CS-22-001):
 | `log_em_transition()` | `Actor '<id>' embargo <A> → <B> for case '<id>'` |
 | `log_case_engagement()` | `Actor '<id>' engaged case '<id>' (RM <A> → <B>)` |
 | `log_invite_received()` | `Actor '<id>' received case invite for '<id>' from '<id>'` |
-| `log_bt_failure()` | `Actor '<id>' BT execution FAILURE for case '<id>': <reason>` |
+| `log_rm_transition()` | `Actor '<id>' RM: <A> → <B> for case '<id>'` |
+
+There is deliberately **no** `log_bt_failure()` helper — see the BT-failure note
+above and the closing `NOTE` in `narrative_log.py`.
 
 `cs_event_label()` derives the event name (`fix ready`, `publicly known`, …) by
 diffing the `CS_vfd`/`CS_pxa` sub-dimensions, so a multi-step transition names
@@ -136,10 +146,16 @@ logging co-located with the protocol-significant action.
 Prefer the **narrowest choke point that knows the before-state**. Two examples
 from the #1988 implementation:
 
-- RM: `update_participant_rm_state()` in `vultron/core/use_cases/_helpers.py`
-  is the single write path for per-participant RM state, so one call there
-  covers every RM transition node. It reads the before-state from the latest
-  `ParticipantStatus` (falling back to `RM.START`).
+- RM: per-participant RM state has **two** write paths, and both log.
+  `update_participant_rm_state()` in `vultron/core/use_cases/_helpers.py` covers
+  the nodes that call it (`TransitionParticipantRMtoAccepted`,
+  `TransitionRMtoValid`, …), reading the before-state from the latest
+  `ParticipantStatus` and falling back to `RM.START`.
+  `CreateParticipantStatusNode` is the second path — `leave.py`,
+  `sync/nodes/effects.py`, and `add_participant_status_trigger_tree.py` set
+  `rm_state=` on it directly without going through the helper — so it logs the
+  RM line itself. A new RM-writing node MUST route through one of these two, or
+  its transition will be missing from the INFO narrative.
 - CS: `CreateParticipantStatusNode` is the shared writer for both VFD and PXA
   snapshots. `TransitionCStoFixReady` / `TransitionCStoFixDeployed` delegate to
   it and log only at DEBUG — they know the target state but not the origin.

--- a/plan/history/2608/implementation/ISSUE-1988.md
+++ b/plan/history/2608/implementation/ISSUE-1988.md
@@ -1,0 +1,77 @@
+---
+source: ISSUE-1988
+timestamp: '2026-08-05T20:45:25.728841+00:00'
+title: Logging narrative remediation (demote infra INFO, add RM/CS/EM lines)
+type: implementation
+---
+
+## Issue #1988 — fix(logging): demote infrastructure INFO lines; add RM/CS/EM narrative messages
+
+PR: <https://github.com/CERTCC/Vultron/pull/2008>
+
+Implements the two-pass logging remediation from CONCERN-1968 (#1968) so that
+reading an actor's INFO log tells the complete CVD protocol story without
+dropping to DEBUG. All 22 acceptance criteria satisfied.
+
+**Pass 1 (SL-04-007) — 11 infrastructure patterns demoted to DEBUG:**
+DataLayer store/save/update, the `BT structure` and `Final BT state` tree dumps
+(now also skipped entirely at INFO via an `isEnabledFor` guard), the duplicate
+activity-parsing pair, the outbox preamble, pipeline outcome echoes, the
+per-recipient sync queue line, per-participant storage chatter, routine
+idempotency skips, and the `discover_actors()` object dump (ID only at INFO).
+
+The `transitions` library logs FSM enter/exit callbacks at INFO on every
+RM/EM/CS/PEC step and cannot be demoted at the call site. New
+`vultron/logging_setup.py` pins those loggers above INFO from both entry points
+(`configure_logging()`, demo CLI) and restores them on lifespan shutdown, so a
+`TestClient` lifetime does not silently reconfigure logging for everything after
+it.
+
+**Pass 2 (SL-04-001, SL-04-006) — 7 narrative messages added** via shared
+helpers in new `vultron/core/behaviors/narrative_log.py`, which owns the
+template so call sites cannot drift (CS-22-001). Each line is wired at the
+narrowest choke point that knows the before-state:
+
+- RM → `update_participant_rm_state()` (the primary write path)
+- RM → also `CreateParticipantStatusNode`, a *second* per-participant RM write
+  path (used by the leave-case RM → CLOSED nodes) that would otherwise have
+  left AC-12 unmet
+- CS/VFD + CS/PXA → `CreateParticipantStatusNode` (shared writer)
+- EM → `SetEmbargoActiveNode`, `ClearActiveEmbargoNode`, `ApplyEmbargoTeardownNode`
+- engagement → `SvcEngageCaseUseCase`, reading the after-state back from storage
+- invite receipt → `InviteActorToCaseReceivedUseCase`
+
+AC-18 was satisfied by folding `get_failure_reason()` into the *existing*
+`BT execution completed: Status.FAILURE` line rather than adding a second
+record — a separate line would have double-logged, fired for the many callers
+that treat FAILURE as an expected idempotent skip (and log their own reason at
+DEBUG), and had no reliable `case_id` to report.
+
+**Three correctness guards found during self-review**, each a case where the
+new line would have been actively misleading:
+
+1. No-op writes emit nothing. A repeat PXA write re-announced the
+   public-disclosure milestone; a repeat engage claimed `RM ACCEPTED → ACCEPTED`.
+2. The PXA before-state must come from the participant's own latest
+   `case_status.pxa`. `CreateParticipantStatusNode` never appends to
+   `case.case_statuses`, so reading `case.current_status` reported a stale `pxa`
+   forever.
+3. Backward CS moves log at WARNING labelled `state regression`. CS events are
+   monotonic, so a regression is an anomaly, not a milestone; previously the
+   label fell through to `no change`, producing a line that claimed a transition
+   and denied it in the same breath.
+
+**AC-22 is an executable ratchet**, not a manual grep:
+`test/architecture/test_infrastructure_logs_not_at_info.py` walks `vultron/`
+with `ast` and fails when any demoted fragment appears in a `logger.info()`
+format string. Its own detector is tested so it cannot go vacuously green, and
+its coverage limits are documented inline.
+
+**Verification:** 6318 unit tests pass (79 new), 1006 integration tests pass,
+0 failures. Black, flake8, mypy, pyright, markdownlint clean. Two regression
+tests (repeat-PXA, RM-via-node) fail against the first-pass implementation and
+pass after the fixes.
+
+Also fixed an unclosed-`SqliteDataLayer` fixture in
+`test_actor_and_announce_nodes.py` that made a latent `ResourceWarning` flake
+reproducible.

--- a/plan/incoming/learnings/20260805-ac18-bt-failure-line-folded-not-added.md
+++ b/plan/incoming/learnings/20260805-ac18-bt-failure-line-folded-not-added.md
@@ -1,0 +1,40 @@
+---
+title: AC-18 satisfied by enriching the existing BT-failure line, not adding a new one
+type: learning
+timestamp: 2026-08-05
+source: ISSUE-1988
+signal: design-question
+---
+
+ISSUE-1988 AC-18 asked for a new INFO line,
+`Actor '<id>' BT execution FAILURE for case '<case_id>': <reason>`, scoped to
+"non-owner actors". It was implemented literally first, then deliberately
+replaced with an enrichment of the *existing*
+`BT execution completed: Status.FAILURE after N ticks - <feedback>` line in
+`BTBridge.execute_tree` (falling back to `get_failure_reason()` when the root
+carries no feedback message).
+
+Three reasons the literal reading was wrong:
+
+1. **Double-logging.** `execute_tree` already emits one INFO record for every
+   terminal status. A second dedicated line meant two INFO records per failure,
+   and three for the many callers that also log their own explanation.
+2. **No "non-owner" discriminator exists.** `execute_with_setup` has 52 call
+   sites and no notion of owner vs non-owner, so the scoping in the AC was not
+   implementable as written. Applied unconditionally, it escalated *expected*
+   FAILUREs to INFO — e.g. the idempotent `CASE_STATUS_ALREADY_PRESENT` skip in
+   `received/status.py`, the non-forward-gap `BufferOutOfOrderEntryNode` return,
+   and the ~10 sites that deliberately log `"BT did not fully succeed"` at DEBUG
+   precisely because the failure is routine.
+3. **No `case_id` to report.** An AST scan found **zero** production
+   `execute_with_setup` call sites that pass `case_id=`. Only 5 trigger use
+   cases inject it via `_extra_execute_kwargs()`, and those raise before
+   reaching the log. Every received-side tree would have rendered
+   `for case ''`.
+
+**Guidance for future ACs of this shape:** before adding a "log the reason"
+line, check whether an existing record at that point can carry the reason
+instead. Also check whether the *absence* of an explanation was the real defect
+(it was here) rather than the absence of a line. And when an AC scopes a
+behaviour to a subset of actors ("non-owner"), verify a discriminator for that
+subset actually exists at the proposed call site before designing around it.

--- a/plan/incoming/learnings/20260805-caplog-captures-setup-phase-records.md
+++ b/plan/incoming/learnings/20260805-caplog-captures-setup-phase-records.md
@@ -1,0 +1,36 @@
+---
+title: caplog captures records from a test's setup phase, not only the at_level() block
+type: learning
+timestamp: 2026-08-05
+source: ISSUE-1988
+signal: tooling-issue
+---
+
+`caplog.at_level(...)` sets a level; it does **not** scope capture to the
+`with` block. Records emitted earlier in the same test — including arrange-phase
+calls made before the block — are already in `caplog.records` when the
+assertions run.
+
+This produced two tests in ISSUE-1988 that passed in isolation and failed in the
+full suite. Both asserted on "the first narrative record", but their arrange
+phase drove the state machine forward a step or two first:
+
+```python
+update_participant_rm_state(case, actor, RM.RECEIVED, dl)   # arrange — logs!
+update_participant_rm_state(case, actor, RM.VALID, dl)      # arrange — logs!
+with caplog.at_level(logging.INFO, logger=NAME):
+    update_participant_rm_state(case, actor, RM.ACCEPTED, dl)
+records[0]  # ← the START → RECEIVED line from arrange, not the assertion target
+```
+
+The order-dependence is what makes it nasty: in isolation the arrange-phase
+records were below the effective level and never captured, so the test was
+green. Once an earlier test in the session had raised the level on that logger,
+they *were* captured and `records[0]` silently became the wrong record.
+
+**Fix:** call `caplog.clear()` immediately before the `at_level()` block that
+the assertion targets, whenever the arrange phase exercises the same logger.
+
+Corollary for tests asserting *absence* (`assert not records`): these are the
+most exposed, since any arrange-phase record makes them fail. Always clear
+first.

--- a/plan/incoming/learnings/20260805-narrative-log-choke-point-needs-before-state.md
+++ b/plan/incoming/learnings/20260805-narrative-log-choke-point-needs-before-state.md
@@ -1,0 +1,52 @@
+---
+title: A state-transition log line belongs at the narrowest writer that knows the before-state
+type: learning
+timestamp: 2026-08-05
+source: ISSUE-1988
+signal: design-question
+---
+
+`notes/structured-logging.md` said to add narrative INFO lines "in the BT leaf
+node that performs the state write". That rule is necessary but not sufficient:
+the leaf node often knows only the *target* state, so following it literally
+produces lines that are wrong rather than merely incomplete.
+
+Three concrete failures from ISSUE-1988, all caught only after the first
+implementation was already passing its own tests:
+
+- **`TransitionCStoFixReady` / `TransitionCStoFixDeployed` are the wrong home.**
+  Each knows it is writing `VFd` / `VFD`, but not the origin — their
+  pre-existing messages literally read `VFD → VFd` and `VFD → VFD`. The
+  before-state lives in `CreateParticipantStatusNode`, which they delegate to.
+  The narrative line went there; the leaf nodes kept DEBUG detail lines.
+
+- **A "single write path" claim must be verified, not assumed.**
+  `update_participant_rm_state()` was documented as *the* per-participant RM
+  writer. `CreateParticipantStatusNode` also appends a `ParticipantStatus` with
+  an explicit `rm_state` without going through it — so the leave-case
+  RM → CLOSED transitions produced no RM line and AC-12 was unmet while the
+  notes asserted it was met. Grep for every writer of the field, not just the
+  obvious helper.
+
+- **The before-state source must be the same store the write lands in.**
+  `CreateParticipantStatusNode` records PXA on the *participant* snapshot and
+  never appends to `case.case_statuses`, so reading `case.current_status.pxa`
+  reported a stale value forever and every repeat write re-announced the
+  public-disclosure milestone. Reading the participant's own latest
+  `case_status.pxa` fixed it.
+
+**Two invariants worth applying to any future transition-logging work:**
+
+1. **Guard the no-op.** If `before == after`, emit nothing. Re-asserting a
+   state is bookkeeping, and a line reading `RM ACCEPTED → ACCEPTED` or
+   `CS: pxa → Pxa` on the second call actively misinforms. Read the after-state
+   back from storage rather than hardcoding the intended target, since BTs can
+   succeed via idempotent paths.
+2. **Guard the monotonicity violation.** CS/RM/EM events are forward-only, so a
+   backward move is an anomaly, not a milestone — log it at WARNING with a
+   distinct label. Deriving an event name by diffing sub-dimensions silently
+   yields "no change" for a regression, producing a line that claims a
+   transition and denies it in the same breath.
+
+A no-op or backward-transition test is the cheapest way to catch all of this:
+run the same write twice and assert the second emits nothing.

--- a/plan/incoming/learnings/20260805-per-test-timeout-marginal-under-load.md
+++ b/plan/incoming/learnings/20260805-per-test-timeout-marginal-under-load.md
@@ -1,0 +1,35 @@
+---
+title: AST-walking architecture ratchets sit near the 5s per-test timeout under full-suite load
+type: learning
+timestamp: 2026-08-05
+source: ISSUE-1988
+signal: concern
+---
+
+The repo sets `timeout = 5` (per test) in `pyproject.toml`. Several
+architecture ratchets parse every file under `vultron/` with `ast` and are
+already close to that ceiling in isolation:
+
+- `test_activity_factory_imports.py::test_vocab_activities_boundary` — ~3.4s
+- `test_no_asgi_transport_in_app_code.py` — ~1.9s
+- `test_core_no_adapter_imports.py` — ~1.2s
+
+Under full-suite load (`uv run pytest -m ""`) one of these times out
+non-deterministically — a *different* test on each run
+(`test_vocab_activities_boundary`, `test_docs_render`, …), which is the
+signature of a load-dependent margin rather than a specific slow test.
+Reproduced on a clean `origin/main` worktree with all ISSUE-1988 changes
+stashed, so it is pre-existing and not a regression. It is invisible when
+running a single directory, which is how these tests are usually exercised.
+
+Mitigation applied to the new ratchet
+(`test/architecture/test_infrastructure_logs_not_at_info.py`): a cheap
+substring prefilter skips `ast.parse()` for files that do not mention any
+target fragment, cutting it from ~2.05s to ~0.67s.
+
+**Suggested follow-up:** apply the same prefilter (or a shared cached
+"parse every vultron module once" session fixture) to the existing ratchets, or
+mark them with a longer per-test timeout. As more ratchets accumulate — this PR
+added one — the aggregate risk of a spurious CI failure grows. Worth a Concern
+issue; the fix is mechanical but touches several files and is out of scope for
+a logging PR.

--- a/test/adapters/driven/test_sqlite_crud.py
+++ b/test/adapters/driven/test_sqlite_crud.py
@@ -270,3 +270,67 @@ def test_exists_returns_false_after_delete(dl, record_factory):
 
 def test_ping_returns_true(dl):
     assert dl.ping() is True
+
+
+# ---------------------------------------------------------------------------
+# Log-level contract (SL-04-007)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenceLogLevels:
+    """DataLayer store/save/update lines are persistence internals → DEBUG.
+
+    SL-04-007: these fire on every write and drown out the CVD protocol
+    story on the INFO channel.  The higher-level "Created X" messages that
+    surround them remain at INFO.
+    """
+
+    _CRUD_LOGGER = "vultron.adapters.driven.datalayer_sqlite.crud"
+
+    def _datalayer_records(self, caplog):
+        return [
+            r
+            for r in caplog.records
+            if r.getMessage().startswith("DataLayer ")
+        ]
+
+    def test_create_logs_stored_at_debug(self, caplog):
+        import logging
+
+        instance = SqliteDataLayer("sqlite:///:memory:")
+        try:
+            with caplog.at_level(logging.DEBUG, logger=self._CRUD_LOGGER):
+                instance.create(Record(id_="urn:x:1", type_="Note", data_={}))
+        finally:
+            instance.close()
+
+        records = self._datalayer_records(caplog)
+        assert records, "Expected a 'DataLayer stored' log entry"
+        assert all(r.levelno == logging.DEBUG for r in records)
+
+    def test_save_logs_saved_at_debug(self, caplog):
+        import logging
+
+        instance = SqliteDataLayer("sqlite:///:memory:")
+        try:
+            with caplog.at_level(logging.DEBUG, logger=self._CRUD_LOGGER):
+                instance.save(Record(id_="urn:x:2", type_="Note", data_={}))
+        finally:
+            instance.close()
+
+        records = self._datalayer_records(caplog)
+        assert records, "Expected a 'DataLayer saved' log entry"
+        assert all(r.levelno == logging.DEBUG for r in records)
+
+    def test_no_datalayer_lines_reach_info(self, caplog):
+        import logging
+
+        instance = SqliteDataLayer("sqlite:///:memory:")
+        try:
+            with caplog.at_level(logging.INFO, logger=self._CRUD_LOGGER):
+                instance.create(Record(id_="urn:x:3", type_="Note", data_={}))
+                instance.save(Record(id_="urn:x:3", type_="Note", data_={}))
+        finally:
+            instance.close()
+
+        assert not self._datalayer_records(caplog)

--- a/test/adapters/driven/test_sync_adapter_log_levels.py
+++ b/test/adapters/driven/test_sync_adapter_log_levels.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Per-recipient sync-queue lines are DEBUG, not INFO (SL-04-007).
+
+``send_announce_log_entry`` fires once per recipient per ledger entry, so at
+INFO it scales with participant count and buries the protocol story.
+"""
+
+import logging
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
+from vultron.core.models.case_ledger import HashChainLedgerRecord
+from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
+
+_CASE_ACTOR = "https://example.org/actors/case-actor"
+_PARTICIPANT = "https://example.org/actors/vendor"
+_CASE_URI = "https://example.org/cases/case-sync-log"
+_ZERO_HASH = "0" * 64
+_ADAPTER_LOGGER = "vultron.adapters.driven.sync_activity_adapter"
+
+
+@pytest.fixture()
+def dl():
+    datalayer = SqliteDataLayer("sqlite:///:memory:", actor_id=_CASE_ACTOR)
+    yield datalayer
+    datalayer.close()
+
+
+@pytest.fixture()
+def entry() -> VultronCaseLedgerEntry:
+    chain = HashChainLedgerRecord(
+        case_id=_CASE_URI,
+        log_index=0,
+        object_id="https://example.org/activities/act-sync-log",
+        event_type="test_event",
+        payload_snapshot={"key": "value"},
+        prev_log_hash=_ZERO_HASH,
+    )
+    return VultronCaseLedgerEntry(
+        case_id=chain.case_id,
+        log_index=chain.log_index,
+        disposition=chain.disposition,
+        term=chain.term,
+        log_object_id=chain.object_id,
+        event_type=chain.event_type,
+        payload_snapshot=dict(chain.payload_snapshot),
+        prev_log_hash=chain.prev_log_hash,
+        entry_hash=chain.entry_hash,
+    )
+
+
+def _queued_records(caplog) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if "sync adapter: queued Announce(CaseLedgerEntry)" in r.getMessage()
+    ]
+
+
+def test_queued_announce_line_is_debug(dl, entry, caplog):
+    """The per-recipient Announce queue line is emitted at DEBUG."""
+    adapter = SyncActivityAdapter(dl)
+
+    with caplog.at_level(logging.DEBUG, logger=_ADAPTER_LOGGER):
+        adapter.send_announce_log_entry(
+            entry=entry, actor_id=_CASE_ACTOR, to=[_PARTICIPANT]
+        )
+
+    records = _queued_records(caplog)
+    assert records, "Expected the queued-Announce log entry"
+    assert all(r.levelno == logging.DEBUG for r in records)
+
+
+def test_queued_announce_line_not_emitted_at_info(dl, entry, caplog):
+    """No queued-Announce record reaches an INFO-only handler."""
+    adapter = SyncActivityAdapter(dl)
+
+    with caplog.at_level(logging.INFO, logger=_ADAPTER_LOGGER):
+        adapter.send_announce_log_entry(
+            entry=entry, actor_id=_CASE_ACTOR, to=[_PARTICIPANT]
+        )
+
+    assert not _queued_records(caplog)
+
+
+def test_announce_is_still_queued_to_the_outbox(dl, entry):
+    """Demoting the log level does not change delivery behaviour."""
+    adapter = SyncActivityAdapter(dl)
+
+    adapter.send_announce_log_entry(
+        entry=entry, actor_id=_CASE_ACTOR, to=[_PARTICIPANT]
+    )
+
+    assert dl.outbox_list_for_actor(_CASE_ACTOR)

--- a/test/adapters/driving/fastapi/test_inbox_route_log_levels.py
+++ b/test/adapters/driving/fastapi/test_inbox_route_log_levels.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Inbox-route HTTP handler chatter is DEBUG, not INFO (SL-04-007).
+
+Two patterns are covered:
+
+- ``Parsing activity from request body`` — HTTP handler internals, and a
+  duplicate of the ``vultron.wire.as2.parser`` line that follows it.
+- ``Activity ... already received by ...; ignoring duplicate submission`` —
+  normal sync-protocol behaviour, not an anomaly worth INFO.
+"""
+
+import logging
+
+from vultron.adapters.driving.fastapi.routers.actors import _inbox
+from vultron.wire.as2.factories import rm_create_report_activity
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    as_VulnerabilityReport,
+)
+
+# The inbox router logs through uvicorn's error logger so its records
+# appear alongside server output.
+_INBOX_LOGGER = "uvicorn.error"
+
+
+def _body() -> dict:
+    activity = rm_create_report_activity(
+        report=as_VulnerabilityReport(
+            name="LOG-001", content="log-level test report"
+        ),
+        actor="https://example.org/actors/finder",
+        to=["https://example.org/actors/vendor"],
+    )
+    return activity.model_dump(by_alias=True, exclude_none=True)
+
+
+def _parsing_records(caplog) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if "Parsing activity from request body" in r.getMessage()
+    ]
+
+
+def test_parse_activity_logs_body_dump_at_debug(caplog):
+    """The request-body dump is emitted at DEBUG."""
+    with caplog.at_level(logging.DEBUG, logger=_INBOX_LOGGER):
+        _inbox.parse_activity(_body())
+
+    records = _parsing_records(caplog)
+    assert records, "Expected the request-body parsing log entry"
+    assert all(r.levelno == logging.DEBUG for r in records)
+
+
+def test_parse_activity_body_dump_not_emitted_at_info(caplog):
+    """No request-body dump reaches an INFO-only handler."""
+    with caplog.at_level(logging.INFO, logger=_INBOX_LOGGER):
+        _inbox.parse_activity(_body())
+
+    assert not _parsing_records(caplog)
+
+
+class _StubInbox:
+    """Inbox stand-in exposing the ``items`` list the dedup guard reads."""
+
+    def __init__(self, items: list[str]) -> None:
+        self.items = items
+
+
+class _StubActor:
+    """CoreActor stand-in exposing only the inbox the guard reads."""
+
+    def __init__(self, received: list[str]) -> None:
+        self.id_ = "https://example.org/actors/vendor"
+        self.inbox = _StubInbox(received)
+
+
+def test_duplicate_submission_guard_still_detects_duplicates():
+    """Demoting the log level does not change the dedup decision."""
+    activity_id = "urn:uuid:already-seen"
+    actor = _StubActor([activity_id])
+
+    assert _inbox._activity_already_received(actor, activity_id)  # type: ignore[arg-type]
+    assert not _inbox._activity_already_received(actor, "urn:uuid:fresh")  # type: ignore[arg-type]

--- a/test/adapters/driving/fastapi/test_outbox_handler.py
+++ b/test/adapters/driving/fastapi/test_outbox_handler.py
@@ -196,3 +196,58 @@ def test_outbox_handler_resolves_actor_by_short_id(monkeypatch):
     asyncio.run(oh.outbox_handler("bob", mock_dl))
 
     mock_dl.find_actor_by_short_id.assert_called_once_with("bob")
+
+
+# ---------------------------------------------------------------------------
+# Log-level contract (SL-04-007)
+# ---------------------------------------------------------------------------
+
+
+def _preamble_records(caplog):
+    return [
+        r
+        for r in caplog.records
+        if "Processing outbox for actor" in r.getMessage()
+    ]
+
+
+def test_processing_outbox_preamble_is_debug(monkeypatch, caplog):
+    """The "Processing outbox for actor" preamble is DEBUG (SL-04-007).
+
+    It is a prefix with no outcome information; the per-item delivery result
+    lines that follow are the meaningful INFO output.
+    """
+    import logging
+
+    queue = _make_queue("urn:test:item-log")
+    mock_dl = _mock_dl_with_queue(queue)
+
+    async def fake_handle(actor_id, activity_id, dl, emitter):
+        return None
+
+    monkeypatch.setattr(oh, "handle_outbox_item", fake_handle)
+
+    with caplog.at_level(logging.DEBUG):
+        asyncio.run(oh.outbox_handler("actor-xyz", mock_dl))
+
+    records = _preamble_records(caplog)
+    assert records, "Expected the outbox preamble log entry"
+    assert all(r.levelno == logging.DEBUG for r in records)
+
+
+def test_processing_outbox_preamble_not_emitted_at_info(monkeypatch, caplog):
+    """No outbox preamble record reaches an INFO-only handler."""
+    import logging
+
+    queue = _make_queue("urn:test:item-log-2")
+    mock_dl = _mock_dl_with_queue(queue)
+
+    async def fake_handle(actor_id, activity_id, dl, emitter):
+        return None
+
+    monkeypatch.setattr(oh, "handle_outbox_item", fake_handle)
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(oh.outbox_handler("actor-xyz", mock_dl))
+
+    assert not _preamble_records(caplog)

--- a/test/architecture/test_infrastructure_logs_not_at_info.py
+++ b/test/architecture/test_infrastructure_logs_not_at_info.py
@@ -56,6 +56,7 @@ DEMOTED_FRAGMENTS: tuple[str, ...] = (
     "store_embedded_participants: stored participant",
     "already exists locally",
     "already received by",
+    "already stored — skipping",
 )
 
 

--- a/test/architecture/test_infrastructure_logs_not_at_info.py
+++ b/test/architecture/test_infrastructure_logs_not_at_info.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Ratchet: infrastructure log lines MUST NOT be emitted at INFO (SL-04-007).
+
+Infrastructure chatter (persistence store/save/update, BT scaffolding dumps,
+HTTP handler parsing echoes, pipeline completion repeats, per-recipient sync
+queue entries, routine idempotency skips) drowns out the CVD protocol story on
+the INFO channel.  ``specs/structured-logging.yaml`` SL-04-007 makes DEBUG-or-
+lower mandatory for these patterns.
+
+This test is the executable form of the grep check documented in
+``notes/structured-logging.md`` § "Grep check after refactor": it walks the
+``vultron/`` tree with ``ast`` and fails when any demoted message fragment
+appears as the first argument of a ``logger.info(...)`` / ``self.logger.info(...)``
+call.
+
+Source concern: #1968.  Implementation: #1988.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+
+_PACKAGE_ROOT = REPO_ROOT / "vultron"
+
+#: Message fragments that MUST NOT appear in a ``logger.info()`` format string.
+#:
+#: Each entry corresponds to a row in the SL-04-007 demotion table in
+#: ``notes/structured-logging.md``.
+DEMOTED_FRAGMENTS: tuple[str, ...] = (
+    "DataLayer stored",
+    "DataLayer saved",
+    "DataLayer updated",
+    "BT structure",
+    "Final BT state",
+    "Parsing activity from",
+    "Processing outbox for actor",
+    "process_payload: outcome",
+    "run_inbox_pipeline: status",
+    "run_inbox_pipeline: replayed",
+    "sync adapter: queued Announce(CaseLedgerEntry)",
+    "store_embedded_participants: stored participant",
+    "already exists locally",
+    "already received by",
+)
+
+
+#: Coverage limits — deliberate, but worth knowing before trusting a green run:
+#:
+#: - Only receivers named ``logger`` / ``_LOGGER`` / ``log``, or attributes
+#:   ``.logger`` / ``._logger``, are recognised. An inline
+#:   ``logging.getLogger(__name__).info(...)`` is not matched.
+#: - Only the *first* argument is inspected, so a message pre-built with ``%``
+#:   or ``.format()`` and passed as a variable is not matched.
+#:
+#: Both patterns are absent from ``vultron/`` today. If one is introduced,
+#: extend ``_is_logger_info_call`` / ``_format_string`` rather than assuming
+#: this ratchet already covers it.
+
+
+def _is_logger_info_call(node: ast.Call) -> bool:
+    """Return True when *node* is a ``<something>.logger.info`` / ``logger.info`` call."""
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr != "info":
+        return False
+    receiver = func.value
+    if isinstance(receiver, ast.Name):
+        return receiver.id in {"logger", "_LOGGER", "log"}
+    if isinstance(receiver, ast.Attribute):
+        return receiver.attr in {"logger", "_logger"}
+    return False
+
+
+def _format_string(node: ast.Call) -> str:
+    """Return the literal text of *node*'s first argument, or ``""``.
+
+    Handles plain string literals, implicitly-concatenated literals (which
+    ``ast`` folds into one ``Constant``), and f-strings, whose literal
+    segments are concatenated so fragments spanning an interpolation are
+    still detected.
+    """
+    if not node.args:
+        return ""
+    first = node.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    if isinstance(first, ast.JoinedStr):
+        return "".join(
+            part.value
+            for part in first.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        )
+    return ""
+
+
+def _find_violations() -> list[str]:
+    """Return ``"<path>:<line>: <fragment>"`` for every INFO-level violation."""
+    violations: list[str] = []
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        # Cheap prefilter: only files that mention a demoted fragment at all
+        # are worth parsing (keeps this well under the 5s per-test timeout).
+        if not any(fragment in source for fragment in DEMOTED_FRAGMENTS):
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:  # pragma: no cover - defensive
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not _is_logger_info_call(
+                node
+            ):
+                continue
+            message = _format_string(node)
+            for fragment in DEMOTED_FRAGMENTS:
+                if fragment in message:
+                    rel = path.relative_to(REPO_ROOT)
+                    violations.append(f"{rel}:{node.lineno}: {fragment!r}")
+    return violations
+
+
+def test_no_demoted_infrastructure_patterns_at_info() -> None:
+    """No SL-04-007 demoted pattern is logged at INFO anywhere in vultron/."""
+    violations = _find_violations()
+    assert not violations, (
+        "Infrastructure log lines MUST be DEBUG or lower (SL-04-007).\n"
+        "Change logger.info(...) to logger.debug(...) at:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_detector_recognises_a_violation() -> None:
+    """The AST detector actually matches a logger.info call it should catch.
+
+    Without this, a detector bug would make the ratchet above vacuously
+    green.
+    """
+    source = 'logger.info("DataLayer stored %s", x)\n'
+    tree = ast.parse(source)
+    calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)]
+    assert len(calls) == 1
+    assert _is_logger_info_call(calls[0])
+    assert "DataLayer stored" in _format_string(calls[0])
+
+
+def test_detector_recognises_fstring_and_self_logger() -> None:
+    """f-string messages on ``self.logger`` are matched too."""
+    source = 'self.logger.info(f"BT structure:\\n{tree_repr}")\n'
+    tree = ast.parse(source)
+    call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call))
+    assert _is_logger_info_call(call)
+    assert "BT structure" in _format_string(call)
+
+
+def test_detector_ignores_debug_calls() -> None:
+    """``logger.debug`` calls are not flagged."""
+    source = 'logger.debug("DataLayer stored %s", x)\n'
+    tree = ast.parse(source)
+    call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call))
+    assert not _is_logger_info_call(call)

--- a/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
+++ b/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
@@ -51,7 +51,12 @@ CASE_ID2 = "https://example.org/cases/case-announce-01"
 
 @pytest.fixture
 def dl():
-    return SqliteDataLayer("sqlite:///:memory:")
+    # Explicitly closed: an unclosed sqlite3 connection is collected at an
+    # unpredictable moment and pytest promotes the resulting ResourceWarning
+    # to a failure via PytestUnraisableExceptionWarning.
+    datalayer = SqliteDataLayer("sqlite:///:memory:")
+    yield datalayer
+    datalayer.close()
 
 
 @pytest.fixture
@@ -322,6 +327,30 @@ class TestSeedAnnouncedCaseNode:
         )
         assert result.status == Status.SUCCESS
         assert dl.read(CASE_ID2) is not None
+
+    def test_idempotent_skip_line_is_debug(
+        self, bridge, dl, case, announce_event, caplog
+    ) -> None:
+        """The routine idempotency skip is DEBUG, not INFO (SL-04-007)."""
+        import logging
+
+        dl.create(case)
+        tree = SeedAnnouncedCaseNode(
+            case_id=CASE_ID2, case_obj=case, request=announce_event
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            bridge.execute_with_setup(
+                tree=tree, actor_id=ACTOR_ID, activity=announce_event
+            )
+
+        skip_records = [
+            r
+            for r in caplog.records
+            if "already exists locally" in r.getMessage()
+        ]
+        assert skip_records, "Expected the idempotent-skip log entry"
+        assert all(r.levelno == logging.DEBUG for r in skip_records)
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -497,6 +497,54 @@ class TestSetEmbargoActiveNode:
         updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em.state == EM.ACTIVE
 
+    def test_activation_logged_in_narrative_form(self, caplog):
+        """EM PROPOSED → ACTIVE is logged at INFO (SL-04-001, AC-16)."""
+        import logging
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = make_case_and_embargo(
+            "sea-narrative", em_state=EM.PROPOSED
+        )
+        case.active_embargo = None
+        dl.create(case)
+
+        with caplog.at_level(logging.INFO):
+            status = self._run(dl, case.id_, embargo.id_)
+
+        assert status == py_trees.common.Status.SUCCESS
+        narrative = [
+            r
+            for r in caplog.records
+            if "embargo PROPOSED → ACTIVE" in r.getMessage()
+            and r.levelno == logging.INFO
+        ]
+        assert narrative, "Expected a narrative embargo-activation line"
+        message = narrative[0].getMessage()
+        assert (
+            message == f"Actor '{ACTOR_ID}' embargo PROPOSED → ACTIVE"
+            f" for case '{case.id_}'"
+        )
+
+    def test_activated_embargo_detail_line_is_debug(self, caplog):
+        """The verbose "Activated embargo ..." detail line is DEBUG."""
+        import logging
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = make_case_and_embargo(
+            "sea-detail", em_state=EM.PROPOSED
+        )
+        case.active_embargo = None
+        dl.create(case)
+
+        with caplog.at_level(logging.DEBUG):
+            self._run(dl, case.id_, embargo.id_)
+
+        detail = [
+            r for r in caplog.records if "Activated embargo" in r.getMessage()
+        ]
+        assert detail, "Expected the 'Activated embargo' detail line"
+        assert all(r.levelno == logging.DEBUG for r in detail)
+
     def test_idempotent_when_embargo_already_active(self):
         """Returns SUCCESS without state mutation when embargo is already active."""
         dl = SqliteDataLayer("sqlite:///:memory:")

--- a/test/core/behaviors/embargo/nodes/test_teardown.py
+++ b/test/core/behaviors/embargo/nodes/test_teardown.py
@@ -144,6 +144,55 @@ class TestClearActiveEmbargoNode:
         assert updated.current_status.em.state == EM.EXITED
         assert updated.active_embargo is None
 
+    def test_teardown_logged_in_narrative_form(self, caplog):
+        """EM ACTIVE → EXITED is logged at INFO (SL-04-001, AC-16)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("caen-narr", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        setup_blackboard(dl, actor_id=ACTOR_ID)
+        node = ClearActiveEmbargoNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        with caplog.at_level(logging.INFO):
+            bt.tick()
+
+        narrative = [
+            r
+            for r in caplog.records
+            if "embargo ACTIVE → EXITED" in r.getMessage()
+            and r.levelno == logging.INFO
+        ]
+        assert narrative, "Expected a narrative embargo-teardown line"
+        assert (
+            narrative[0].getMessage()
+            == f"Actor '{ACTOR_ID}' embargo ACTIVE → EXITED"
+            f" for case '{case.id_}'"
+        )
+
+    def test_cleared_embargo_detail_line_is_debug(self, caplog):
+        """The verbose "Cleared active embargo" detail line is DEBUG."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("caen-detail", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ClearActiveEmbargoNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        with caplog.at_level(logging.DEBUG):
+            bt.tick()
+
+        detail = [
+            r
+            for r in caplog.records
+            if "Cleared active embargo" in r.getMessage()
+        ]
+        assert detail, "Expected the 'Cleared active embargo' detail line"
+        assert all(r.levelno == logging.DEBUG for r in detail)
+
     def test_transitions_em_revise_to_exited(self):
         """Transitions EM.REVISE → EXITED."""
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -312,6 +361,51 @@ class TestApplyEmbargoTeardownNode:
         updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em.state == EM.EXITED
         assert updated.active_embargo is None
+
+    def test_teardown_logged_in_narrative_form(self, caplog):
+        """ApplyEmbargoTeardownNode logs EM ACTIVE → EXITED at INFO."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("atn-narr", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ApplyEmbargoTeardownNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        with caplog.at_level(logging.INFO):
+            bt.tick()
+
+        narrative = [
+            r
+            for r in caplog.records
+            if "embargo ACTIVE → EXITED" in r.getMessage()
+            and r.levelno == logging.INFO
+        ]
+        assert narrative, "Expected a narrative embargo-teardown line"
+        assert f"for case '{case.id_}'" in narrative[0].getMessage()
+
+    def test_teardown_applied_detail_line_is_debug(self, caplog):
+        """The verbose "Embargo teardown applied" detail line is DEBUG."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("atn-detail", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ApplyEmbargoTeardownNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        with caplog.at_level(logging.DEBUG):
+            bt.tick()
+
+        detail = [
+            r
+            for r in caplog.records
+            if "Embargo teardown applied" in r.getMessage()
+        ]
+        assert detail, "Expected the 'Embargo teardown applied' detail line"
+        assert all(r.levelno == logging.DEBUG for r in detail)
 
     def test_transitions_em_revise_to_exited(self):
         """Node transitions EM.REVISE → EM.EXITED (also a valid terminate path)."""

--- a/test/core/behaviors/inbox/test_process_payload.py
+++ b/test/core/behaviors/inbox/test_process_payload.py
@@ -359,3 +359,49 @@ class TestProcessPayloadThreadSafety:
         assert not errors
         assert all(o.status == "processed" for o in results)
         assert len(results) == 4
+
+
+# ---------------------------------------------------------------------------
+# Log-level contract (SL-04-007)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPayloadLogLevels:
+    """The `process_payload: outcome status=...` echo is DEBUG (SL-04-007).
+
+    It restates the outcome the caller already has; the meaningful protocol
+    lines are emitted by the use cases the dispatcher invokes.
+    """
+
+    _LOGGER = "vultron.core.behaviors.inbox._process_payload"
+
+    def _outcome_records(self, caplog):
+        return [
+            r
+            for r in caplog.records
+            if "process_payload: outcome" in r.getMessage()
+        ]
+
+    def test_outcome_echo_is_debug(self, report_activity, caplog):
+        import logging
+
+        ingress = _StubIngressAdapter(activity=report_activity)
+        dispatch = _StubDispatchAdapter()
+
+        with caplog.at_level(logging.DEBUG, logger=self._LOGGER):
+            process_payload({}, ingress, dispatch)
+
+        records = self._outcome_records(caplog)
+        assert records, "Expected the process_payload outcome log entry"
+        assert all(r.levelno == logging.DEBUG for r in records)
+
+    def test_outcome_echo_not_emitted_at_info(self, report_activity, caplog):
+        import logging
+
+        ingress = _StubIngressAdapter(activity=report_activity)
+        dispatch = _StubDispatchAdapter()
+
+        with caplog.at_level(logging.INFO, logger=self._LOGGER):
+            process_payload({}, ingress, dispatch)
+
+        assert not self._outcome_records(caplog)

--- a/test/core/behaviors/report/test_deploy_fix_tree.py
+++ b/test/core/behaviors/report/test_deploy_fix_tree.py
@@ -573,6 +573,50 @@ class TestTransitionCStoFixDeployed:
         )
         assert result.status == Status.FAILURE
 
+    def test_fix_deployed_logged_in_narrative_form(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_deployer: VultronCase,
+        caplog,
+    ) -> None:
+        """AC-13: the d→D transition reads as a CVD milestone at INFO.
+
+        The narrative line comes from ``CreateParticipantStatusNode``, which is
+        the only place that knows the VFd before-state; this node's own
+        message is DEBUG detail (SL-04-007).
+        """
+        import logging
+
+        _seed_status(bt_scenario, CASE_ID, DEPLOYER_ACTOR_ID, vfd=CS_vfd.VFd)
+        node = TransitionCStoFixDeployed(
+            case_id=CASE_ID, actor_id=DEPLOYER_ACTOR_ID, result_out={}
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            assert (
+                bt_scenario.run(node, actor_id=DEPLOYER_ACTOR_ID).status
+                == Status.SUCCESS
+            )
+
+        narrative = [
+            r
+            for r in caplog.records
+            if " CS: " in r.getMessage() and r.levelno == logging.INFO
+        ]
+        assert narrative, "Expected a CS narrative line at INFO"
+        message = narrative[0].getMessage()
+        assert f"Actor '{DEPLOYER_ACTOR_ID}' CS: VFd → VFD" in message
+        assert "(fix deployed)" in message
+
+        detail = [
+            r
+            for r in caplog.records
+            if "VFd → VFD (fix deployed)" in r.getMessage()
+            and r.name.endswith("TransitionCStoFixDeployed")
+        ]
+        assert detail, "Expected the node's own detail line"
+        assert all(r.levelno == logging.DEBUG for r in detail)
+
 
 class TestEmitCDActivity:
     def test_success_emits_cd_activity(

--- a/test/core/behaviors/report/test_develop_fix_tree.py
+++ b/test/core/behaviors/report/test_develop_fix_tree.py
@@ -492,6 +492,52 @@ class TestTransitionCStoFixReady:
         )
         assert result.status == Status.FAILURE
 
+    def test_fix_ready_logged_in_narrative_form(
+        self,
+        bt_scenario: BTTestScenario,
+        case_with_vendor: VultronCase,
+        caplog,
+    ) -> None:
+        """AC-13: the f→F transition reads as a CVD milestone at INFO.
+
+        The narrative line comes from ``CreateParticipantStatusNode``, the only
+        place that knows the before-state; this node's own message is DEBUG
+        detail (SL-04-007).
+        """
+        import logging
+
+        _seed_rm_state(bt_scenario, CASE_ID, VENDOR_ACTOR_ID, RM.ACCEPTED)
+        node = TransitionCStoFixReady(
+            case_id=CASE_ID, actor_id=VENDOR_ACTOR_ID, result_out={}
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            assert (
+                bt_scenario.run(node, actor_id=VENDOR_ACTOR_ID).status
+                == Status.SUCCESS
+            )
+
+        narrative = [
+            r
+            for r in caplog.records
+            if " CS: " in r.getMessage() and r.levelno == logging.INFO
+        ]
+        assert narrative, "Expected a CS narrative line at INFO"
+        message = narrative[0].getMessage()
+        # The fixture participant starts at `vfd`, so this single write
+        # advances two sub-dimensions and the label names both.
+        assert f"Actor '{VENDOR_ACTOR_ID}' CS: vfd → VFd" in message
+        assert "fix ready" in message
+
+        detail = [
+            r
+            for r in caplog.records
+            if "VFD → VFd" in r.getMessage()
+            and r.name.endswith("TransitionCStoFixReady")
+        ]
+        assert detail, "Expected the node's own detail line"
+        assert all(r.levelno == logging.DEBUG for r in detail)
+
 
 CASE_MANAGER_ACTOR_ID = "https://example.org/actors/case-manager-001"
 

--- a/test/core/behaviors/test_bridge.py
+++ b/test/core/behaviors/test_bridge.py
@@ -445,13 +445,14 @@ def test_get_failure_reason_finds_first_failing_child():
 # Log-level tests
 
 
-def test_final_bt_state_logged_at_info_on_success(
-    bridge, test_actor_id, caplog
+@pytest.mark.parametrize("tree_factory", [AlwaysSucceed, AlwaysFail])
+def test_final_bt_state_logged_at_debug(
+    bridge, test_actor_id, caplog, tree_factory
 ):
-    """Final BT state tree visualization is logged at INFO on SUCCESS."""
+    """Final BT state tree dump is DEBUG-only scaffolding (SL-04-007)."""
     import logging
 
-    tree = AlwaysSucceed()
+    tree = tree_factory()
     bt = bridge.setup_tree(tree=tree, actor_id=test_actor_id)
 
     with caplog.at_level(logging.DEBUG):
@@ -462,26 +463,102 @@ def test_final_bt_state_logged_at_info_on_success(
     ]
     assert final_state_records, "Expected 'Final BT state' log entry"
     assert all(
-        r.levelno == logging.INFO for r in final_state_records
-    ), f"Expected INFO but got {final_state_records[0].levelname}"
+        r.levelno == logging.DEBUG for r in final_state_records
+    ), f"Expected DEBUG but got {final_state_records[0].levelname}"
 
 
-def test_final_bt_state_logged_at_info_on_failure(
-    bridge, test_actor_id, caplog
-):
-    """Final BT state tree visualization is logged at INFO on FAILURE."""
+def test_bt_structure_logged_at_debug(bridge, test_actor_id, caplog):
+    """The pre-execution BT structure dump is DEBUG-only (SL-04-007)."""
     import logging
 
-    tree = AlwaysFail()
-    bt = bridge.setup_tree(tree=tree, actor_id=test_actor_id)
-
     with caplog.at_level(logging.DEBUG):
-        bridge.execute_tree(bt)
+        bridge.setup_tree(tree=AlwaysSucceed(), actor_id=test_actor_id)
 
-    final_state_records = [
-        r for r in caplog.records if "Final BT state" in r.message
+    structure_records = [
+        r for r in caplog.records if "BT structure" in r.message
     ]
-    assert final_state_records, "Expected 'Final BT state' log entry"
-    assert all(
-        r.levelno == logging.INFO for r in final_state_records
-    ), f"Expected INFO but got {final_state_records[0].levelname}"
+    assert structure_records, "Expected 'BT structure' log entry"
+    assert all(r.levelno == logging.DEBUG for r in structure_records)
+
+
+def test_bt_structure_not_emitted_at_info(bridge, test_actor_id, caplog):
+    """No 'BT structure' record reaches an INFO-only handler (SL-04-007)."""
+    import logging
+
+    with caplog.at_level(logging.INFO):
+        bridge.setup_tree(tree=AlwaysSucceed(), actor_id=test_actor_id)
+
+    assert not [r for r in caplog.records if "BT structure" in r.message]
+
+
+def _completion_records(caplog):
+    import logging
+
+    return [
+        r
+        for r in caplog.records
+        if "BT execution completed" in r.getMessage()
+        and r.levelno == logging.INFO
+    ]
+
+
+def test_failure_reason_folded_into_completion_line(
+    bridge, test_actor_id, caplog
+):
+    """AC-18: the FAILURE completion line carries a reason, not a bare status.
+
+    ``AlwaysFail`` sets ``feedback_message``, so that is the reason reported.
+    """
+    import logging
+
+    with caplog.at_level(logging.INFO):
+        result = bridge.execute_with_setup(
+            tree=AlwaysFail(), actor_id=test_actor_id
+        )
+
+    assert result.status == Status.FAILURE
+    records = _completion_records(caplog)
+    assert records, "Expected a BT completion line at INFO"
+    assert "Failure" in records[0].getMessage()
+
+
+def test_failure_reason_recovered_when_root_has_no_feedback(
+    bridge, test_actor_id, caplog
+):
+    """A silent root reports the failing leaf's identity, not an empty tail.
+
+    Without the ``get_failure_reason()`` fallback this line read
+    ``... Status.FAILURE after 1 ticks - `` with nothing after the dash — the
+    exact symptom CONCERN-1968 flagged.
+    """
+    import logging
+
+    root = py_trees.composites.Sequence(name="SilentRoot", memory=False)
+    root.add_child(AlwaysFail(name="InnerFail"))
+
+    with caplog.at_level(logging.INFO):
+        bridge.execute_with_setup(tree=root, actor_id=test_actor_id)
+
+    records = _completion_records(caplog)
+    assert records, "Expected a BT completion line at INFO"
+    message = records[0].getMessage()
+    assert not message.rstrip().endswith("-"), (
+        "FAILURE completion line must not end with a bare dash;"
+        f" got {message!r}"
+    )
+    assert "Failure" in message
+
+
+def test_only_one_completion_record_per_failure(bridge, test_actor_id, caplog):
+    """The reason is folded in, not added as a second INFO record.
+
+    Many callers treat FAILURE as an expected idempotent skip and log their
+    own explanation at DEBUG; a second INFO line would triple-log a benign
+    no-op.
+    """
+    import logging
+
+    with caplog.at_level(logging.INFO):
+        bridge.execute_with_setup(tree=AlwaysFail(), actor_id=test_actor_id)
+
+    assert len(_completion_records(caplog)) == 1

--- a/test/core/behaviors/test_narrative_log.py
+++ b/test/core/behaviors/test_narrative_log.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for the narrative INFO log helpers (SL-04-001, SL-04-006)."""
+
+import logging
+
+import pytest
+
+from vultron.core.behaviors.narrative_log import (
+    NO_CHANGE_LABEL,
+    REGRESSION_LABEL,
+    cs_event_label,
+    log_case_engagement,
+    log_cs_transition,
+    log_em_transition,
+    log_invite_received,
+    log_rm_transition,
+)
+from vultron.core.states.cs import CS_pxa, CS_vfd
+from vultron.core.states.em import EM
+from vultron.core.states.rm import RM
+
+ACTOR = "https://example.org/actors/vendor"
+CASE = "https://example.org/cases/case-001"
+
+logger = logging.getLogger("test.narrative_log")
+
+
+class TestCsEventLabel:
+    """cs_event_label() names the sub-dimension(s) that advanced."""
+
+    @pytest.mark.parametrize(
+        "before,after,expected",
+        [
+            (CS_vfd.vfd, CS_vfd.Vfd, "vendor aware"),
+            (CS_vfd.Vfd, CS_vfd.VFd, "fix ready"),
+            (CS_vfd.VFd, CS_vfd.VFD, "fix deployed"),
+            (CS_pxa.pxa, CS_pxa.Pxa, "publicly known"),
+            (CS_pxa.Pxa, CS_pxa.PXa, "exploit public"),
+            (CS_pxa.Pxa, CS_pxa.PxA, "attacks observed"),
+        ],
+    )
+    def test_single_dimension_label(self, before, after, expected):
+        assert cs_event_label(before, after) == expected
+
+    def test_multi_dimension_label_joins_all_events(self):
+        """A multi-step transition names every sub-dimension that advanced."""
+        assert (
+            cs_event_label(CS_pxa.pxa, CS_pxa.PXa)
+            == "publicly known, exploit public"
+        )
+
+    def test_no_change_label(self):
+        assert cs_event_label(CS_vfd.Vfd, CS_vfd.Vfd) == NO_CHANGE_LABEL
+
+    @pytest.mark.parametrize(
+        "before,after",
+        [
+            (CS_vfd.VFd, CS_vfd.vfd),
+            (CS_vfd.VFD, CS_vfd.VFd),
+            (CS_pxa.Pxa, CS_pxa.pxa),
+        ],
+    )
+    def test_backward_move_is_labelled_a_regression(self, before, after):
+        """CS events are monotonic, so a backward move is an anomaly.
+
+        Without this branch the label fell through to "no change", producing a
+        line that simultaneously claimed a transition and denied it.
+        """
+        assert cs_event_label(before, after) == REGRESSION_LABEL
+
+    def test_mixed_dimensions_raise_type_error(self):
+        """A VFD/PXA mix has non-comparable fields — fail loudly, not silently.
+
+        Previously this raised an opaque ``AttributeError`` from inside the
+        comparison loop.
+        """
+        with pytest.raises(TypeError, match="same CS dimension"):
+            cs_event_label(CS_vfd.vfd, CS_pxa.Pxa)
+
+
+class TestLogCsTransition:
+    """log_cs_transition() emits the SL-04-006 CS template at INFO."""
+
+    def test_vfd_transition_logged_at_info(self, caplog):
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_cs_transition(logger, ACTOR, CASE, CS_vfd.Vfd, CS_vfd.VFd)
+
+        assert (
+            f"Actor '{ACTOR}' CS: Vfd → VFd (fix ready) for case '{CASE}'"
+            in caplog.text
+        )
+        assert caplog.records[0].levelno == logging.INFO
+
+    def test_pxa_transition_logged_at_info(self, caplog):
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_cs_transition(logger, ACTOR, CASE, CS_pxa.pxa, CS_pxa.Pxa)
+
+        assert (
+            f"Actor '{ACTOR}' CS: pxa → Pxa (publicly known)"
+            f" for case '{CASE}'" in caplog.text
+        )
+
+    def test_no_op_transition_emits_nothing(self, caplog):
+        """An unchanged CS dimension is not a protocol event (SL-04-007)."""
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_cs_transition(logger, ACTOR, CASE, CS_vfd.Vfd, CS_vfd.Vfd)
+
+        assert caplog.records == []
+
+    def test_backward_move_logged_at_warning_not_info(self, caplog):
+        """A regression is an anomaly to investigate, not a case milestone."""
+        with caplog.at_level(logging.DEBUG, logger=logger.name):
+            log_cs_transition(logger, ACTOR, CASE, CS_vfd.VFd, CS_vfd.vfd)
+
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.WARNING
+        assert REGRESSION_LABEL in caplog.text
+
+
+class TestLogRmTransition:
+    """log_rm_transition() emits the SL-04-006 RM template at INFO."""
+
+    def test_transition_logged_at_info(self, caplog):
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_rm_transition(logger, ACTOR, CASE, RM.VALID, RM.ACCEPTED)
+
+        assert (
+            f"Actor '{ACTOR}' RM: VALID → ACCEPTED for case '{CASE}'"
+            in caplog.text
+        )
+        assert caplog.records[0].levelno == logging.INFO
+
+    def test_no_op_transition_emits_nothing(self, caplog):
+        """Re-asserting the current RM state is bookkeeping (SL-04-007)."""
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_rm_transition(logger, ACTOR, CASE, RM.ACCEPTED, RM.ACCEPTED)
+
+        assert caplog.records == []
+
+
+class TestLogEmTransition:
+    """log_em_transition() emits the SL-04-006 embargo template at INFO."""
+
+    def test_proposed_to_active_logged_at_info(self, caplog):
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_em_transition(logger, ACTOR, CASE, EM.PROPOSED, EM.ACTIVE)
+
+        assert (
+            f"Actor '{ACTOR}' embargo PROPOSED → ACTIVE for case '{CASE}'"
+            in caplog.text
+        )
+        assert caplog.records[0].levelno == logging.INFO
+
+    def test_active_to_exited_logged_at_info(self, caplog):
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_em_transition(logger, ACTOR, CASE, EM.ACTIVE, EM.EXITED)
+
+        assert (
+            f"Actor '{ACTOR}' embargo ACTIVE → EXITED for case '{CASE}'"
+            in caplog.text
+        )
+
+    def test_no_op_transition_emits_nothing(self, caplog):
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_em_transition(logger, ACTOR, CASE, EM.ACTIVE, EM.ACTIVE)
+
+        assert caplog.records == []
+
+
+class TestOtherNarrativeHelpers:
+    """Engagement and invite-receipt templates (SL-04-006)."""
+
+    def test_case_engagement_logged_at_info(self, caplog):
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_case_engagement(logger, ACTOR, CASE, RM.VALID, RM.ACCEPTED)
+
+        assert (
+            f"Actor '{ACTOR}' engaged case '{CASE}' (RM VALID → ACCEPTED)"
+            in caplog.text
+        )
+        assert caplog.records[0].levelno == logging.INFO
+
+    def test_invite_received_logged_at_info(self, caplog):
+        sender = "https://example.org/actors/coordinator"
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_invite_received(logger, ACTOR, CASE, sender)
+
+        assert (
+            f"Actor '{ACTOR}' received case invite for '{CASE}'"
+            f" from '{sender}'" in caplog.text
+        )
+        assert caplog.records[0].levelno == logging.INFO
+
+    def test_engagement_no_op_emits_nothing(self, caplog):
+        """Re-engaging an already-engaged case did not engage it.
+
+        ``update_participant_rm_state`` returns ``True`` on the idempotent
+        path, so the BT succeeds and ``_handle_result`` still runs — the guard
+        has to live here.
+        """
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            log_case_engagement(logger, ACTOR, CASE, RM.ACCEPTED, RM.ACCEPTED)
+
+        assert caplog.records == []

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -101,6 +101,69 @@ class TestInviteActorUseCases:
         stored = dl.get(invite.type_.value, invite.id_)
         assert stored is not None
 
+    def test_invite_receipt_logged_in_narrative_form(
+        self, make_payload, caplog
+    ):
+        """The invitee logs the invite receipt at INFO (SL-04-001, AC-17)."""
+        import logging
+
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        invitee_id = "https://example.org/users/coordinator"
+        sender_id = "https://example.org/users/owner"
+        case_id = "https://example.org/cases/case1"
+
+        invite = rm_invite_to_case_activity(
+            as_Actor(id_=invitee_id),
+            target=case_id,
+            actor=sender_id,
+            id_=f"{case_id}/invitations/narrative-1",
+        )
+        event = make_payload(invite)
+
+        with caplog.at_level(logging.INFO):
+            InviteActorToCaseReceivedUseCase(dl, event).execute()
+
+        narrative = [
+            r
+            for r in caplog.records
+            if "received case invite" in r.getMessage()
+            and r.levelno == logging.INFO
+        ]
+        assert narrative, "Expected a narrative invite-receipt line at INFO"
+        message = narrative[0].getMessage()
+        assert (
+            message == f"Actor '{invitee_id}' received case invite"
+            f" for '{case_id}' from '{sender_id}'"
+        )
+
+    def test_invite_stub_awaiting_line_is_debug(self, make_payload, caplog):
+        """The "Awaiting AnnounceVulnerabilityCase" note is DEBUG detail."""
+        import logging
+
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        invite = rm_invite_to_case_activity(
+            as_Actor(id_="https://example.org/users/coordinator"),
+            target="https://example.org/cases/case1",
+            actor="https://example.org/users/owner",
+            id_="https://example.org/cases/case1/invitations/narrative-2",
+        )
+        event = make_payload(invite)
+
+        with caplog.at_level(logging.DEBUG):
+            InviteActorToCaseReceivedUseCase(dl, event).execute()
+
+        awaiting = [
+            r
+            for r in caplog.records
+            if "Awaiting AnnounceVulnerabilityCase" in r.getMessage()
+        ]
+        assert awaiting, "Expected the case-stub awaiting log entry"
+        assert all(r.levelno == logging.DEBUG for r in awaiting)
+
     def test_invite_actor_to_case_idempotent(self, monkeypatch, make_payload):
         """InviteActorToCaseReceivedUseCase skips storing a duplicate Invite."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer

--- a/test/core/use_cases/received/case/test_bootstrap_participants.py
+++ b/test/core/use_cases/received/case/test_bootstrap_participants.py
@@ -155,6 +155,29 @@ class TestBootstrapParticipantStorage:
             "DataLayer record after bootstrap so BT nodes can look it up by ID"
         )
 
+    def test_stored_participant_line_is_debug(self, dl, create_event, caplog):
+        """Per-participant storage chatter is DEBUG, not INFO (SL-04-007).
+
+        This fires once per participant on every case announcement, so it
+        drowns out the protocol story on the INFO channel.
+        """
+        import logging
+
+        link = _build_link()
+        dl.save(link)
+
+        with caplog.at_level(logging.DEBUG):
+            CreateCaseReceivedUseCase(dl, create_event).execute()
+
+        stored_records = [
+            r
+            for r in caplog.records
+            if "store_embedded_participants: stored participant"
+            in r.getMessage()
+        ]
+        assert stored_records, "Expected the stored-participant log entry"
+        assert all(r.levelno == logging.DEBUG for r in stored_records)
+
     def test_participant_stored_when_case_already_existed(
         self, dl, create_event, case_with_two_participants
     ):

--- a/test/core/use_cases/test_rm_narrative_logging.py
+++ b/test/core/use_cases/test_rm_narrative_logging.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute
+#    to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype
+#  is licensed under a MIT (SEI)-style license, please see LICENSE.md
+#  distributed with this Software or contact permission@sei.cmu.edu for full
+#  terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Narrative RM logging tests for ``update_participant_rm_state``.
+
+Covers SL-04-001 (all state transitions logged at INFO), SL-04-006 (narrative
+template), and SL-04-007 (the idempotent no-op line is DEBUG, not INFO).
+"""
+
+import logging
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.states.rm import RM
+from vultron.core.use_cases._helpers import (
+    current_participant_rm_state,
+    update_participant_rm_state,
+)
+from vultron.enums.roles import CVDRole
+
+_ACTOR_ID = "https://example.org/actors/vendor-001"
+_CASE_ID = "https://example.org/cases/case-001"
+_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor-001"
+_HELPERS_LOGGER = "vultron.core.use_cases._helpers"
+
+
+@pytest.fixture()
+def dl() -> SqliteDataLayer:
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture()
+def seeded_case(dl: SqliteDataLayer) -> VulnerabilityCase:
+    """Case with one VENDOR participant registered on both surfaces."""
+    participant = CaseParticipant(
+        id_=_PARTICIPANT_ID,
+        attributed_to=_ACTOR_ID,
+        context=_CASE_ID,
+        case_roles=[CVDRole.VENDOR],
+    )
+    dl.create(participant)
+    case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+    case.add_participant(participant)
+    dl.create(case)
+    stored = dl.read(_CASE_ID)
+    assert isinstance(stored, VulnerabilityCase)
+    return stored
+
+
+def _narrative_records(caplog) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if "RM:" in r.getMessage() and r.levelno == logging.INFO
+    ]
+
+
+class TestUpdateParticipantRmStateLogging:
+    """update_participant_rm_state emits the RM narrative line at INFO."""
+
+    def test_first_transition_logged_from_start(
+        self, seeded_case: VulnerabilityCase, dl: SqliteDataLayer, caplog
+    ) -> None:
+        """A participant with no prior status reports RM START as before."""
+        with caplog.at_level(logging.INFO, logger=_HELPERS_LOGGER):
+            assert update_participant_rm_state(
+                _CASE_ID, _ACTOR_ID, RM.RECEIVED, dl
+            )
+
+        records = _narrative_records(caplog)
+        assert records, "Expected a narrative RM line at INFO"
+        message = records[0].getMessage()
+        assert (
+            message == f"Actor '{_ACTOR_ID}' RM: START → RECEIVED"
+            f" for case '{_CASE_ID}'"
+        )
+
+    def test_subsequent_transition_reports_actual_before_state(
+        self, seeded_case: VulnerabilityCase, dl: SqliteDataLayer, caplog
+    ) -> None:
+        """The before-state is read from the latest ParticipantStatus."""
+        assert update_participant_rm_state(
+            _CASE_ID, _ACTOR_ID, RM.RECEIVED, dl
+        )
+        assert update_participant_rm_state(_CASE_ID, _ACTOR_ID, RM.VALID, dl)
+
+        # Drop the setup transitions: caplog captures every record emitted
+        # during the test, not only those inside the at_level() block.
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=_HELPERS_LOGGER):
+            assert update_participant_rm_state(
+                _CASE_ID, _ACTOR_ID, RM.ACCEPTED, dl
+            )
+
+        records = _narrative_records(caplog)
+        assert records, "Expected a narrative RM line at INFO"
+        assert (
+            records[0].getMessage()
+            == f"Actor '{_ACTOR_ID}' RM: VALID → ACCEPTED"
+            f" for case '{_CASE_ID}'"
+        )
+
+    def test_idempotent_repeat_is_debug_not_info(
+        self, seeded_case: VulnerabilityCase, dl: SqliteDataLayer, caplog
+    ) -> None:
+        """A no-op repeat is bookkeeping, not a transition (SL-04-007)."""
+        assert update_participant_rm_state(
+            _CASE_ID, _ACTOR_ID, RM.RECEIVED, dl
+        )
+
+        # Drop the setup transition's own narrative line before asserting.
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger=_HELPERS_LOGGER):
+            assert update_participant_rm_state(
+                _CASE_ID, _ACTOR_ID, RM.RECEIVED, dl
+            )
+
+        assert not _narrative_records(caplog)
+        idempotent = [
+            r for r in caplog.records if "(idempotent)" in r.getMessage()
+        ]
+        assert idempotent, "Expected the idempotent line to still be emitted"
+        assert all(r.levelno == logging.DEBUG for r in idempotent)
+
+    def test_blocked_transition_emits_no_narrative_line(
+        self, seeded_case: VulnerabilityCase, dl: SqliteDataLayer, caplog
+    ) -> None:
+        """A rejected RM transition must not claim it happened.
+
+        ``START → CLOSED`` is not a legal RM transition, so the helper must
+        return ``False`` and emit no narrative line.
+        """
+        with caplog.at_level(logging.DEBUG, logger=_HELPERS_LOGGER):
+            blocked = update_participant_rm_state(
+                _CASE_ID, _ACTOR_ID, RM.CLOSED, dl
+            )
+
+        assert blocked is False
+        assert not _narrative_records(caplog)
+
+
+class TestCurrentParticipantRmState:
+    """current_participant_rm_state reads the latest RM state, or START."""
+
+    def test_returns_start_when_no_status_recorded(
+        self, seeded_case: VulnerabilityCase, dl: SqliteDataLayer
+    ) -> None:
+        assert (
+            current_participant_rm_state(seeded_case, _ACTOR_ID, dl)
+            == RM.START
+        )
+
+    def test_returns_start_for_unknown_actor(
+        self, seeded_case: VulnerabilityCase, dl: SqliteDataLayer
+    ) -> None:
+        result = current_participant_rm_state(
+            seeded_case, "https://example.org/actors/stranger", dl
+        )
+        assert result == RM.START
+
+    def test_returns_latest_recorded_state(
+        self, seeded_case: VulnerabilityCase, dl: SqliteDataLayer
+    ) -> None:
+        assert update_participant_rm_state(
+            _CASE_ID, _ACTOR_ID, RM.RECEIVED, dl
+        )
+        assert update_participant_rm_state(_CASE_ID, _ACTOR_ID, RM.VALID, dl)
+
+        case = dl.read(_CASE_ID)
+        assert isinstance(case, VulnerabilityCase)
+        assert current_participant_rm_state(case, _ACTOR_ID, dl) == RM.VALID

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -599,3 +599,154 @@ class TestCreateParticipantStatusNode:
         assert isinstance(stored, ParticipantStatus)
         # No prior statuses → defaults to RM.START
         assert stored.rm.state == RM.START
+
+    def _cs_narrative_records(self, caplog):
+        """Return INFO-level CS narrative records emitted during the run."""
+        import logging
+
+        return [
+            r
+            for r in caplog.records
+            if " CS: " in r.getMessage() and r.levelno == logging.INFO
+        ]
+
+    def test_vfd_transition_logged_at_info(self, caplog):
+        """A VFD advance emits the SL-04-006 CS narrative line at INFO."""
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            self._run_node(rm_state=None, vfd_state=CS_vfd.Vfd, pxa_state=None)
+
+        records = self._cs_narrative_records(caplog)
+        assert records, "Expected a CS narrative line at INFO for VFD advance"
+        message = records[0].getMessage()
+        assert f"Actor '{self.actor.id_}' CS: vfd → Vfd" in message
+        assert "(vendor aware)" in message
+        assert f"for case '{self.case.id_}'" in message
+
+    def test_pxa_transition_logged_at_info(self, caplog):
+        """A PXA advance emits the SL-04-006 CS narrative line at INFO."""
+        import logging
+
+        from vultron.core.states.cs import CS_pxa
+
+        with caplog.at_level(logging.INFO):
+            self._run_node(rm_state=None, vfd_state=None, pxa_state=CS_pxa.Pxa)
+
+        records = self._cs_narrative_records(caplog)
+        assert records, "Expected a CS narrative line at INFO for PXA advance"
+        message = records[0].getMessage()
+        assert f"Actor '{self.actor.id_}' CS: pxa → Pxa" in message
+        assert "(publicly known)" in message
+
+    def test_no_cs_line_when_no_cs_dimension_changes(self, caplog):
+        """An RM-only snapshot emits no CS narrative line (SL-04-007)."""
+        import logging
+
+        from vultron.core.states.rm import RM
+
+        with caplog.at_level(logging.INFO):
+            self._run_node(
+                rm_state=RM.ACCEPTED, vfd_state=None, pxa_state=None
+            )
+
+        assert not self._cs_narrative_records(caplog)
+
+    def test_no_cs_line_when_vfd_state_unchanged(self, caplog):
+        """Re-asserting the current VFD state is not a transition."""
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            self._run_node(rm_state=None, vfd_state=CS_vfd.vfd, pxa_state=None)
+
+        assert not self._cs_narrative_records(caplog)
+
+    def test_created_participantstatus_line_is_debug(self, caplog):
+        """The "Created ParticipantStatus" bookkeeping line is DEBUG."""
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            self._run_node(rm_state=None, vfd_state=None, pxa_state=None)
+
+        created = [
+            r
+            for r in caplog.records
+            if "Created ParticipantStatus" in r.getMessage()
+        ]
+        assert created, "Expected the ParticipantStatus creation line"
+        assert all(r.levelno == logging.DEBUG for r in created)
+
+    def test_repeat_pxa_write_emits_no_second_cs_line(self, caplog):
+        """The same public-disclosure milestone is not re-logged.
+
+        The before-state must come from the participant's own latest
+        ``case_status.pxa``: this node never appends to ``case.case_statuses``,
+        so reading ``case.current_status`` reported a stale ``pxa`` and made
+        every repeat write look like a fresh disclosure event.
+        """
+        import logging
+
+        from vultron.core.states.cs import CS_pxa
+
+        self._run_node(rm_state=None, vfd_state=None, pxa_state=CS_pxa.Pxa)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            self._run_node(rm_state=None, vfd_state=None, pxa_state=CS_pxa.Pxa)
+
+        assert not self._cs_narrative_records(caplog), (
+            "A repeat PXA write is a no-op and must not re-announce the"
+            " public-disclosure milestone"
+        )
+
+    def _rm_narrative_records(self, caplog):
+        import logging
+
+        return [
+            r
+            for r in caplog.records
+            if " RM: " in r.getMessage() and r.levelno == logging.INFO
+        ]
+
+    def test_rm_transition_logged_at_info(self, caplog):
+        """AC-12: this node is a second per-participant RM write path.
+
+        ``update_participant_rm_state()`` is not the only RM writer — this node
+        appends a ``ParticipantStatus`` with an explicit ``rm_state`` directly
+        (used by e.g. the leave-case RM → CLOSED nodes), so it must emit the
+        narrative RM line itself.
+        """
+        import logging
+
+        from vultron.core.states.rm import RM
+
+        with caplog.at_level(logging.INFO):
+            self._run_node(
+                rm_state=RM.RECEIVED, vfd_state=None, pxa_state=None
+            )
+
+        records = self._rm_narrative_records(caplog)
+        assert records, "Expected a narrative RM line at INFO"
+        message = records[0].getMessage()
+        assert f"Actor '{self.actor.id_}' RM: START → RECEIVED" in message
+        assert f"for case '{self.case.id_}'" in message
+
+    def test_no_rm_line_when_rm_state_unchanged(self, caplog):
+        """Re-asserting the current RM state is not a transition."""
+        import logging
+
+        from vultron.core.states.rm import RM
+
+        with caplog.at_level(logging.INFO):
+            self._run_node(rm_state=RM.START, vfd_state=None, pxa_state=None)
+
+        assert not self._rm_narrative_records(caplog)
+
+    def test_no_rm_line_when_rm_state_not_requested(self, caplog):
+        """A CS-only snapshot emits no RM narrative line."""
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            self._run_node(rm_state=None, vfd_state=CS_vfd.Vfd, pxa_state=None)
+
+        assert not self._rm_narrative_records(caplog)

--- a/test/core/use_cases/triggers/case/test_engage.py
+++ b/test/core/use_cases/triggers/case/test_engage.py
@@ -149,6 +149,68 @@ class TestEngageCaseRMTransitionViaBT:
             len(to_ids) == 1
         ), f"PCR-08-001: exactly one recipient expected, got {to_ids!r}"
 
+    def test_engage_logged_with_actual_before_state(self, caplog):
+        """Engagement reports the real RM before-state (SL-04-006, AC-15).
+
+        The fixture seeds the vendor at RM.VALID, so the narrative line must
+        read ``RM VALID → ACCEPTED`` — not a bare ``RM → ACCEPTED``.
+        """
+        import logging
+
+        request = EngageCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+        )
+
+        with caplog.at_level(logging.INFO):
+            SvcEngageCaseUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()
+
+        narrative = [
+            r
+            for r in caplog.records
+            if "engaged case" in r.getMessage() and r.levelno == logging.INFO
+        ]
+        assert narrative, "Expected a narrative engagement line at INFO"
+        assert (
+            narrative[0].getMessage()
+            == f"Actor '{self.vendor.id_}' engaged case '{self.case.id_}'"
+            " (RM VALID → ACCEPTED)"
+        )
+
+    def test_repeat_engage_emits_no_engagement_line(self, caplog):
+        """Re-engaging an already-engaged case did not engage it.
+
+        ``update_participant_rm_state`` takes its idempotent branch and returns
+        ``True``, so the BT succeeds and ``_handle_result`` still runs. The
+        after-state is read back from storage, so before == after and the line
+        is suppressed rather than claiming ``RM ACCEPTED → ACCEPTED``.
+        """
+        import logging
+
+        request = EngageCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+        )
+        SvcEngageCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            SvcEngageCaseUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()
+
+        assert not [
+            r for r in caplog.records if "engaged case" in r.getMessage()
+        ], "A repeat engage is a no-op and must not claim an engagement"
+
     def test_engage_case_rm_not_updated_when_no_participant(self):
         case_solo = as_VulnerabilityCase(name="Solo Case")
         case_solo.actor_participant_index[self.vendor.id_] = (

--- a/test/demo/test_discover_actors_logging.py
+++ b/test/demo/test_discover_actors_logging.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""``discover_actors()`` logs only the actor ID at INFO (SL-04-007).
+
+The full ``logfmt()`` object dump is DEBUG-only: at INFO the only part of a
+discovered actor that carries narrative value is its ID.
+"""
+
+import logging
+from typing import cast
+
+import pytest
+
+from vultron.demo.utils import DataLayerClient, discover_actors
+
+_UTILS_LOGGER = "vultron.demo.utils"
+
+_FINDER_ID = "https://example.org/actors/finn"
+_VENDOR_ID = "https://example.org/actors/vendorco"
+_COORDINATOR_ID = "https://example.org/actors/cert"
+
+_ACTORS: list[dict] = [
+    {"type": "Person", "id": _FINDER_ID, "name": "Finn the Finder"},
+    {"type": "Organization", "id": _VENDOR_ID, "name": "VendorCo Inc"},
+    {"type": "Organization", "id": _COORDINATOR_ID, "name": "Coordinator CC"},
+]
+
+
+class _StubClient:
+    """Minimal DataLayerClient stand-in returning a fixed actor list."""
+
+    def get(self, path: str, **kwargs) -> list[dict]:
+        assert path == "/actors/"
+        return _ACTORS
+
+
+@pytest.fixture()
+def client() -> DataLayerClient:
+    return cast(DataLayerClient, _StubClient())
+
+
+def _found_records(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if "actor:" in r.getMessage()]
+
+
+def test_info_records_contain_only_the_actor_id(client, caplog):
+    """At INFO each discovered actor is reported by ID, not full object."""
+    with caplog.at_level(logging.INFO, logger=_UTILS_LOGGER):
+        finder, vendor, coordinator = discover_actors(client)
+
+    assert finder.id_ == _FINDER_ID
+    assert vendor.id_ == _VENDOR_ID
+    assert coordinator.id_ == _COORDINATOR_ID
+
+    info_records = [
+        r for r in _found_records(caplog) if r.levelno == logging.INFO
+    ]
+    assert len(info_records) == 3, "Expected one INFO line per actor"
+    messages = [r.getMessage() for r in info_records]
+    assert messages == [
+        f"Found finder actor: {_FINDER_ID}",
+        f"Found vendor actor: {_VENDOR_ID}",
+        f"Found coordinator actor: {_COORDINATOR_ID}",
+    ]
+    # The logfmt() dump renders the actor name; it must not appear at INFO.
+    assert not any("Finn the Finder" in m for m in messages)
+
+
+def test_full_object_dump_is_available_at_debug(client, caplog):
+    """The full ``logfmt()`` dump is still emitted, at DEBUG."""
+    with caplog.at_level(logging.DEBUG, logger=_UTILS_LOGGER):
+        discover_actors(client)
+
+    debug_messages = [
+        r.getMessage()
+        for r in _found_records(caplog)
+        if r.levelno == logging.DEBUG
+    ]
+    assert len(debug_messages) == 3, "Expected one DEBUG dump per actor"
+    assert any("Finn the Finder" in m for m in debug_messages)

--- a/test/test_logging_setup.py
+++ b/test/test_logging_setup.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for third-party log-noise suppression (SL-04-007).
+
+The ``transitions`` library logs ``"<Machine> Finished processing state X
+enter/exit callbacks."`` at INFO on every RM/EM/CS/PEC state machine step.
+Those are FSM internals, so SL-04-007 requires they stay off the INFO channel.
+"""
+
+import logging
+
+import pytest
+
+from vultron.logging_setup import (
+    NOISY_INFO_LOGGERS,
+    restore_third_party_log_levels,
+    suppress_third_party_info_noise,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_logger_levels():
+    """Restore the noisy loggers' levels so tests do not leak configuration."""
+    saved = {
+        name: logging.getLogger(name).level for name in NOISY_INFO_LOGGERS
+    }
+    yield
+    for name, level in saved.items():
+        logging.getLogger(name).setLevel(level)
+
+
+def test_transitions_is_in_the_noisy_logger_list():
+    """The `transitions` FSM library is the SL-04-007 target."""
+    assert "transitions" in NOISY_INFO_LOGGERS
+
+
+def test_info_app_level_pins_noisy_loggers_to_warning():
+    """At app INFO, the FSM callback chatter is suppressed."""
+    suppress_third_party_info_noise(logging.INFO)
+
+    transitions_logger = logging.getLogger("transitions")
+    assert transitions_logger.level == logging.WARNING
+    assert not transitions_logger.isEnabledFor(logging.INFO)
+
+
+def test_debug_app_level_keeps_noisy_loggers_available():
+    """At app DEBUG the library output is still available for debugging."""
+    suppress_third_party_info_noise(logging.DEBUG)
+
+    transitions_logger = logging.getLogger("transitions")
+    assert transitions_logger.level == logging.DEBUG
+    assert transitions_logger.isEnabledFor(logging.INFO)
+
+
+def test_warning_app_level_also_suppresses():
+    """Levels above INFO also suppress the library chatter."""
+    suppress_third_party_info_noise(logging.WARNING)
+
+    assert logging.getLogger("transitions").level == logging.WARNING
+
+
+def test_em_machine_callbacks_produce_no_info_records(caplog):
+    """An EM state transition emits no `transitions` INFO record."""
+    from vultron.core.states.em import EM_Trigger, create_em_machine
+
+    suppress_third_party_info_noise(logging.INFO)
+
+    class _Model:
+        pass
+
+    model = _Model()
+    machine = create_em_machine()
+    machine.add_model(model)
+
+    with caplog.at_level(logging.INFO):
+        getattr(model, str(EM_Trigger.PROPOSE))()
+
+    fsm_records = [
+        r
+        for r in caplog.records
+        if r.name.startswith("transitions") and r.levelno == logging.INFO
+    ]
+    assert not fsm_records, (
+        "transitions FSM callback lines must not reach INFO (SL-04-007);"
+        f" got {[r.getMessage() for r in fsm_records]}"
+    )
+
+
+def test_restore_returns_loggers_to_their_prior_level():
+    """Suppression is undoable so it does not leak out of an entry point.
+
+    The FastAPI lifespan calls this on shutdown; without it, one TestClient
+    lifetime silently reconfigured `transitions` for every test that followed.
+    """
+    transitions_logger = logging.getLogger("transitions")
+    transitions_logger.setLevel(logging.NOTSET)
+
+    suppress_third_party_info_noise(logging.INFO)
+    assert transitions_logger.level == logging.WARNING
+
+    restore_third_party_log_levels()
+    assert transitions_logger.level == logging.NOTSET
+
+
+def test_restore_is_idempotent_and_safe_without_suppression():
+    """Calling restore with nothing suppressed is a no-op, not an error."""
+    transitions_logger = logging.getLogger("transitions")
+    transitions_logger.setLevel(logging.ERROR)
+
+    restore_third_party_log_levels()
+    restore_third_party_log_levels()
+
+    assert transitions_logger.level == logging.ERROR
+
+
+def test_restore_preserves_the_original_level_across_repeat_suppression():
+    """Repeat suppression must not overwrite the saved original level."""
+    transitions_logger = logging.getLogger("transitions")
+    transitions_logger.setLevel(logging.NOTSET)
+
+    suppress_third_party_info_noise(logging.INFO)
+    suppress_third_party_info_noise(logging.INFO)
+    restore_third_party_log_levels()
+
+    assert transitions_logger.level == logging.NOTSET
+
+
+def test_server_lifespan_does_not_leak_suppression(monkeypatch):
+    """A TestClient lifetime restores third-party levels on shutdown."""
+    from fastapi.testclient import TestClient
+
+    from vultron.adapters.driving.fastapi.app import app_v2
+
+    transitions_logger = logging.getLogger("transitions")
+    transitions_logger.setLevel(logging.NOTSET)
+
+    with TestClient(app_v2):
+        pass
+
+    assert transitions_logger.level == logging.NOTSET, (
+        "configure_logging() pinned `transitions` globally; the lifespan"
+        " shutdown must restore it"
+    )
+
+
+def test_configure_logging_wires_up_suppression(monkeypatch):
+    """AC-6 wire-up: configure_logging() calls the suppression helper.
+
+    The call is a one-liner a refactor could silently drop while every
+    unit test of the helper itself stayed green.
+    """
+    from vultron.adapters.driving.fastapi import app as app_module
+
+    calls: list[int] = []
+    monkeypatch.setattr(
+        "vultron.logging_setup.suppress_third_party_info_noise",
+        lambda level: calls.append(level),
+    )
+
+    app_module.configure_logging()
+
+    assert calls, "configure_logging() must suppress third-party INFO noise"
+
+
+def test_demo_cli_wires_up_suppression(monkeypatch):
+    """AC-6 wire-up: the demo CLI calls the suppression helper."""
+    import click
+
+    import vultron.demo.cli as cli_module
+
+    calls: list[int] = []
+    monkeypatch.setattr(
+        cli_module, "suppress_third_party_info_noise", calls.append
+    )
+
+    # Invoke the group callback directly: `--help` short-circuits before it.
+    # The callback is @click.pass_context-decorated, so it needs an active
+    # context rather than one passed positionally.
+    with click.Context(cli_module.main):
+        cli_module.main.callback(debug=False, log_file=None)  # type: ignore[misc]
+
+    assert calls, "demo CLI main() must suppress third-party INFO noise"
+    assert calls == [logging.INFO]

--- a/test/wire/as2/test_parser.py
+++ b/test/wire/as2/test_parser.py
@@ -104,3 +104,23 @@ def test_parse_activity_extracts_invite_response_semantics_from_nested_stub_case
             getattr(event, "invitee_id", None)
             == "https://example.org/actors/coordinator"
         )
+
+
+def test_parsing_activity_line_is_debug_not_info(caplog):
+    """ "Parsing activity from body" is HTTP handler internals (SL-04-007)."""
+    import logging
+
+    with caplog.at_level(logging.DEBUG, logger="vultron.wire.as2.parser"):
+        parse_activity(
+            {
+                "type": "Create",
+                "actor": "https://example.org/alice",
+                "object": "https://example.org/notes/1",
+            }
+        )
+
+    parsing = [
+        r for r in caplog.records if "Parsing activity from" in r.getMessage()
+    ]
+    assert parsing, "Expected the 'Parsing activity from body' log entry"
+    assert all(r.levelno == logging.DEBUG for r in parsing)

--- a/vultron/adapters/driven/datalayer_sqlite/crud.py
+++ b/vultron/adapters/driven/datalayer_sqlite/crud.py
@@ -67,7 +67,7 @@ def create(
         )
         session.add(row)
         session.commit()
-    logger.info("DataLayer stored %s '%s'", rec.type_, rec.id_)
+    logger.debug("DataLayer stored %s '%s'", rec.type_, rec.id_)
 
 
 def read(
@@ -149,7 +149,7 @@ def save(
             row.data = rec.data_
         session.add(row)
         session.commit()
-    logger.info("DataLayer saved %s '%s'", rec.type_, rec.id_)
+    logger.debug("DataLayer saved %s '%s'", rec.type_, rec.id_)
     if rec.type_ == "CaseParticipant":
         logger.debug(
             "DataLayer saved CaseParticipant '%s' (dl_actor_id=%r): %s",
@@ -192,7 +192,7 @@ def save_many(
             session.add(row)
         session.commit()
     for rec in rows:
-        logger.info("DataLayer saved %s '%s' (batch)", rec.type_, rec.id_)
+        logger.debug("DataLayer saved %s '%s' (batch)", rec.type_, rec.id_)
 
 
 def delete(
@@ -298,7 +298,7 @@ def update(
         row.data = record.data_
         session.add(row)
         session.commit()
-        logger.info("DataLayer updated %s '%s'", record.type_, id_)
+        logger.debug("DataLayer updated %s '%s'", record.type_, id_)
         return True
 
 

--- a/vultron/adapters/driven/sync_activity_adapter.py
+++ b/vultron/adapters/driven/sync_activity_adapter.py
@@ -113,7 +113,7 @@ class SyncActivityAdapter:
         )
         self._dl.save(announce)
         add_activity_to_outbox(actor_id, announce.id_, self._dl)
-        logger.info(
+        logger.debug(
             "sync adapter: queued Announce(CaseLedgerEntry) '%s' → %s",
             announce.id_,
             to,

--- a/vultron/adapters/driving/fastapi/app.py
+++ b/vultron/adapters/driving/fastapi/app.py
@@ -66,6 +66,11 @@ def configure_logging() -> None:
     # to reduce DEBUG output noise by ~30%.
     logging.getLogger("httpx2").setLevel(logging.WARNING)
 
+    # Drop `transitions` FSM callback chatter from INFO (SL-04-007).
+    from vultron.logging_setup import suppress_third_party_info_noise
+
+    suppress_third_party_info_noise(log_level)
+
 
 def _auto_inject_isolated_datalayer(application: FastAPI) -> None:
     """Auto-inject an in-memory DataLayer if none is already registered.
@@ -171,6 +176,14 @@ def _make_lifespan(*, configure_globals: bool = True):
         # TestClient lifetimes on the same app singleton.
         if configure_globals:
             application.state.emitter = None
+            # configure_logging() pinned third-party logger levels globally;
+            # undo it so a TestClient lifetime does not reconfigure logging
+            # for everything that runs after it.
+            from vultron.logging_setup import (
+                restore_third_party_log_levels,
+            )
+
+            restore_third_party_log_levels()
 
         if not configure_globals:
             _teardown_per_app_state(application)

--- a/vultron/adapters/driving/fastapi/inbox_orchestration.py
+++ b/vultron/adapters/driving/fastapi/inbox_orchestration.py
@@ -367,7 +367,7 @@ async def run_inbox_pipeline(
     # task runs first, the hash-chain check fails → spurious Reject (issue #1525).
     async with _get_actor_lock(actor_id):
         outcome = process_payload(payload, ingress, dispatch_adp, queue)
-        logger.info(
+        logger.debug(
             "run_inbox_pipeline: status=%s context_id=%s",
             outcome.status,
             outcome.context_id,
@@ -383,7 +383,7 @@ async def run_inbox_pipeline(
             replay_outcome = process_payload(
                 item_id, stored_ingress, dispatch_adp, queue
             )
-            logger.info(
+            logger.debug(
                 "run_inbox_pipeline: replayed status=%s context_id=%s",
                 replay_outcome.status,
                 replay_outcome.context_id,

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -239,7 +239,7 @@ async def outbox_handler(
         logger.warning("Actor %s not found in outbox_handler.", actor_id)
         return
 
-    logger.info("Processing outbox for actor %s", actor_id)
+    logger.debug("Processing outbox for actor %s", actor_id)
     err_count = 0
     while dl.outbox_list():
         activity_id = dl.outbox_pop()

--- a/vultron/adapters/driving/fastapi/routers/actors/_inbox.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_inbox.py
@@ -59,7 +59,7 @@ def parse_activity(body: dict[str, Any]) -> as_Activity:
         HTTPException: 400 if the `type` field is missing; 422 for all other
             parse failures (unknown type, validation error).
     """
-    logger.info(
+    logger.debug(
         "Parsing activity from request body (type=%r):\n%s",
         body.get("type"),
         json.dumps(body, indent=2, default=str),

--- a/vultron/adapters/driving/fastapi/routers/actors/_routes.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_routes.py
@@ -362,7 +362,7 @@ def post_actor_inbox(
     canonical_actor_id = actor.id_
 
     if _activity_already_received(actor, activity.id_):
-        logger.info(
+        logger.debug(
             "Activity %s already received by %s; ignoring duplicate submission.",
             activity.id_,
             canonical_actor_id,

--- a/vultron/core/behaviors/bridge.py
+++ b/vultron/core/behaviors/bridge.py
@@ -204,9 +204,10 @@ class BTBridge:
 
         self.logger.info(f"BT setup complete for actor {actor_id}")
 
-        # Log tree structure for visibility (INFO level) — shows behavioral decisions
-        tree_repr = unicode_tree(tree, show_status=True)
-        self.logger.info(f"BT structure:\n{tree_repr}")
+        # BT scaffolding, not protocol story — DEBUG only (SL-04-007).
+        if self.logger.isEnabledFor(logging.DEBUG):
+            tree_repr = unicode_tree(tree, show_status=True)
+            self.logger.debug(f"BT structure:\n{tree_repr}")
 
         return bt
 
@@ -248,11 +249,28 @@ class BTBridge:
                 if root_status in (Status.SUCCESS, Status.FAILURE):
                     feedback = bt.root.feedback_message
 
+                    # SL-04-001/AC-18: a bare "Status.FAILURE" is not a story.
+                    # Fold the failing leaf's reason into the line that was
+                    # already emitted, rather than adding a second record —
+                    # many callers treat FAILURE as an expected idempotent
+                    # skip and log their own explanation at DEBUG.
+                    detail = feedback
+                    if root_status == Status.FAILURE:
+                        detail = (
+                            detail
+                            or self.get_failure_reason(bt.root)
+                            or "<no reason reported>"
+                        )
                     self.logger.info(
-                        f"BT execution completed: {root_status} after {iteration} ticks - {feedback}"
+                        "BT execution completed: %s after %d ticks - %s",
+                        root_status,
+                        iteration,
+                        detail,
                     )
-                    tree_repr = unicode_tree(bt.root, show_status=True)
-                    self.logger.info(f"Final BT state:\n{tree_repr}")
+                    # Tree dump is scaffolding, not story — DEBUG (SL-04-007).
+                    if self.logger.isEnabledFor(logging.DEBUG):
+                        tree_repr = unicode_tree(bt.root, show_status=True)
+                        self.logger.debug(f"Final BT state:\n{tree_repr}")
 
                     return BTExecutionResult(
                         status=root_status,

--- a/vultron/core/behaviors/case/nodes/announce.py
+++ b/vultron/core/behaviors/case/nodes/announce.py
@@ -75,7 +75,7 @@ class SeedAnnouncedCaseNode(DataLayerAction):
         existing = self.datalayer.read(self.case_id)
         if existing is not None:
             # Idempotent path — case already present locally (MV-10-004).
-            self.logger.info(
+            self.logger.debug(
                 "%s: case '%s' already exists locally"
                 " — skipping save (idempotent, MV-10-004)",
                 self.name,

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -21,6 +21,10 @@ from vultron.core.behaviors.case.nodes.participant.common import (
     resolve_participant_state_from_dl,
 )
 from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.narrative_log import (
+    log_cs_transition,
+    log_rm_transition,
+)
 from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.participant_status import (
     ParticipantStatus,
@@ -51,6 +55,40 @@ def _resolve_em_state(case: object) -> EM:
         current_status.em.state if hasattr(current_status, "em") else None
     )
     return em_state if em_state is not None else EM.NONE
+
+
+def _pxa_from_case(case: object) -> CS_pxa | None:
+    """Return the case-level PXA state, or ``None`` when unavailable."""
+    try:
+        current_status = case.current_status  # type: ignore[attr-defined]
+    except (AttributeError, ValueError):
+        return None
+    pxa_state = getattr(getattr(current_status, "pxa", None), "state", None)
+    return pxa_state if isinstance(pxa_state, CS_pxa) else None
+
+
+def _resolve_pxa_state(case: object, participant: object) -> CS_pxa:
+    """Return the PXA state in force before this node writes a new snapshot.
+
+    The participant's own latest ``ParticipantStatus.case_status.pxa`` is
+    authoritative: this node records PXA on the *participant* snapshot and
+    does not append to ``case.case_statuses``, so ``case.current_status``
+    would report a stale ``pxa`` and make every repeat write look like a fresh
+    public-disclosure event.
+
+    Falls back to the case-level PXA (then ``CS_pxa.pxa``) when the
+    participant has no PXA-bearing snapshot yet.
+    """
+    statuses = getattr(participant, "participant_statuses", None) or []
+    for status in reversed(statuses):
+        pxa_state = getattr(
+            getattr(getattr(status, "case_status", None), "pxa", None),
+            "state",
+            None,
+        )
+        if isinstance(pxa_state, CS_pxa):
+            return pxa_state
+    return _pxa_from_case(case) or CS_pxa.pxa
 
 
 class CreateParticipantStatusNode(DataLayerAction):
@@ -105,8 +143,15 @@ class CreateParticipantStatusNode(DataLayerAction):
             )
             return Status.FAILURE
 
+        current_rm, current_vfd = resolve_participant_state_from_dl(
+            dl, participant_id
+        )
+        participant_obj = dl.read(participant_id)
+
         case_status: CaseStatus | None = None
+        pxa_before: CS_pxa | None = None
         if self._pxa_state is not None:
+            pxa_before = _resolve_pxa_state(case, participant_obj)
             case_status = CaseStatus(
                 context=self._case_id,
                 attributed_to=self._actor_id,
@@ -114,10 +159,6 @@ class CreateParticipantStatusNode(DataLayerAction):
                 pxa=PxaDimension(state=self._pxa_state),
             )
 
-        current_rm, current_vfd = resolve_participant_state_from_dl(
-            dl, participant_id
-        )
-        participant_obj = dl.read(participant_id)
         participant_roles = (
             participant_obj.roles
             if isinstance(participant_obj, CaseParticipant)
@@ -177,11 +218,52 @@ class CreateParticipantStatusNode(DataLayerAction):
         self._result_out["status_id"] = status.id_
         self._result_out["participant_id"] = participant_id
 
-        self.logger.info(
+        self.logger.debug(
             "%s: Created ParticipantStatus '%s' for actor '%s' in case '%s'",
             self.name,
             status.id_,
             self._actor_id,
             self._case_id,
         )
+        self._log_transitions(current_rm, current_vfd, pxa_before)
         return Status.SUCCESS
+
+    def _log_transitions(
+        self,
+        rm_before: RM,
+        vfd_before: CS_vfd,
+        pxa_before: CS_pxa | None,
+    ) -> None:
+        """Emit narrative INFO lines for the dimensions this node advanced.
+
+        The RM/CS dimension changes carried by the snapshot are the protocol
+        story (SL-04-001); the helpers suppress no-op writes.
+
+        This node is a second per-participant RM write path alongside
+        ``update_participant_rm_state()`` (used by e.g. the leave-case
+        RM → CLOSED nodes), so it must log the RM line itself.
+        """
+        if self._rm_state is not None:
+            log_rm_transition(
+                self.logger,
+                self._actor_id,
+                self._case_id,
+                rm_before,
+                self._rm_state,
+            )
+        if self._vfd_state is not None:
+            log_cs_transition(
+                self.logger,
+                self._actor_id,
+                self._case_id,
+                vfd_before,
+                self._vfd_state,
+            )
+        if self._pxa_state is not None and pxa_before is not None:
+            log_cs_transition(
+                self.logger,
+                self._actor_id,
+                self._case_id,
+                pxa_before,
+                self._pxa_state,
+            )

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -31,6 +31,7 @@ from vultron.core.behaviors.embargo.nodes.reject_proposed import (  # noqa: F401
     SendRejectEmbargoActivityNode,
 )
 from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.narrative_log import log_em_transition
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import EmDimension
 from vultron.core.services.embargo_lifecycle import (
@@ -449,7 +450,15 @@ class SetEmbargoActiveNode(DataLayerAction):
             f"Activated embargo '{self.embargo_id}' on case"
             f" '{self.case_id}' (EM {current_em} → ACTIVE)"
         )
-        self.logger.info("%s: %s", self.name, self.feedback_message)
+        self.logger.debug("%s: %s", self.name, self.feedback_message)
+        # SL-04-001/SL-04-006: embargo activation is a protocol milestone.
+        log_em_transition(
+            self.logger,
+            self.actor_id or "<unknown>",
+            self.case_id,
+            current_em,
+            EM.ACTIVE,
+        )
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -21,6 +21,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.embargo.nodes.em_state import ReadEmStateNode
 from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.narrative_log import log_em_transition
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import EmDimension
 from vultron.core.states.em import EM, is_valid_em_transition
@@ -134,7 +135,15 @@ class ClearActiveEmbargoNode(DataLayerAction):
             f"Cleared active embargo on case '{self.case_id}'"
             f" (EM {current_em} → EXITED)"
         )
-        self.logger.info("%s: %s", self.name, self.feedback_message)
+        self.logger.debug("%s: %s", self.name, self.feedback_message)
+        # SL-04-001/SL-04-006: embargo teardown is a protocol milestone.
+        log_em_transition(
+            self.logger,
+            self.actor_id or "<unknown>",
+            self.case_id,
+            current_em,
+            EM.EXITED,
+        )
         return Status.SUCCESS
 
 
@@ -246,7 +255,15 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
             f"Embargo teardown applied on case '{case_id}'"
             f" (EM {current_em} → EXITED)"
         )
-        self.logger.info("%s: %s", self.name, self.feedback_message)
+        self.logger.debug("%s: %s", self.name, self.feedback_message)
+        # SL-04-001/SL-04-006: embargo teardown is a protocol milestone.
+        log_em_transition(
+            self.logger,
+            self.actor_id or "<unknown>",
+            case_id,
+            current_em,
+            EM.EXITED,
+        )
         return Status.SUCCESS
 
 

--- a/vultron/core/behaviors/inbox/_process_payload.py
+++ b/vultron/core/behaviors/inbox/_process_payload.py
@@ -210,7 +210,7 @@ def process_payload(
         finally:
             _restore_inbox_keys(storage, saved)
 
-    logger.info(
+    logger.debug(
         "process_payload: outcome status=%s context_id=%s",
         outcome.status,
         outcome.context_id,

--- a/vultron/core/behaviors/narrative_log.py
+++ b/vultron/core/behaviors/narrative_log.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Narrative INFO log helpers for protocol state transitions (SL-04-006).
+
+Every protocol-visible state change SHOULD emit exactly one INFO line
+following the narrative template so that reading an actor's INFO log tells
+the complete CVD protocol story without dropping to DEBUG:
+
+.. code-block:: text
+
+    Actor '<actor_id>' <verb> '<object_id>' (<STATE_A> → <STATE_B>)
+
+The helpers here own that formatting so call sites cannot drift from the
+template (CS-22-001).  See ``notes/structured-logging.md`` for the full verb
+inventory and ``specs/structured-logging.yaml`` SL-04-001, SL-04-006.
+"""
+
+import logging
+
+from vultron.core.states.cs import CS_pxa, CS_vfd
+from vultron.core.states.em import EM
+from vultron.core.states.rm import RM
+
+#: Human-readable CS event labels keyed by the sub-dimension that flipped.
+#:
+#: Each entry maps ``(field_name, new_value)`` to the CVD event name for the
+#: transition.  Values are the single-character state codes used by the
+#: ``CS_vfd`` / ``CS_pxa`` named tuples.
+_CS_EVENT_LABELS: dict[tuple[str, str], str] = {
+    ("vendor_awareness", "V"): "vendor aware",
+    ("fix_readiness", "F"): "fix ready",
+    ("fix_deployment", "D"): "fix deployed",
+    ("public_awareness", "P"): "publicly known",
+    ("exploit_publication", "X"): "exploit public",
+    ("attack_observation", "A"): "attacks observed",
+}
+
+
+#: Label used when a CS write moves *backward* (an event being un-done).
+#:
+#: CS events are monotonic by protocol definition, so this indicates a bug or
+#: a state-sync override rather than a normal transition.
+REGRESSION_LABEL = "state regression"
+
+#: Label used when before == after (no sub-dimension moved).
+NO_CHANGE_LABEL = "no change"
+
+
+def cs_event_label(
+    before: CS_vfd | CS_pxa,
+    after: CS_vfd | CS_pxa,
+) -> str:
+    """Return the CVD event name(s) for a CS dimension transition.
+
+    Compares the sub-dimension fields of *before* and *after* and names each
+    one that advanced (e.g. ``Vfd`` → ``VFd`` is ``"fix ready"``).
+
+    Returns:
+        A comma-joined list of event labels; :data:`NO_CHANGE_LABEL` when the
+        two states are equal; :data:`REGRESSION_LABEL` when a sub-dimension
+        moved *backward* (CS events are monotonic, so this signals a bug or a
+        state-sync override — never a normal transition).
+
+    Raises:
+        TypeError: If *before* and *after* are different CS dimensions (e.g. a
+            ``CS_vfd`` compared against a ``CS_pxa``); their sub-dimension
+            fields are not comparable.
+    """
+    if type(before) is not type(after):
+        raise TypeError(
+            "cs_event_label() requires both states from the same CS"
+            f" dimension; got {type(before).__name__} and"
+            f" {type(after).__name__}"
+        )
+    if before == after:
+        return NO_CHANGE_LABEL
+
+    labels: list[str] = []
+    for field, new_value in zip(after.value._fields, after.value, strict=True):
+        if getattr(before.value, field) == new_value:
+            continue
+        label = _CS_EVENT_LABELS.get((field, str(new_value)))
+        if label is None:
+            # The field changed but the *new* value is not an event-triggering
+            # (uppercase) code — i.e. the dimension moved backward.
+            return REGRESSION_LABEL
+        labels.append(label)
+    return ", ".join(labels)
+
+
+def log_cs_transition(
+    logger: logging.Logger,
+    actor_id: str,
+    case_id: str,
+    before: CS_vfd | CS_pxa,
+    after: CS_vfd | CS_pxa,
+) -> None:
+    """Log a CS (VFD or PXA) transition at INFO per SL-04-006.
+
+    Emits nothing when *before* equals *after*: a no-op write is not a
+    protocol event and would only add noise (SL-04-007).
+
+    A *backward* move is logged at WARNING rather than INFO: CS events are
+    monotonic by protocol definition, so a regression is an anomaly to
+    investigate, not a milestone in the case narrative.
+
+    Args:
+        logger: Logger to emit on (usually the BT node's ``self.logger``).
+        actor_id: Actor whose CS dimension changed.
+        case_id: Case the transition applies to.
+        before: CS state before the transition.
+        after: CS state after the transition.
+    """
+    if before == after:
+        return
+    label = cs_event_label(before, after)
+    level = logging.WARNING if label == REGRESSION_LABEL else logging.INFO
+    logger.log(
+        level,
+        "Actor '%s' CS: %s → %s (%s) for case '%s'",
+        actor_id,
+        before.name,
+        after.name,
+        label,
+        case_id,
+    )
+
+
+def log_rm_transition(
+    logger: logging.Logger,
+    actor_id: str,
+    case_id: str,
+    before: RM,
+    after: RM,
+) -> None:
+    """Log a per-participant RM transition at INFO per SL-04-006.
+
+    Emits nothing when *before* equals *after*: re-asserting the current RM
+    state is bookkeeping, not a transition (SL-04-007).
+
+    Args:
+        logger: Logger to emit on.
+        actor_id: Actor whose RM state changed.
+        case_id: Case the transition applies to.
+        before: RM state before the transition.
+        after: RM state after the transition.
+    """
+    if before == after:
+        return
+    logger.info(
+        "Actor '%s' RM: %s → %s for case '%s'",
+        actor_id,
+        before,
+        after,
+        case_id,
+    )
+
+
+def log_em_transition(
+    logger: logging.Logger,
+    actor_id: str,
+    case_id: str,
+    before: EM,
+    after: EM,
+) -> None:
+    """Log an embargo (EM) lifecycle transition at INFO per SL-04-006.
+
+    Emits nothing when *before* equals *after*.
+
+    Args:
+        logger: Logger to emit on.
+        actor_id: Actor that caused the transition.
+        case_id: Case the embargo belongs to.
+        before: EM state before the transition.
+        after: EM state after the transition.
+    """
+    if before == after:
+        return
+    logger.info(
+        "Actor '%s' embargo %s → %s for case '%s'",
+        actor_id,
+        before,
+        after,
+        case_id,
+    )
+
+
+def log_case_engagement(
+    logger: logging.Logger,
+    actor_id: str,
+    case_id: str,
+    rm_before: RM,
+    rm_after: RM,
+) -> None:
+    """Log a case engagement at INFO per SL-04-006.
+
+    Emits nothing when *rm_before* equals *rm_after*: re-engaging a case the
+    actor already engaged is an idempotent no-op, and claiming
+    ``RM ACCEPTED → ACCEPTED`` would assert an engagement that did not happen
+    (SL-04-007).
+
+    Args:
+        logger: Logger to emit on.
+        actor_id: Actor that engaged the case.
+        case_id: Case engaged.
+        rm_before: Actor's RM state before engaging.
+        rm_after: Actor's RM state after engaging, read back from storage.
+    """
+    if rm_before == rm_after:
+        return
+    logger.info(
+        "Actor '%s' engaged case '%s' (RM %s → %s)",
+        actor_id,
+        case_id,
+        rm_before,
+        rm_after,
+    )
+
+
+def log_invite_received(
+    logger: logging.Logger,
+    actor_id: str,
+    case_id: str,
+    sender_id: str,
+) -> None:
+    """Log receipt of a case invitation at INFO per SL-04-006.
+
+    Args:
+        logger: Logger to emit on.
+        actor_id: Actor that received the invite.
+        case_id: Case the invite refers to.
+        sender_id: Actor that sent the invite.
+    """
+    logger.info(
+        "Actor '%s' received case invite for '%s' from '%s'",
+        actor_id,
+        case_id,
+        sender_id,
+    )
+
+
+# NOTE: BT-execution failures are *not* logged from here.  AC-18 asked for a
+# reason alongside the bare ``BT execution completed: Status.FAILURE`` line, and
+# ``BTBridge.execute_tree`` folds ``get_failure_reason()`` into that existing
+# record instead.  A second dedicated line would double-log, would fire for the
+# many callers that treat FAILURE as an expected idempotent skip (and log their
+# own explanation at DEBUG), and had no reliable ``case_id`` to report: no
+# production ``execute_with_setup`` call site passes one.

--- a/vultron/core/behaviors/report/nodes/deploy_fix.py
+++ b/vultron/core/behaviors/report/nodes/deploy_fix.py
@@ -376,8 +376,10 @@ class TransitionCStoFixDeployed(DataLayerAction):
         try:
             status = node.update()
             if status == Status.SUCCESS:
-                self.logger.info(
-                    "%s: VFD → VFD (fix deployed) for actor '%s' in case '%s'",
+                # The narrative INFO line (SL-04-006) is emitted by
+                # CreateParticipantStatusNode, which knows the before-state.
+                self.logger.debug(
+                    "%s: VFd → VFD (fix deployed) for actor '%s' in case '%s'",
                     self.name,
                     self._actor_id,
                     self._case_id,

--- a/vultron/core/behaviors/report/nodes/develop_fix.py
+++ b/vultron/core/behaviors/report/nodes/develop_fix.py
@@ -313,7 +313,9 @@ class TransitionCStoFixReady(DataLayerAction):
         try:
             status = node.update()
             if status == Status.SUCCESS:
-                self.logger.info(
+                # The narrative INFO line (SL-04-006) is emitted by
+                # CreateParticipantStatusNode, which knows the before-state.
+                self.logger.debug(
                     "%s: VFD → VFd for actor '%s' in case '%s'",
                     self.name,
                     self._actor_id,

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -308,10 +308,12 @@ def update_participant_rm_state(
             else getattr(actor_ref, "id_", str(actor_ref))
         )
         if p_actor_id == actor_id:
+            rm_before: RM | None = None
             if participant.participant_statuses:
                 latest = participant.participant_statuses[-1]
-                if latest.rm.state == new_rm_state:
-                    logger.info(
+                rm_before = latest.rm.state
+                if rm_before == new_rm_state:
+                    logger.debug(
                         "Participant '%s' already in RM state %s in case '%s' "
                         "(idempotent)",
                         actor_id,
@@ -332,11 +334,18 @@ def update_participant_rm_state(
                 )
                 return False
             dl.save(participant)
-            logger.info(
-                "Set participant '%s' RM state to %s in case '%s'",
+            # SL-04-001/SL-04-006 narrative template: the per-participant RM
+            # transition is the primary RM story line at INFO.
+            from vultron.core.behaviors.narrative_log import (
+                log_rm_transition,
+            )
+
+            log_rm_transition(
+                logger,
                 actor_id,
-                new_rm_state,
                 case_id,
+                rm_before if rm_before is not None else RM.START,
+                new_rm_state,
             )
             return True
 
@@ -347,6 +356,28 @@ def update_participant_rm_state(
         case_id,
     )
     return False
+
+
+def current_participant_rm_state(
+    case: VulnerabilityCase, actor_id: str, dl: CasePersistence
+) -> RM:
+    """Return *actor_id*'s latest RM state in *case*, or ``RM.START``.
+
+    Used by narrative logging (SL-04-006) to report the before-state of an RM
+    transition.  Returns ``RM.START`` when the actor is not yet a participant
+    or has no recorded status, which is the RM machine's initial state.
+    """
+    participant_id = resolve_case_participant_id_for_actor(case, actor_id, dl)
+    if participant_id is None:
+        return RM.START
+    participant = dl.read(participant_id)
+    if not isinstance(participant, CaseParticipant):
+        return RM.START
+    statuses = participant.participant_statuses
+    if not statuses:
+        return RM.START
+    state = statuses[-1].rm.state
+    return state if isinstance(state, RM) else RM.START
 
 
 def _resolve_case_manager_id(

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -8,6 +8,7 @@ import hashlib
 import logging
 from typing import Any
 
+from vultron.core.behaviors.narrative_log import log_rm_transition
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
@@ -238,7 +239,9 @@ def _idempotent_create(
     if not type_key or not id_key:
         return
     if dl.read(id_key) is not None:
-        logger.info("'%s' already stored — skipping (idempotent)", id_key)
+        # Routine idempotency skip — infrastructure, not protocol story
+        # (SL-04-007).  Fires on essentially every received-side activity.
+        logger.debug("'%s' already stored — skipping (idempotent)", id_key)
         return
     if obj is not None:
         dl.create(obj)
@@ -336,10 +339,6 @@ def update_participant_rm_state(
             dl.save(participant)
             # SL-04-001/SL-04-006 narrative template: the per-participant RM
             # transition is the primary RM story line at INFO.
-            from vultron.core.behaviors.narrative_log import (
-                log_rm_transition,
-            )
-
             log_rm_transition(
                 logger,
                 actor_id,

--- a/vultron/core/use_cases/received/actor/invite.py
+++ b/vultron/core/use_cases/received/actor/invite.py
@@ -13,6 +13,7 @@ from vultron.core.behaviors.case.invite_actor_to_case_received_tree import (
     create_invite_actor_to_case_received_tree,
     create_reject_invite_actor_to_case_received_tree,
 )
+from vultron.core.behaviors.narrative_log import log_invite_received
 from vultron.core.models.events.actor import (
     AcceptInviteActorToCaseReceivedEvent,
     InviteActorToCaseReceivedEvent,
@@ -93,7 +94,15 @@ class InviteActorToCaseReceivedUseCase:
             # details arrive later in an AnnounceVulnerabilityCase (MV-10-003).
             case_stub_id = request.target_id
             if case_stub_id:
-                logger.info(
+                # SL-04-001/SL-04-006: the invitee's receipt of the invite is a
+                # protocol milestone and must read in human terms at INFO.
+                log_invite_received(
+                    logger,
+                    request.object_id or "<unknown>",
+                    case_stub_id,
+                    request.actor_id or "<unknown>",
+                )
+                logger.debug(
                     "InviteActorToCase: received invite with case stub '%s'."
                     " Awaiting AnnounceVulnerabilityCase before creating case.",
                     case_stub_id,

--- a/vultron/core/use_cases/received/case/_helpers.py
+++ b/vultron/core/use_cases/received/case/_helpers.py
@@ -89,7 +89,7 @@ def _store_embedded_participants(
         if _would_regress_participant(participant_ref, dl, pid, case_id):
             continue
         dl.save(participant_ref)
-        logger.info(
+        logger.debug(
             "store_embedded_participants: stored participant '%s'"
             " for case '%s' (CBT-05-005, #566)",
             pid,

--- a/vultron/core/use_cases/triggers/case/engage.py
+++ b/vultron/core/use_cases/triggers/case/engage.py
@@ -21,6 +21,8 @@ import py_trees.behaviour
 from vultron.core.behaviors.case.engage_defer_trigger_tree import (
     engage_case_trigger_bt,
 )
+from vultron.core.behaviors.narrative_log import log_case_engagement
+from vultron.core.use_cases._helpers import current_participant_rm_state
 from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
@@ -42,7 +44,13 @@ class SvcEngageCaseUseCase(SvcBTTriggerBase):
         request = cast(EngageCaseTriggerRequest, self._request)
         actor = resolve_actor(request.actor_id, self._dl)
         self._actor_id = actor.id_
-        self._case_id = resolve_case(request.case_id, self._dl).id_
+        case = resolve_case(request.case_id, self._dl)
+        self._case_id = case.id_
+        # Captured before the BT runs so the narrative log can report the
+        # actual RM transition rather than only the target state (SL-04-006).
+        self._rm_before = current_participant_rm_state(
+            case, self._actor_id, self._dl
+        )
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
@@ -61,8 +69,15 @@ class SvcEngageCaseUseCase(SvcBTTriggerBase):
         )
 
     def _handle_result(self) -> None:
-        logger.info(
-            "Actor '%s' engaged case '%s' (RM → ACCEPTED)",
+        # Read the after-state back from storage rather than assuming
+        # RM.ACCEPTED: the BT can succeed via an idempotent no-op path, and
+        # the narrative line must not claim a transition that did not occur
+        # (SL-04-006).
+        case = resolve_case(self._case_id, self._dl)
+        log_case_engagement(
+            logger,
             self._actor_id,
             self._case_id,
+            self._rm_before,
+            current_participant_rm_state(case, self._actor_id, self._dl),
         )

--- a/vultron/demo/cli.py
+++ b/vultron/demo/cli.py
@@ -54,6 +54,7 @@ import vultron.demo.scenario.fvv_demo as fvv_demo
 import vultron.demo.exchange.transfer_ownership_demo as transfer_ownership_demo
 import vultron.demo.exchange.trigger_demo as trigger_demo
 import vultron.demo.scenario.fv_demo as fv_demo
+from vultron.logging_setup import suppress_third_party_info_noise
 from vultron.demo.seed_config import SeedConfig
 from vultron.demo.utils import DataLayerClient, BASE_URL, seed_actor
 import vultron.bt.base.demo.pacman as pacman_demo
@@ -105,6 +106,7 @@ def main(ctx: click.Context, debug: bool, log_file: str | None) -> None:
         handlers=handlers,
         force=True,
     )
+    suppress_third_party_info_noise(level)
     ctx.ensure_object(dict)
     ctx.obj["debug"] = debug
 

--- a/vultron/demo/utils.py
+++ b/vultron/demo/utils.py
@@ -258,6 +258,16 @@ def reset_datalayer(client: DataLayerClient, init: bool = True) -> dict:
     return client.delete("/datalayer/reset/", params={"init": init})
 
 
+def _log_discovered_actor(role: str, actor: as_Actor) -> None:
+    """Log a discovered demo actor: ID at INFO, full object at DEBUG.
+
+    The full ``logfmt()`` dump is DEBUG-only per SL-04-007; only the actor ID
+    carries narrative value at INFO.
+    """
+    logger.info("Found %s actor: %s", role, actor.id_ or "<unknown>")
+    logger.debug("Found %s actor: %s", role, logfmt(actor))
+
+
 def discover_actors(
     client: DataLayerClient,
 ) -> Tuple[as_Actor, as_Actor, as_Actor]:
@@ -277,13 +287,13 @@ def discover_actors(
         actor = as_Actor(**actor_json)
         if actor.name and actor.name.startswith("Finn"):
             finder = actor
-            logger.info(f"Found finder actor: {logfmt(finder)}")
+            _log_discovered_actor("finder", finder)
         elif actor.name and actor.name.startswith("Vendor"):
             vendor = actor
-            logger.info(f"Found vendor actor: {logfmt(vendor)}")
+            _log_discovered_actor("vendor", vendor)
         elif actor.name and actor.name.startswith("Coordinator"):
             coordinator = actor
-            logger.info(f"Found coordinator actor: {logfmt(coordinator)}")
+            _log_discovered_actor("coordinator", coordinator)
 
     if finder is None:
         raise ValueError("Finder actor not found.")

--- a/vultron/logging_setup.py
+++ b/vultron/logging_setup.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Shared third-party log-noise suppression (SL-04-007).
+
+Some libraries Vultron depends on emit high-volume lifecycle chatter at INFO.
+Those lines are infrastructure internals, not protocol story, so they MUST NOT
+appear at INFO (SL-04-007).  This module centralises the suppression so that
+both the FastAPI server (:func:`vultron.adapters.driving.fastapi.app.configure_logging`)
+and the demo CLI apply the same policy.
+
+See ``notes/structured-logging.md``.
+"""
+
+import logging
+
+#: Loggers whose INFO output is library internals rather than protocol story.
+#:
+#: ``transitions`` emits ``"<Machine> Finished processing state X enter/exit
+#: callbacks."`` and ``"Executed callback '<func>'"`` at INFO for every RM/EM/
+#: CS/PEC state machine step.  The narrative EM/RM transition messages Vultron
+#: emits itself already carry that information (SL-04-006).
+NOISY_INFO_LOGGERS: tuple[str, ...] = ("transitions",)
+
+
+#: Levels captured the first time :func:`suppress_third_party_info_noise` runs,
+#: so :func:`restore_third_party_log_levels` can undo the global mutation.
+_SAVED_LEVELS: dict[str, int] = {}
+
+
+def suppress_third_party_info_noise(app_log_level: int) -> None:
+    """Raise noisy third-party loggers above INFO (SL-04-007).
+
+    When *app_log_level* is above ``DEBUG`` the noisy loggers are pinned to
+    ``WARNING`` so their INFO chatter is dropped.  When the application is
+    running at ``DEBUG`` the loggers are set to ``DEBUG`` so their output is
+    still available for troubleshooting.
+
+    This mutates process-global logger state, which is appropriate for an
+    application entry point (the server lifespan, the demo CLI) but would be
+    rude if it were permanent for library importers and leaks across tests.
+    The pre-existing levels are captured on first call so
+    :func:`restore_third_party_log_levels` can undo it.
+
+    Args:
+        app_log_level: The effective application log level (e.g.
+            ``logging.INFO``).
+    """
+    library_level = (
+        logging.DEBUG if app_log_level <= logging.DEBUG else logging.WARNING
+    )
+    for name in NOISY_INFO_LOGGERS:
+        library_logger = logging.getLogger(name)
+        _SAVED_LEVELS.setdefault(name, library_logger.level)
+        library_logger.setLevel(library_level)
+
+
+def restore_third_party_log_levels() -> None:
+    """Undo :func:`suppress_third_party_info_noise`.
+
+    Restores each noisy logger to the level it had before the first
+    suppression call.  Safe to call when no suppression is active (no-op).
+    """
+    while _SAVED_LEVELS:
+        name, level = _SAVED_LEVELS.popitem()
+        logging.getLogger(name).setLevel(level)

--- a/vultron/wire/as2/parser.py
+++ b/vultron/wire/as2/parser.py
@@ -110,7 +110,7 @@ def parse_activity(body: dict[str, Any]) -> as_Activity:
         VultronParseUnknownTypeError: If the `type` value is not in the vocabulary.
         VultronParseValidationError: If Pydantic validation fails.
     """
-    logger.info("Parsing activity from body (type=%r)", body.get("type"))
+    logger.debug("Parsing activity from body (type=%r)", body.get("type"))
 
     type_ = body.get("type")
     if type_ is None:


### PR DESCRIPTION
- Closes #1988

## Summary

Implements the two-pass logging remediation from CONCERN-1968 so that reading an
actor's INFO log tells the complete CVD protocol story without dropping to DEBUG.
Pass 1 demotes 11 infrastructure patterns off the INFO channel (SL-04-007);
Pass 2 adds the 7 missing narrative state-transition messages (SL-04-001,
SL-04-006).

## Changes

### Pass 1 — INFO → DEBUG demotions (AC-1 … AC-11)

- **`vultron/adapters/driven/datalayer_sqlite/crud.py`**: `DataLayer stored/saved/updated` → DEBUG (4 sites).
- **`vultron/core/behaviors/bridge.py`**: `BT structure` and `Final BT state` tree dumps → DEBUG, guarded by `isEnabledFor(DEBUG)` so the `unicode_tree()` render is skipped entirely at INFO.
- **`vultron/wire/as2/parser.py`**, **`.../routers/actors/_inbox.py`**: the duplicate activity-parsing pair → DEBUG.
- **`.../fastapi/outbox_handler.py`**: `Processing outbox for actor` preamble → DEBUG.
- **`vultron/core/behaviors/inbox/_process_payload.py`**, **`.../fastapi/inbox_orchestration.py`**: pipeline outcome echoes → DEBUG.
- **`vultron/logging_setup.py`** (new): AC-6. The `transitions` library logs FSM enter/exit callbacks at INFO on every RM/EM/CS/PEC step, so it cannot be demoted at the call site. `suppress_third_party_info_noise()` pins those loggers above INFO; called from `configure_logging()` and the demo CLI, and undone by `restore_third_party_log_levels()` on lifespan shutdown so a `TestClient` lifetime does not silently reconfigure logging for everything after it.
- **`vultron/adapters/driven/sync_activity_adapter.py`**: per-recipient `Announce(CaseLedgerEntry)` queue line → DEBUG.
- **`vultron/core/use_cases/received/case/_helpers.py`**: per-participant storage chatter → DEBUG.
- **`vultron/core/behaviors/case/nodes/announce.py`**, **`.../actors/_routes.py`**: routine idempotency skips → DEBUG.
- **`vultron/demo/utils.py`**: `discover_actors()` logs the actor ID at INFO; the full `logfmt()` dump moves to DEBUG.

### Pass 2 — narrative INFO messages (AC-12 … AC-18)

- **`vultron/core/behaviors/narrative_log.py`** (new): owns the SL-04-006 template so call sites cannot drift (CS-22-001). `cs_event_label()` derives the event name (`fix ready`, `publicly known`, …) by diffing the `CS_vfd`/`CS_pxa` sub-dimensions, naming every dimension that advanced.
- **`vultron/core/use_cases/_helpers.py`**: RM line at the `update_participant_rm_state()` choke point, which reads the real before-state; adds `current_participant_rm_state()`.
- **`vultron/core/behaviors/case/nodes/participant/status.py`**: CS/VFD and CS/PXA lines, plus the RM line for this node — it is a *second* per-participant RM write path (used by the leave-case RM → CLOSED nodes) and would otherwise have left AC-12 unmet.
- **`.../report/nodes/develop_fix.py`**, **`deploy_fix.py`**: their own messages drop to DEBUG; the narrative line comes from the node that knows the before-state.
- **`.../embargo/nodes/lifecycle.py`**, **`teardown.py`**: EM PROPOSED → ACTIVE and ACTIVE → EXITED.
- **`vultron/core/use_cases/triggers/case/engage.py`**: engagement line reports the real `RM VALID → ACCEPTED` and reads the after-state back from storage.
- **`vultron/core/use_cases/received/actor/invite.py`**: human-readable invite receipt.
- **AC-18** is satisfied by folding `get_failure_reason()` into the *existing* `BT execution completed: Status.FAILURE` line rather than adding a second record. A separate line would have double-logged, fired for the many callers that treat FAILURE as an expected idempotent skip (and log their own reason at DEBUG), and had no reliable `case_id`: no production `execute_with_setup` call site passes one.

### Correctness guards found during self-review

Three cases where a narrative line would have been actively misleading:

- **No-op writes emit nothing.** Re-asserting the current RM/CS/EM state, or re-engaging an already-engaged case, is bookkeeping — not a transition. Without the guard, a repeat PXA write re-announced the public-disclosure milestone, and a repeat engage claimed `RM ACCEPTED → ACCEPTED`.
- **PXA before-state comes from the participant, not the case.** This node records PXA on the *participant* snapshot and never appends to `case.case_statuses`, so reading `case.current_status` reported a stale `pxa` forever.
- **Backward CS moves log at WARNING, labelled `state regression`.** CS events are monotonic, so a regression is an anomaly to investigate. Previously the label fell through to `no change`, producing a line that claimed a transition and denied it in the same breath. A mixed `CS_vfd`/`CS_pxa` comparison now raises `TypeError` instead of an opaque `AttributeError` from inside a logging helper.

### Docs and ratchet

- **`test/architecture/test_infrastructure_logs_not_at_info.py`** (new): AC-22 as an executable ratchet. Walks `vultron/` with `ast` and fails when any demoted fragment appears in a `logger.info()` format string, replacing the manual grep. Its own detector is tested so it cannot go vacuously green, and its coverage limits are documented.
- **`notes/structured-logging.md`**: records the helper inventory, the choke-point rule, the `transitions` suppression, and the per-line implementation locations. Corrects the EM terminal state to `EXITED` (the trigger is `terminate`; the state is `EXITED`).

## Verification

- 6318 unit tests pass (79 new), 1006 integration tests pass, 0 failures.
- Black, flake8, mypy, pyright clean; markdownlint clean.
- Two regression tests (repeat-PXA, RM-via-node) fail against the first-pass implementation and pass after the fixes.
- Fixed an unclosed-`SqliteDataLayer` fixture in `test_actor_and_announce_nodes.py` that made a latent `ResourceWarning` flake reproducible.

### Pre-existing, not from this change

`test_vocab_activities_boundary` runs ~3.4s against the repo's 5s per-test timeout and intermittently times out under full-suite load. Reproduced on a clean `origin/main` worktree; deselected for the full-suite runs above and verified passing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)