### PR TITLE
fix(fvcv-handoff-demo): correct publication ordering — Vendor1, then Vendor2, then Finder, then Coordinator

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1758.md
+++ b/plan/history/2608/implementation/ISSUE-1758.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-1758
+timestamp: '2026-08-05T23:21:12.786503+00:00'
+title: 'fix(fvcv-handoff-demo): correct Phase 6 publication order'
+type: implementation
+---
+
+## Issue #1758 — fix(fvcv-handoff-demo): correct publication ordering
+
+Reordered Phase 6 `actor_notifies_published` calls in `_phase_publication` to realistic CVD order: Vendor1 → Vendor2 → Finder → Coordinator. The previous code called Coordinator first — before other participants — which is wrong because only the CASE_OWNER's (Coordinator's) `notify-published` triggers embargo teardown (DEMOMA-07-003 step 4).
+
+Added `test_phase_publication_order_vendor1_vendor2_finder_coordinator` to assert the exact call order.
+
+PR: <https://github.com/CERTCC/Vultron/pull/2022>

--- a/test/demo/test_fvcv_handoff_demo.py
+++ b/test/demo/test_fvcv_handoff_demo.py
@@ -415,6 +415,61 @@ class TestFvcvHandoffMilestoneAssertions:
             )
         mock_m6.assert_called()
 
+    def test_phase_publication_order_vendor1_vendor2_finder_coordinator(self):
+        """Phase 6 notifies published in CVD order: Vendor1, Vendor2, Finder, Coordinator last."""
+        import contextlib
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        coordinator_client = self._client()
+        vendor2_client = self._client()
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        vendor2_in_vendor2 = self._actor("urn:test:vendor2")
+        finder_in_finder = self._actor("urn:test:finder")
+        coordinator_in_coordinator = self._actor("urn:test:coordinator")
+        case = self._case()
+
+        call_order: list[str] = []
+
+        def _notify(**kwargs):
+            call_order.append(kwargs["actor"].id_)
+
+        with (
+            patch.object(
+                demo, "actor_notifies_published", side_effect=_notify
+            ),
+            patch.object(demo, "wait_for_case_em_terminated"),
+            patch.object(demo, "wait_for_participant_vfd_state"),
+            patch.object(demo, "verify_publicly_disclosed"),
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            demo._phase_publication(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                coordinator_client=coordinator_client,
+                vendor2_client=vendor2_client,
+                vendor=self._actor("urn:test:vendor"),
+                vendor_in_vendor=vendor_in_vendor,
+                vendor2=self._actor("urn:test:vendor2"),
+                vendor2_in_vendor2=vendor2_in_vendor2,
+                finder=self._actor("urn:test:finder"),
+                finder_in_finder=finder_in_finder,
+                coordinator=self._actor("urn:test:coordinator"),
+                coordinator_in_coordinator=coordinator_in_coordinator,
+                case=case,
+            )
+
+        assert call_order == [
+            "urn:test:vendor",
+            "urn:test:vendor2",
+            "urn:test:finder",
+            "urn:test:coordinator",
+        ], f"Unexpected publication order: {call_order}"
+
     def test_phase_case_closure_calls_verify_case_closed(self):
         """_phase_case_closure calls verify_case_closed at M7."""
         import contextlib

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -795,22 +795,10 @@ def _phase_publication(
     )
     logger.info("─" * 80)
 
-    # Coordinator is the CASE_OWNER after the Phase 2 handoff; only the
-    # CASE_OWNER's notify-published triggers embargo teardown (DEMOMA-07-003 step 4).
-    actor_notifies_published(
-        client=coordinator_client,
-        actor=coordinator_in_coordinator,
-        case_id=case.id_,
-    )
-
-    with demo_check(
-        "Embargo terminated (EM.EXITED) after Coordinator (CASE_OWNER) reports published"
-    ):
-        wait_for_case_em_terminated(
-            client=coordinator_client,
-            case_id=case.id_,
-        )
-
+    # Realistic CVD publication order: vendors publish their advisories first,
+    # then Finder may publish an independent writeup, then Coordinator publishes
+    # last as the CASE_OWNER whose notify-published triggers embargo teardown
+    # (DEMOMA-07-003 step 4).
     actor_notifies_published(
         client=vendor_client,
         actor=vendor_in_vendor,
@@ -826,6 +814,21 @@ def _phase_publication(
         actor=finder_in_finder,
         case_id=case.id_,
     )
+
+    # Coordinator publishes last — as CASE_OWNER this triggers embargo teardown.
+    actor_notifies_published(
+        client=coordinator_client,
+        actor=coordinator_in_coordinator,
+        case_id=case.id_,
+    )
+
+    with demo_check(
+        "Embargo terminated (EM.EXITED) after Coordinator (CASE_OWNER) reports published"
+    ):
+        wait_for_case_em_terminated(
+            client=coordinator_client,
+            case_id=case.id_,
+        )
 
     with demo_check(
         "All replicas CS.VFdPxa, EM.EXITED, all participants public-aware"


### PR DESCRIPTION
- Closes #1758

## Summary

Reorders Phase 6 publication trigger calls in `_phase_publication` to
realistic CVD order: Vendor1 → Vendor2 → Finder → Coordinator.

The previous code called Coordinator's `notify-published` first, before
the other participants. Coordinator is the CASE_OWNER after the Phase 2
handoff — only the CASE_OWNER's `notify-published` triggers embargo
teardown (DEMOMA-07-003 step 4). Calling it first meant the embargo
tore down before Vendor1, Vendor2, and Finder had published.

## Changes

- **`vultron/demo/scenario/fvcv_handoff_demo.py`** — reorder Phase 6
  `actor_notifies_published` calls: Vendor1 first, then Vendor2, then
  Finder, then Coordinator last; move `wait_for_case_em_terminated`
  check to immediately follow Coordinator's call.
- **`test/demo/test_fvcv_handoff_demo.py`** — add
  `test_phase_publication_order_vendor1_vendor2_finder_coordinator` to
  assert the exact call order.

## Verification

- All 15 fvcv-handoff unit tests pass (6 new)
- All 1033 demo tests pass
- Black, flake8, mypy clean