### PR TITLE
Demo CI: scenario coverage analysis and minimum PR validation set (DEMOCI-06)

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -1,10 +1,14 @@
-# Demo Integration — build and run the two-actor Vultron demo on PRs.
+# Demo Integration — build and run the Vultron multi-actor demo on PRs and pushes.
 #
 # Kept separate from python-app.yml so that the Docker-compose build time
 # does not block the unit-test and lint pipeline; both workflows run
 # concurrently on PRs.  See specs/demo-ci.yaml DEMOCI-02-001.
 #
-# Triggers: PRs to main (path-filtered) and workflow_dispatch.
+# Triggers:
+#   pull_request  — minimum PR validation set (3 scenarios, DEMOCI-06-002)
+#   push to main  — full 8-scenario suite (DEMOCI-06-003, DEMOCI-05-001)
+#   workflow_dispatch — full 8-scenario suite (for manual re-runs)
+#
 # Dependabot PRs are skipped — python-app.yml still guards broken deps.
 # See DEMOCI-02-002, DEMOCI-02-003, DEMOCI-02-004.
 #
@@ -14,6 +18,17 @@
 #
 # This gives each scenario two independent pass/fail statuses on the PR so
 # invariant failures are visible even when the demo job itself fails.
+#
+# Minimum PR set (DEMOCI-06-002): fv, fvcv-handoff, fcvcv
+#   - fv covers the 4 universal event types (2-actor baseline)
+#   - fvcv-handoff adds invite_actor_to_case + accept_invite_actor_to_case
+#     + ownership-transfer protocol path
+#   - fcvcv adds offer_case_participant and ≥3-actor invite/accept chains
+# Full set adds: fvv, fvcv-extension, fccv-extension, fccv-handoff, fcv
+#
+# The matrix includes a boolean `full_suite_only` field. On pull_request events
+# the job `if:` condition skips entries where full_suite_only==true, leaving
+# only the 3-scenario minimum PR set running. On push/dispatch all 8 run.
 
 name: Demo Integration
 
@@ -26,6 +41,15 @@ on:
       - "integration_tests/**"
       # Invariant harness / CI test changes must re-run the demos that feed
       # them, else a broken assertion merges untested (see #1602 regression).
+      - "test/ci/**"
+      - "pyproject.toml"
+      - "uv.lock"
+  push:
+    branches: ["main"]
+    paths:
+      - "vultron/**"
+      - "docker/**"
+      - "integration_tests/**"
       - "test/ci/**"
       - "pyproject.toml"
       - "uv.lock"
@@ -42,29 +66,41 @@ jobs:
     # DEMOCI-02-009: 15-minute cap to prevent indefinite hangs.
     timeout-minutes: 15
     # DEMOCI-02-004: skip Dependabot PRs; python-app.yml guards broken deps.
-    if: "!startsWith(github.head_ref, 'dependabot/')"
-    # DEMOCI-03-003, DEMOCI-03-004, DEMOCI-03-005: matrix over scenarios so
-    # failures are independently reported and each entry declares its test_file.
+    # DEMOCI-06-002: on pull_request, skip full-suite-only entries so only the
+    # minimum 3-scenario PR validation set runs.
+    if: >-
+      !startsWith(github.head_ref, 'dependabot/') &&
+      (github.event_name != 'pull_request' || matrix.full_suite_only == false)
     strategy:
       fail-fast: false
       matrix:
+        # DEMOCI-06-002 minimum PR validation set (full_suite_only: false).
+        # DEMOCI-06-003 additional scenarios (full_suite_only: true — push/dispatch only).
         include:
           - demo: fv
             test_file: test/ci/invariants/test_fv_invariants.py
-          - demo: fvv
-            test_file: test/ci/invariants/test_fvv_invariants.py
-          - demo: fvcv-extension
-            test_file: test/ci/invariants/test_fvcv_extension_invariants.py
+            full_suite_only: false
           - demo: fvcv-handoff
             test_file: test/ci/invariants/test_fvcv_handoff_invariants.py
-          - demo: fccv-extension
-            test_file: test/ci/invariants/test_fccv_extension_invariants.py
-          - demo: fccv-handoff
-            test_file: test/ci/invariants/test_fccv_handoff_invariants.py
+            full_suite_only: false
           - demo: fcvcv
             test_file: test/ci/invariants/test_fcvcv_invariants.py
+            full_suite_only: false
+          - demo: fvv
+            test_file: test/ci/invariants/test_fvv_invariants.py
+            full_suite_only: true
+          - demo: fvcv-extension
+            test_file: test/ci/invariants/test_fvcv_extension_invariants.py
+            full_suite_only: true
+          - demo: fccv-extension
+            test_file: test/ci/invariants/test_fccv_extension_invariants.py
+            full_suite_only: true
+          - demo: fccv-handoff
+            test_file: test/ci/invariants/test_fccv_handoff_invariants.py
+            full_suite_only: true
           - demo: fcv
             test_file: test/ci/invariants/test_fcv_invariants.py
+            full_suite_only: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -140,28 +176,40 @@ jobs:
     runs-on: ubuntu-latest
     # DEMOCI-04-002: always run after the demo job, even on demo failure.
     # DEMOCI-02-004: skip Dependabot PRs (demo is skipped, no artifact exists).
+    # DEMOCI-06-002: mirror the demo job gate — skip full-suite-only entries on PR.
     needs: demo
-    if: always() && !startsWith(github.head_ref, 'dependabot/')
+    if: >-
+      always() &&
+      !startsWith(github.head_ref, 'dependabot/') &&
+      (github.event_name != 'pull_request' || matrix.full_suite_only == false)
     strategy:
       fail-fast: false
       matrix:
         include:
           - demo: fv
             test_file: test/ci/invariants/test_fv_invariants.py
-          - demo: fvv
-            test_file: test/ci/invariants/test_fvv_invariants.py
-          - demo: fvcv-extension
-            test_file: test/ci/invariants/test_fvcv_extension_invariants.py
+            full_suite_only: false
           - demo: fvcv-handoff
             test_file: test/ci/invariants/test_fvcv_handoff_invariants.py
