### PR TITLE
docs: plan concern #1755 — ownership transfer notification underspecified

### DIFF
--- a/docs/adr/0053-ownership-transfer-routed-via-caseactor.md
+++ b/docs/adr/0053-ownership-transfer-routed-via-caseactor.md
@@ -1,0 +1,125 @@
+---
+status: accepted
+date: 2026-08-05
+---
+
+# Route Ownership-Transfer Offer and Accept Through the CaseActor
+
+## Context and Problem Statement
+
+The current ownership-transfer protocol has two routing gaps:
+
+1. The offering actor sends `Offer(VulnerabilityCase)` (ownership-transfer
+   variant) **directly to the transferee's inbox**, bypassing the CaseActor.
+   No CaseLedgerEntry is committed for the offer-in-flight, so participants
+   not involved in the transfer (e.g., Finder) receive no notification that
+   a transfer is being negotiated.
+
+2. The accepting actor sends `Accept(Offer(VulnerabilityCase))` **directly
+   to the offerer's inbox**, bypassing the CaseActor.
+   `AcceptCaseOwnershipTransferReceivedUseCase` therefore only runs when the
+   Accept is manually self-delivered (as in the FVCV-handoff demo workaround).
+   No CaseLedgerEntry is committed after the ownership change, so the Announce
+   broadcast never fires and participants not involved in the transfer are
+   never notified of the completed ownership change.
+
+Issue: CONCERN-1755, Epic: #1753.
+
+## Decision Drivers
+
+- The canonical communication model (`notes/case-communication-model.md`,
+  PCR-08) requires that all case-scoped state changes flow through the
+  CaseActor and propagate via `CaseLedgerEntry → Announce` broadcast.
+- Participants who are not the old or new owner have no reliable way to
+  learn who is currently responsible for a case.  In multi-party cases
+  this causes messages to be routed to the wrong actor.
+- The Invite/Accept handshake (ADR-0026, PCR-08-007/008) established the
+  same principle for participant invitation: the Invite is sent **by** the
+  CaseActor, and the Accept is addressed **to** the CaseActor.
+  Ownership-transfer should follow the same pattern.
+
+## Considered Options
+
+1. **Route both Offer and Accept through the CaseActor** — the Offer is
+   sent to the CaseActor, which records it and forwards to the transferee;
+   the Accept is addressed to the CaseActor, which applies the ownership
+   change and commits a CaseLedgerEntry → broadcast.
+2. **Route Accept through CaseActor only; leave Offer direct** — Accept
+   routing is the critical path for the broadcast cascade; Offer routing
+   can remain direct.
+3. **Keep current routing; add a post-Accept notification trigger** —
+   after the offerer receives the Accept, it manually emits an
+   `Announce(VulnerabilityCase)` to all participants.
+4. **Demo-level workaround only** — keep the protocol underspecified;
+   patch the demo.
+
+## Decision Outcome
+
+Chosen option: **Option 1 — route both Offer and Accept through the
+CaseActor**, because it aligns with the established canonical communication
+model (PCR-08) and ensures all participants receive CaseLedgerEntry
+notifications for both the offer-in-flight and the completed transfer.
+
+### Concrete routing model
+
+**Offer flow:**
+
+```text
+Offering actor triggers offer-case-ownership-transfer
+  → EmitOfferCaseOwnershipTransferNode constructs
+    Offer(VulnerabilityCase, target=transferee_id, to=[case_actor_id])
+  → CaseActor's OfferCaseOwnershipTransferReceivedUseCase:
+      1. Records the offer object.
+      2. Commits a CaseLedgerEntry (offer-recorded).
+      3. Announce(CaseLedgerEntry) → all participants.
+      4. Forwards the Offer to the transferee's inbox.
+```
+
+**Accept flow:**
+
+```text
+Accepting actor triggers accept-case-ownership-transfer
+  → EmitAcceptCaseOwnershipTransferNode constructs
+    Accept(Offer(VulnerabilityCase), to=[case_actor_id])
+  → CaseActor's AcceptCaseOwnershipTransferReceivedUseCase:
+      1. AcceptCaseOwnershipTransferNode applies role changes (CM-21-001–004).
+      2. Commits a CaseLedgerEntry (ownership-transferred).
+      3. Announce(CaseLedgerEntry) → all participants.
+```
+
+### Consequences
+
+- Good, because all participants (including Finder, Vendor2, etc.) are
+  notified of both the pending offer and the completed transfer via the
+  normal CaseLedgerEntry broadcast — no separate notification mechanism.
+- Good, because the `AcceptCaseOwnershipTransferReceivedUseCase` now
+  runs automatically on the CaseActor without a manual self-delivery
+  workaround.
+- Good, because the routing pattern is identical to the Invite/Accept
+  handshake (ADR-0026); developers can apply the same mental model.
+- Bad, because this is a breaking change to the wire routing for both
+  activities; existing devlogs and test fixtures must be updated.
+- Bad, because `OfferCaseOwnershipTransferReceivedUseCase` must be
+  extended to forward the Offer to the transferee — currently it only
+  stores the offer object.
+
+## Validation
+
+- Spec entries CM-21-005 through CM-21-007 in `specs/case-management.yaml`
+  encode the MUST requirements; the architecture ratchet tests verify
+  boundary compliance.
+- The FVCV-handoff demo (`fvcv_handoff_demo.py`) removes the
+  `post_to_inbox_and_wait` self-delivery workaround and verifies Finder
+  receives an `Announce(CaseLedgerEntry)` for the transfer automatically.
+- Unit tests confirm `EmitOfferCaseOwnershipTransferNode` and
+  `EmitAcceptCaseOwnershipTransferNode` address the CaseActor.
+
+## More Information
+
+- `notes/case-communication-model.md` — canonical communication model (PCR-08)
+- `notes/ownership-transfer.md` — implementation guidance for this routing model
+- ADR-0026 — CaseActor-Routed Actor Suggestion (precedent for same pattern)
+- CONCERN-1755 — source concern
+
+Generated spec requirements: `specs/case-management.yaml` CM-21-005, CM-21-006,
+CM-21-007.

