### PR TITLE
fix(idempotency): silent guard no-op + SilentIdempotencyGuardMixin (CLP-13)

### DIFF
--- a/notes/bt-pitfalls.md
+++ b/notes/bt-pitfalls.md
@@ -936,10 +936,12 @@ misleads human readers and tooling alike (ADR-0019).
 | Received-side canonical entry | ✅ yes | `"recorded"` | CaseActor accepts a protocol assertion |
 | Idempotency guard no-op | ❌ **no** | — | Already-processed duplicate detected |
 
-Implement idempotency guards using `SilentIdempotencyGuardMixin`
-(CLP-13-002) once it exists, or follow the same `logger.info → FAILURE`
-pattern and add a unit test that asserts no `create_commit_log_entry_tree`
-call is made when the guard fires.
+**Resolved** (issue #2010, PR #2024, 2026-08-06): `SilentIdempotencyGuardMixin`
+(`vultron/core/behaviors/idempotency.py`) now exists and satisfies CLP-13-002.
+Both `CheckInviteeNotAlreadyParticipantNode` and `CheckCaseStatusIdempotencyNode`
+inherit it.  Implement all idempotency guards using this mixin — the
+`_idempotent_failure()` method returns `FAILURE` immediately after logging,
+making the "no ledger write" guarantee structural.
 
 ---
 

--- a/plan/history/2608/implementation/ISSUE-2010.md
+++ b/plan/history/2608/implementation/ISSUE-2010.md
@@ -1,0 +1,22 @@
+---
+source: ISSUE-2010
+timestamp: '2026-08-06T00:13:41.703499+00:00'
+title: 'Fix ledger idempotency guard rejections (issue #2010)'
+type: implementation
+---
+
+## Issue #2010 — Fix ledger idempotency guard rejections: silent no-op + reusable guard node
+
+Implemented CLP-13-001/CLP-13-002 compliance for BT idempotency guard nodes.
+
+### What was done
+
+- Created `vultron/core/behaviors/idempotency.py` with `SilentIdempotencyGuardMixin` (CLP-13-002): structural enforcement that guard no-ops never write a `CaseLedgerEntry`
+- Fixed `CheckInviteeNotAlreadyParticipantNode` in `accept_invite_tree.py`: true-duplicate (backfill-complete) path now uses `_idempotent_failure` → FAILURE; backfill-incomplete resume path correctly returns SUCCESS
+- Applied mixin to `CheckCaseStatusIdempotencyNode` in `status/nodes/case_status.py`
+- Added 15 unit tests in `test/core/behaviors/case/nodes/test_idempotency_guards.py`
+- Added `check_no_rejected_invite_entries` and `test_invariant_clp13_no_rejected_invite_entries` in CI invariants for fvcv_handoff
+
+### PR
+
+<https://github.com/CERTCC/Vultron/pull/2024>

--- a/test/ci/invariants/common.py
+++ b/test/ci/invariants/common.py
@@ -644,3 +644,28 @@ def check_cs_state_transitions_observed(
             "pxa_state starting with 'P' (published/public-aware) never observed"
         )
     return missing
+
+
+def check_no_rejected_invite_entries(
+    replicas: dict[str, list[dict]],
+) -> list[str]:
+    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
+
+    Idempotency guards MUST NOT write any CaseLedgerEntry.  A spurious
+    ``disposition="rejected"`` entry on an ``invite_actor_to_case`` event type
+    indicates an idempotency guard incorrectly wrote to the ledger.
+
+    Returns one violation string per offending entry.
+    """
+    violations: list[str] = []
+    for actor, entries in replicas.items():
+        for e in entries:
+            if (
+                event_type(e) == "invite_actor_to_case"
+                and e.get("disposition") == "rejected"
+            ):
+                violations.append(
+                    f"Actor {actor!r} logIndex={log_index(e)}: spurious"
+                    f" rejected invite_actor_to_case entry (CLP-13-001 violation)"
+                )
+    return violations

--- a/test/ci/invariants/test_fccv_extension_invariants.py
+++ b/test/ci/invariants/test_fccv_extension_invariants.py
@@ -46,6 +46,7 @@ from test.ci.invariants.common import (
     check_log_starts_at_genesis,
     check_nested_objects_inlined,
     check_no_gaps_in_log_indices,
+    check_no_rejected_invite_entries,
     check_no_rm_state_oscillation,
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
@@ -286,6 +287,23 @@ def test_invariant_15_cs_state_transitions_observed(
     violations = check_cs_state_transitions_observed(fccv_extension_replicas)
     assert not violations, "Missing CS-transition observations:\n" + "\n".join(
         violations
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_clp13_no_rejected_invite_entries(
+    fccv_extension_replicas: dict[str, list[dict]],
+) -> None:
+    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
+
+    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
+    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
+    called create_commit_log_entry_tree.
+    """
+    violations = check_no_rejected_invite_entries(fccv_extension_replicas)
+    assert not violations, (
+        f"Found {len(violations)} spurious rejected invite_actor_to_case"
+        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
     )
 
 

--- a/test/ci/invariants/test_fccv_handoff_invariants.py
+++ b/test/ci/invariants/test_fccv_handoff_invariants.py
@@ -43,6 +43,7 @@ from test.ci.invariants.common import (
     check_log_starts_at_genesis,
     check_nested_objects_inlined,
     check_no_gaps_in_log_indices,
+    check_no_rejected_invite_entries,
     check_no_rm_state_oscillation,
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
@@ -279,6 +280,23 @@ def test_invariant_15_cs_state_transitions_observed(
     violations = check_cs_state_transitions_observed(fccv_handoff_replicas)
     assert not violations, "Missing CS-transition observations:\n" + "\n".join(
         violations
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_clp13_no_rejected_invite_entries(
+    fccv_handoff_replicas: dict[str, list[dict]],
+) -> None:
+    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
+
+    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
+    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
+    called create_commit_log_entry_tree.
+    """
+    violations = check_no_rejected_invite_entries(fccv_handoff_replicas)
+    assert not violations, (
+        f"Found {len(violations)} spurious rejected invite_actor_to_case"
+        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
     )
 
 

--- a/test/ci/invariants/test_fcv_invariants.py
+++ b/test/ci/invariants/test_fcv_invariants.py
@@ -36,6 +36,7 @@ from test.ci.invariants.common import (
     check_log_starts_at_genesis,
     check_nested_objects_inlined,
     check_no_gaps_in_log_indices,
+    check_no_rejected_invite_entries,
     check_no_rm_state_oscillation,
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
@@ -255,6 +256,23 @@ def test_invariant_15_cs_state_transitions_observed(
     violations = check_cs_state_transitions_observed(fcv_replicas)
     assert not violations, "Missing CS-transition observations:\n" + "\n".join(
         violations
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_clp13_no_rejected_invite_entries(
+    fcv_replicas: dict[str, list[dict]],
+) -> None:
+    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
+
+    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
+    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
+    called create_commit_log_entry_tree.
+    """
+    violations = check_no_rejected_invite_entries(fcv_replicas)
+    assert not violations, (
+        f"Found {len(violations)} spurious rejected invite_actor_to_case"
+        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
     )
 
 

--- a/test/ci/invariants/test_fcvcv_invariants.py
+++ b/test/ci/invariants/test_fcvcv_invariants.py
@@ -47,6 +47,7 @@ from test.ci.invariants.common import (
     check_log_starts_at_genesis,
     check_nested_objects_inlined,
     check_no_gaps_in_log_indices,
+    check_no_rejected_invite_entries,
     check_no_rm_state_oscillation,
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
@@ -271,6 +272,23 @@ def test_invariant_15_cs_state_transitions_observed(
     violations = check_cs_state_transitions_observed(fcvcv_replicas)
     assert not violations, "Missing CS-transition observations:\n" + "\n".join(
         violations
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_clp13_no_rejected_invite_entries(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
+
+    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
+    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
+    called create_commit_log_entry_tree.
+    """
+    violations = check_no_rejected_invite_entries(fcvcv_replicas)
+    assert not violations, (
+        f"Found {len(violations)} spurious rejected invite_actor_to_case"
+        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
     )
 
 

--- a/test/ci/invariants/test_fv_invariants.py
+++ b/test/ci/invariants/test_fv_invariants.py
@@ -26,6 +26,7 @@ from test.ci.invariants.common import (
     check_log_starts_at_genesis,
     check_nested_objects_inlined,
     check_no_gaps_in_log_indices,
+    check_no_rejected_invite_entries,
     check_no_rm_state_oscillation,
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
@@ -272,6 +273,23 @@ def test_invariant_15_cs_state_transitions_observed(
         "Missing CS-transition observations in "
         "add_participant_status_to_participant entries:\n"
         + "\n".join(violations)
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_clp13_no_rejected_invite_entries(
+    fv_replicas: dict[str, list[dict]],
+) -> None:
+    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
+
+    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
+    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
+    called create_commit_log_entry_tree.
+    """
+    violations = check_no_rejected_invite_entries(fv_replicas)
+    assert not violations, (
+        f"Found {len(violations)} spurious rejected invite_actor_to_case"
+        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
     )
 
 

--- a/test/ci/invariants/test_fvcv_extension_invariants.py
+++ b/test/ci/invariants/test_fvcv_extension_invariants.py
@@ -36,6 +36,7 @@ from test.ci.invariants.common import (
     check_log_starts_at_genesis,
     check_nested_objects_inlined,
     check_no_gaps_in_log_indices,
+    check_no_rejected_invite_entries,
     check_no_rm_state_oscillation,
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
@@ -269,6 +270,23 @@ def test_invariant_15_cs_state_transitions_observed(
     violations = check_cs_state_transitions_observed(fvcv_extension_replicas)
     assert not violations, "Missing CS-transition observations:\n" + "\n".join(
         violations
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_clp13_no_rejected_invite_entries(
+    fvcv_extension_replicas: dict[str, list[dict]],
+) -> None:
+    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
+
+    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
+    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
+    called create_commit_log_entry_tree.
+    """
+    violations = check_no_rejected_invite_entries(fvcv_extension_replicas)
+    assert not violations, (
+        f"Found {len(violations)} spurious rejected invite_actor_to_case"
+        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
     )
 
 

--- a/test/ci/invariants/test_fvcv_handoff_invariants.py
+++ b/test/ci/invariants/test_fvcv_handoff_invariants.py
@@ -43,6 +43,7 @@ from test.ci.invariants.common import (
     check_log_starts_at_genesis,
     check_nested_objects_inlined,
     check_no_gaps_in_log_indices,
+    check_no_rejected_invite_entries,
     check_no_rm_state_oscillation,
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
@@ -195,6 +196,23 @@ def test_invariant_9_participant_status_schema_completeness(
     assert not violations, (
         f"{len(violations)} ParticipantStatus entries missing required fields:\n"
         + "\n".join(violations[:20])
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_clp13_no_rejected_invite_entries(
+    fvcv_handoff_replicas: dict[str, list[dict]],
+) -> None:
+    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
+
+    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
+    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
+    called create_commit_log_entry_tree.
+    """
+    violations = check_no_rejected_invite_entries(fvcv_handoff_replicas)
+    assert not violations, (
+        f"Found {len(violations)} spurious rejected invite_actor_to_case"
+        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
     )
 
 

--- a/test/ci/invariants/test_fvv_invariants.py
+++ b/test/ci/invariants/test_fvv_invariants.py
@@ -35,6 +35,7 @@ from test.ci.invariants.common import (
     check_log_starts_at_genesis,
     check_nested_objects_inlined,
     check_no_gaps_in_log_indices,
+    check_no_rejected_invite_entries,
     check_no_rm_state_oscillation,
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
@@ -253,6 +254,23 @@ def test_invariant_15_cs_state_transitions_observed(
     violations = check_cs_state_transitions_observed(fvv_replicas)
     assert not violations, "Missing CS-transition observations:\n" + "\n".join(
         violations
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_clp13_no_rejected_invite_entries(
+    fvv_replicas: dict[str, list[dict]],
+) -> None:
+    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
+
+    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
+    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
+    called create_commit_log_entry_tree.
+    """
+    violations = check_no_rejected_invite_entries(fvv_replicas)
+    assert not violations, (
+        f"Found {len(violations)} spurious rejected invite_actor_to_case"
+        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
     )
 
 

--- a/test/core/behaviors/case/nodes/test_idempotency_guards.py
+++ b/test/core/behaviors/case/nodes/test_idempotency_guards.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for idempotency guard nodes satisfying CLP-13-001/CLP-13-002.
+
+AC-1: Guard nodes return FAILURE with no CaseLedgerEntry written on true-duplicate fire.
+AC-2: Guard nodes inherit SilentIdempotencyGuardMixin.
+AC-3: CLP-13-001 and CLP-13-002 satisfied.
+"""
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.case.accept_invite_tree import (
+    CheckInviteeNotAlreadyParticipantNode,
+)
+from vultron.core.behaviors.idempotency import SilentIdempotencyGuardMixin
+from vultron.core.behaviors.status.nodes.case_status import (
+    CheckCaseStatusIdempotencyNode,
+    CASE_STATUS_ALREADY_PRESENT,
+)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_status import CaseStatus
+from vultron.core.models.vultron_types import VultronParticipant
+from test.core.behaviors.bt_harness import BTTestScenario
+
+_CASE_ID = "https://example.org/cases/case-001"
+_INVITEE_ID = "https://example.org/actors/invitee"
+_ACTOR_ID = "https://example.org/actors/vendor"
+
+
+# ---------------------------------------------------------------------------
+# SilentIdempotencyGuardMixin — AC-2 (structural)
+# ---------------------------------------------------------------------------
+
+
+class TestSilentIdempotencyGuardMixinMembership:
+    """CLP-13-002: guard nodes MUST inherit SilentIdempotencyGuardMixin."""
+
+    def test_check_invitee_not_already_participant_uses_mixin(self) -> None:
+        assert issubclass(
+            CheckInviteeNotAlreadyParticipantNode, SilentIdempotencyGuardMixin
+        )
+
+    def test_check_case_status_idempotency_uses_mixin(self) -> None:
+        assert issubclass(
+            CheckCaseStatusIdempotencyNode, SilentIdempotencyGuardMixin
+        )
+
+
+# ---------------------------------------------------------------------------
+# CheckInviteeNotAlreadyParticipantNode — AC-1
+# ---------------------------------------------------------------------------
+
+
+def _seed_case_with_participant(
+    bt_scenario: BTTestScenario,
+    *,
+    backfill_complete: bool = True,
+) -> VulnerabilityCase:
+    """Seed a case that already has the invitee as a participant."""
+    from vultron.core.models.replication_state import VultronReplicationState
+
+    participant = VultronParticipant(
+        id_=f"{_CASE_ID}/participants/invitee",
+        attributed_to=_INVITEE_ID,
+        context=_CASE_ID,
+    )
+    case = VulnerabilityCase(
+        id_=_CASE_ID,
+        name="Test Case",
+    )
+    case.add_participant(participant)
+    bt_scenario.dl.create(participant)
+    bt_scenario.dl.create(case)
+
+    if backfill_complete:
+        state = VultronReplicationState(
+            case_id=_CASE_ID,
+            peer_id=_INVITEE_ID,
+            join_backfill_target_index=0,
+            join_backfill_last_sent_index=0,
+            join_backfill_complete=True,
+        )
+        bt_scenario.dl.save(state)
+
+    return case
+
+
+def _seed_fresh_case(bt_scenario: BTTestScenario) -> VulnerabilityCase:
+    """Seed a case with no participants."""
+    case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+    bt_scenario.dl.create(case)
+    return case
+
+
+class TestCheckInviteeNotAlreadyParticipantNode:
+    """CLP-13-001: guard FAILURE must not call create_commit_log_entry_tree."""
+
+    def test_returns_failure_when_backfill_complete_duplicate(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """True duplicate (backfill complete) → FAILURE."""
+        _seed_case_with_participant(bt_scenario, backfill_complete=True)
+        node = CheckInviteeNotAlreadyParticipantNode(
+            case_id=_CASE_ID, invitee_id=_INVITEE_ID
+        )
+        result = bt_scenario.run(node, actor_id=_ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_no_ledger_entry_written_on_true_duplicate(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """AC-1: no CaseLedgerEntry is written to the datalayer when a duplicate fires."""
+        from vultron.core.models.case_ledger_entry import CaseLedgerEntry
+
+        _seed_case_with_participant(bt_scenario, backfill_complete=True)
+        node = CheckInviteeNotAlreadyParticipantNode(
+            case_id=_CASE_ID, invitee_id=_INVITEE_ID
+        )
+        bt_scenario.run(node, actor_id=_ACTOR_ID)
+        entries = [
+            obj
+            for obj in bt_scenario.dl.list_objects("CaseLedgerEntry")
+            if isinstance(obj, CaseLedgerEntry) and obj.case_id == _CASE_ID
+        ]
+        assert (
+            entries == []
+        ), f"Guard wrote {len(entries)} ledger entry/entries — CLP-13-001 violated"
+
+    def test_returns_success_for_backfill_incomplete_resume_no_state(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Resume path (no replication state marker) → SUCCESS, tree continues."""
+        _seed_case_with_participant(bt_scenario, backfill_complete=False)
+        node = CheckInviteeNotAlreadyParticipantNode(
+            case_id=_CASE_ID, invitee_id=_INVITEE_ID
+        )
+        result = bt_scenario.run(node, actor_id=_ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_returns_success_for_backfill_incomplete_resume_with_state(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Resume path (replication state exists, join_backfill_complete=False) → SUCCESS."""
+        from vultron.core.models.replication_state import (
+            VultronReplicationState,
+        )
+
+        _seed_case_with_participant(bt_scenario, backfill_complete=False)
+        # Explicitly create an incomplete replication state record.
+        state = VultronReplicationState(
+            case_id=_CASE_ID,
+            peer_id=_INVITEE_ID,
+            join_backfill_target_index=5,
+            join_backfill_last_sent_index=2,
+            join_backfill_complete=False,
+        )
+        bt_scenario.dl.save(state)
+        node = CheckInviteeNotAlreadyParticipantNode(
+            case_id=_CASE_ID, invitee_id=_INVITEE_ID
+        )
+        result = bt_scenario.run(node, actor_id=_ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_returns_success_when_not_participant(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        _seed_fresh_case(bt_scenario)
+        node = CheckInviteeNotAlreadyParticipantNode(
+            case_id=_CASE_ID, invitee_id=_INVITEE_ID
+        )
+        result = bt_scenario.run(node, actor_id=_ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_sets_invitee_already_participant_true_on_true_duplicate(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Guard writes invitee_already_participant=True before returning FAILURE."""
+        import py_trees
+
+        _seed_case_with_participant(bt_scenario, backfill_complete=True)
+        node = CheckInviteeNotAlreadyParticipantNode(
+            case_id=_CASE_ID, invitee_id=_INVITEE_ID
+        )
+        bt_scenario.run(node, actor_id=_ACTOR_ID)
+        bb = py_trees.blackboard.Client(name="test-reader")
+        bb.register_key(
+            key="invitee_already_participant",
+            access=py_trees.common.Access.READ,
+        )
+        assert bb.get("invitee_already_participant") is True
+
+    def test_sets_invitee_already_participant_false_on_fresh(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        import py_trees
+
+        _seed_fresh_case(bt_scenario)
+        node = CheckInviteeNotAlreadyParticipantNode(
+            case_id=_CASE_ID, invitee_id=_INVITEE_ID
+        )
+        bt_scenario.run(node, actor_id=_ACTOR_ID)
+        bb = py_trees.blackboard.Client(name="test-reader-fresh")
+        bb.register_key(
+            key="invitee_already_participant",
+            access=py_trees.common.Access.READ,
+        )
+        assert bb.get("invitee_already_participant") is False
+
+    def test_returns_failure_when_case_not_found(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        node = CheckInviteeNotAlreadyParticipantNode(
+            case_id="https://example.org/cases/nonexistent",
+            invitee_id=_INVITEE_ID,
+        )
+        result = bt_scenario.run(node, actor_id=_ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# CheckCaseStatusIdempotencyNode — AC-1
+# ---------------------------------------------------------------------------
+
+
+def _seed_case_with_status(
+    bt_scenario: BTTestScenario,
+) -> tuple[VulnerabilityCase, CaseStatus]:
+    """Seed a case that already has a CaseStatus entry."""
+    status = CaseStatus(context=_CASE_ID)
+    case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+    case.case_statuses.append(status.id_)
+    bt_scenario.dl.create(status)
+    bt_scenario.dl.create(case)
+    return case, status
+
+
+class TestCheckCaseStatusIdempotencyNode:
+    """CLP-13-001: guard FAILURE must not write a CaseLedgerEntry on duplicate fire."""
+
+    def test_returns_failure_when_status_already_present(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        _, status = _seed_case_with_status(bt_scenario)
+        node = CheckCaseStatusIdempotencyNode(
+            case_id=_CASE_ID, status_id=status.id_
+        )
+        result = bt_scenario.run(node, actor_id=_ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_no_ledger_entry_written_on_status_duplicate(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """AC-1: no CaseLedgerEntry is written when the status-idempotency guard fires."""
+        from vultron.core.models.case_ledger_entry import CaseLedgerEntry
+
+        _, status = _seed_case_with_status(bt_scenario)
+        node = CheckCaseStatusIdempotencyNode(
+            case_id=_CASE_ID, status_id=status.id_
+        )
+        bt_scenario.run(node, actor_id=_ACTOR_ID)
+        entries = [
+            obj
+            for obj in bt_scenario.dl.list_objects("CaseLedgerEntry")
+            if isinstance(obj, CaseLedgerEntry) and obj.case_id == _CASE_ID
+        ]
+        assert (
+            entries == []
+        ), f"Guard wrote {len(entries)} ledger entry/entries — CLP-13-001 violated"
+
+    def test_sets_feedback_message_on_duplicate(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        _, status = _seed_case_with_status(bt_scenario)
+        node = CheckCaseStatusIdempotencyNode(
+            case_id=_CASE_ID, status_id=status.id_
+        )
+        bt_scenario.run(node, actor_id=_ACTOR_ID)
+        assert node.feedback_message == CASE_STATUS_ALREADY_PRESENT
+
+    def test_returns_success_when_status_not_present(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+        bt_scenario.dl.create(case)
+        node = CheckCaseStatusIdempotencyNode(
+            case_id=_CASE_ID, status_id="https://example.org/statuses/new"
+        )
+        result = bt_scenario.run(node, actor_id=_ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_returns_failure_when_case_not_found(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        node = CheckCaseStatusIdempotencyNode(
+            case_id="https://example.org/cases/missing",
+            status_id="https://example.org/statuses/s1",
+        )
+        result = bt_scenario.run(node, actor_id=_ACTOR_ID)
+        assert result.status == Status.FAILURE

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -50,6 +50,7 @@ from vultron.core.behaviors.case.nodes.accept_invite import (
     EmitAddCaseParticipantNode,
 )
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.idempotency import SilentIdempotencyGuardMixin
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.models.case_participant import CaseParticipant
@@ -149,12 +150,29 @@ class CapturePreCommitBackfillTargetNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class CheckInviteeNotAlreadyParticipantNode(DataLayerCondition):
-    """Idempotency guard: FAILURE when invitee is already a participant.
+class CheckInviteeNotAlreadyParticipantNode(
+    SilentIdempotencyGuardMixin, DataLayerCondition
+):
+    """Idempotency guard: FAILURE when invitee is already a fully-joined participant.
 
     Returns SUCCESS (allow proceeding) when the invitee is NOT yet
-    registered in ``case.actor_participant_index``.
-    Returns FAILURE (abort tree) when the invitee is already a participant.
+    registered in ``case.actor_participant_index``, or when the invitee IS
+    registered but join-time backfill is still incomplete (resume path).
+
+    Returns FAILURE (abort tree) with no ledger write when the invitee is
+    already a participant AND backfill is complete — a true idempotent no-op
+    (CLP-13-001, CLP-13-002).
+
+    Three paths:
+
+    1. **Fresh invite**: invitee not yet a participant → SUCCESS, tree runs in full.
+    2. **Backfill-incomplete resume**: invitee is a participant but backfill is
+       still in progress → SUCCESS with ``invitee_already_participant = True``,
+       so downstream effect nodes skip participant-creation while the commit and
+       backfill steps still run.
+    3. **Backfill-complete (true duplicate)**: invitee is a participant and
+       backfill is done → ``_idempotent_failure`` (FAILURE, INFO log, no ledger
+       write — CLP-13-001).
     """
 
     def __init__(
@@ -200,16 +218,21 @@ class CheckInviteeNotAlreadyParticipantNode(DataLayerCondition):
                 state.join_backfill_complete
                 or state.join_backfill_target_index == -1
             ):
-                self.logger.info(
+                # True duplicate: backfill complete — silent FAILURE, no ledger
+                # write (CLP-13-001).
+                self.blackboard.invitee_already_participant = True
+                return self._idempotent_failure(
+                    self.logger,
                     "%s: actor '%s' already participant in case '%s'"
-                    " — skipping (idempotent)",
+                    " — skipping (idempotent, CLP-13-001)",
                     self.name,
                     self.invitee_id,
                     self.case_id,
                 )
-                self.blackboard.invitee_already_participant = True
-                return Status.FAILURE
 
+            # Resume path: backfill is incomplete (or no marker yet).  Set the
+            # flag so downstream effect nodes skip participant-creation, but
+            # return SUCCESS to allow the commit + backfill steps to run.
             if state is None:
                 self.logger.info(
                     "%s: actor '%s' already participant in case '%s' with no "
@@ -815,6 +838,14 @@ def create_accept_invite_actor_to_case_tree(
         ├── EmitAddCaseParticipantNode             — emit Add(CaseParticipant), commit ledger
         ├── EmitAnnounceCaseToInviteeNode          — queue Announce to invitee
         └── BackfillCanonicalLedgerToInviteeNode   — send prior ledger to invitee
+
+    The idempotency guard ``CheckInviteeNotAlreadyParticipantNode`` uses
+    :class:`~vultron.core.behaviors.idempotency.SilentIdempotencyGuardMixin`
+    to enforce CLP-13-001: when a true duplicate is detected (invitee already
+    joined AND backfill is complete), the guard returns ``Status.FAILURE`` with
+    an INFO log and no ledger write.  When backfill is incomplete, it returns
+    SUCCESS with ``invitee_already_participant = True`` so the tree continues
+    to the commit + backfill steps without re-creating the participant.
 
     Args:
         case_id: ID of the VulnerabilityCase the invitee accepted.

--- a/vultron/core/behaviors/idempotency.py
+++ b/vultron/core/behaviors/idempotency.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Reusable BT mixin enforcing the CLP-13 idempotency guard silence contract.
+
+Per ``specs/case-ledger-processing.yaml`` CLP-13-001, CLP-13-002, CLP-13-003.
+"""
+
+import logging
+
+from py_trees.common import Status
+
+
+class SilentIdempotencyGuardMixin:
+    """CLP-13-002: Silent-FAILURE-on-duplicate contract for BT guard nodes.
+
+    BT guard nodes that detect a duplicate activity (idempotency no-op) MUST:
+
+    - Return ``Status.FAILURE`` so the enclosing Sequence aborts (CLP-13-001).
+    - Make NO call to ``create_commit_log_entry_tree`` — no ``CaseLedgerEntry``
+      of any disposition (CLP-13-001: MUST_NOT).
+    - Emit a ``logger.info`` or ``logger.debug`` message (CLP-13-003: MUST).
+
+    This mixin provides :meth:`_idempotent_failure` as the single call site
+    for this contract.  Using it makes the "no ledger write" guarantee
+    structural: the method returns ``FAILURE`` immediately after logging, so
+    no subsequent write can follow within the same call chain.
+
+    Usage::
+
+        class MyGuardNode(SilentIdempotencyGuardMixin, DataLayerCondition):
+            def update(self) -> Status:
+                if duplicate_detected:
+                    return self._idempotent_failure(
+                        self.logger,
+                        "%s: duplicate detected for '%s' — skipping (CLP-13-001)",
+                        self.name,
+                        self.some_id,
+                    )
+                return Status.SUCCESS
+
+    Per ``specs/case-ledger-processing.yaml`` CLP-13-001, CLP-13-002, CLP-13-003.
+    """
+
+    def _idempotent_failure(
+        self,
+        logger: logging.Logger,
+        message: str,
+        *args: object,
+    ) -> Status:
+        """Log the idempotent no-op and return FAILURE. No ledger write may follow.
+
+        Callers MUST return the result of this call immediately — they MUST NOT
+        call ``create_commit_log_entry_tree`` or any other DataLayer write after
+        this method (CLP-13-001).
+
+        Args:
+            logger: The node's managed logger.
+            message: ``logging``-style format string describing the duplicate.
+            *args: Format arguments for ``message``.
+
+        Returns:
+            ``Status.FAILURE`` unconditionally.
+        """
+        logger.info(message, *args)
+        return Status.FAILURE
+
+
+__all__ = ["SilentIdempotencyGuardMixin"]

--- a/vultron/core/behaviors/status/nodes/case_status.py
+++ b/vultron/core/behaviors/status/nodes/case_status.py
@@ -25,6 +25,7 @@ from typing import Any
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.idempotency import SilentIdempotencyGuardMixin
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.protocols import PersistableModel
@@ -40,11 +41,14 @@ logger = logging.getLogger(__name__)
 CASE_STATUS_ALREADY_PRESENT = "case_status_already_present"
 
 
-class CheckCaseStatusIdempotencyNode(DataLayerCondition):
+class CheckCaseStatusIdempotencyNode(
+    SilentIdempotencyGuardMixin, DataLayerCondition
+):
     """AC-1: Verify the CaseStatus has not already been added to the case.
 
     Returns FAILURE with ``feedback_message == CASE_STATUS_ALREADY_PRESENT``
-    when *status_id* is already in ``case.case_statuses`` — a benign no-op.
+    when *status_id* is already in ``case.case_statuses`` — a benign no-op
+    with no ledger write (CLP-13-001, CLP-13-002).
 
     Returns FAILURE with a distinct message when the case itself is not found.
 
@@ -80,13 +84,13 @@ class CheckCaseStatusIdempotencyNode(DataLayerCondition):
         existing_ids = [_as_id(s) for s in case.case_statuses]
         if self.status_id in existing_ids:
             self.feedback_message = CASE_STATUS_ALREADY_PRESENT
-            self.logger.debug(
+            return self._idempotent_failure(
+                self.logger,
                 "CheckCaseStatusIdempotency: status '%s' already in case '%s'"
-                " — skipping (idempotent)",
+                " — skipping (idempotent, CLP-13-001)",
                 self.status_id,
                 self.case_id,
             )
-            return Status.FAILURE
 
         return Status.SUCCESS
 


### PR DESCRIPTION
- Closes #2010
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Implements `SilentIdempotencyGuardMixin` and wires it into both idempotency guard nodes so that true-duplicate detections never write a `CaseLedgerEntry` (CLP-13-001/CLP-13-002). Adds 15 unit tests and a new CI invariant check for the `fvcv_handoff` scenario.

## Changes

- **`vultron/core/behaviors/idempotency.py`** (new): `SilentIdempotencyGuardMixin` with `_idempotent_failure()` — logs INFO and returns `FAILURE`; no subsequent write can follow (CLP-13-002)
- **`vultron/core/behaviors/case/accept_invite_tree.py`**: `CheckInviteeNotAlreadyParticipantNode` inherits mixin; true-duplicate (backfill-complete) path uses `_idempotent_failure`; backfill-incomplete resume path still returns `SUCCESS` so commit + backfill run
- **`vultron/core/behaviors/status/nodes/case_status.py`**: `CheckCaseStatusIdempotencyNode` inherits mixin; uses `_idempotent_failure` instead of inline `logger.debug` + `return FAILURE`
- **`test/core/behaviors/case/nodes/test_idempotency_guards.py`** (new): 15 tests — mixin membership (AC-2), no `CaseLedgerEntry` after guard fire (AC-1), FAILURE on true-duplicate, SUCCESS on both resume sub-cases
- **`test/ci/invariants/common.py`**: `check_no_rejected_invite_entries` function
- **`test/ci/invariants/test_fvcv_handoff_invariants.py`**: `test_invariant_clp13_no_rejected_invite_entries` (AC-5)

## Design note

The backfill-incomplete resume path is intentionally NOT a true duplicate — the invitee is already registered but join-time ledger backfill is still in progress. The guard returns `SUCCESS` in that case so the tree proceeds to commit the receipt entry and run `BackfillCanonicalLedgerToInviteeNode`. Only the backfill-complete path triggers the silent `FAILURE`.

## Verification

- 15 new unit tests pass; 6414 total passed (0 failed) post-freshen
- black, flake8, mypy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)