### PR TITLE
docs: plan concern #1754 — ledger idempotency guard rejections

### DIFF
--- a/notes/bt-pitfalls.md
+++ b/notes/bt-pitfalls.md
@@ -9,6 +9,7 @@ description: >
 related_specs:
   - specs/behavior-tree-integration.yaml
   - specs/behavior-tree-node-design.yaml
+  - specs/case-ledger-processing.yaml
 related_notes:
   - notes/bt-integration.md
   - notes/bt-canonical-reference.md

--- a/notes/bt-pitfalls.md
+++ b/notes/bt-pitfalls.md
@@ -897,6 +897,51 @@ via `GuardedCommit` in `create_receive_activity_tree`).
 
 ---
 
+## Idempotency Guards Must Be Silent — No Ledger Write on Duplicate
+
+(CONCERN-1754, 2026-08-05)
+
+`disposition="rejected"` is valid for **emit-side correlation markers** (see
+above).  It is **not** valid for **idempotency guard no-ops**.
+
+An idempotency guard is a `DataLayerCondition` node that detects "this event
+was already processed" and returns `Status.FAILURE` to abort the tree.
+Examples: `CheckInviteeNotAlreadyParticipantNode` (actor already a
+participant), `CheckCaseStatusIdempotencyNode` (status already appended).
+
+When a guard fires, **no ledger entry of any disposition must be written**
+(CLP-13-001).  Use only `logger.info` / `logger.debug`:
+
+```python
+self.logger.info(
+    "%s: actor '%s' already participant in case '%s' — skipping (idempotent)",
+    self.name, self.invitee_id, self.case_id,
+)
+return Status.FAILURE
+```
+
+**Why it matters**: A spurious `disposition="rejected"` entry for
+`invite_actor_to_case` appeared in the `fvcv_handoff_demo` ledger as
+"Invited an actor to the case [rejected]" with no actor name and no state
+transition.  Because the canonical ledger is replicated and contributes to
+the hash chain, any non-protocol content pollutes participants' replicas and
+misleads human readers and tooling alike (ADR-0019).
+
+**Distinction table**:
+
+| Pattern | Ledger entry? | Disposition | Use case |
+|---|---|---|---|
+| Emit-side correlation marker | ✅ yes | `"rejected"` | Dedup guard for outbound activities |
+| Received-side canonical entry | ✅ yes | `"recorded"` | CaseActor accepts a protocol assertion |
+| Idempotency guard no-op | ❌ **no** | — | Already-processed duplicate detected |
+
+Implement idempotency guards using `SilentIdempotencyGuardMixin`
+(CLP-13-002) once it exists, or follow the same `logger.info → FAILURE`
+pattern and add a unit test that asserts no `create_commit_log_entry_tree`
+call is made when the guard fires.
+
+---
+
 ## suggest-actor Accept Path Does Not Thread Roles Into Invite
 
 (ISSUE-1406, 2026-07-14)

--- a/plan/history/2608/learning/CONCERN-1754.md
+++ b/plan/history/2608/learning/CONCERN-1754.md
@@ -1,0 +1,40 @@
+---
+source: CONCERN-1754
+timestamp: '2026-08-05T21:00:53.282093+00:00'
+title: Ledger idempotency guards must be silent — no rejected entries on duplicate
+  detection
+type: learning
+---
+
+## Context
+
+Concern #1754: when `CheckInviteeNotAlreadyParticipantNode` fires (actor already a participant),
+a downstream `disposition="rejected"` ledger entry was written, appearing in demo reports as
+"Invited an actor to the case [rejected]" with no actor name and no state transition.
+
+## Root Cause
+
+Two distinct uses of `disposition="rejected"` were conflated:
+
+1. **Emit-side correlation markers** (valid, documented bt-pitfalls ISSUE-1325): written by
+   the emitter to detect duplicate outbound activities. These entries are local-only, bypass
+   `_validate_canonical_entry`, and anchor dedup.
+
+2. **Idempotency guard no-ops** (invalid per ADR-0019): when a guard detects "already processed,"
+   it should return `Status.FAILURE` with only `logger.info`/`logger.debug` — no ledger write
+   of any kind.
+
+ADR-0019 states the ledger should "either record the event or stay silent." Guard no-ops are
+process-log content, not protocol events.
+
+## Resolution
+
+- Added CLP-13 spec group (`specs/case-ledger-processing.yaml`): CLP-13-001 (idempotency guards
+  MUST_NOT write ledger entries) and CLP-13-002 (behaviour must be in a reusable
+  `SilentIdempotencyGuardMixin`).
+- Added bt-pitfalls section "Idempotency Guards Must Be Silent" with three-row distinction table.
+
+## Outcome
+
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/2009>
+- Implementation issue: #2010 (child of epic #1753 "FVCV-Handoff demo credibility", Schedule=Focus)

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -522,3 +522,53 @@ groups:
     adr:
     - ADR-0015
     - ADR-0041
