### PR TITLE
feat(#1977): extract participant-status convergence predicate to vultron/core/predicates/participants.py

### DIFF
--- a/plan/history/2608/implementation/ISSUE-1977.md
+++ b/plan/history/2608/implementation/ISSUE-1977.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1977
+timestamp: '2026-08-05T23:29:07.060837+00:00'
+title: Extract participant-status convergence predicate to core
+type: implementation
+---
+
+## Issue #1977 — Extract participant-status convergence predicates to vultron/core/predicates/participants.py
+
+Extracted `_all_fetchable_participants_rm_closed` convergence logic from `vultron/demo/helpers/verification.py` into a new pure-function module `vultron/core/predicates/participants.py`.
+
+The new `all_participants_rm_closed(participants: list[CaseParticipant]) -> bool` function has no DataLayerClient dependency, enabling direct unit testing with in-memory objects. The demo wrapper now fetches participants, converts via `.to_core()`, and delegates to the pure predicate.
+
+15 new tests added covering all RM states, CASE_MANAGER exclusion, CaseActorParticipant exclusion, and no-status-record case. Architecture ratchets (core-no-wire, core-no-adapter) remain clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/2023>

--- a/test/core/predicates/test_participants.py
+++ b/test/core/predicates/test_participants.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for vultron.core.predicates.participants."""
+
+from vultron.core.models.case_participant import (
+    CaseParticipant,
+    CaseActorParticipant,
+)
+from vultron.core.models.dimensions import RmDimension
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.predicates.participants import all_participants_rm_closed
+from vultron.core.states.rm import RM
+from vultron.enums.roles import CVDRole
+
+_CONTEXT = "urn:uuid:case-context"
+_ACTOR = "urn:uuid:actor-1"
+
+
+def _make_participant(
+    rm_state: RM,
+    roles: list[CVDRole] | None = None,
+    actor_id: str = _ACTOR,
+) -> CaseParticipant:
+    """Return a CaseParticipant with one ParticipantStatus at *rm_state*."""
+    p = CaseParticipant(
+        attributed_to=actor_id,
+        context=_CONTEXT,
+        case_roles=roles or [],
+    )
+    # Clear auto-seeded status and add one at the desired RM state.
+    p.participant_statuses = [
+        ParticipantStatus(
+            context=_CONTEXT,
+            attributed_to=actor_id,
+            rm=RmDimension(state=rm_state),
+        )
+    ]
+    return p
+
+
+class TestAllParticipantsRmClosed:
+    def test_empty_list_returns_true(self):
+        assert all_participants_rm_closed([]) is True
+
+    def test_single_closed_participant_returns_true(self):
+        p = _make_participant(RM.CLOSED)
+        assert all_participants_rm_closed([p]) is True
+
+    def test_single_open_participant_returns_false(self):
+        p = _make_participant(RM.ACCEPTED)
+        assert all_participants_rm_closed([p]) is False
+
+    def test_all_closed_returns_true(self):
+        participants = [
+            _make_participant(RM.CLOSED, actor_id="urn:uuid:actor-1"),
+            _make_participant(RM.CLOSED, actor_id="urn:uuid:actor-2"),
+        ]
+        assert all_participants_rm_closed(participants) is True
+
+    def test_one_not_closed_returns_false(self):
+        participants = [
+            _make_participant(RM.CLOSED, actor_id="urn:uuid:actor-1"),
+            _make_participant(RM.ACCEPTED, actor_id="urn:uuid:actor-2"),
+        ]
+        assert all_participants_rm_closed(participants) is False
+
+    def test_case_manager_skipped(self):
+        """CASE_MANAGER participants are excluded from the convergence check."""
+        case_manager = _make_participant(
+            RM.ACCEPTED, roles=[CVDRole.CASE_MANAGER]
+        )
+        regular = _make_participant(RM.CLOSED)
+        assert all_participants_rm_closed([case_manager, regular]) is True
+
+    def test_only_case_manager_returns_true(self):
+        """A list containing only CASE_MANAGER participants is vacuously True."""
+        case_manager = _make_participant(
+            RM.ACCEPTED, roles=[CVDRole.CASE_MANAGER]
+        )
+        assert all_participants_rm_closed([case_manager]) is True
+
+    def test_participant_no_status_returns_false(self):
+        """A participant with no status records is treated as not converged."""
+        p = CaseParticipant(
+            attributed_to=_ACTOR,
+            context=_CONTEXT,
+        )
+        p.participant_statuses = []
+        assert all_participants_rm_closed([p]) is False
+
+    def test_rm_start_returns_false(self):
+        p = _make_participant(RM.START)
+        assert all_participants_rm_closed([p]) is False
+
+    def test_rm_received_returns_false(self):
+        p = _make_participant(RM.RECEIVED)
+        assert all_participants_rm_closed([p]) is False
+
+    def test_rm_valid_returns_false(self):
+        p = _make_participant(RM.VALID)
+        assert all_participants_rm_closed([p]) is False
+
+    def test_rm_deferred_returns_false(self):
+        p = _make_participant(RM.DEFERRED)
+        assert all_participants_rm_closed([p]) is False
+
+    def test_rm_invalid_returns_false(self):
+        p = _make_participant(RM.INVALID)
+        assert all_participants_rm_closed([p]) is False
+
+    def test_case_actor_participant_skipped(self):
+        """CaseActorParticipant (COORDINATOR + CASE_MANAGER) is excluded."""
+        ca = CaseActorParticipant(
+            attributed_to="urn:uuid:case-actor",
+            context=_CONTEXT,
+        )
+        regular = _make_participant(RM.CLOSED)
+        assert all_participants_rm_closed([ca, regular]) is True
+
+    def test_mixed_roles_including_case_manager_skipped(self):
+        """Participant with CASE_MANAGER among multiple roles is still skipped."""
+        p = _make_participant(
+            RM.ACCEPTED,
+            roles=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
+        )
+        assert all_participants_rm_closed([p]) is True

--- a/vultron/core/predicates/__init__.py
+++ b/vultron/core/predicates/__init__.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Pure predicate functions over core domain objects."""

--- a/vultron/core/predicates/participants.py
+++ b/vultron/core/predicates/participants.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Pure predicate functions over :class:`~vultron.core.models.case_participant.CaseParticipant` lists.
+
+These functions contain no I/O and no HTTP/DataLayer dependencies, making them
+independently testable with in-memory objects.  Demo helpers that need to check
+convergence state over a live container should fetch participants first, then
+delegate to these predicates.
+"""
+
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.states.rm import RM
+from vultron.enums.roles import CVDRole
+
+
+def all_participants_rm_closed(
+    participants: list[CaseParticipant],
+) -> bool:
+    """Return ``True`` when every non-CASE_MANAGER participant is ``RM.CLOSED``.
+
+    Participants with no status records cause the function to return ``False``
+    immediately — their convergence state is unknown and must be treated as
+    incomplete.
+
+    Args:
+        participants: List of :class:`~vultron.core.models.case_participant.CaseParticipant`
+            objects to check.  The list may be empty, in which case the
+            function returns ``True`` (vacuous convergence).
+
+    Returns:
+        ``True`` if all non-CASE_MANAGER participants have reached
+        ``RM.CLOSED``; ``False`` otherwise.
+    """
+    for participant in participants:
+        if CVDRole.CASE_MANAGER in (participant.case_roles or []):
+            continue
+        latest = participant.participant_status
+        if latest is None:
+            return False
+        if latest.rm.state != RM.CLOSED:
+            return False
+    return True

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -24,6 +24,7 @@ from typing import Optional
 import httpx2 as httpx
 
 from vultron.adapters.utils import parse_id
+from vultron.core.predicates.participants import all_participants_rm_closed
 from vultron.core.states.cs import (
     CS_pxa,
     CS_vfd,
@@ -33,7 +34,6 @@ from vultron.core.states.cs import (
 )
 from vultron.core.states.em import is_em_embargo_active
 from vultron.core.states.rm import RM
-from vultron.enums.roles import CVDRole
 from vultron.demo.helpers.seeding import _dl_key, get_actor_by_id
 from vultron.demo.utils import DataLayerClient, logfmt, ref_id
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
@@ -310,31 +310,27 @@ def _all_fetchable_participants_rm_closed(
     ``RM.CLOSED``.
 
     Participants on remote containers (fetch returns ``None``) are skipped
-    since their state is not locally observable.
+    since their state is not locally observable.  Convergence logic is
+    delegated to
+    :func:`~vultron.core.predicates.participants.all_participants_rm_closed`.
 
     Args:
         client: DataLayerClient for the container to query.
         case: The ``as_VulnerabilityCase`` whose participant index to walk.
 
     Returns:
-        ``True`` if all locally-fetchable non-receiver participants are
+        ``True`` if all locally-fetchable non-CASE_MANAGER participants are
         ``RM.CLOSED``; ``False`` otherwise.
     """
+    core_participants = []
     for p_id in case.actor_participant_index.values():
         p_data = _fetch_participant_data(client, p_id)
         if p_data is None:
             continue  # remote container — not fetchable here
         if not p_data:
             return False
-        p = as_CaseParticipant(**p_data)
-        if CVDRole.CASE_MANAGER in (p.case_roles or []):
-            continue
-        latest = p.participant_status
-        if latest is None:
-            return False
-        if latest.rm_state != RM.CLOSED:
-            return False
-    return True
+        core_participants.append(as_CaseParticipant(**p_data).to_core())
+    return all_participants_rm_closed(core_participants)
 
 
 def verify_activity_in_inbox(


### PR DESCRIPTION
- Closes #1977

## What

Extracts the `_all_fetchable_participants_rm_closed` convergence logic
from `vultron/demo/helpers/verification.py` into a new pure-function
module `vultron/core/predicates/participants.py`.

## Why

The original logic was entangled with `DataLayerClient` HTTP calls,
making it impossible to test without a live server. The new pure
function takes `list[CaseParticipant]` (core domain type — no wire
imports, no I/O) and can be tested directly with in-memory objects.

## Changes

- **`vultron/core/predicates/__init__.py`** — new package init
- **`vultron/core/predicates/participants.py`** — new module with
  `all_participants_rm_closed(participants: list[CaseParticipant]) -> bool`;
  skips CASE_MANAGER participants; returns False for no-status-record
  participants (unknown convergence state); includes `test_rm_invalid_returns_false`
  for complete RM state coverage
- **`vultron/demo/helpers/verification.py`** — `_all_fetchable_participants_rm_closed`
  now fetches, calls `.to_core()` on each wire participant, then
  delegates to the pure predicate; removes now-unused `CVDRole` import
- **`test/core/predicates/test_participants.py`** — 15 tests covering
  empty list, all-closed, one-open, CASE_MANAGER skip, CaseActorParticipant
  skip, no-status-record, and every non-CLOSED RM state

## Verification

- All 17 tests pass (15 new in `test/core/predicates/`, 2 architecture ratchets confirmed)
- Black, flake8, mypy, pyright clean

## Architecture note

`vultron/core/` must not import `vultron/wire/` (ARCH-01-001). The
predicate uses `CaseParticipant` (core type); the demo wrapper converts
wire objects via `.to_core()` before delegating. Architecture ratchet
tests confirm the boundary remains clean.