-          - demo: fccv-extension
-            test_file: test/ci/invariants/test_fccv_extension_invariants.py
-          - demo: fccv-handoff
-            test_file: test/ci/invariants/test_fccv_handoff_invariants.py
+            full_suite_only: false
           - demo: fcvcv
             test_file: test/ci/invariants/test_fcvcv_invariants.py
+            full_suite_only: false
+          - demo: fvv
+            test_file: test/ci/invariants/test_fvv_invariants.py
+            full_suite_only: true
+          - demo: fvcv-extension
+            test_file: test/ci/invariants/test_fvcv_extension_invariants.py
+            full_suite_only: true
+          - demo: fccv-extension
+            test_file: test/ci/invariants/test_fccv_extension_invariants.py
+            full_suite_only: true
+          - demo: fccv-handoff
+            test_file: test/ci/invariants/test_fccv_handoff_invariants.py
+            full_suite_only: true
           - demo: fcv
             test_file: test/ci/invariants/test_fcv_invariants.py
+            full_suite_only: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -184,7 +232,3 @@ jobs:
         env:
           TEST_FILE: ${{ matrix.test_file }}
         run: uv run pytest "$TEST_FILE" -v --tb=short
-
-# Future scenarios to add when stable:
-#   - three-actor  (multi-coordinator; add as matrix entry per DEMOCI-03-003)
-#   - multi-vendor (add as matrix entry per DEMOCI-03-003)

--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -70,7 +70,7 @@ jobs:
     # minimum 3-scenario PR validation set runs.
     if: >-
       !startsWith(github.head_ref, 'dependabot/') &&
-      (github.event_name != 'pull_request' || matrix.full_suite_only == false)
+      (github.event_name != 'pull_request' || matrix.full_suite_only != true)
     strategy:
       fail-fast: false
       matrix:
@@ -181,7 +181,7 @@ jobs:
     if: >-
       always() &&
       !startsWith(github.head_ref, 'dependabot/') &&
-      (github.event_name != 'pull_request' || matrix.full_suite_only == false)
+      (github.event_name != 'pull_request' || matrix.full_suite_only != true)
     strategy:
       fail-fast: false
       matrix:

--- a/notes/README.md
+++ b/notes/README.md
@@ -558,6 +558,15 @@ scenario, and the spec-test sync rule.
 adding or changing a scenario's expected event types, or debugging a silent
 invariant harness failure in CI.
 
+**`demo-ci-scenario-coverage.md`**
+Coverage matrix mapping all 8 demo scenarios to the distinct protocol
+`event_type` values each exercises, plus the minimum-PR-validation-set
+analysis (DEMOCI-06): which 3 scenarios cover all 7 event types, rationale
+for the minimum set, and workflow implementation notes.
+**Load when**: evaluating which demo scenarios to include in the PR gate,
+adding a new scenario and determining whether it changes the minimum set, or
+auditing `full_suite_only` assignments in `demo-integration.yml`.
+
 **`codebase-structure-fastapi-patterns.md`**
 FastAPI and test infrastructure patterns: router test override pattern
 (`_shared_dl`, `dependency_overrides`), circular import fix pattern

--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -1,0 +1,107 @@
+---
+title: Demo CI Scenario Coverage Matrix and Minimum PR Validation Set
+status: active
+related_specs:
+  - specs/demo-ci.yaml
+  - specs/multi-actor-demo.yaml
+---
+
+# Demo CI: Scenario Coverage Matrix and Minimum PR Validation Set
+
+Spec: DEMOCI-06. Analysis performed as part of ISSUE-1996.
+
+## Coverage Matrix
+
+The table below maps each of the 8 demo scenarios to the distinct protocol
+event types it exercises. Event types are those recorded as `event_type` in
+`CaseLedgerEntry` and validated by Invariant 5
+(`test_invariant_5_expected_event_types_present`) in each scenario's
+`test/ci/invariants/test_XXX_invariants.py` file.
+
+| Scenario | validate_report | add_participant_status_to_participant | close_case | add_note_to_case | invite_actor_to_case | offer_case_participant | accept_invite_actor_to_case |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| fv                | ✓ | ✓ | ✓ | ✓ |   |   |   |
+| fvv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
+| fvcv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| fvcv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
+| fccv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| fccv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
+| fcvcv             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| fcv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
+
+**Notes:**
+
+- The four universal types (`validate_report`, `add_participant_status_to_participant`,
+  `close_case`, `add_note_to_case`) appear in every scenario (DEMOMA-16-001).
+- Ownership transfer (`attributed_to` mutation via `AcceptCaseOwnershipTransferNode`)
+  is exercised by `fvcv-handoff` and `fccv-handoff` but does **not** emit a
+  `CaseLedgerEntry` with a named `event_type`. It is therefore not observable via
+  Invariant 5 — instead it is verified by `demo_check` assertions in the scenario
+  script itself. The ownership-transfer protocol path is covered by `fvcv-handoff`
+  in the minimum PR set.
+- `fccv-extension` spec entry DEMOMA-16-010 was added as part of ISSUE-1996;
+  the test constant was already correct.
+- `fvv`, `fvcv-extension`, and `fcv` were missing `accept_invite_actor_to_case`
+  from their `_EXPECTED_EVENT_TYPES` lists; corrected as part of ISSUE-1996 (AC-2).
+
+## AC-2 Corrections Applied
+
+| File | Added event type |
+|---|---|
+| `test/ci/invariants/test_fvv_invariants.py` | `accept_invite_actor_to_case` |
+| `test/ci/invariants/test_fcv_invariants.py` | `accept_invite_actor_to_case` |
+| `test/ci/invariants/test_fvcv_extension_invariants.py` | `accept_invite_actor_to_case` |
+
+Corresponding DEMOMA-16 spec entries updated: 16-003, 16-004, 16-007.
+New spec entry DEMOMA-16-010 added for `fccv-extension`.
+
+## Minimum PR Validation Set (DEMOCI-06-002)
+
+**Set: `fv`, `fvcv-handoff`, `fcvcv`**
+
+| Scenario | Covered by minimum set | Rationale |
+|---|:---:|---|
+| fv | ✓ (member) | 2-actor baseline; covers all 4 universal event types with no invitation phases |
+| fvcv-handoff | ✓ (member) | Adds `invite_actor_to_case` + `accept_invite_actor_to_case` + ownership-transfer protocol path |
+| fcvcv | ✓ (member) | Adds `offer_case_participant` + ≥3-actor invite/accept chains |
+| fvv | covered by fvcv-handoff | Same invite+accept coverage; no additional phases |
+| fvcv-extension | covered by fcvcv | Same offer+invite+accept coverage; no additional phases |
+| fccv-extension | covered by fcvcv | Same offer+invite+accept coverage; no additional phases |
+| fccv-handoff | covered by fvcv-handoff | Same invite+accept+ownership-transfer; no additional phases |
+| fcv | covered by fvcv-handoff | Same invite+accept coverage; no additional phases |
+
+### Coverage proof
+
+The minimum set of 3 scenarios covers all 7 distinct event types:
+
+| Event type | Covered by |
+|---|---|
+| validate_report | fv |
+| add_participant_status_to_participant | fv |
+| close_case | fv |
+| add_note_to_case | fv |
+| invite_actor_to_case | fvcv-handoff |
+| accept_invite_actor_to_case | fvcv-handoff |
+| offer_case_participant | fcvcv |
+
+The 5 remaining scenarios (`fvv`, `fvcv-extension`, `fccv-extension`,
+`fccv-handoff`, `fcv`) produce no event type not already covered by the
+minimum set. They run only on push to `main` (DEMOCI-06-003) to provide
+regression coverage without increasing PR wall-clock cost.
+
+## Workflow Implementation (DEMOCI-06-003)
+
+`.github/workflows/demo-integration.yml` was updated to:
+
+1. Add a `push: branches: ["main"]` trigger (implements DEMOCI-05-001 and
+   DEMOCI-06-003, which were previously unimplemented).
+2. Mark `fv`, `fvcv-handoff`, and `fcvcv` as `full_suite_only: false` — they
+   run on every `pull_request` event.
+3. Mark the remaining 5 scenarios as `full_suite_only: true` — they run only
+   on `push` to main and `workflow_dispatch`.
+4. Add a job-level `if:` condition that skips `full_suite_only: true` entries
+   on `pull_request` events. Both `demo` and `invariant-harness` jobs carry the
+   same gate condition so the artifact/download pairing stays consistent.
+
+See ADR-0052 for the accepted barrier + concurrency group design that DEMOCI-06
+finalises.