+
+- id: CLP-13
+  title: Idempotency Guard Silence
+  description: >-
+    Requirements ensuring that BT idempotency guards (duplicate-detection
+    conditions that abort processing when an event has already been handled)
+    do NOT write ledger entries of any disposition.  The canonical case ledger
+    records protocol assertions; internal guard no-ops are process-log content
+    only (ADR-0019).
+  specs:
+  - id: CLP-13-001
+    priority: MUST_NOT
+    kind: project
+    statement: >-
+      A BT idempotency guard that detects a duplicate and returns
+      ``Status.FAILURE`` to abort processing MUST NOT write a
+      ``CaseLedgerEntry`` of any disposition (``"recorded"`` or
+      ``"rejected"``).  The guard MUST emit only a Python
+      ``logger.info`` / ``logger.debug`` message.
+    rationale: >-
+      Concern #1754: when ``CheckInviteeNotAlreadyParticipantNode`` fired
+      (actor already a participant), it caused a downstream
+      ``disposition="rejected"`` ledger entry to be written.  That entry
+      appeared in demo reports as "Invited an actor to the case [rejected]"
+      with no actor name and no state transition — a misleading non-event
+      in the canonical audit trail.  ADR-0019 states the ledger "should
+      either record the event or stay silent."  An already-handled
+      duplicate is a guard no-op, not a protocol event; it belongs in the
+      process log (Python ``logging``), not in the replicated ledger.
+    relationships:
+    - rel_type: refines
+      spec_id: CLP-07-001
+    adr:
+    - ADR-0019
+  - id: CLP-13-002
+    priority: MUST
+    kind: project
+    statement: >-
+      Idempotency guard behaviour MUST be encapsulated in a reusable
+      ``SilentIdempotencyGuardMixin`` (or equivalent composable BT pattern)
+      so that the silent-failure-on-duplicate invariant is expressed once
+      and tested once, not re-implemented per call site.
+    rationale: >-
+      Concern #1754 audit revealed multiple ad-hoc duplicate-detection
+      checks scattered across BT trees.  Centralising the pattern prevents
+      future call sites from inadvertently re-introducing ledger writes on
+      guard no-ops.
+    relationships:
+    - rel_type: refines
+      spec_id: CLP-13-001

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -539,8 +539,7 @@ groups:
       A BT idempotency guard that detects a duplicate and returns
       ``Status.FAILURE`` to abort processing MUST NOT write a
       ``CaseLedgerEntry`` of any disposition (``"recorded"`` or
-      ``"rejected"``).  The guard MUST emit only a Python
-      ``logger.info`` / ``logger.debug`` message.
+      ``"rejected"``).
     rationale: >-
       Concern #1754: when ``CheckInviteeNotAlreadyParticipantNode`` fired
       (actor already a participant), it caused a downstream
@@ -570,5 +569,21 @@ groups:
       future call sites from inadvertently re-introducing ledger writes on
       guard no-ops.
     relationships:
-    - rel_type: refines
+    - rel_type: implements
+      spec_id: CLP-13-001
+  - id: CLP-13-003
+    priority: MUST
+    kind: project
+    statement: >-
+      When an idempotency guard fires and returns ``Status.FAILURE``, it
+      MUST emit a Python ``logger.info`` or ``logger.debug`` message
+      recording the duplicate detection.  No other observable side effect
+      (ledger write, outbox enqueue, DataLayer mutation) is permitted.
+    rationale: >-
+      Separating the positive logging obligation (CLP-13-003, priority: MUST)
+      from the prohibition on ledger writes (CLP-13-001, priority: MUST_NOT)
+      makes each requirement independently testable and visible to tooling
+      that filters by priority level.
+    relationships:
+    - rel_type: implements
       spec_id: CLP-13-001


### PR DESCRIPTION
- Closes #1754

## Summary

Plans Concern #1754: idempotency guards that detect a duplicate must be
silent (no ledger write of any kind). Adds a CLP-13 spec group and a new
bt-pitfalls entry documenting the distinction between valid
`disposition="rejected"` correlation markers and guard no-ops.

## Changes

- **`specs/case-ledger-processing.yaml`**: add CLP-13 group —
  CLP-13-001 (idempotency guards MUST_NOT write ledger entries, only
  `logger.info`/`debug`) and CLP-13-002 (reusable
  `SilentIdempotencyGuardMixin` required, CLP-13-002)
- **`notes/bt-pitfalls.md`**: new pitfall "Idempotency Guards Must Be
  Silent" — documents the three-row distinction table
  (emit-side correlation marker vs canonical recorded entry vs guard
  no-op), root cause from Concern #1754, and the test expectation

## Implementation Issues

- #2010