### PR TITLE
fix(fvcv-handoff-demo): correct case closure ordering — Coordinator closes last

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1759.md
+++ b/plan/history/2608/implementation/ISSUE-1759.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-1759
+timestamp: '2026-08-05T23:20:50.833207+00:00'
+title: 'fix(fvcv-handoff-demo): correct case closure ordering'
+type: implementation
+---
+
+## Issue #1759 — fix(fvcv-handoff-demo): correct case closure ordering — Coordinator closes last
+
+Reordered Phase 7 `actor_closes_case` calls in `_phase_case_closure` so Coordinator (the case owner) closes after Vendor1, Vendor2, and Finder. Previously the order was Vendor1 → Vendor2 → Coordinator → Finder; corrected to Vendor1 → Vendor2 → Finder → Coordinator.
+
+Added `test_phase_case_closure_coordinator_closes_last` to assert the ordering invariant.
+
+PR: <https://github.com/CERTCC/Vultron/pull/2021>

--- a/plan/incoming/learnings/20260805-fvcv-extension-fccv-handoff-close-order.md
+++ b/plan/incoming/learnings/20260805-fvcv-extension-fccv-handoff-close-order.md
@@ -1,0 +1,21 @@
+---
+title: fvcv_extension_demo and fccv_handoff_demo have same wrong case closure ordering
+type: learning
+timestamp: 2026-08-05
+source: ISSUE-1759
+signal: concern
+---
+
+While fixing the closure ordering in `fvcv_handoff_demo.py` (ISSUE-1759), the same
+ordering bug was observed in two peer scenarios:
+
+- `vultron/demo/scenario/fvcv_extension_demo.py` — Phase 7 closes:
+  Vendor1 → Vendor2 → Coordinator → Finder (Coordinator before Finder)
+- `vultron/demo/scenario/fccv_handoff_demo.py` — Phase 7 closes:
+  c1 → c2 → Vendor → Finder (Vendor before Finder, where c1/c2 are coordinators)
+
+The CVD protocol principle — case owner closes last — applies equally to these
+scenarios. Both should be fixed with the same reorder pattern applied in #2021.
+
+Suggested follow-up: create a GitHub issue (or sub-issues of Epic #1753) to fix
+the same ordering bug in the extension and fccv_handoff demos.

--- a/test/demo/test_fvcv_handoff_demo.py
+++ b/test/demo/test_fvcv_handoff_demo.py
@@ -470,3 +470,72 @@ class TestFvcvHandoffMilestoneAssertions:
                 case=case,
             )
         mock_m7.assert_called()
+
+    def test_phase_case_closure_coordinator_closes_last(self):
+        """Coordinator (case owner) must close after Vendor1, Vendor2, and Finder."""
+        import contextlib
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        coordinator_client = self._client()
+        vendor2_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        vendor2 = self._actor("urn:test:vendor2")
+        vendor2_in_vendor2 = self._actor("urn:test:vendor2")
+        finder = self._actor("urn:test:finder")
+        finder_in_finder = self._actor("urn:test:finder")
+        coordinator = self._actor("urn:test:coordinator")
+        coordinator_in_coordinator = self._actor("urn:test:coordinator")
+        case = self._case()
+        case.id_ = "urn:test:case"
+        vendor_client.get.return_value = {
+            "e0": {
+                "case_id": case.id_,
+                "log_index": 0,
+                "entry_hash": "h0",
+                "event_type": "close_case",
+            }
+        }
+
+        mock_close = MagicMock()
+
+        with (
+            patch.object(demo, "actor_closes_case", mock_close),
+            patch.object(demo, "wait_for_all_participants_rm_closed"),
+            patch.object(demo, "verify_case_closed"),
+            patch.object(demo, "wait_for_event_type_in_ledger"),
+            patch.object(demo, "wait_for_contiguous_ledger_coverage"),
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            demo._phase_case_closure(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                coordinator_client=coordinator_client,
+                vendor2_client=vendor2_client,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                vendor2=vendor2,
+                vendor2_in_vendor2=vendor2_in_vendor2,
+                finder=finder,
+                finder_in_finder=finder_in_finder,
+                coordinator=coordinator,
+                coordinator_in_coordinator=coordinator_in_coordinator,
+                case=case,
+            )
+
+        actors_closed = [
+            call.kwargs["actor"].id_ for call in mock_close.call_args_list
+        ]
+        assert (
+            actors_closed[-1] == coordinator_in_coordinator.id_
+        ), "Coordinator (case owner) must close last; got order: " + str(
+            actors_closed
+        )
+        assert actors_closed.index(finder_in_finder.id_) < actors_closed.index(
+            coordinator_in_coordinator.id_
+        ), "Finder must close before Coordinator"

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -891,13 +891,14 @@ def _phase_case_closure(
         case_id=case.id_,
     )
     actor_closes_case(
-        client=coordinator_client,
-        actor=coordinator_in_coordinator,
-        case_id=case.id_,
-    )
-    actor_closes_case(
         client=finder_client,
         actor=finder_in_finder,
+        case_id=case.id_,
+    )
+    # Coordinator is the case owner and closes last (case owner closes last).
+    actor_closes_case(
+        client=coordinator_client,
+        actor=coordinator_in_coordinator,
         case_id=case.id_,
     )
 


### PR DESCRIPTION
- Closes #1759

## Summary

In `_phase_case_closure`, Coordinator (the case owner) was closing before Finder, violating the CVD protocol principle that the case owner closes last. This fix reorders the four `actor_closes_case` calls so Coordinator closes after Vendor1, Vendor2, and Finder.

## Changes

- **`vultron/demo/scenario/fvcv_handoff_demo.py`**: swapped Finder and Coordinator close calls so Coordinator (case owner) closes last
- **`test/demo/test_fvcv_handoff_demo.py`**: added `test_phase_case_closure_coordinator_closes_last` to assert the call order invariant (Coordinator last, Finder before Coordinator)

## Verification

- All 15 unit tests pass (1 new)
- Full demo suite: 1033 passed, 1 xpassed (pre-existing)
- Black, flake8, mypy, pyright clean