### PR TITLE
docs: reconcile PAD specs with Project #24 board — retire PRIORITIES.md/group: refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -522,6 +522,14 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   `RejectInviteActorToCaseReceivedUseCase`. The same nesting applies to
   `Accept(Invite(actor, case))` — `AcceptInviteActorToCaseReceivedEvent.case_id` already
   follows this pattern. See CM-11-003. *Source: ISSUE-1747*
+- **Retiring a File or Label Requires Auditing All Specs for Bare-Filename References** —
+  `MS-15` (`_check_phantom_paths`) only flags backtick-quoted tokens containing a directory
+  separator (e.g. `` `plan/PRIORITIES.md` ``). Bare filenames such as `PRIORITIES.md` or
+  bare label names such as `group:unscheduled` written without backticks or without a `/`
+  pass the lint check silently. When retiring any file, label, or convention, grep
+  `specs/` for the bare name as well as the quoted/path form, and update every spec entry
+  that references it — including `statement:`, `rationale:`, and cross-reference fields.
+  *Source: ISSUE-2011*
 
 ---
 

--- a/plan/history/2608/learning/CONCERN-2011.md
+++ b/plan/history/2608/learning/CONCERN-2011.md
@@ -1,0 +1,43 @@
+---
+source: CONCERN-2011
+timestamp: '2026-08-06T17:41:56.879189+00:00'
+title: PAD-03 still named archived plan/PRIORITIES.md as authoritative, contradicting
+  rewritten PD-06
+type: learning
+---
+
+## Problem
+
+PR #2006 rewrote `PD-06-004`/`PD-06-005` so that priority ordering is "the sole
+responsibility of the `Schedule` field (Now/Next/Later/Someday) on GitHub
+Project #24" — `plan/PRIORITIES.md` was archived in `51fa5aee4`.
+
+`specs/parallel-development.yaml` was not updated, so the registry held two
+contradictory MUSTs:
+
+- `PAD-03-001` (MUST) — "PRIORITIES.md MUST remain the authoritative ordering document for work priority."
+- `PAD-03-002` (MUST_NOT) — "Agents MUST NOT write to PRIORITIES.md."
+- `PAD-03-003` (MUST) — "When the `build` skill selects a task, it MUST read PRIORITIES.md once..."
+
+Additionally, 16 other PAD entries across PAD-01, PAD-02, PAD-08, PAD-09, PAD-12,
+and PAD-13 still referenced `PRIORITIES.md` or `group:` labels that were retired
+in June 2026.
+
+## Root Cause
+
+PR #693 retired PRIORITIES.md from tooling and notes; PR #2006 updated PD-06 in
+specs; but `specs/parallel-development.yaml` was never synchronized. This created
+a live contradiction between PD-06-004/005 and PAD-03.
+
+## Lessons
+
+- When retiring a file or label, audit ALL specs for bare-filename references.
+  `MS-15` (`_check_phantom_paths`) only catches backtick-quoted tokens with a path
+  separator — bare filenames like `PRIORITIES.md` and bare label names like
+  `group:unscheduled` pass silently.
+- Incremental spec updates that fix one half of a cross-spec reference must also
+  fix the other half in the same PR, or create a follow-up Concern immediately.
+
+**Resolved**: 2026-08-06 — implementation tracked in #2036.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2035>.
+Spec: `specs/parallel-development.yaml`.

--- a/specs/parallel-development.yaml
+++ b/specs/parallel-development.yaml
@@ -25,15 +25,17 @@ groups:
         priority: MUST
         kind: process
         statement: >-
