### PR TITLE
chore(orient-agent): run graphify update before graph queries

### DIFF
--- a/.agents/skills/orient-agent/SKILL.md
+++ b/.agents/skills/orient-agent/SKILL.md
@@ -16,10 +16,21 @@ description: >
 
 ### Step 0 — Graph orientation (if graph exists)
 
-Check whether `graphify-out/GRAPH_REPORT.md` exists. If it does, read it now.
-It contains god nodes (highest-connectivity files), surprising cross-community
-connections, and community labels — the structural map of the codebase. This
-primes the agent with topology context before reading docs or selecting an issue.
+If `graphify-out/graph.json` exists, sync the graph with any code changes that
+landed since the last commit (fast-forward merges and cherry-picks don't fire the
+post-commit hook, so the graph can be stale after a `git pull`):
+
+```bash
+graphify update . 2>/dev/null || true
+```
+
+This is AST-only — no LLM, no API key, typically a few seconds. Run it
+unconditionally when the graph is present; skip silently if the file is absent.
+
+Then read `graphify-out/GRAPH_REPORT.md`. It contains god nodes
+(highest-connectivity files), surprising cross-community connections, and community
+labels — the structural map of the codebase. This primes the agent with topology
+context before reading docs or selecting an issue.
 
 Skip this step silently if the file is absent.
 

--- a/vultron/__init__.py
+++ b/vultron/__init__.py
@@ -20,3 +20,4 @@ try:
 except ImportError:
     __version__ = "unknown version"
     version_tuple = (0, 0, "unknown version")
+# hook-test

--- a/vultron/__init__.py
+++ b/vultron/__init__.py
@@ -20,4 +20,3 @@ try:
 except ImportError:
     __version__ = "unknown version"
     version_tuple = (0, 0, "unknown version")
-# hook-test


### PR DESCRIPTION
## Summary

Adds a `graphify update .` call at the start of orient-agent's Step 0 so the graph is always current before queries run. Fast-forward merges and cherry-picks don't fire the post-commit hook, leaving the graph stale after a `git pull`.

## Changes

- **`.agents/skills/orient-agent/SKILL.md`**: add `graphify update .` before reading `GRAPH_REPORT.md`; document that it is AST-only (no LLM, no API key) and safe to run every time