--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -18,16 +18,16 @@ event types it exercises. Event types are those recorded as `event_type` in
 (`test_invariant_5_expected_event_types_present`) in each scenario's
 `test/ci/invariants/test_XXX_invariants.py` file.
 
-| Scenario | validate_report | add_participant_status_to_participant | close_case | add_note_to_case | invite_actor_to_case | offer_case_participant | accept_invite_actor_to_case |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| fv                | ✓ | ✓ | ✓ | ✓ |   |   |   |
-| fvv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
-| fvcv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| fvcv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
-| fccv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| fccv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
-| fcvcv             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| fcv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
+| Scenario | validate_report | add_participant_status_to_participant | close_case | add_note_to_case | invite_actor_to_case | offer_case_participant | accept_invite_actor_to_case | accept_actor_recommendation |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| fv                | ✓ | ✓ | ✓ | ✓ |   |   |   |   |
+| fvv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |
+| fvcv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| fvcv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |
+| fccv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| fccv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |
+| fcvcv             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| fcv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |
 
 **Notes:**
 
@@ -39,10 +39,23 @@ event types it exercises. Event types are those recorded as `event_type` in
   Invariant 5 — instead it is verified by `demo_check` assertions in the scenario
   script itself. The ownership-transfer protocol path is covered by `fvcv-handoff`
   in the minimum PR set.
+- `accept_actor_recommendation` is emitted by `AcceptActorRecommendationNode`
+  (`vultron/core/behaviors/case/nodes/suggest_actor/emit.py:283`) when an actor
+  approves a suggested participant. It fires only in scenarios that include the
+  ADR-0026 suggest-actor flow: `fvcv-extension`, `fccv-extension`, and `fcvcv`.
+- `add_case_participant` is emitted by `AcceptInviteNode`
+  (`vultron/core/behaviors/case/nodes/accept_invite.py:181`) on the CaseActor
+  received-side when processing Accept(Invite). This event records the internal
+  participant-list bookkeeping rather than a protocol-visible coordination action.
+  It fires in every scenario with invite/accept flows (7 of 8) but is intentionally
+  excluded from `_EXPECTED_EVENT_TYPES` lists: it is a `CaseActor`-internal
+  ledger entry, not a coordination event that invariant checks should mandate.
 - `fccv-extension` spec entry DEMOMA-16-010 was added as part of ISSUE-1996;
   the test constant was already correct.
 - `fvv`, `fvcv-extension`, and `fcv` were missing `accept_invite_actor_to_case`
   from their `_EXPECTED_EVENT_TYPES` lists; corrected as part of ISSUE-1996 (AC-2).
+- `fcvcv`, `fvcv-extension`, and `fccv-extension` were missing
+  `accept_actor_recommendation`; corrected as part of ISSUE-1996 (AC-2 follow-up).
 
 ## AC-2 Corrections Applied
 
@@ -51,9 +64,56 @@ event types it exercises. Event types are those recorded as `event_type` in
 | `test/ci/invariants/test_fvv_invariants.py` | `accept_invite_actor_to_case` |
 | `test/ci/invariants/test_fcv_invariants.py` | `accept_invite_actor_to_case` |
 | `test/ci/invariants/test_fvcv_extension_invariants.py` | `accept_invite_actor_to_case` |
+| `test/ci/invariants/test_fcvcv_invariants.py` | `accept_actor_recommendation` |
+| `test/ci/invariants/test_fvcv_extension_invariants.py` | `accept_actor_recommendation` |
+| `test/ci/invariants/test_fccv_extension_invariants.py` | `accept_actor_recommendation` |
 
 Corresponding DEMOMA-16 spec entries updated: 16-003, 16-004, 16-007.
 New spec entry DEMOMA-16-010 added for `fccv-extension`.
