### PR TITLE
Fix CreateInviteeParticipantAtReceivedNode: record RM.RECEIVED only on Accept(Invite)

### DIFF
--- a/plan/history/2608/implementation/ISSUE-2017.md
+++ b/plan/history/2608/implementation/ISSUE-2017.md
@@ -1,0 +1,20 @@
+---
+source: ISSUE-2017
+timestamp: '2026-08-06T17:51:33.036987+00:00'
+title: 'Fix invitee RM entry point: RM.RECEIVED only on Accept(Invite)'
+type: implementation
+---
+
+## Issue #2017 — Fix CreateInviteeParticipantAtReceivedNode: record RM.RECEIVED only on Accept(Invite)
+
+Per CM-11-001 (corrected by #1756 / PR #2014), `Accept(Invite)` signals willingness to join the case, not triage of the vulnerability report. The prior code recorded R→V→A atomically, conflating case-joining with report triage.
+
+Changes:
+
+- Renamed `CreateInviteeParticipantAtAcceptedNode` → `CreateInviteeParticipantAtReceivedNode`
+- Removed `append_rm_state(RM.VALID)` and `append_rm_state(RM.ACCEPTED)` calls; kept only `append_rm_state(RM.RECEIVED)`
+- Updated docstrings, comments, and log messages to reference CM-11-001
+- Fixed redundant ternary `case_roles=roles if roles else []` → `case_roles=roles`
+- Updated tests: renamed methods, assert RM.RECEIVED, exclusion checks for VALID/ACCEPTED
+
+PR: <https://github.com/CERTCC/Vultron/pull/2041>

--- a/plan/incoming/learnings/20260806-append-rm-state-no-call-count-guard.md
+++ b/plan/incoming/learnings/20260806-append-rm-state-no-call-count-guard.md
@@ -1,0 +1,23 @@
+---
+title: append_rm_state has no per-session call-count guard; valid-transition chains silently over-advance RM state
+type: learning
+timestamp: 2026-08-06
+source: ISSUE-2017
+signal: concern
+---
+
+`CaseParticipant.append_rm_state()` validates each individual hop against
+`is_valid_rm_transition`. It cannot detect a caller that strings together a
+chain of valid individual transitions (e.g. START→RECEIVED, RECEIVED→VALID,
+VALID→ACCEPTED) when only one was appropriate for the construction context.
+
+This is the root class of bug fixed in #2017: the node called
+`append_rm_state` three times, all individually valid, but the business rule
+(CM-11-001) only permits recording RM.RECEIVED at Accept(Invite) time.
+
+**Risk**: Any future BT node that creates a `VultronParticipant` and calls
+`append_rm_state` multiple times will silently reproduce this class of bug.
+
+**Suggested fix**: A `VultronParticipant.from_invite(case_id, invitee_id, roles)`
+named constructor that calls `append_rm_state(RM.RECEIVED)` exactly once would
+encode the CM-11-001 invariant structurally. Tracked as Concern #2042.

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -371,15 +371,14 @@ class TestInviteActorUseCases:
         participant_obj = cast(Any, participant_obj)
         assert embargo.id_ in participant_obj.accepted_embargo_ids
 
-    def test_accept_invite_participant_can_reach_rm_accepted(
+    def test_accept_invite_participant_recorded_at_rm_received(
         self, make_payload
     ):
-        """Accepted invite advances the participant to RM.ACCEPTED via BT.
+        """Accepted invite records the participant at RM.RECEIVED only.
 
-        PCR-08-010: Accept(Invite) IS the engage decision.  The use case
-        delegates to AcceptInviteActorToCaseBT which records the participant
-        at RM.ACCEPTED — no separate engage-case BT or proxy RmEngageCaseActivity
-        is emitted.
+        CM-11-001: Accept(Invite) signals willingness to join; the CaseActor
+        records RM.RECEIVED only.  The full triage cycle (VALID/ACCEPTED) is
+        a distinct step run by the invitee after the case replica is delivered.
         """
         from typing import Any, cast
 
@@ -414,7 +413,6 @@ class TestInviteActorUseCases:
         )
         event = make_payload(accept)
 
-        # No TriggerActivityAdapter needed: RM.ACCEPTED is reached via BT.
         AcceptInviteActorToCaseReceivedUseCase(
             dl, event, sync_port=MagicMock()
         ).execute()
@@ -422,14 +420,19 @@ class TestInviteActorUseCases:
         updated_case = cast(Any, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index.get(invitee_id)
         participant_obj = cast(Any, dl.get(id_=participant_id))
+        rm_states = [s.rm.state for s in participant_obj.participant_statuses]
+        assert RM.VALID not in rm_states, "CM-11-001: no VALID at invite time"
+        assert (
+            RM.ACCEPTED not in rm_states
+        ), "CM-11-001: no ACCEPTED at invite time"
         latest_status = participant_obj.participant_statuses[-1]
-        assert latest_status.rm.state == RM.ACCEPTED
+        assert latest_status.rm.state == RM.RECEIVED
 
     def test_accept_invite_no_identity_spoofing(self, make_payload):
         """PCR-07-008: AcceptInviteActorToCaseReceivedUseCase MUST NOT emit
         RmEngageCaseActivity (Join) with actor=invitee_id from the Case Actor
-        context.  The Accept(Invite) IS the engage decision; the BT records
-        RM.ACCEPTED for the invitee without spoofing the invitee's identity.
+        context.  The BT records RM.RECEIVED for the invitee without spoofing
+        the invitee's identity (CM-11-001, PCR-08-010).
         """
         from typing import Any, cast
 
@@ -484,7 +487,7 @@ class TestInviteActorUseCases:
         ).execute()
 
         # PCR-07-008: no RmEngageCaseActivity (Join) with actor=invitee_id
-        # should be queued — the BT records RM.ACCEPTED for the invitee
+        # should be queued — the BT records RM.RECEIVED for the invitee
         # without spoofing the invitee's identity.
         outbox_items = dl.clone_for_actor(invitee_id).outbox_list()
         for item_id in outbox_items:
@@ -495,15 +498,20 @@ class TestInviteActorUseCases:
                     f"actor={invitee_id!r} found in outbox — identity spoofing"
                 )
 
-        # The participant should be at RM.ACCEPTED (via BT).
+        # The participant should be at RM.RECEIVED only (CM-11-001).
         updated_case = cast(Any, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index.get(invitee_id)
         assert participant_id is not None
         participant_obj = cast(Any, dl.get(id_=participant_id))
         assert participant_obj is not None
+        rm_states = [s.rm.state for s in participant_obj.participant_statuses]
+        assert RM.VALID not in rm_states, "CM-11-001: no VALID at invite time"
+        assert (
+            RM.ACCEPTED not in rm_states
+        ), "CM-11-001: no ACCEPTED at invite time"
         latest_status = participant_obj.participant_statuses[-1]
-        assert latest_status.rm.state == RM.ACCEPTED, (
-            f"Expected RM.ACCEPTED after BT transition, "
+        assert latest_status.rm.state == RM.RECEIVED, (
+            f"Expected RM.RECEIVED after Accept(Invite) (CM-11-001), "
             f"got {latest_status.rm.state}"
         )
 
@@ -1050,7 +1058,7 @@ class TestInviteActorUseCases:
 
 
 class TestAcceptInviteRolesAC4:
-    """AC-4: CreateInviteeParticipantAtAcceptedNode reads roles from Invite."""
+    """AC-4: CreateInviteeParticipantAtReceivedNode reads roles from Invite."""
 
     def test_roles_from_invite_set_on_participant(self, make_payload):
         """AC-4: Accept(Invite) causes new participant to inherit roles from Invite."""

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -591,7 +591,7 @@ class PersistInviteeParticipantNode(DataLayerAction):
         self.datalayer.save(case)
         self.logger.info(
             "%s: participant '%s' persisted and attached to case '%s'"
-            " (RM.ACCEPTED, PCR-08-010)",
+            " (RM.RECEIVED, CM-11-001)",
             self.name,
             participant.id_,
             self.case_id,

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -25,7 +25,7 @@ Tree structure::
     ├── CheckInviteeNotAlreadyParticipantNode  — idempotency guard
     ├── CapturePreCommitBackfillTargetNode     — snapshot ledger for resume case
     ├── GuardedCommitCaseLedgerEntryBT         — record receipt (CLP-10-006)
-    ├── CreateInviteeParticipantAtAcceptedNode — build participant at RM.ACCEPTED
+    ├── CreateInviteeParticipantAtReceivedNode — build participant at RM.RECEIVED
     ├── MaybeSignEmbargoConsentNode            — sign when embargo is EM.ACTIVE
     ├── PersistInviteeParticipantNode          — dl.create, attach, save case
     ├── EmitAddCaseParticipantNode             — emit Add(CaseParticipant), commit ledger
@@ -273,13 +273,13 @@ class CheckInviteeNotAlreadyParticipantNode(
         return None
 
 
-class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
-    """Build a ``VultronParticipant`` for the invitee at RM.ACCEPTED.
+class CreateInviteeParticipantAtReceivedNode(DataLayerAction):
+    """Build a ``VultronParticipant`` for the invitee at RM.RECEIVED.
 
-    Per PCR-08-010, ``Accept(Invite)`` IS the engage signal.  The
-    participant's full RECEIVED→VALID→ACCEPTED arc is implicit; the
-    CaseActor records RM.ACCEPTED directly in its own DataLayer rather
-    than running an engage-case BT as the invitee.
+    Per CM-11-001, ``Accept(Invite)`` signals willingness to join; the
+    CaseActor records RM.RECEIVED only.  The full triage cycle
+    (VALID/ACCEPTED) is a distinct subsequent step run by the invitee
+    after the case replica has been delivered (PCR-08-010).
 
     Writes ``new_invite_participant`` to the blackboard.
     """
@@ -384,18 +384,13 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
             id_=f"{self.case_id}/participants/{self.invitee_id.split('/')[-1]}",
             attributed_to=self.invitee_id,
             context=self.case_id,
-            case_roles=roles if roles else [],
+            case_roles=roles,
         )
-        # PCR-08-010: Accept(Invite) IS the engage signal; record all three
-        # RM transitions on behalf of the invitee in the CaseActor's DataLayer.
+        # CM-11-001: Accept(Invite) records RM.RECEIVED only. The full
+        # triage cycle is a distinct step run by the invitee after replica
+        # delivery (PCR-08-010).
         participant.append_rm_state(
             RM.RECEIVED, actor=self.invitee_id, context=self.case_id
-        )
-        participant.append_rm_state(
-            RM.VALID, actor=self.invitee_id, context=self.case_id
-        )
-        participant.append_rm_state(
-            RM.ACCEPTED, actor=self.invitee_id, context=self.case_id
         )
         if roles:
             self.logger.info(
@@ -407,8 +402,8 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
             )
         self.blackboard.new_invite_participant = participant
         self.logger.info(
-            "%s: created participant object for invitee '%s' at RM.ACCEPTED"
-            " (PCR-08-010)",
+            "%s: created participant object for invitee '%s' at RM.RECEIVED"
+            " (CM-11-001)",
             self.name,
             self.invitee_id,
         )
@@ -832,7 +827,7 @@ def create_accept_invite_actor_to_case_tree(
         ├── CheckInviteeNotAlreadyParticipantNode  — idempotency guard
         ├── CapturePreCommitBackfillTargetNode     — snapshot ledger for resume case
         ├── GuardedCommitCaseLedgerEntryBT         — record receipt (CLP-10-006)
-        ├── CreateInviteeParticipantAtAcceptedNode — build participant at ACCEPTED
+        ├── CreateInviteeParticipantAtReceivedNode — build participant at RM.RECEIVED
         ├── MaybeSignEmbargoConsentNode            — sign when EM.ACTIVE
         ├── PersistInviteeParticipantNode          — persist, attach, save case
         ├── EmitAddCaseParticipantNode             — emit Add(CaseParticipant), commit ledger
@@ -865,7 +860,7 @@ def create_accept_invite_actor_to_case_tree(
             CapturePreCommitBackfillTargetNode(case_id=case_id),
         ],
         effect_nodes=[
-            CreateInviteeParticipantAtAcceptedNode(
+            CreateInviteeParticipantAtReceivedNode(
                 case_id=case_id, invitee_id=invitee_id
             ),
             MaybeSignEmbargoConsentNode(
@@ -888,7 +883,7 @@ def create_accept_invite_actor_to_case_tree(
 __all__ = [
     "CapturePreCommitBackfillTargetNode",
     "CheckInviteeNotAlreadyParticipantNode",
-    "CreateInviteeParticipantAtAcceptedNode",
+    "CreateInviteeParticipantAtReceivedNode",
     "EmitAddCaseParticipantNode",
     "MaybeSignEmbargoConsentNode",
     "PersistInviteeParticipantNode",

--- a/vultron/wire/as2/factories/case.py
+++ b/vultron/wire/as2/factories/case.py
@@ -716,7 +716,7 @@ def rm_invite_to_case_activity(
             or a bare URI string.
         roles: Optional list of intended CVD role strings for the invitee
             (CM-17-003).  When provided the Invite carries the intended
-            participant roles so ``CreateInviteeParticipantAtAcceptedNode``
+            participant roles so ``CreateInviteeParticipantAtReceivedNode``
             can set them on the new ``VultronParticipant``.
         embargo_obj: The fetched ``EmbargoEvent`` for the case, used when
             *target* is a ``as_VulnerabilityCase`` and ``em_state == EM.ACTIVE``


### PR DESCRIPTION
- Closes #2017

## Summary

Per CM-11-001 (corrected by #1756 / PR #2014), `Accept(Invite)` signals
willingness to join the case, not validation of the vulnerability report.
The prior code recorded R→V→A atomically, conflating case-joining with
report triage. This PR corrects the BT node to record RM.RECEIVED only.

## Changes

- **`vultron/core/behaviors/case/accept_invite_tree.py`**: Rename
  `CreateInviteeParticipantAtAcceptedNode` →
  `CreateInviteeParticipantAtReceivedNode`; remove
  `append_rm_state(RM.VALID, ...)` and `append_rm_state(RM.ACCEPTED, ...)`;
  update docstring, comment, and log message to reference CM-11-001;
  fix redundant ternary `case_roles=roles if roles else []` → `case_roles=roles`
- **`vultron/wire/as2/factories/case.py`**: Update docstring reference to new
  node name
- **`test/core/use_cases/received/actor/test_invite.py`**: Rename test
  methods; assert invitee lands at RM.RECEIVED (not ACCEPTED); add exclusion
  checks confirming RM.VALID and RM.ACCEPTED are absent from participant
  status history (AC-5)

## Verification

- 3177 unit tests pass (2 updated)
- Black, flake8, mypy, pyright clean

## DEFER

Altitude finding: `append_rm_state` has no per-session call-count guard — a
future node that calls it multiple times during construction would silently
over-advance RM state. A `VultronParticipant.from_invite()` named constructor
would encode the invariant structurally. Tracking as a separate follow-up.