### PR TITLE
docs: plan issue #2020 — architecture ratchet shared corpus and xdist audit

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -590,6 +590,15 @@ sync-log-entry context field, and testing patterns.
 the resolved design rationale for the trigger architecture, or auditing trigger
 classification (demo-only vs general-purpose).
 
+**`architecture-ratchet-corpus.md`**
+Design decisions and measurements for the shared corpus pattern in
+`test/architecture/`: why a module-level source cache beats a session fixture
+(timeout-window constraints), the prefilter approach, memory budget comparison,
+xdist compatibility notes, and alternatives considered.
+**Load when**: implementing or reviewing `test/architecture/_corpus.py`, adding
+a new architecture ratchet test, auditing full-suite performance, or evaluating
+xdist compatibility.
+
 **`flaky-tests.md`**
 Fast-lookup catalog of known flaky tests and CI jobs → tracking issue numbers.
 Used by `pr-execute` as a cache before querying GitHub. GitHub is ground truth;

--- a/notes/architecture-ratchet-corpus.md
+++ b/notes/architecture-ratchet-corpus.md
@@ -1,0 +1,153 @@
+---
+title: Architecture Ratchet Corpus — Test-Suite Performance Design Notes
+status: active
+---
+
+# Architecture Ratchet Corpus
+
+Design decisions and measurements for the shared corpus pattern in
+`test/architecture/`. Normative requirements are in
+`specs/testability.yaml` TB-13.
+
+---
+
+## Problem
+
+`test/architecture/` contains ~18 files that enforce architectural
+boundaries by walking the source tree with `ast`. As of CONCERN-2020
+(2026-08-06), the three slowest tests approach or exceed the 5 s per-test
+timeout under full-suite load:
+
+| Test | Isolated | Under full-suite load |
+|---|---|---|
+| `test_vocab_activities_boundary` | 3.8 s | times out non-deterministically |
+| `test_no_asgi_transport_in_app_code` | 2.76 s | |
+| `test_core_no_adapter_imports` | 0.88 s | |
+
+The full-suite timing profile (all markers, single process):
+
+| Directory | Total time |
+|---|---|
+| `test/demo` | 46 s |
+| `test/core` | 30.8 s |
+| `test/metadata` | 27.7 s |
+| `test/adapters` | 17.1 s |
+| `test/architecture` | 10.4 s |
+| others | ~7 s |
+| **total** | **~170 s** |
+
+## Root Cause
+
+Each ratchet independently calls `pathlib.Path.rglob("*.py")` and
+`ast.parse()` inside a test function. With ~1 179 Python files across
+`vultron/` + `test/`, this means:
+
+- **Read cost**: ~0.25–0.18 s per `rglob` pass (I/O, file system)
+- **Parse cost**: ~0.65 s for `vultron/`, ~1.64 s for `test/`
+- **Walk cost**: ~0.47–0.71 s per tree walk
+
+Each ratchet pays some or all of those costs independently; the costs are
+not shared. Under full-suite load the reads compete for disk I/O and
+CPU time, pushing already-marginal tests over the 5 s ceiling.
+
+## Key Timeout Measurement
+
+The `pytest-timeout` setting of `timeout = 5` (configured in
+`pyproject.toml`) covers:
+
+- ✅ **test function call time** — covered
+- ✅ **fixture setup time (session, module, function scope)** — covered
+- ❌ **module import time** — **exempt** (verified experimentally)
+
+This means a module-level corpus (read at import time) is not subject to
+the per-test timeout. A session-scoped fixture is subject to it, and a
+cold parse of all 1 179 files (~2.3 s) would recreate exactly the margin
+problem it was meant to fix.
+
+## Chosen Design: Module-Level Source Cache + Lazy AST Cache
+
+`test/architecture/_corpus.py` reads all `*.py` source files at import
+time (import-time cost ~1 s, memory ~18 MB). ASTs are cached lazily on
+first demand. Each ratchet:
+
+1. Calls `_corpus.files_mentioning(*fragments, under=root)` which uses a
+   plain `in` substring check (~1 µs per file) to filter before calling
+   `ast.parse()`.
+2. Receives an iterator of `(path, ast.AST)` pairs for matching files
+   only.
+
+Measured after applying the shared corpus + prefilter to
+`test_vocab_activities_boundary`:
+
+| Before | After |
+|---|---|
+| 3.8 s (scans vultron + test, parses all) | 0.04 s (26 files match) |
+
+For `test_no_asgi_transport_in_app_code` (target string: `"ASGITransport"`):
+
+| Before | After |
+|---|---|
+| 2.76 s + 0.95 s (two tests, no prefilter) | ~0.003 s (0 matches in vultron/) |
+
+## Alternatives Considered
+
+### Session-scoped pytest fixture
+
+A `@pytest.fixture(scope="session")` that parses all files once was the
+original preferred approach (issue body). Rejected because:
+
+- Session-fixture setup is inside the 5 s timeout window.
+- A cold parse of all 1 179 files takes ~2.3 s, leaving only 2.7 s before
+  timeout, which is the same marginal budget the design is meant to fix.
+- Holding all parsed ASTs in memory requires ~211 MB vs ~18 MB for the
+  source-string cache.
+
+### Inline substring prefilter (no shared module)
+
+Applying the prefilter in-place to each ratchet (as done in
+`test_infrastructure_logs_not_at_info.py`) reduces the worst offenders to
+<0.1 s but:
+
+- Duplicates the file-discovery pattern across ~14 files (violates
+  CS-22-001 DRY).
+- Does nothing to prevent the next ratchet author from writing
+  another unfiltered scanner.
+- No structural enforcement (no meta-ratchet).
+
+### Raise the per-test timeout for `test/architecture/`
+
+Using `@pytest.mark.timeout(N)` hides cost rather than removing it. Noted
+as the weakest option in the issue body; rejected.
+
+## Meta-Ratchet
+
+`test/architecture/test_ratchet_hygiene.py` enforces the pattern by
+failing when any sibling file contains `ast.parse(` or `.rglob(` outside
+of `_corpus.py`. This makes the shared-corpus requirement self-enforcing.
+
+## xdist Compatibility
+
+`pytest-xdist` is a declared dependency (`pyproject.toml`) but not
+currently enabled in CI or local runs. Enabling `-n auto` could reduce
+full-suite wall-clock by 50–70% on multi-core runners.
+
+Known xdist hazards in this codebase:
+
+- `py_trees.blackboard.Blackboard.storage` is a process-global dict.
+  Tests that do not reset it (some BT tests) would race under parallel
+  execution.
+- Module-level singletons used by some demo tests (e.g., actor
+  configuration globals).
+
+A compatibility audit (TB-13-005) is a prerequisite before enabling xdist.
+
+## Spec Requirements
+
+See `specs/testability.yaml` TB-13-001 through TB-13-005.
+
+## Related
+
+- CONCERN-2020 — source issue
+- `test/architecture/_corpus.py` — the shared corpus module
+- `test/architecture/test_ratchet_hygiene.py` — the meta-ratchet
+- `notes/flaky-tests.md` — tracking issue for known-flaky tests

