### PR TITLE
chore(graphify): add worktree-local hook opt-in and exclude plan/history

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Forwarder: see .githooks/pre-commit for why core.hooksPath needs these.
+# The shared post-checkout has the same worktree gate as post-commit, so it will
+# exit 0 here anyway -- but forwarding keeps behavior identical to not overriding.
+set -e
+_SHARED="$(git rev-parse --git-common-dir)/hooks/post-checkout"
+if [ -x "$_SHARED" ]; then
+    exec "$_SHARED" "$@"
+fi
+exit 0

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,142 @@
+#!/bin/sh
+# Worktree-local graphify post-commit hook.
+#
+# WHY THIS EXISTS
+# The shared hook in $GIT_COMMON_DIR/hooks/post-commit deliberately exits 0 in any
+# linked worktree (it compares --git-dir against --git-common-dir). That gate is
+# correct: hooks are shared across worktrees but graphify-out/ is per-worktree, so
+# without it a commit in one worktree would rebuild whichever graphify-out/ happened
+# to be in cwd. This hook opts THIS worktree back in, scoped to this worktree only
+# via `git config --worktree core.hooksPath .githooks`.
+#
+# SCOPE: code files only (AST, deterministic, no LLM, no API key). Doc/markdown
+# changes are NOT covered -- those need semantic extraction via `/graphify . --update`.
+#
+# KNOWN TRADEOFF: the rebuild re-runs community detection. When the community set
+# shifts, graphify renames affected communities after their highest-degree hub node
+# (e.g. "CasePersistence" instead of "Case Persistence & DataLayer Actions"), and the
+# log says "run `graphify label` to refresh names". Structure and edges stay correct;
+# only the human-readable community names degrade. Re-run `/graphify . --update` (or
+# `graphify label`) when you want descriptive names back.
+#
+# Set GRAPHIFY_SKIP_HOOK=1 to bypass.
+
+set -u
+
+[ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ] && exit 0
+
+# Deterministic clustering: networkx louvain iterates string-keyed sets whose order
+# is randomized per-process by PYTHONHASHSEED, so community assignments churn
+# run-to-run. Pinning it keeps graphify-out reproducible.
+export PYTHONHASHSEED=0
+
+# Skip during rebase/merge/cherry-pick: a rebuild mid-sequence leaves unstaged
+# graphify-out/ changes that block --continue.
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
+# Always operate on the worktree root, not the subdir git invoked us from.
+WT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$WT_ROOT" || exit 0
+
+# Nothing to do if this worktree has no graph yet.
+[ -f graphify-out/graph.json ] || exit 0
+
+CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
+[ -z "$CHANGED" ] && exit 0
+
+# Skip when only graphify-out/ artifacts changed (avoids a rebuild loop).
+_NON_GRAPH=$(echo "$CHANGED" | grep -v '^graphify-out/' || true)
+[ -z "$_NON_GRAPH" ] && exit 0
+
+# Only rebuild when a file graphify extracts structurally actually changed.
+# Keep this list in sync with graphify.detect.CODE_EXTENSIONS.
+_CODE=$(echo "$_NON_GRAPH" | grep -Ei '\.(py|ts|tsx|js|jsx|go|rs|java|cpp|cc|cxx|c|h|hpp|rb|swift|kt|kts|cs|scala|php|lua)$' || true)
+if [ -z "$_CODE" ]; then
+    echo "[graphify hook] no code changes; docs need '/graphify . --update' (semantic extraction)"
+    exit 0
+fi
+
+# Resolve a Python that has graphify importable. Prefer the path the skill/CLI
+# recorded for THIS worktree. find_spec avoids paying the full package import.
+_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
+GRAPHIFY_PYTHON=""
+if [ -f graphify-out/.graphify_python ]; then
+    _FROM_FILE=$(tr -d '[:space:]' < graphify-out/.graphify_python 2>/dev/null)
+    case "$_FROM_FILE" in
+        *[!a-zA-Z0-9/_.@:-]*) _FROM_FILE="" ;;   # path allowlist
+    esac
+    if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="$_FROM_FILE"
+    fi
+fi
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    _BIN=$(command -v graphify 2>/dev/null)
+    if [ -n "$_BIN" ]; then
+        _SHEBANG=$(head -c 256 "$_BIN" 2>/dev/null | tr -d '\000' | head -n 1 | sed 's/^#![[:space:]]*//')
+        case "$_SHEBANG" in */env\ *) _SHEBANG="${_SHEBANG#*/env }" ;; esac
+        case "$_SHEBANG" in *[!a-zA-Z0-9/_.@:-]*) _SHEBANG="" ;; esac
+        if [ -n "$_SHEBANG" ] && "$_SHEBANG" -c "$_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_SHEBANG"
+        fi
+    fi
+fi
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1 && python3 -c "$_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    else
+        echo "[graphify hook] no Python with graphify installed; skipping rebuild" >&2
+        exit 0
+    fi
+fi
+
+# Rebuild detached so `git commit` returns immediately.
+_LOG="graphify-out/rebuild.log"
+export GRAPHIFY_CHANGED="$_CODE"
+export GRAPHIFY_REBUILD_LOG="$_LOG"
+echo "[graphify hook] launching background code rebuild (log: $_LOG)"
+
+"$GRAPHIFY_PYTHON" -c "import os, subprocess, sys
+_src = '''
+import os, signal, sys
+from pathlib import Path
+
+changed = [Path(f.strip()) for f in os.environ.get(\"GRAPHIFY_CHANGED\", \"\").strip().splitlines() if f.strip()]
+if not changed:
+    sys.exit(0)
+print(f\"[graphify hook] {len(changed)} code file(s) changed - rebuilding...\", flush=True)
+try:
+    from graphify.watch import _rebuild_code, _apply_resource_limits
+    _apply_resource_limits()
+    _t = int(os.environ.get(\"GRAPHIFY_REBUILD_TIMEOUT\", \"900\"))
+    if _t > 0 and hasattr(signal, \"SIGALRM\"):
+        signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f\"rebuild exceeded {_t}s\")))
+        signal.alarm(_t)
+    _force = os.environ.get(\"GRAPHIFY_FORCE\", \"\").lower() in (\"1\", \"true\", \"yes\")
+    # Rebuild THIS worktree. Ignore .graphify_root: a folder copied from another
+    # worktree can point elsewhere, which is exactly the contamination the shared
+    # hook gate protects against.
+    _rebuild_code(Path(\".\"), changed_paths=changed, force=_force)
+    print(\"[graphify hook] done\", flush=True)
+except TimeoutError as exc:
+    print(f\"[graphify hook] {exc}\", flush=True); sys.exit(1)
+except Exception as exc:
+    print(f\"[graphify hook] rebuild failed: {exc}\", flush=True); sys.exit(1)
+'''
+_log = os.environ.get('GRAPHIFY_REBUILD_LOG') or 'graphify-out/rebuild.log'
+try:
+    os.makedirs(os.path.dirname(_log) or '.', exist_ok=True)
+    _out = open(_log, 'a', buffering=1, encoding='utf-8', errors='replace')
+except OSError:
+    _out = subprocess.DEVNULL
+_kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
+_cmd = [sys.executable, '-c', _src]
+if os.name == 'nt':
+    subprocess.Popen(_cmd, creationflags=0x08000000 | 0x00000200, **_kw)
+else:
+    subprocess.Popen(_cmd, start_new_session=True, **_kw)
+"
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Forwarder: core.hooksPath REPLACES the hooks directory wholesale, so pointing it
+# at .githooks/ would silently disable the repo's real pre-commit hook (installed by
+# the pre-commit framework into $GIT_COMMON_DIR/hooks). This delegates back to it so
+# Black/flake8/markdownlint still run.
+#
+# Keep this file for any hook that exists in the shared hooks dir but that we do not
+# override here; without it, that hook stops firing in this worktree.
+
+set -e
+
+_SHARED="$(git rev-parse --git-common-dir)/hooks/pre-commit"
+if [ -x "$_SHARED" ]; then
+    exec "$_SHARED" "$@"
+fi
+exit 0

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,4 @@
+# Append-only work archive: 1000+ historical narrative entries that add
+# weakly-connected nodes and distort community detection. Excluded from the
+# knowledge graph by deliberate scope decision.
+plan/history/

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -81,3 +81,37 @@ graphify hook install
 The graphify hooks run in the background and only fire when `graphify-out/` already
 exists (i.e., after you've run `/graphify .` at least once). They won't interfere
 with the pre-commit hooks or slow down your commits.
+
+### Knowledge graph hooks in a linked worktree
+
+`graphify hook install` writes to the shared hooks directory, and its hook
+deliberately exits early in any linked worktree (it compares `git rev-parse
+--git-dir` against `--git-common-dir` and bails when they differ). That guard is
+correct: hooks are shared across worktrees but `graphify-out/` is per-worktree, so
+without it a commit in one worktree would rebuild whichever `graphify-out/` happened
+to be in the current directory.
+
+To opt a single worktree back in, point that worktree at the tracked `.githooks/`
+directory:
+
+```shell
+git config extensions.worktreeConfig true
+git config --worktree core.hooksPath .githooks
+```
+
+Use `--worktree`, not `--local`: `--local` writes to the shared `.git/config` and
+would apply to every worktree at once.
+
+Two caveats:
+
+- `core.hooksPath` **replaces** the hooks directory wholesale, which is why
+  `.githooks/pre-commit` and `.githooks/post-checkout` forward to the shared hooks.
+  Without those forwarders, `pre-commit` (black, flake8, markdownlint) silently
+  stops running in that worktree.
+- The rebuild covers code files only (AST, no LLM). It re-runs community detection,
+  so descriptive community names may be replaced by hub-node symbol names. Run
+  `/graphify . --update` to refresh doc coverage and community labels.
+
+`.graphifyignore` excludes `plan/history/` from the graph: those 1000+ append-only
+archive entries are historical narrative that add weakly-connected nodes and distort
+community detection.


### PR DESCRIPTION
## Summary

Linked worktrees currently get no graphify graph maintenance at all. This adds a tracked `.githooks/` directory that a worktree can opt into, excludes `plan/history/` from the graph, and documents both in `README-DEV.md`.

No issue reference — this came out of hands-on debugging in a worktree rather than a filed issue.

## Background

The post-commit hook installed by `graphify hook install` lives in the shared hooks directory and deliberately exits early in any linked worktree — it compares `git rev-parse --git-dir` against `--git-common-dir` and bails when they differ.

That guard is **correct and left untouched**: hooks are shared across worktrees while `graphify-out/` is per-worktree, so without it a commit in one worktree would rebuild whichever `graphify-out/` happened to be in the current directory. The fix is to let individual worktrees opt back in, not to weaken the guard.

Opt-in is per-worktree:

```shell
git config extensions.worktreeConfig true
git config --worktree core.hooksPath .githooks
```

`--worktree` matters — `--local` writes to the shared `.git/config` and would apply to every worktree at once.

## Changes

- **`.githooks/post-commit`**: code-only incremental rebuild (AST, no LLM, no API key), launched detached so `git commit` returns immediately. Skips rebase/merge/cherry-pick, `graphify-out/`-only commits, and commits with no code changes. Rebuilds the worktree root rather than trusting `.graphify_root`, which a copied `graphify-out/` can point at a different tree.
- **`.githooks/pre-commit`**, **`.githooks/post-checkout`**: forwarders to the shared hooks. These are load-bearing: `core.hooksPath` **replaces** the hooks directory wholesale, so without them the pre-commit framework (black, flake8, markdownlint) silently stops running in that worktree.
- **`.graphifyignore`**: exclude `plan/history/` — 1000+ append-only archive entries whose historical narrative adds weakly-connected nodes and distorts community detection. Cuts the semantic-extraction corpus from 1233 files to 171.
- **`README-DEV.md`**: document the worktree opt-in, the `--worktree` vs `--local` distinction, and the two caveats below.

## Known tradeoffs (documented, not bugs)

- The rebuild re-runs community detection, so descriptive community names can be replaced by hub-node symbol names (`CasePersistence` rather than `Case Persistence & DataLayer Actions`). Structure and edges are unaffected. `no_cluster=True` is not a fix — it drops community structure entirely.
- Coverage is code-only. Doc/markdown/ADR changes still need `/graphify . --update` for semantic extraction; the hook prints a reminder rather than silently skipping.

## Verification

- Hook tested end-to-end on a real commit touching 2 `.py` files: rebuild completed, graph went to 22,868 nodes / 48,767 edges with 0 dangling edges, 0 absolute `source_file` values, and `plan/history/` correctly excluded.
- Docs-only skip path verified (prints the `/graphify . --update` reminder instead of rebuilding).
- Config scope verified as `worktree`, not `local`; other worktrees confirmed to still have `core.hooksPath` unset.
- `pre-commit run --files` on all changed files: markdownlint and flake8 pass, rest skipped (no matching files).
- Black (1184 files), mypy (659 files), pyright: clean. The 3 pre-existing flake8 findings in `scripts/` are unchanged on `origin/main` and untouched here.
- `sh -n` syntax check passes on all three hooks; no hardcoded paths or worktree names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)