+
+## Coverage Scope: What the Matrix Covers and Why
+
+The matrix above is scoped to `CaseLedgerEntry.event_type` values that represent
+distinct **coordination protocol phases** — actions a participant takes that
+advance the CVD protocol state and are recorded in the replicated case ledger.
+
+### Dimensions in scope (observable via Invariant 5)
+
+| Column | Protocol phase |
+|---|---|
+| `validate_report` | Report validation (RM state: received → valid) |
+| `add_participant_status_to_participant` | Participant status tracking |
+| `close_case` | Case closure |
+| `add_note_to_case` | Case note / information sharing |
+| `invite_actor_to_case` | Actor invitation |
+| `offer_case_participant` | Suggest-actor flow (ADR-0026) |
+| `accept_invite_actor_to_case` | Invitation acceptance |
+| `accept_actor_recommendation` | Recommendation approval (ADR-0026) |
+
+### Dimensions covered outside Invariant 5
+
+| Dimension | Covered by | How verified |
+|---|---|---|
+| Ownership transfer | `fvcv-handoff`, `fccv-handoff` | `demo_check` assertions in scenario script (not a ledger event_type) |
+| CVD role variation | All 8 scenarios | Scenario scripts define actor roles (deployer/vendor-only/coordinator) |
+| Fix-ready / fix-deployed lifecycle (VFd vs VFD) | All scenarios run to RM closed | Invariant 7 (`test_invariant_7_log_terminates_all_rm_closed`) |
+| Multi-vendor vs single-vendor fix paths | `fvv`, `fcvcv`, `fvcv-extension` (multiple vendors) vs `fv`, `fcv` (single) | Scenario composition; covered by minimum set via `fcvcv` |
+| Embargo lifecycle phases | Scenarios with Coordinator actors | `demo_check` + EM state assertions in scenario scripts |
+
+### Why the minimum set is sufficient
+
+The 3-scenario minimum set (`fv`, `fvcv-handoff`, `fcvcv`) covers all 8
+`event_type` columns and the ownership-transfer path. The additional dimensions
+(CVD role variation, multi-vendor fix paths, embargo phases) are either:
+
+- exercised by multiple minimum-set scenarios (multi-vendor: `fcvcv`), or
+- verified by separate invariants that do not require additional scenarios (RM
+  closure: Invariant 7), or
+- scenario-script `demo_check` assertions that run with the scenario regardless
+  of which CI tier it lands in.
+
+The 5 full-suite-only scenarios add regression depth but not breadth relative to
+the minimum set's event-type and protocol-path coverage.
 
 ## Minimum PR Validation Set (DEMOCI-06-002)
 
@@ -63,7 +123,7 @@ New spec entry DEMOMA-16-010 added for `fccv-extension`.
 |---|:---:|---|
 | fv | ✓ (member) | 2-actor baseline; covers all 4 universal event types with no invitation phases |
 | fvcv-handoff | ✓ (member) | Adds `invite_actor_to_case` + `accept_invite_actor_to_case` + ownership-transfer protocol path |
-| fcvcv | ✓ (member) | Adds `offer_case_participant` + ≥3-actor invite/accept chains |
+| fcvcv | ✓ (member) | Adds `offer_case_participant` + `accept_actor_recommendation` + ≥3-actor invite/accept chains |
 | fvv | covered by fvcv-handoff | Same invite+accept coverage; no additional phases |
 | fvcv-extension | covered by fcvcv | Same offer+invite+accept coverage; no additional phases |
 | fccv-extension | covered by fcvcv | Same offer+invite+accept coverage; no additional phases |
@@ -72,7 +132,7 @@ New spec entry DEMOMA-16-010 added for `fccv-extension`.
 
 ### Coverage proof
 
-The minimum set of 3 scenarios covers all 7 distinct event types:
+The minimum set of 3 scenarios covers all 8 distinct event types:
 
 | Event type | Covered by |
 |---|---|
@@ -83,6 +143,7 @@ The minimum set of 3 scenarios covers all 7 distinct event types:
 | invite_actor_to_case | fvcv-handoff |
 | accept_invite_actor_to_case | fvcv-handoff |
 | offer_case_participant | fcvcv |
+| accept_actor_recommendation | fcvcv |
 
 The 5 remaining scenarios (`fvv`, `fvcv-extension`, `fccv-extension`,
 `fccv-handoff`, `fcv`) produce no event type not already covered by the

--- a/plan/history/2608/implementation/ISSUE-1996.md
+++ b/plan/history/2608/implementation/ISSUE-1996.md
@@ -1,0 +1,30 @@
+---
+source: ISSUE-1996
+timestamp: '2026-08-06T14:51:42.136878+00:00'
+title: Demo CI scenario coverage analysis and minimum PR validation set
+type: implementation
+---
+
+## Issue #1996 — Demo CI: scenario coverage analysis and minimum PR validation set (DEMOCI-06)
+
+Implemented all 7 acceptance criteria. PR: <https://github.com/CERTCC/Vultron/pull/2030>
+
+### What was done
+
+**AC-2 — Fix invariant constants**: Added `accept_invite_actor_to_case` to `_EXPECTED_EVENT_TYPES` in `test_fvv_invariants.py`, `test_fcv_invariants.py`, and `test_fvcv_extension_invariants.py`. All three scenarios call `accept-case-invite` triggers in their scenario scripts but the event type was missing from Invariant 5.
+
+**AC-2 spec**: Updated DEMOMA-16-003, 16-004, 16-007 to require `accept_invite_actor_to_case`. Added DEMOMA-16-010 for `fccv-extension` (test was correct, spec entry was missing).
+
+**AC-3/AC-6 — Coverage notes**: Created `notes/demo-ci-scenario-coverage.md` with 8-scenario coverage matrix, correction log, minimum-set coverage proof, and workflow notes.
+
+**AC-4 — Minimum PR set**: `fv` + `fvcv-handoff` + `fcvcv` covers all 7 distinct protocol event types. The 5 remaining scenarios exercise no event type not already covered.
+
+**AC-5 — Workflow split**: Added `push: branches: ["main"]` trigger (implements DEMOCI-05-001, previously unimplemented). Added `full_suite_only` boolean matrix field with job-level `if:` gates. PR runs 3-scenario minimum set; push/dispatch runs all 8.
+
+**AC-7 — DEMOCI-06 spec**: Updated DEMOCI-06-001/002/003 with validated minimum set, corrected scenario count (7→8), and push trigger requirement.
+
+### Key findings
+
+- Ownership transfer is NOT a `CaseLedgerEntry` event_type — it is verified by `demo_check` assertions in the scenario scripts. It is covered by `fvcv-handoff` in the minimum PR set without needing a separate event-type entry.
+- DEMOCI-05-001 (push-to-main trigger) was not implemented in the workflow prior to this PR. DEMOCI-06 depended on it and this PR implements both together.
+- `fccv-extension` test file (`test_fccv_extension_invariants.py`) was already correct — only the spec entry was missing.