--- a/notes/architecture-ratchet-corpus.md
+++ b/notes/architecture-ratchet-corpus.md
@@ -1,5 +1,5 @@
 ---
-title: Architecture Ratchet Corpus — Test-Suite Performance Design Notes
+title: Architecture Ratchet Corpus
 status: active
 ---
 

--- a/plan/history/2608/learning/CONCERN-2020.md
+++ b/plan/history/2608/learning/CONCERN-2020.md
@@ -1,0 +1,29 @@
+---
+source: CONCERN-2020
+timestamp: '2026-08-06T17:47:32.472902+00:00'
+title: AST-walking architecture ratchets sit near the 5s per-test timeout and fail
+  non-deterministically under full-suite load
+type: learning
+---
+
+Several architecture ratchets parse every file under `vultron/` with `ast`
+and run close to the repo's 5s per-test timeout. Under full-suite load one
+of them times out non-deterministically — a different test on each run —
+which is the signature of a load-dependent margin rather than a specific
+slow test.
+
+Measured in isolation: `test_activity_factory_imports.py::test_vocab_activities_boundary`
+~3.4s; `test_no_asgi_transport_in_app_code.py` ~1.9s;
+`test_core_no_adapter_imports.py` ~1.2s. Full-suite wall-clock profiled at
+~170s (demo=46s, core=30.8s, metadata=27.7s, architecture=10.4s).
+
+Root cause: each ratchet calls `rglob` + `ast.parse` independently inside
+the test function body, which is inside the 5s timeout window.
+Module-import time is exempt.
+
+**Resolved**: 2026-08-06 — implementation tracked in #2038 (shared corpus +
+meta-ratchet), #2039 (xdist audit), #2040 (metadata spec-dump cost as
+separate concern).
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2037>.
+Spec: `specs/testability.yaml` TB-13-001..005.
+Notes: `notes/architecture-ratchet-corpus.md`.