-          Issues MUST be organized in up to three levels: Epic (Priority
-          Group), Task (coherent unit of work), and Subtask (atomic PR-sized
+          Issues MUST be organized in up to three levels: Epic (thematic
+          group), Task (coherent unit of work), and Subtask (atomic PR-sized
           chunk). Leaf issues (those with no sub-issues) are the claimable
           work units.
       - id: PAD-01-003
         priority: MUST
         kind: process
         statement: >-
-          Epic Issues MUST correspond to a named priority group in PRIORITIES.md.
+          Epic Issues MUST be wired on GitHub Project #24 with a `Schedule`
+          field value (Now/Next/Later/Someday) that reflects the current
+          priority tier of the thematic group they represent.
       - id: PAD-01-005
         priority: MUST
         kind: process
@@ -64,17 +66,13 @@ groups:
         priority: MUST
         kind: process
         statement: >-
-          Every Issue MUST carry a `group:<name>` label whose value matches
-          the corresponding priority group name in PRIORITIES.md (e.g.,
-          `group:architecture-hardening`).
-      - id: PAD-02-002
-        priority: MUST
-        kind: process
-        statement: >-
-          Issues that have not yet been slotted into PRIORITIES.md MUST carry
-          the label `group:unscheduled`. Only humans (and the
-          `review-priorities` skill) may change a `group:unscheduled` label
-          to a named group label.
+          Every Issue added to GitHub Project #24 MUST have a `Schedule`
+          field value (Now/Next/Later/Someday). Issues not yet prioritised
+          default to `Schedule=Someday`.
+        rationale: >-
+          `group:<name>` labels and `PRIORITIES.md` were retired in June 2026
+          in favour of the Project #24 `Schedule` field. Do not create new
+          `group:` labels.
       - id: PAD-02-004
         priority: MUST
         kind: process
@@ -104,58 +102,30 @@ groups:
           Docs-only PRs (containing only `specs/` and `notes/` changes) MUST
           carry the `specs-notes` label to identify them as docs-only for
           reviewers.
-      - id: PAD-02-007
-        priority: MUST_NOT
-        kind: process
-        statement: >-
-          The `group:` label name MUST NOT include a priority number. The label
-          name MUST be a short, descriptive kebab-case slug derived from the
-          priority group title (e.g., `group:architecture-hardening` for
-          "Priority 473: Architecture Hardening"). Priority ordering is expressed
-          in PRIORITIES.md; embedding numbers in label names causes conflicts
-          when priorities are reordered.
-      - id: PAD-02-012
-        priority: MUST
-        kind: process
-        statement: >-
-          When creating a new `group:` label on GitHub, the label description
-          MUST use the priority group title (not the priority number) so it
-          remains accurate if the priority number changes.
-        relationships:
-        - rel_type: refines
-          spec_id: PAD-02-007
       - id: PAD-02-008
         priority: MUST
         kind: process
         statement: >-
-          Every priority group that has two or more open leaf Issues MUST have
-          exactly one open Epic Issue. A leaf Issue is any Issue with no open
-          sub-issues.
+          Every thematic group that has two or more open leaf Issues MUST have
+          exactly one open Epic Issue on GitHub Project #24. A leaf Issue is
+          any Issue with no open sub-issues.
       - id: PAD-02-009
         priority: MUST
         kind: process
         statement: >-
           Epic Issues MUST be created using the GitHub `Epic` issue type (via
           GraphQL `createIssue` with the appropriate `issueTypeId`) and MUST
-          carry the `group:<name>` label matching their priority group.
+          be added to GitHub Project #24 with the appropriate `Schedule` value.
       - id: PAD-02-013
         priority: MUST
         kind: process
         statement: >-
           The `create-epic` skill MUST be used to create Epic Issues to ensure
-          consistent wiring of sub-issues and correct issue type assignment.
+          consistent sub-issue wiring, correct issue type assignment, and
+          addition to Project #24.
         relationships:
         - rel_type: implements
           spec_id: PAD-02-009
-      - id: PAD-02-010
-        priority: MUST
-        kind: process
-        statement: >-
-          The Epic Issue number for each priority group MUST be recorded in
-          `PRIORITIES.md` next to the group heading, e.g.
-          `## Priority 473 — Epic #NNN: Architecture Hardening`. This serves
-          as the authoritative lookup for agents that need to find or link to
-          the Epic for a given group.
 
   - id: PAD-03
     title: Priority Ordering Authority
@@ -164,23 +134,27 @@ groups:
         priority: MUST
         kind: process
         statement: >-
-          PRIORITIES.md MUST remain the authoritative ordering document for
-          work priority. Priority changes MUST be made by editing PRIORITIES.md
-          and updating affected Issues' `group:` labels — not by reordering
-          issues in the GitHub tracker.
+          The `Schedule` field (Now/Next/Later/Someday) on GitHub Project #24
+          MUST be the authoritative source for work priority ordering.
+          Priority changes MUST be made by updating the `Schedule` field on
+          the relevant Epic or Issue — not by maintaining any external file.
+        rationale: >-
+          `plan/PRIORITIES.md` was archived in June 2026 (PR #693). The
+          Project #24 board is the single source of truth for scheduling.
       - id: PAD-03-002
         priority: MUST_NOT
         kind: process
         statement: >-
-          Agents MUST NOT write to PRIORITIES.md. Only humans and the
-          `review-priorities` skill may modify it.
+          Agents MUST NOT create or write to any external priority-ordering
+          file. Only the `review-priorities` skill (and humans directly) may
+          change `Schedule` field values on GitHub Project #24.
       - id: PAD-03-003
         priority: MUST
         kind: process
         statement: >-
-          When the `build` skill selects a task, it MUST read PRIORITIES.md
-          once to determine the current top-priority group name, then query
-          GitHub for open, unblocked leaf Issues with that `group:` label.
+          When the `build` skill selects a task, it MUST query GitHub
+          Project #24 for Epics with `Schedule=Now`, then select an open
+          unblocked leaf Issue that is a sub-issue of one of those Epics.
 
   - id: PAD-04
     title: Task Claiming Protocol
@@ -292,10 +266,10 @@ groups:
         priority: MUST
         kind: process
         statement: >-
-          The `build` skill MUST select work by querying GitHub for open,
-          unblocked leaf Issues in the top-priority group (as determined by
-          reading PRIORITIES.md), filtered to exclude Issues with
-          `stale-claim` or that are already assigned.
+          The `build` skill MUST select work by querying GitHub Project #24
+          for Epics with `Schedule=Now`, then querying for open unblocked
+          leaf Issues that are sub-issues of those Epics, filtered to exclude
+          Issues with `stale-claim` or that are already assigned.
       - id: PAD-08-002
         priority: MUST
         kind: process
@@ -334,15 +308,17 @@ groups:
         statement: >-
           After the docs-only PR is opened, `ingest-idea` MUST create a
           GitHub Issue with: a title and description derived from the spec,
-          the `group:unscheduled` label, the appropriate `size:` label (from
-          AC count per PAD-05-001), and a link to the spec file in the body.
+          the appropriate `size:` label (from AC count per PAD-05-001), and a
+          link to the spec file in the body. The Issue MUST be added to
+          GitHub Project #24 (defaulting to `Schedule=Someday`).
       - id: PAD-09-003
         priority: MUST_NOT
         kind: process
         statement: >-
           `ingest-idea` MUST NOT begin implementation work. It MUST stop after
-          creating the Issue. Implementation work begins only when a human runs
-          `review-priorities` to slot the Issue into PRIORITIES.md.
+          creating the Issue. Implementation work begins only when a human (or
+          the `review-priorities` skill) promotes the Issue to an active
+          `Schedule` tier on GitHub Project #24.
 
   - id: PAD-10
     title: Orphan Recovery — Stale Claim Sweeper
@@ -395,29 +371,30 @@ groups:
           resolve the conflict and remove the label.
 
   - id: PAD-12
-    title: Review-Priorities — Unscheduled Issue Triage
+    title: Review-Priorities — Issue Triage
     specs:
       - id: PAD-12-001
         priority: MUST
         kind: process
         statement: >-
-          The `review-priorities` skill MUST fetch all open GitHub Issues
-          carrying the `group:unscheduled` label and surface them as a triage
-          list alongside any untracked PRIORITIES.md items.
+          The `review-priorities` skill MUST query GitHub Project #24 for
+          Issues with `Schedule=Someday` and surface them as a triage list
+          for the current review session.
       - id: PAD-12-002
         priority: MUST
         kind: process
         statement: >-
-          For each `group:unscheduled` Issue, the `review-priorities` skill
-          MUST use `ask_user` to determine where to slot it in PRIORITIES.md
-          or whether to close or defer it.
+          For each `Schedule=Someday` Issue surfaced in triage, the
+          `review-priorities` skill MUST use `ask_user` to determine which
+          Schedule tier (Now/Next/Later) to promote it to, or whether to
+          close or defer it.
       - id: PAD-12-003
         priority: MUST
         kind: process
         statement: >-
           After the user confirms a placement, the `review-priorities` skill
-          MUST update the Issue's `group:` label from `group:unscheduled` to
-          the chosen group label and update PRIORITIES.md accordingly.
+          MUST update the Issue's `Schedule` field on GitHub Project #24 to
+          the chosen tier via the GitHub API.
 
   - id: PAD-13
     title: Update-Plan — Issue Creation
@@ -433,9 +410,9 @@ groups:
         priority: MUST
         kind: process
         statement: >-
-          Issues created by `update-plan` MUST carry the `group:unscheduled`
-          label and the appropriate initial `size:` label (from AC count per
-          PAD-05-001).
+          Issues created by `update-plan` MUST be added to GitHub Project #24
+          with `Schedule=Someday` and the appropriate initial `size:` label
+          (from AC count per PAD-05-001).
 
   - id: PAD-14
     title: GitHub Actions Requirements


### PR DESCRIPTION
- Closes #2011
- Closes #2036
<!-- ⚠️  MUST be first — before any ## header. -->

## Summary

Reconciles `specs/parallel-development.yaml` PAD-01 through PAD-13 with the
June 2026 migration from `plan/PRIORITIES.md` + `group:` labels to the GitHub
Project #24 `Schedule` field. Eliminates the live contradiction between
PAD-03 (still pointing to the archived file) and PD-06-004/005 (already
updated in PR #2006).

## Changes

- **`specs/parallel-development.yaml`**: Rewrite PAD-01-003 (Epics must have
  Schedule field), PAD-02-001 (Schedule replaces group: label), remove stale
  PAD-02-007/010/012 group:-label entries, update PAD-02-008/009/013 for
  board-aware Epic creation, rewrite PAD-03 (Schedule field is sole priority
  authority; review-priorities writes to board; build queries Schedule=Now
  Epics), rewrite PAD-08-001 (build selects via Schedule=Now + sub-issue
  traversal), update PAD-09-002/003 (no group:unscheduled; issues default to
  Schedule=Someday), rewrite PAD-12 (review-priorities triages Schedule=Someday
  items), update PAD-13-002 (update-plan issues get Schedule=Someday).
- **`AGENTS.md`**: Add pitfall — retiring a file or label requires auditing
  specs for bare-filename references not caught by MS-15 `_check_phantom_paths`.

## Implementation Issues

- #2036