--- a/plan/incoming/learnings/20260806-democi05-push-trigger-not-implemented.md
+++ b/plan/incoming/learnings/20260806-democi05-push-trigger-not-implemented.md
@@ -1,0 +1,24 @@
+---
+title: DEMOCI-05-001 push-to-main trigger was specced but not implemented
+type: learning
+timestamp: 2026-08-06T14:55:00Z
+source: ISSUE-1996
+signal: process-issue
+---
+
+DEMOCI-05-001 requires the demo-integration workflow to run on push events to
+main. DEMOCI-06 explicitly depends on it (DEMOCI-06-003 refines DEMOCI-05-001).
+However, the `demo-integration.yml` workflow had no `push:` trigger before
+PR #2030 — only `pull_request` and `workflow_dispatch`.
+
+Neither the DEMOCI-06 issue body nor the DEMOCI-05 spec entry flagged that
+DEMOCI-05-001 was unimplemented. DEMOCI-06 was accepted as a task without this
+blocker being surfaced.
+
+The gap was discovered during implementation and the push trigger was added in
+the same PR (PR #2030). But DEMOCI-05 should be marked as having an open
+implementation gap — or a dedicated task should have been created to implement
+the push trigger before DEMOCI-06 was built on top of it.
+
+Action: consider whether DEMOCI-05 needs a follow-up spec verification step
+to confirm all DEMOCI-05-001 requirements are now satisfied in the merged workflow.

--- a/plan/incoming/learnings/20260806-gha-matrix-boolean-coercion.md
+++ b/plan/incoming/learnings/20260806-gha-matrix-boolean-coercion.md
@@ -1,0 +1,32 @@
+---
+title: GHA matrix boolean fields are coerced to strings in if: expressions
+type: learning
+timestamp: 2026-08-06T14:55:00Z
+source: ISSUE-1996
+signal: concern
+---
+
+In `.github/workflows/demo-integration.yml` (PR #2030), the `full_suite_only`
+matrix field is declared as a YAML boolean (`false`/`true`) and referenced in
+job `if:` conditions as:
+
+```yaml
+github.event_name != 'pull_request' || matrix.full_suite_only == false
+```
+
+GitHub Actions evaluates matrix context values as strings in `if:` expressions.
+The boolean `false` may be coerced to the string `"false"`, causing
+`matrix.full_suite_only == false` to always be `false` (a string never equals
+a boolean). If so, all 8 scenarios would run on every PR, defeating the
+minimum-set split.
+
+The safe form is:
+
+```yaml
+github.event_name != 'pull_request' || matrix.full_suite_only != true
+```
+
+or declare the field as a string in the matrix (`full_suite_only: "false"`) and
+compare as a string. This should be validated by observing the first PR that
+fires after the workflow merges — if all 8 scenarios run on that PR instead of
+3, the coercion bug is confirmed and the condition needs updating.

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -489,14 +489,15 @@ groups:
         kind: project
         statement: >-
           A scenario coverage analysis MUST be performed that maps each of the
-          7 demo scenarios to the distinct Vultron protocol phases and
+          8 demo scenarios to the distinct Vultron protocol phases and
           message-type milestones it exercises, producing a coverage matrix.
           The analysis MUST inspect the actual milestone sets defined in each
           scenario script (not assume they are complete), and MAY update
           scenario milestone sets where copy-paste from simpler scenarios has
-          left them incomplete.
+          left them incomplete. The validated coverage matrix MUST be recorded
+          in `notes/demo-ci-scenario-coverage.md`.
         rationale: >-
-          The 7 scenarios share common helper phases but each exercises a
+          The 8 scenarios share common helper phases but each exercises a
           distinct set of protocol phases (e.g. invite_actor_to_case,
           offer_case_participant, accept_invite_actor_to_case). Milestone sets
           were often copied from simpler scenarios and may under-report what a
@@ -512,17 +513,21 @@ groups:
         priority: MUST
         kind: project
         statement: >-
-          Based on the coverage matrix (DEMOCI-06-001), a minimum PR validation
-          scenario set MUST be defined: the smallest subset of scenarios that
-          together covers all distinct protocol phases exercised by the full
-          scenario suite. Scenarios not in the minimum set SHOULD run only on
-          the post-merge (push-to-main) trigger, reducing the PR matrix size
-          and thus the fan-in barrier wall-clock cost.
+          The minimum PR validation scenario set is `fv`, `fvcv-handoff`, and
+          `fcvcv`. Together these three scenarios cover all 7 distinct protocol
+          event types exercised by the full 8-scenario suite: the four universal
+          types plus `invite_actor_to_case`, `offer_case_participant`, and
+          `accept_invite_actor_to_case`. The `demo-integration.yml` workflow
+          MUST use this 3-scenario set as the `pull_request` matrix and run
+          only these scenarios on every PR commit.
         rationale: >-
-          Running all scenarios on every PR commit incurs a fan-in barrier
-          proportional to the slowest scenario. A minimum set that preserves
-          full protocol coverage lets the PR run faster while the post-merge
-          run retains full coverage for regression detection. See ADR-0052.
+          Running all 8 scenarios on every PR commit incurs a fan-in barrier
+          proportional to the slowest scenario. The 3-scenario minimum set
+          preserves full protocol-phase coverage while reducing PR wall-clock
+          cost. FV covers the 2-actor baseline; FVCV-handoff adds invite +
+          accept + ownership-transfer; FCVCV adds offer_case_participant and
+          ≥3-actor invite/accept chains. Rationale recorded in
+          `notes/demo-ci-scenario-coverage.md`. See ADR-0052.
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-06-001
@@ -531,10 +536,13 @@ groups:
         priority: MUST
         kind: project
         statement: >-
-          The full scenario suite MUST continue to run on push events to main
-          (DEMOCI-05-001), regardless of which subset runs for PR validation,
-          so that all scenario variants continue to generate case-log invariant
-          signals on the default branch.
+          The full 8-scenario suite MUST run on push events to main, regardless
+          of which subset runs for PR validation, so that all scenario variants
+          continue to generate case-log invariant signals on the default branch.
+          The `demo-integration.yml` workflow MUST include a `push: branches:
+          ["main"]` trigger that runs all 8 scenarios (`fv`, `fvv`,
+          `fvcv-extension`, `fvcv-handoff`, `fccv-extension`, `fccv-handoff`,
+          `fcvcv`, `fcv`).
         rationale: >-
           The post-merge run is the safety net for cross-PR regressions; it
           must cover all scenarios to ensure no scenario silently degrades after

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -514,20 +514,21 @@ groups:
         kind: project
         statement: >-
           The minimum PR validation scenario set is `fv`, `fvcv-handoff`, and
-          `fcvcv`. Together these three scenarios cover all 7 distinct protocol
+          `fcvcv`. Together these three scenarios cover all 8 distinct protocol
           event types exercised by the full 8-scenario suite: the four universal
-          types plus `invite_actor_to_case`, `offer_case_participant`, and
-          `accept_invite_actor_to_case`. The `demo-integration.yml` workflow
-          MUST use this 3-scenario set as the `pull_request` matrix and run
-          only these scenarios on every PR commit.
+          types plus `invite_actor_to_case`, `offer_case_participant`,
+          `accept_invite_actor_to_case`, and `accept_actor_recommendation`. The
+          `demo-integration.yml` workflow MUST use this 3-scenario set as the
+          `pull_request` matrix and run only these scenarios on every PR commit.
         rationale: >-
           Running all 8 scenarios on every PR commit incurs a fan-in barrier
           proportional to the slowest scenario. The 3-scenario minimum set
           preserves full protocol-phase coverage while reducing PR wall-clock
           cost. FV covers the 2-actor baseline; FVCV-handoff adds invite +
-          accept + ownership-transfer; FCVCV adds offer_case_participant and
-          ≥3-actor invite/accept chains. Rationale recorded in
-          `notes/demo-ci-scenario-coverage.md`. See ADR-0052.
+          accept + ownership-transfer; FCVCV adds offer_case_participant,
+          accept_actor_recommendation, and ≥3-actor invite/accept chains.
+          Rationale recorded in `notes/demo-ci-scenario-coverage.md`. See
+          ADR-0052.
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-06-001

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1861,8 +1861,10 @@ groups:
     kind: project
     statement: >-
       The FVV scenario expected-event-types list MUST include
-      `invite_actor_to_case` in addition to the four universal types
-      (DEMOMA-16-001), because Vendor1 invites Vendor2 into the case.
+      `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
+      to the four universal types (DEMOMA-16-001), because Vendor1 invites
+      Vendor2 into the case and Vendor2 explicitly accepts via the
+      `accept-case-invite` trigger.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001
@@ -1874,10 +1876,12 @@ groups:
     kind: project
     statement: >-
       The FVCV-extension scenario expected-event-types list MUST include
-      `invite_actor_to_case` and `offer_case_participant` in addition to the
-      four universal types (DEMOMA-16-001), because Vendor1 invites
-      Coordinator, and Coordinator uses the ADR-0026 suggest-actor flow
-      (`offer_case_participant`) to propose Vendor2.
+      `invite_actor_to_case`, `offer_case_participant`, and
+      `accept_invite_actor_to_case` in addition to the four universal types
+      (DEMOMA-16-001), because Vendor1 invites Coordinator, Coordinator uses
+      the ADR-0026 suggest-actor flow (`offer_case_participant`) to propose
+      Vendor2, CaseActor converts the proposal into an invitation, and Vendor2
+      explicitly accepts via the `accept-case-invite` trigger.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001
@@ -1919,9 +1923,10 @@ groups:
     kind: project
     statement: >-
       The FCV scenario expected-event-types list MUST include
-      `invite_actor_to_case` in addition to the four universal types
-      (DEMOMA-16-001), because the Coordinator invites both the Finder
-      and the Vendor into the case.
+      `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
+      to the four universal types (DEMOMA-16-001), because the Coordinator
+      invites both the Finder and the Vendor into the case, and both Finder
+      and Vendor explicitly accept via the `accept-case-invite` trigger.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001
@@ -1970,6 +1975,23 @@ groups:
       spec_id: DEMOMA-16-001
     - rel_type: refines
       spec_id: DEMOMA-19-001
+
+  - id: DEMOMA-16-010
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCCV-extension scenario expected-event-types list MUST include
+      `invite_actor_to_case`, `offer_case_participant`, and
+      `accept_invite_actor_to_case` in addition to the four universal types
+      (DEMOMA-16-001), because Coordinator1 invites Coordinator2, Coordinator2
+      uses the ADR-0026 suggest-actor flow (`offer_case_participant`) to propose
+      the Vendor, CaseActor converts the proposal into an invitation, and the
+      Vendor explicitly accepts via the `accept-case-invite` trigger.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+    - rel_type: refines
+      spec_id: DEMOMA-13-001
 
 - id: DEMOMA-18
   title: In-Process Fuzz Simulation Scenario

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1876,12 +1876,14 @@ groups:
     kind: project
     statement: >-
       The FVCV-extension scenario expected-event-types list MUST include
-      `invite_actor_to_case`, `offer_case_participant`, and
-      `accept_invite_actor_to_case` in addition to the four universal types
-      (DEMOMA-16-001), because Vendor1 invites Coordinator, Coordinator uses
-      the ADR-0026 suggest-actor flow (`offer_case_participant`) to propose
-      Vendor2, CaseActor converts the proposal into an invitation, and Vendor2
-      explicitly accepts via the `accept-case-invite` trigger.
+      `invite_actor_to_case`, `offer_case_participant`,
+      `accept_invite_actor_to_case`, and `accept_actor_recommendation` in
+      addition to the four universal types (DEMOMA-16-001), because Vendor1
+      invites Coordinator, Coordinator uses the ADR-0026 suggest-actor flow
+      (`offer_case_participant`) to propose Vendor2, Vendor1 approves the
+      recommendation (`accept_actor_recommendation`), CaseActor converts the
+      approval into an invitation, and Vendor2 explicitly accepts via the
+      `accept-case-invite` trigger.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001
@@ -1955,21 +1957,24 @@ groups:
     kind: project
     statement: >-
       The FCVCV scenario expected-event-types list MUST include
-      `invite_actor_to_case`, `offer_case_participant`, and
-      `accept_invite_actor_to_case` in addition to the four universal types
-      (DEMOMA-16-001). `invite_actor_to_case` appears at least three times
-      (C1 invites V1, C1 invites C2, and CaseActor invites V2 via the
-      ADR-0026 path); `offer_case_participant` appears at least once (C2
-      suggests V2 to C1 via the ADR-0026 suggest-actor flow);
+      `invite_actor_to_case`, `offer_case_participant`,
+      `accept_invite_actor_to_case`, and `accept_actor_recommendation` in
+      addition to the four universal types (DEMOMA-16-001).
+      `invite_actor_to_case` appears at least three times (C1 invites V1, C1
+      invites C2, and CaseActor invites V2 via the ADR-0026 path);
+      `offer_case_participant` appears at least once (C2 suggests V2 to C1
+      via the ADR-0026 suggest-actor flow); `accept_actor_recommendation`
+      appears at least once (C1 approves C2's recommendation);
       `accept_invite_actor_to_case` appears at least three times (V1, C2,
       and V2 each accept their respective invitations).
     rationale: >-
       FCVCV is the first scenario with two independent coordinators and two
       independent vendor actors. C1 directly invites V1 and C2; C2 suggests
-      V2 via ADR-0026 (offer_case_participant → CaseActor invite → V2
-      accept); all three vendor/coordinator invitees issue explicit accepts.
-      Verifying these event types confirms the full ADR-0026 suggest-actor
-      path and the multi-vendor invitation chain are exercised end-to-end.
+      V2 via ADR-0026 (offer_case_participant → C1 approves via
+      accept_actor_recommendation → CaseActor invite → V2 accept); all three
+      vendor/coordinator invitees issue explicit accepts. Verifying these
+      event types confirms the full ADR-0026 suggest-actor path and the
+      multi-vendor invitation chain are exercised end-to-end.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001
@@ -1981,12 +1986,14 @@ groups:
     kind: project
     statement: >-
       The FCCV-extension scenario expected-event-types list MUST include
-      `invite_actor_to_case`, `offer_case_participant`, and
-      `accept_invite_actor_to_case` in addition to the four universal types
-      (DEMOMA-16-001), because Coordinator1 invites Coordinator2, Coordinator2
-      uses the ADR-0026 suggest-actor flow (`offer_case_participant`) to propose
-      the Vendor, CaseActor converts the proposal into an invitation, and the
-      Vendor explicitly accepts via the `accept-case-invite` trigger.
+      `invite_actor_to_case`, `offer_case_participant`,
+      `accept_invite_actor_to_case`, and `accept_actor_recommendation` in
+      addition to the four universal types (DEMOMA-16-001), because
+      Coordinator1 invites Coordinator2, Coordinator2 uses the ADR-0026
+      suggest-actor flow (`offer_case_participant`) to propose the Vendor,
+      Coordinator1 approves the recommendation (`accept_actor_recommendation`),
+      CaseActor converts the approval into an invitation, and the Vendor
+      explicitly accepts via the `accept-case-invite` trigger.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001

--- a/test/ci/invariants/test_fccv_extension_invariants.py
+++ b/test/ci/invariants/test_fccv_extension_invariants.py
@@ -74,6 +74,10 @@ _FCCV_EXTENSION_EXPECTED_EVENT_TYPES = [
     pytest.param(
         "accept_invite_actor_to_case", id="accept_invite_actor_to_case"
     ),
+    # C1 approves C2's actor recommendation (ADR-0026 suggest-actor flow).
+    pytest.param(
+        "accept_actor_recommendation", id="accept_actor_recommendation"
+    ),
 ]
 
 #: Actors with per-actor chain / contiguity / completeness checks.

--- a/test/ci/invariants/test_fcv_invariants.py
+++ b/test/ci/invariants/test_fcv_invariants.py
@@ -9,6 +9,7 @@ Actor set: ``finder``, ``coordinator``, ``vendor``, ``case-actor``.
 FCV-specific invariants (DEMOMA-12-008/009):
 - ``validate_report`` event type is present (Coordinator validates Finder's report).
 - ``invite_actor_to_case`` appears at least twice (Finder + Vendor invitations).
+- ``accept_invite_actor_to_case`` appears at least twice (Finder and Vendor each accept).
 - ``close_case`` event type is present.
 - CS transitions VFd and VFD observed in Vendor's add_participant_status entries.
 - P-transition observed in Coordinator's add_participant_status entries.
@@ -59,8 +60,11 @@ _FCV_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
-    # DEMOMA-16-007: Coordinator invites both Finder and Vendor.
+    # DEMOMA-16-007: Coordinator invites both Finder and Vendor; both accept.
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
+    pytest.param(
+        "accept_invite_actor_to_case", id="accept_invite_actor_to_case"
+    ),
 ]
 
 #: Actors with per-actor chain / contiguity / completeness checks.

--- a/test/ci/invariants/test_fcvcv_invariants.py
+++ b/test/ci/invariants/test_fcvcv_invariants.py
@@ -75,6 +75,10 @@ _FCVCV_EXPECTED_EVENT_TYPES = [
     pytest.param(
         "accept_invite_actor_to_case", id="accept_invite_actor_to_case"
     ),
+    # C1 approves C2's actor recommendation (ADR-0026 suggest-actor flow).
+    pytest.param(
+        "accept_actor_recommendation", id="accept_actor_recommendation"
+    ),
 ]
 
 #: Actors with per-actor chain / contiguity / completeness checks.

--- a/test/ci/invariants/test_fvcv_extension_invariants.py
+++ b/test/ci/invariants/test_fvcv_extension_invariants.py
@@ -66,6 +66,10 @@ _FVCV_EXPECTED_EVENT_TYPES = [
     pytest.param(
         "accept_invite_actor_to_case", id="accept_invite_actor_to_case"
     ),
+    # Vendor1 approves Coordinator's actor recommendation (ADR-0026 suggest-actor flow).
+    pytest.param(
+        "accept_actor_recommendation", id="accept_actor_recommendation"
+    ),
 ]
 
 #: Actors with per-actor chain / contiguity / completeness checks.

--- a/test/ci/invariants/test_fvcv_extension_invariants.py
+++ b/test/ci/invariants/test_fvcv_extension_invariants.py
@@ -8,7 +8,9 @@ Actor set: ``finder``, ``vendor``, ``coordinator``, ``vendor2``,
 ``case-actor``.
 
 FVCV-extension-specific invariants:
-- ``invite_actor_to_case`` appears at least twice (Finder, then Vendor2).
+- ``invite_actor_to_case`` appears at least twice (Finder, then Vendor2 via CaseActor).
+- ``offer_case_participant`` appears at least once (Coordinator suggests Vendor2).
+- ``accept_invite_actor_to_case`` appears at least once (Vendor2 accepts CaseActor invite).
 - Vendor2 is a late joiner — replica holds the complete log from genesis.
 - Finder is a late joiner — replica holds the complete log from genesis.
 - Coordinator is a late joiner — replica holds the complete log from genesis.
@@ -56,10 +58,14 @@ _FVCV_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
-    # DEMOMA-16-004: Vendor1 invites Coordinator and Coordinator
-    # uses the suggest-actor flow to propose Vendor2.
+    # DEMOMA-16-004: Vendor1 invites Coordinator; Coordinator uses the
+    # suggest-actor flow (offer_case_participant) to propose Vendor2;
+    # CaseActor converts the offer to an invite; Vendor2 accepts.
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
     pytest.param("offer_case_participant", id="offer_case_participant"),
+    pytest.param(
+        "accept_invite_actor_to_case", id="accept_invite_actor_to_case"
+    ),
 ]
 
 #: Actors with per-actor chain / contiguity / completeness checks.

--- a/test/ci/invariants/test_fvv_invariants.py
+++ b/test/ci/invariants/test_fvv_invariants.py
@@ -10,6 +10,7 @@ Universal invariants (1–15) are applied via ``common.py``.
 
 FVV-specific invariants:
 - ``invite_actor_to_case`` appears at least once (Vendor1 invites Vendor2).
+- ``accept_invite_actor_to_case`` appears at least once (Vendor2 accepts).
 - Vendor2 replica holds the complete log from genesis (late-joiner backfill).
 - Finder replica holds the complete log from genesis (late-joiner backfill).
 
@@ -55,8 +56,11 @@ _FVV_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
-    # DEMOMA-16-003: Vendor1 invites Vendor2.
+    # DEMOMA-16-003: Vendor1 invites Vendor2; Vendor2 accepts.
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
+    pytest.param(
+        "accept_invite_actor_to_case", id="accept_invite_actor_to_case"
+    ),
 ]
 
 #: Actors with per-actor chain / contiguity / completeness checks.


### PR DESCRIPTION
- Closes #1996
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Implements DEMOCI-06: performs the 8-scenario coverage analysis, corrects three invariant test files that were missing `accept_invite_actor_to_case` (AC-2), documents the minimum PR validation set (`fv` + `fvcv-handoff` + `fcvcv`), and splits the demo-integration workflow so PRs run only the 3-scenario minimum set while pushes to main run all 8.

## Changes

- **`test/ci/invariants/test_fvv_invariants.py`**: add `accept_invite_actor_to_case` to `_FVV_EXPECTED_EVENT_TYPES` (AC-2 — Vendor2 explicitly accepts via `accept-case-invite` trigger)
- **`test/ci/invariants/test_fcv_invariants.py`**: add `accept_invite_actor_to_case` to `_FCV_EXPECTED_EVENT_TYPES` (AC-2 — Finder and Vendor both accept)
- **`test/ci/invariants/test_fvcv_extension_invariants.py`**: add `accept_invite_actor_to_case` to `_FVCV_EXPECTED_EVENT_TYPES` (AC-2 — Vendor2 accepts CaseActor invite after ADR-0026 suggest-actor flow)
- **`specs/multi-actor-demo.yaml`**: update DEMOMA-16-003/004/007 to require `accept_invite_actor_to_case`; add DEMOMA-16-010 for `fccv-extension` (spec entry was missing; test was already correct)
- **`notes/demo-ci-scenario-coverage.md`**: new file — 8-scenario coverage matrix, AC-2 correction log, minimum-set coverage proof, and workflow implementation notes (AC-3/AC-6)
- **`specs/demo-ci.yaml`**: update DEMOCI-06-001/002/003 — correct scenario count (7→8), document validated minimum set (`fv`/`fvcv-handoff`/`fcvcv`), require push trigger (AC-7)
- **`.github/workflows/demo-integration.yml`**: add `push: branches: ["main"]` trigger with same `paths:` filter as PR trigger; add `full_suite_only` matrix field; add `if:` gates on `demo` and `invariant-harness` jobs to skip full-suite-only entries on `pull_request` events (AC-5 + DEMOCI-05-001)

## Verification

- All 6429 unit tests pass (0 new failures; 2 pre-existing xfail)
- Black, flake8, mypy, pyright clean
- `test_notes_frontmatter` passes for new notes file
- Pre-commit hooks (black, markdownlint, notes frontmatter, flake8, spec linter) all pass