--- a/specs/testability.yaml
+++ b/specs/testability.yaml
@@ -363,6 +363,9 @@ groups:
       The meta-ratchet makes the shared-corpus pattern self-enforcing. Without it, the
       next ratchet author can inadvertently reintroduce the pattern the corpus was
       designed to eliminate, and the problem silently recurs with each new ratchet.
+      The hygiene check itself MUST use plain substring scanning on source strings
+      (via `_corpus.py`) rather than calling `ast.parse()` directly — otherwise it
+      would violate the rule it enforces.
       Source: CONCERN-2020.
     relationships:
     - rel_type: refines
@@ -377,8 +380,10 @@ groups:
     rationale: >-
       The full-suite wall-clock is the metric that matters for developer feedback
       loops and CI cost. Per-test timeouts are a safety net, not a performance budget.
-      The 90 s target gives headroom above the current ~170 s baseline while keeping
-      the suite fast enough that developers run it locally. Source: CONCERN-2020.
+      The 90 s target is aspirational — well below the current ~170 s baseline and
+      achievable only after the shared corpus + xdist parallelisation work lands. It
+      leaves headroom for future test additions above any fully-optimised baseline.
+      Source: CONCERN-2020.
   - id: TB-13-005
     priority: SHOULD
     kind: project

--- a/specs/testability.yaml
+++ b/specs/testability.yaml
@@ -313,3 +313,82 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: TB-12-001
+- id: TB-13
+  title: Architecture Ratchet Corpus
+  specs:
+  - id: TB-13-001
+    priority: MUST
+    kind: project
+    lint_suppress:
+    - phantom_path_ref
+    statement: >-
+      All architecture ratchet tests in `test/architecture/` that scan the source tree
+      MUST obtain file paths and source text from a shared module-level corpus helper
+      (`test/architecture/_corpus.py`) rather than calling `pathlib.Path.rglob` or
+      reading files directly.
+    rationale: >-
+      Scanning 1 179 Python files at module-import time (exempt from the 5 s per-test
+      timeout) costs ~1 s for source reads and populates an 18 MB string cache. All
+      subsequent ratchets share those bytes for free. Direct `rglob` calls inside test
+      functions compete for disk I/O inside the timeout window and accumulate as more
+      ratchets are added. Source: CONCERN-2020.
+  - id: TB-13-002
+    priority: MUST
+    kind: project
+    statement: >-
+      Architecture ratchet tests MUST apply a substring prefilter before calling
+      `ast.parse()`. A file that does not contain any target fragment string as a plain
+      substring MUST be skipped entirely; `ast.parse()` MUST NOT be called on it.
+    rationale: >-
+      `ast.parse()` is the dominant per-file cost (~1 ms each). A plain `in` substring
+      check is ~1 µs. For import-boundary ratchets the prefilter string is the module
+      path being guarded (e.g., `"vultron.wire.as2.vocab.activities"`); for
+      attribute-name ratchets it is the attribute string (e.g., `"ASGITransport"`).
+      Measured reduction: `test_vocab_activities_boundary` 3.8 s → 0.04 s.
+      Source: CONCERN-2020.
+    relationships:
+    - rel_type: refines
+      spec_id: TB-13-001
+  - id: TB-13-003
+    priority: MUST
+    kind: project
+    lint_suppress:
+    - phantom_path_ref
+    statement: >-
+      No file in `test/architecture/` MAY call `ast.parse()` or `pathlib.Path.rglob`
+      directly. A meta-ratchet in `test/architecture/test_ratchet_hygiene.py` MUST
+      fail when any sibling file contains a bare `ast.parse(` or `.rglob(` call
+      outside of `_corpus.py`.
+    rationale: >-
+      The meta-ratchet makes the shared-corpus pattern self-enforcing. Without it, the
+      next ratchet author can inadvertently reintroduce the pattern the corpus was
+      designed to eliminate, and the problem silently recurs with each new ratchet.
+      Source: CONCERN-2020.
+    relationships:
+    - rel_type: refines
+      spec_id: TB-13-001
+  - id: TB-13-004
+    priority: SHOULD
+    kind: project
+    statement: >-
+      The full pytest suite (all markers, `uv run pytest -m ""`) SHOULD complete in
+      under 90 seconds on the reference CI runner. Individual architecture ratchet
+      tests SHOULD each complete in under 0.5 seconds.
+    rationale: >-
+      The full-suite wall-clock is the metric that matters for developer feedback
+      loops and CI cost. Per-test timeouts are a safety net, not a performance budget.
+      The 90 s target gives headroom above the current ~170 s baseline while keeping
+      the suite fast enough that developers run it locally. Source: CONCERN-2020.
+  - id: TB-13-005
+    priority: SHOULD
+    kind: project
+    statement: >-
+      The test suite SHOULD be validated for `pytest-xdist` (`-n auto`) compatibility.
+      Tests that rely on shared global state (e.g., `py_trees` blackboard, module-level
+      singletons) MUST be identified and either isolated or marked `xdist`-unsafe before
+      parallel execution is enabled in CI.
+    rationale: >-
+      `pytest-xdist` is already a declared dependency. Enabling `-n auto` on a
+      fully compatible suite can reduce full-suite wall-clock by 50–70% on multi-core
+      runners. Unguarded shared state causes non-deterministic failures under xdist.
+      Source: CONCERN-2020.


### PR DESCRIPTION
- Closes #2020

## Summary

Adds TB-13 spec group and design notes for the shared module-level corpus
pattern in `test/architecture/`, which eliminates redundant `ast.parse()`
calls and non-deterministic per-test timeout failures as more ratchets
accumulate.

## Changes

- **`specs/testability.yaml`**: New TB-13 group (TB-13-001..005) —
  shared corpus MUST, mandatory prefilter, meta-ratchet enforcement,
  full-suite wall-clock budget, and xdist compatibility audit requirement.
- **`notes/architecture-ratchet-corpus.md`**: Design rationale and
  measurements — why module-level source cache beats a session fixture
  (timeout-window constraints), prefilter approach, memory budget
  comparison (18 MB vs 211 MB), xdist hazard notes, alternatives
  considered.
- **`notes/README.md`**: Index entry for the new notes file.

## Implementation Issues

- #2038 — refactor: shared corpus module for test/architecture/ ratchet tests
- #2039 — spike: pytest-xdist compatibility audit and full-suite parallelization
- #2040 — concern: test/metadata spec-dump invocations dominate full-suite time