### PR TITLE
docs: plan issue #1756 — invite-path participants enter at RM.RECEIVED

### DIFF
--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -504,6 +504,63 @@ from the start.
 
 ---
 
+## Invite-Path Participant RM Entry Point
+
+> **Source**: CONCERN-1756. Corrects CM-11-001 and `CreateInviteeParticipantAtAcceptedNode`.
+
+Participants who join a case via the invite-accept path enter at **RM.RECEIVED**,
+not RM.ACCEPTED. This is a protocol-correctness requirement, not merely a
+demo-visibility gap.
+
+### Why Accept(Invite) ≠ RM.ACCEPTED
+
+When an actor sends `Accept(Invite(actor, case))`, they have seen only a redacted
+or stub view of the `VulnerabilityCase` — enough to agree to join and consent to
+the embargo, but not the full vulnerability details (report, description, affected
+versions, etc.). The full case is replicated to them *after* the CaseActor
+processes their Accept. Therefore:
+
+- `Accept(Invite)` = "I am willing to join this case and accept its embargo terms."
+- It does NOT mean "I have validated the vulnerability and committed to remediation."
+
+Recording the invitee at RM.ACCEPTED on Accept is incorrect because RM.ACCEPTED
+means the participant has validated the report and chosen to engage. An actor
+cannot be in that state before seeing the report.
+
+### Correct Lifecycle for Invited Participants
+
+After the CaseActor processes `Accept(Invite)`:
+
+1. CaseActor records invitee at **RM.RECEIVED**.
+2. CaseActor replicates the full `VulnerabilityCase` to the invitee via
+   `Announce(VulnerabilityCase)` and join-time ledger backfill.
+3. Invitee reviews the full case, runs their own validation:
+   - Transitions to **RM.VALID** or **RM.INVALID** and notifies the CaseActor.
+4. If valid, invitee decides to engage or defer:
+   - Transitions to **RM.ACCEPTED** or **RM.DEFERRED** and notifies the CaseActor.
+5. CaseActor updates its representation of the invitee's RM state based on
+   the received status messages (CM-11-002).
+
+### Scope Boundary
+
+This rule applies to **post-initialization invitees** only — participants added
+to an existing case via `Invite(actor, case)`. It does not apply to the initial
+reporter and receiver participants created during case initialization (CM-12,
+CM-13), whose RM states are set as part of the case creation sequence.
+
+### Implementation
+
+- **`CreateInviteeParticipantAtReceivedNode`** (renamed from
+  `CreateInviteeParticipantAtAcceptedNode`) records only `RM.RECEIVED` for
+  the invitee in the CaseActor's DataLayer.
+- The invitee's subsequent V/A transitions are driven by received RM status
+  messages from the invitee themselves.
+
+**Normative requirements**: `specs/case-management.yaml` CM-11-001 through
+CM-11-004.
+
+---
+
 ## Pre-Case Event Backfill on Case Creation
 
 > **Note**: Under ADR-0015, the case is created at report receipt, so

--- a/plan/history/2608/learning/CONCERN-1756.md
+++ b/plan/history/2608/learning/CONCERN-1756.md
@@ -1,0 +1,23 @@
+---
+source: CONCERN-1756
+timestamp: '2026-08-05T21:25:30.896377+00:00'
+title: invited participants must follow full RM lifecycle from RM:RECEIVED
+type: learning
+---
+
+## Summary
+
+Participants who join a case via invite-and-accept go directly to participation status without running the RM lifecycle from RM:RECEIVED. The protocol requires that all participants — regardless of how they joined — complete the VALID/INVALID and then ACCEPTED/DEFERRED transitions before being treated as committed participants.
+
+## Surface Symptom vs. Underlying Problem
+
+**Surface:** In the FVCV-handoff demo, Vendor2 accepts an invite and becomes a participant with no explicit validation step — no RM:RECEIVED → RM:VALID → RM:ACCEPTED transition is demonstrated.
+
+**Deeper problem:** Accepting a case invite should place the joining participant at RM:RECEIVED, after which they are responsible for running the standard RM triage cycle. This is required protocol behavior for all participants, but it was not enforced or demonstrated for invite-joining participants. CM-11-001 in the spec incorrectly stated that Accept(Invite) MUST advance the invitee to RM.ACCEPTED, conflating two distinct protocol acts: joining the case and validating its vulnerability content. An invited participant has seen only a redacted/stub view of the case when they accept — they cannot be in RM.ACCEPTED before reviewing the full case.
+
+## Resolution
+
+**Resolved**: 2026-08-05 — implementation tracked in #2017, #2018, #2019.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2014>.
+Spec: `specs/case-management.yaml` CM-11-001 through CM-11-004 (corrected).
+Notes: `notes/case-state-model.md` § "Invite-Path Participant RM Entry Point".

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -218,8 +218,13 @@ groups:
   - id: BT-10-005
     priority: SHOULD
     kind: protocol
-    statement: When an actor accepts a case invitation, the system SHOULD automatically advance the accepting actor's RM state
-      to ACCEPTED via BT or use-case execution
+    statement: >-
+      When an actor accepts a case invitation, the system SHOULD automatically record the accepting actor's RM state as
+      RM.RECEIVED via BT or use-case execution. The invitee's subsequent triage (RM.VALID/INVALID → RM.ACCEPTED/DEFERRED)
+      is driven by RM status messages from the invitee after the full case replica has been delivered to them.
+    note: >-
+      Prior text read "advance the accepting actor's RM state to ACCEPTED", which conflated joining the case with validating
+      its vulnerability content. Corrected to align with CM-11-001 (as amended in CONCERN-1756).
     relationships:
     - rel_type: implements
       spec_id: CM-11-001

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -439,7 +439,29 @@ groups:
   - id: CM-11-001
     priority: MUST
     kind: protocol