--- a/docs/adr/0053-ownership-transfer-routed-via-caseactor.md
+++ b/docs/adr/0053-ownership-transfer-routed-via-caseactor.md
@@ -1,6 +1,9 @@
 ---
 status: accepted
 date: 2026-08-05
+deciders: Allen D. Householder
+consulted: []
+informed: []
 ---
 
 # Route Ownership-Transfer Offer and Accept Through the CaseActor

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -122,6 +122,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0050 Leave(VulnerabilityCase) Is the Canonical RM Case Closure Mechanism](0050-leave-vul-case-canonical-rm-closure.md)
 - [ADR-0051 CaseActor Has Its Own RM Lifecycle Tracked via CaseParticipant](0051-caseactor-rm-lifecycle.md)
 - [ADR-0052 Demo CI Job Structure: Accept Barrier + Concurrency Group Over Job Consolidation](0052-demo-ci-job-structure-barrier-accepted.md) *(provisional)*
+- [ADR-0053 Route Ownership-Transfer Offer and Accept Through the CaseActor](0053-ownership-transfer-routed-via-caseactor.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -270,6 +270,7 @@ nav:
       - Leave(VulnerabilityCase) Is the Canonical RM Closure Mechanism: 'adr/0050-leave-vul-case-canonical-rm-closure.md'
       - CaseActor Has Its Own RM Lifecycle via CaseParticipant: 'adr/0051-caseactor-rm-lifecycle.md'
       - Demo CI Job Structure — Accept Barrier and Concurrency Group: 'adr/0052-demo-ci-job-structure-barrier-accepted.md'
+      - Route Ownership-Transfer Offer and Accept Through the CaseActor: 'adr/0053-ownership-transfer-routed-via-caseactor.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/README.md
+++ b/notes/README.md
@@ -685,6 +685,16 @@ flowchart and future BT automation notes.
 **Load when**: understanding or evolving the agent skill pipeline, automating
 the development loop, or deciding which skill to run next.
 
+**`ownership-transfer.md`**
+Implementation guidance for the ownership-transfer routing model (ADR-0053):
+Offer and Accept MUST route through the CaseActor; correct flow for
+`EmitOfferCaseOwnershipTransferNode`, `EmitAcceptCaseOwnershipTransferNode`,
+`OfferCaseOwnershipTransferReceivedUseCase`, and the cascade wiring in
+`ownership_transfer_tree.py`. Includes the demo workaround removal checklist.
+**Load when**: implementing ownership-transfer routing fixes (CM-21-005,
+CM-21-006, CM-21-007), auditing transfer routing in demos, or understanding
+why the CaseActor must be the intermediary for ownership transfers.
+
 **`coordination-agents.md`**
 Design guidance for coordination agents — external capabilities (human, skill,
 or LLM agent) that answer Vultron call-out points. Covers the two-surface

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -1,0 +1,156 @@
+---
+title: Ownership Transfer Protocol — Routing and Cascade Model
+status: active
+description: >
+  Implementation guidance for the ownership-transfer routing model introduced
+  in ADR-0053: Offer and Accept MUST route through the CaseActor so that
+  all participants receive CaseLedgerEntry broadcast notifications for both
+  the pending offer and the completed transfer.
+related_specs:
+  - specs/case-management.yaml
+related_notes:
+  - notes/case-communication-model.md
+  - notes/protocol-event-cascades.md
+relevant_packages:
+  - vultron/core/behaviors/case/nodes/
+  - vultron/core/use_cases/received/actor/
+  - vultron/demo/scenario/fvcv_handoff_demo.py
+---
+
+# Ownership Transfer Protocol — Routing and Cascade Model
+
+**Source**: ADR-0053 / CONCERN-1755 planning session 2026-08-05.
+Normative requirements: CM-21-005, CM-21-006, CM-21-007.
+
+---
+
+## The Problem (Pre-ADR-0053)
+
+Before ADR-0053 the ownership-transfer protocol had two routing gaps:
+
+1. **Offer sent directly to transferee** — `EmitOfferCaseOwnershipTransferNode`
+   addressed the Offer to the transferee's inbox, bypassing the CaseActor.
+   No CaseLedgerEntry was written for the offer-in-flight; participants not
+   involved in the negotiation received no notification.
+
+2. **Accept sent directly to offerer** — `EmitAcceptCaseOwnershipTransferNode`
+   addressed the Accept to the offerer's inbox, bypassing the CaseActor.
+   `AcceptCaseOwnershipTransferReceivedUseCase` only ran when the Accept was
+   manually self-delivered (the `post_to_inbox_and_wait` workaround in
+   `fvcv_handoff_demo.py`).  No CaseLedgerEntry was written after the role
+   change; the Announce broadcast never fired.
+
+---
+
+## Correct Routing Model (ADR-0053)
+
+Both activities MUST flow through the CaseActor.
+
+### Offer flow
+
+```text
+Offering actor calls trigger: offer-case-ownership-transfer
+  → EmitOfferCaseOwnershipTransferNode
+      constructs: Offer(VulnerabilityCase, target=transferee_id)
+      addressed:  to=[case_actor_id]         ← MUST (CM-21-005)
+      queued in:  offering actor's outbox
+
+CaseActor inbox receives Offer
+  → OfferCaseOwnershipTransferReceivedUseCase:
+      1. Records the Offer object (idempotent).
+      2. Commits CaseLedgerEntry (offer-recorded).
+      3. Announce(CaseLedgerEntry) → all participants.   ← CM-21-006 cascade
+      4. Forwards Offer to transferee's inbox.
+```
+
+### Accept flow
+
+```text
+Accepting actor calls trigger: accept-case-ownership-transfer
+  → EmitAcceptCaseOwnershipTransferNode
+      constructs: Accept(Offer(VulnerabilityCase))
+      addressed:  to=[case_actor_id]         ← MUST (CM-21-006)
+      queued in:  accepting actor's outbox
+
+CaseActor inbox receives Accept
+  → AcceptCaseOwnershipTransferReceivedUseCase (guarded-commit pattern):
+      guard:  receiving_actor_id == case_actor_id (skip if not CaseActor)
+      1. AcceptCaseOwnershipTransferNode applies role changes (CM-21-001–004).
+      2. Commits CaseLedgerEntry (ownership-transferred).  ← CM-21-007
+      3. Announce(CaseLedgerEntry) → all participants.
+```
+
+---
+
+## Implementation Checklist
+
+### EmitOfferCaseOwnershipTransferNode
+
+- `_emit()` MUST resolve `case_actor_id` from the DataLayer and set
+  `to=[case_actor_id]`.  Do not use the `transferee_id` as the `to` field.
+- The `target` field of the Offer carries `transferee_id` (as before).
+
+### EmitAcceptCaseOwnershipTransferNode
+
+- `_emit()` MUST resolve `case_actor_id` from the DataLayer (using
+  `_resolve_case_manager_id()` or equivalent) and set `to=[case_actor_id]`.
+- Do not address the Accept to the offerer's actor ID.
+
+### OfferCaseOwnershipTransferReceivedUseCase
+
+Extend to:
+
+1. Store the Offer object (existing behaviour — keep it).
+2. Commit a `CaseLedgerEntry` recording the offer.
+3. Forward the Offer to the transferee's inbox (new behaviour).
+
+Use the guarded-commit pattern: only runs when `receiving_actor_id == case_actor_id`.
+
+### AcceptCaseOwnershipTransferReceivedUseCase / ownership_transfer_tree.py
+
+Extend `create_accept_ownership_transfer_tree()` to append a
+`CommitCaseLedgerEntryNode` (and fan-out) after `AcceptCaseOwnershipTransferNode`.
+
+Use the guarded-commit pattern: the `BTBridge` call already runs in the
+CaseActor's context; add a `CheckIsCaseManagerNode` guard as the first
+child of the root Sequence so that the tree is a no-op on non-CaseActor
+replicas that happen to receive the same Accept activity.
+
+### fvcv_handoff_demo.py
+
+Remove the `post_to_inbox_and_wait` self-delivery block (lines ~427–434).
+The Accept now reaches the CaseActor automatically because
+`EmitAcceptCaseOwnershipTransferNode` addresses it there.
+
+---
+
+## Analogy: Invite/Accept Handshake
+
+This routing model is identical to the Invite/Accept handshake (ADR-0026,
+PCR-08-007/008):
+
+| Invite/Accept | Ownership Transfer |
+|---|---|
+| `Invite` sent **by** CaseActor | `Offer` addressed **to** CaseActor → forwarded |
+| `Accept(Invite)` addressed **to** CaseActor | `Accept(Offer)` addressed **to** CaseActor |
+| CaseActor creates `CaseParticipant` | CaseActor applies CM-21 role changes |
+| CaseLedgerEntry → broadcast | CaseLedgerEntry → broadcast |
+
+Use this analogy when explaining the model to new contributors.
+
+---
+
+## Guarded-Commit Pattern Reminder
+
+`AcceptCaseOwnershipTransferReceivedUseCase` is a **received-side** use case.
+Both the CaseActor and participant replicas may receive the same Accept
+activity (once routing is corrected). The guarded-commit ensures only the
+CaseActor writes the ledger entry:
+
+```python
+if request.receiving_actor_id != case_actor_id:
+    return  # not CaseActor — skip commit
+```
+
+See `notes/case-communication-model.md` § "Antipattern: Received-Side
+Guarded Commit with Foreign CaseActor ID" for the full pattern.

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -59,7 +59,7 @@ CaseActor inbox receives Offer
   → OfferCaseOwnershipTransferReceivedUseCase:
       1. Records the Offer object (idempotent).
       2. Commits CaseLedgerEntry (offer-recorded).
-      3. Announce(CaseLedgerEntry) → all participants.   ← CM-21-006 cascade
+      3. Announce(CaseLedgerEntry) → all participants.   ← CM-21-005 rationale
       4. Forwards Offer to transferee's inbox.
 ```
 

--- a/plan/history/2608/learning/CONCERN-1755.md
+++ b/plan/history/2608/learning/CONCERN-1755.md
@@ -1,0 +1,28 @@
+---
+source: CONCERN-1755
+timestamp: '2026-08-05T21:25:05.200985+00:00'
+title: Ownership transfer notification to non-involved participants is underspecified
+type: learning
+---
+
+## Summary
+
+When case ownership transfers from one actor to another, participants not
+directly involved in the transfer (e.g., Finder, Vendor2) receive no explicit
+notification of the change. The protocol did not specify who announces the
+transfer, to whom, from where, or in what order.
+
+**Surface:** In the FVCV-handoff demo, Finder is not notified that Vendor1
+has transferred ownership to Coordinator. From Finder's perspective, the case
+owner silently changed.
+
+**Deeper problem:** Both `Offer(VulnerabilityCase)` and
+`Accept(Offer(VulnerabilityCase))` (ownership-transfer variant) were sent
+actor-to-actor, bypassing the CaseActor. No `CaseLedgerEntry` was committed,
+so the `Announce(CaseLedgerEntry)` broadcast never fired.
+
+**Resolved**: 2026-08-05 — implementation tracked in #2015, #2016.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2013>.
+Spec: `specs/case-management.yaml` CM-21-005, CM-21-006, CM-21-007.
+Notes: `notes/ownership-transfer.md`.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -1171,6 +1171,70 @@ groups:
       spec_id: CM-21-002
     - rel_type: refines
       spec_id: CM-21-003
+  - id: CM-21-005
+    priority: MUST
+    kind: protocol
+    statement: >-
+      An actor emitting `Offer(VulnerabilityCase)` (ownership-transfer variant)
+      MUST address the activity to the CaseActor's inbox (`to: [case_actor_id]`)
+      rather than directly to the transferee.  The CaseActor MUST forward the
+      Offer to the transferee's inbox after recording it.
+    rationale: >-
+      Routing the Offer through the CaseActor enables it to commit a
+      `CaseLedgerEntry` for the offer-in-flight and broadcast
+      `Announce(CaseLedgerEntry)` to all participants (including those not
+      involved in the transfer, such as a Finder or second Vendor).  Direct
+      actor-to-actor delivery bypasses the canonical log and leaves non-involved
+      participants unaware that a transfer is being negotiated.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-21-001
+    adr:
+    - ADR-0053
+  - id: CM-21-006
+    priority: MUST
+    kind: protocol
+    statement: >-
+      An actor emitting `Accept(Offer(VulnerabilityCase))` (ownership-transfer
+      variant) MUST address the activity to the CaseActor's inbox
+      (`to: [case_actor_id]`) rather than directly to the offerer.
+    rationale: >-
+      Routing the Accept through the CaseActor is required for the
+      `AcceptCaseOwnershipTransferReceivedUseCase` to run on the authoritative
+      CaseActor and trigger the post-transfer CaseLedgerEntry cascade
+      (CM-21-007).  Addressing the Accept to the offerer's inbox means the use
+      case only runs there; the CaseActor never learns of the completed transfer
+      and cannot broadcast it.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-21-001
+    - rel_type: refines
+      spec_id: CM-21-005
+    adr:
+    - ADR-0053
+  - id: CM-21-007
+    priority: MUST
+    kind: protocol
+    statement: >-
+      After `AcceptCaseOwnershipTransferReceivedUseCase` successfully applies
+      the ownership-role changes (CM-21-002, CM-21-003, CM-21-004), the
+      CaseActor MUST commit a `CaseLedgerEntry` recording the completed transfer
+      and MUST broadcast `Announce(CaseLedgerEntry)` to all case participants.
+    rationale: >-
+      The CaseLedgerEntry broadcast is the only mechanism by which participants
+      not involved in the transfer (e.g., a Finder or second Vendor) learn that
+      the case owner has changed.  Without it, those participants have no
+      reliable way to determine who is currently responsible for the case,
+      leading to messages being directed to the wrong actor and coordination
+      breakdown.  This requirement closes the surface-level symptom described
+      in CONCERN-1755.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-21-002
+    - rel_type: refines
+      spec_id: CM-21-006
+    adr:
+    - ADR-0053
 - id: CM-22
   title: CaseActor-Authoritative Case Creation
   description: >-


### PR DESCRIPTION
- Closes #1755

## Summary

Plans CONCERN-1755: ownership-transfer notification to non-involved
participants is underspecified. Root cause: both `Offer(VulnerabilityCase)`
and `Accept(Offer(VulnerabilityCase))` are sent actor-to-actor, bypassing the
CaseActor, so no `CaseLedgerEntry` is committed and participants such as Finder
receive no notification that ownership changed.

## Changes

- **ADR-0053** (`docs/adr/0053-ownership-transfer-routed-via-caseactor.md`):
  route both Offer and Accept through the CaseActor, following the same
  pattern as the Invite/Accept handshake (ADR-0026/PCR-08-007/008).
- **notes/ownership-transfer.md**: implementation guide covering corrected
  routing for `EmitOfferCaseOwnershipTransferNode`,
  `EmitAcceptCaseOwnershipTransferNode`,
  `OfferCaseOwnershipTransferReceivedUseCase`, cascade wiring in
  `ownership_transfer_tree.py`, and demo workaround removal checklist.
- **CM-21-005**: Offer MUST be addressed to CaseActor (not transferee directly).
- **CM-21-006**: Accept MUST be addressed to CaseActor (not offerer directly).
- **CM-21-007**: CaseActor MUST commit `CaseLedgerEntry` after applying
  ownership transfer and broadcast `Announce(CaseLedgerEntry)` to all
  participants.
- `docs/adr/index.md`, `notes/README.md`, `mkdocs.yml` nav updated.

## Implementation Issues

(to be added after Phase 8 issue creation)

- #2015 (routing + cascade — blocked by #1755)
- #2016 (demo cleanup + tests — blocked by #2015)