-    statement: When an actor accepts a case invitation, the accepting actor's RM state MUST advance to ACCEPTED
+    statement: >-
+      When an actor accepts a case invitation, the CaseActor MUST record the accepting actor's
+      RM state as RM.RECEIVED — not RM.ACCEPTED. `Accept(Invite)` signals willingness to join
+      the case and, when an active embargo is in scope, consent to the embargo. It does NOT
+      constitute validation of the vulnerability report. The accepting actor has received only
+      a case stub at that point and has not yet seen the full case (report details, vulnerability
+      description, etc.). The full VALID/INVALID and ACCEPTED/DEFERRED triage cycle is a
+      distinct subsequent step that the invitee runs after the case replica has been replicated
+      to them.
+    note: >-
+      This corrects the prior statement ("MUST advance to ACCEPTED"), which conflated two
+      distinct protocol acts: joining the case and validating its content. The correction
+      applies only to post-initialization invitees — the initial reporter and receiver
+      participants are established during case creation at their correct RM states.
+    rationale: >-
+      An actor who accepts an invitation has seen only a redacted or stub view of the
+      `VulnerabilityCase`. Recording them at RM.ACCEPTED before they have reviewed the
+      full case violates the RM state machine semantics (a participant cannot accept what
+      they have not seen). The `Accept(Invite)` message means "I am willing to participate
+      and I accept the embargo terms"; it does not mean "I have validated the vulnerability
+      and committed to remediation." Only after the full case replica is delivered and the
+      invitee has run their triage cycle (RECEIVED → VALID or INVALID → ACCEPTED or DEFERRED)
+      should their RM state advance past RECEIVED.
     relationships:
     - rel_type: implements
       spec_id: VP-03-012
@@ -448,11 +470,35 @@ groups:
   - id: CM-11-002
     priority: SHOULD
     kind: protocol
-    statement: After auto-engagement (CM-11-001), the accepting actor SHOULD emit an `RmEngageCaseActivity` to notify the
-      case owner
+    statement: >-
+      After accepting a case invitation and receiving the full case replica, the accepting
+      actor SHOULD run the standard RM triage cycle: validating the reported vulnerability
+      (RM.VALID or RM.INVALID), then deciding to engage or defer (RM.ACCEPTED or RM.DEFERRED).
+      Each transition SHOULD be communicated to the CaseActor via the appropriate RM status
+      message so the CaseActor can update its representation of the invitee's RM state.
+    note: Prior text read "After auto-engagement (CM-11-001), the accepting actor SHOULD emit an RmEngageCaseActivity
+      to notify the case owner." That text assumed CM-11-001 advanced the state to ACCEPTED;
+      under the corrected CM-11-001 the engagement notification is part of the triage cycle
+      described here.
     relationships:
     - rel_type: depends_on
       spec_id: OX-02-001
+    - rel_type: depends_on
+      spec_id: CM-11-001
+  - id: CM-11-004
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The CaseActor MUST NOT treat an invited participant as having committed to the case
+      (RM.ACCEPTED) until it receives the corresponding RM status message from the invitee
+      confirming that state transition.
+    rationale: >-
+      Only the invitee can confirm they have validated the vulnerability and chosen to
+      engage. The CaseActor cannot infer acceptance from the `Accept(Invite)` alone
+      because at that point the invitee has not yet received the full case content.
+    relationships:
+    - rel_type: depends_on
+      spec_id: CM-11-001
   - id: CM-11-003
     priority: MUST
     kind: protocol


### PR DESCRIPTION
- Closes #1756

## Summary

Corrects a protocol specification error: `Accept(Invite)` maps to RM.RECEIVED
for the invitee, not RM.ACCEPTED. The prior CM-11-001 wording conflated two
distinct acts — joining a case and validating its vulnerability content.

An invited participant accepts only on the basis of a case stub (redacted view);
they have not yet seen the full case. Full triage (VALID/INVALID → ACCEPTED/DEFERRED)
is a distinct subsequent step that must run after the full case replica has been
delivered to the invitee.

## Changes

- **`specs/case-management.yaml`**
  - CM-11-001: corrected to state Accept(Invite) → RM.RECEIVED; added rationale
    explaining why Accept cannot imply ACCEPTED
  - CM-11-002: amended — now describes the invitee's required full triage cycle
    post-replication rather than an auto-engagement notification
  - CM-11-004 (new): CaseActor MUST NOT treat an invitee as RM.ACCEPTED until
    it receives the corresponding RM status message from the invitee

- **`notes/case-state-model.md`**
  - New section "Invite-Path Participant RM Entry Point" documenting the correct
    lifecycle, the Accept(Invite) ≠ RM.ACCEPTED rationale, scope boundary
    (post-init invitees only), and the implementation consequence
    (rename `CreateInviteeParticipantAtAcceptedNode` →
    `CreateInviteeParticipantAtReceivedNode` and remove the V/A transitions)

## Test plan

- [x] Spec registry linter passes (confirmed via pre-commit + post-freshen)
- [x] Markdownlint passes (confirmed via pre-commit + post-freshen)
- [x] Notes frontmatter validation passes (confirmed via pre-commit)
- [ ] Implementation issues track the code changes to `accept_invite_tree.py`
      and demo scenarios (see impl issues created below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Implementation Issues

- #2017
- #2018
- #2019