### PR TITLE
fix(ownership-transfer): route Offer and Accept through CaseActor (CM-21-005/006/007)

### DIFF
--- a/plan/history/2608/implementation/ISSUE-2015.md
+++ b/plan/history/2608/implementation/ISSUE-2015.md
@@ -1,0 +1,31 @@
+---
+source: ISSUE-2015
+timestamp: '2026-08-06T18:23:35.154192+00:00'
+title: Fix ownership-transfer routing via CaseActor (CM-21-005/006/007)
+type: implementation
+---
+
+Implemented ADR-0053: corrected two routing gaps in the ownership-transfer
+protocol so both `Offer(VulnerabilityCase)` and `Accept(Offer(VulnerabilityCase))`
+are addressed to the CaseActor instead of directly to the transferee/offerer.
+
+## Changes
+
+- `EmitOfferCaseOwnershipTransferNode._emit()` resolves `case_actor_id` via
+  `_resolve_case_manager_id()` and passes `to=[case_actor_id]` (CM-21-005).
+- `EmitAcceptCaseOwnershipTransferNode` gains `case_id` constructor param;
+  `_emit()` resolves `case_actor_id` and passes `to=[case_actor_id]` (CM-21-006).
+- `create_accept_ownership_transfer_tree()` rewritten using
+  `create_receive_activity_tree()` to add guarded-commit (CaseLedgerEntry +
+  Announce broadcast) after `AcceptCaseOwnershipTransferNode` (CM-21-007).
+- `AcceptCaseOwnershipTransferReceivedUseCase` now passes `receiving_actor_id`
+  (not `new_owner_id`) to `BTBridge` so `CheckIsCaseManagerNode` gates correctly.
+- `OfferCaseOwnershipTransferReceivedUseCase` extended to commit CaseLedgerEntry
+  and forward Offer to transferee's inbox.
+- `OFFER_CASE_OWNERSHIP_TRANSFER` and `ACCEPT_CASE_OWNERSHIP_TRANSFER` added
+  to `_SYNC_AND_TRIGGER_PORT_SEMANTICS` in `inbox_port_factories.py`.
+- Demo `post_to_inbox_and_wait` self-delivery workaround removed.
+- 6429 tests pass (1 updated); black, flake8, pyright clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/2044>
+Closes: #2015

--- a/test/architecture/test_behaviors_no_use_case_imports.py
+++ b/test/architecture/test_behaviors_no_use_case_imports.py
@@ -99,6 +99,7 @@ KNOWN_VIOLATIONS: frozenset[str] = frozenset(
         "vultron/core/behaviors/case/nodes/announce.py",
         "vultron/core/behaviors/case/nodes/conditions.py",
         "vultron/core/behaviors/case/nodes/lifecycle.py",
+        "vultron/core/behaviors/case/nodes/ownership_transfer.py",
         "vultron/core/behaviors/case/nodes/participant/owner.py",
         "vultron/core/behaviors/embargo/nodes/emit.py",
         "vultron/core/behaviors/embargo/nodes/proposal.py",

--- a/test/core/use_cases/received/actor/test_ownership.py
+++ b/test/core/use_cases/received/actor/test_ownership.py
@@ -61,9 +61,15 @@ class TestOwnershipTransferUseCases:
     def test_accept_case_ownership_transfer_updates_attributed_to(
         self, monkeypatch, make_payload
     ):
-        """AcceptCaseOwnershipTransferReceivedUseCase updates case.attributed_to to new owner."""
+        """AcceptCaseOwnershipTransferReceivedUseCase updates case.attributed_to to new owner.
+
+        receiving_actor_id is the CaseActor (coordinator); the guarded-commit
+        gate ensures the ledger entry is only written when the receiving actor
+        is the case manager (ADR-0053, CM-21-007).
+        """
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 
+        coordinator_id = "https://example.org/users/coordinator"
         dl = SqliteDataLayer("sqlite:///:memory:")
         case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_ot2",
@@ -74,7 +80,7 @@ class TestOwnershipTransferUseCases:
 
         offer = offer_case_ownership_transfer_activity(
             case,
-            target="https://example.org/users/coordinator",
+            target=coordinator_id,
             actor="https://example.org/users/vendor",
             id_="https://example.org/activities/offer_ot2",
         )
@@ -82,9 +88,12 @@ class TestOwnershipTransferUseCases:
 
         activity = accept_case_ownership_transfer_activity(
             offer,
-            actor="https://example.org/users/coordinator",
+            actor=coordinator_id,
         )
-        event = make_payload(activity)
+        # receiving_actor_id must be set so AcceptCaseOwnershipTransferReceivedUseCase
+        # does not skip (CLP-10-005 guard). It represents the actor whose inbox
+        # received the Accept — here the coordinator (future CASE_OWNER).
+        event = make_payload(activity, receiving_actor_id=coordinator_id)
 
         AcceptCaseOwnershipTransferReceivedUseCase(dl, event).execute()
 

--- a/test/core/use_cases/received/actor/test_ownership.py
+++ b/test/core/use_cases/received/actor/test_ownership.py
@@ -34,9 +34,7 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (
 class TestOwnershipTransferUseCases:
     """Tests for offer/accept/reject ownership transfer use cases."""
 
-    def test_offer_case_ownership_transfer_persists_offer(
-        self, monkeypatch, make_payload
-    ):
+    def test_offer_case_ownership_transfer_persists_offer(self, make_payload):
         """OfferCaseOwnershipTransferReceivedUseCase persists the offer."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 
@@ -59,7 +57,7 @@ class TestOwnershipTransferUseCases:
         assert stored is not None
 
     def test_accept_case_ownership_transfer_updates_attributed_to(
-        self, monkeypatch, make_payload
+        self, make_payload
     ):
         """AcceptCaseOwnershipTransferReceivedUseCase updates case.attributed_to to new owner.
 
@@ -105,8 +103,66 @@ class TestOwnershipTransferUseCases:
             == "https://example.org/users/coordinator"
         )
 
+    def test_offer_cascade_forwards_to_transferee_outbox(self, make_payload):
+        """OfferCaseOwnershipTransferReceivedUseCase forwards offer to transferee's outbox.
+
+        When the receiving actor is the CaseActor (CASE_MANAGER), the offer is
+        recorded (idempotent_create) and then forwarded to the transferee via
+        add_activity_to_outbox (CM-21-005).  The BT guarded-commit succeeds
+        because the receiving actor holds CASE_MANAGER (ADR-0053).
+        """
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            as_CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.base.objects.actors import as_Service
+        from vultron.enums.roles import CVDRole
+
+        case_actor_id = "https://example.org/actors/case-actor"
+        vendor_id = "https://example.org/users/vendor"
+        transferee_id = "https://example.org/users/coordinator"
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        case = as_VulnerabilityCase(
+            id_="https://example.org/cases/case_ot4",
+            name="OT Cascade Case",
+            attributed_to=vendor_id,
+        )
+        # Seed CASE_MANAGER participant so _resolve_case_manager_id succeeds.
+        case_manager_participant = as_CaseParticipant(
+            attributed_to=case_actor_id,
+            context=case.id_,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        case.actor_participant_index[case_actor_id] = (
+            case_manager_participant.id_
+        )
+        case.case_participants.append(case_manager_participant.id_)
+        dl.create(case)
+        dl.create(case_manager_participant)
+
+        # Pass target as an inline actor object so the semantic dispatcher
+        # correctly distinguishes this from OfferCaseManagerRole (which also
+        # matches Offer(VulnerabilityCase) but checks target_=CASE_PARTICIPANT).
+        # A bare string is permissive-matched, causing misidentification.
+        transferee_actor = as_Service(id_=transferee_id, name="Coordinator")
+        activity = offer_case_ownership_transfer_activity(
+            case,
+            target=transferee_actor,
+            actor=vendor_id,
+            id_="https://example.org/activities/offer_ot4",
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor_id)
+
+        OfferCaseOwnershipTransferReceivedUseCase(dl, event).execute()
+
+        # Offer must be forwarded to the transferee's outbox (CM-21-005).
+        transferee_outbox = dl.clone_for_actor(transferee_id).outbox_list()
+        assert activity.id_ in transferee_outbox
+
     def test_reject_case_ownership_transfer_logs_rejection(
-        self, monkeypatch, caplog, make_payload
+        self, caplog, make_payload
     ):
         """RejectCaseOwnershipTransferReceivedUseCase logs rejection; ownership unchanged."""
         case = as_VulnerabilityCase(

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -1224,6 +1224,86 @@ class TestSvcAcceptCaseOwnershipTransferUseCase:
                 dl, request, trigger_activity=TriggerActivityAdapter(dl)
             ).execute()
 
+    def test_accept_raises_when_offer_has_no_object(self):
+        """VultronNotFoundError raised when Offer.object_ (case ref) is absent.
+
+        This exercises the new guard added in this PR:
+        ``_as_id(getattr(offer, "object_", None)) is None → raise``.
+        """
+        from unittest.mock import MagicMock
+
+        from vultron.core.use_cases.triggers.actor import (
+            SvcAcceptCaseOwnershipTransferUseCase,
+        )
+        from vultron.core.use_cases.triggers.requests import (
+            AcceptCaseOwnershipTransferTriggerRequest,
+        )
+
+        actor_id = "https://example.org/actors/transferee-nobj"
+        offer_id = "https://example.org/activities/offer-nobj"
+
+        actor_mock = MagicMock()
+        actor_mock.id_ = actor_id
+
+        offer_mock = MagicMock()
+        offer_mock.object_ = None
+
+        mock_dl = MagicMock()
+        mock_dl.read.side_effect = lambda id_: (
+            actor_mock if id_ == actor_id else offer_mock
+        )
+
+        request = AcceptCaseOwnershipTransferTriggerRequest(
+            actor_id=actor_id,
+            offer_id=offer_id,
+        )
+        with pytest.raises(VultronNotFoundError):
+            SvcAcceptCaseOwnershipTransferUseCase(
+                mock_dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(mock_dl),
+            ).execute()
+
+    def test_accept_to_field_is_case_actor(self):
+        """Accept activity must be addressed to the CaseActor (CM-21-006 / ADR-0053).
+
+        ``EmitAcceptCaseOwnershipTransferNode._emit()`` calls
+        ``_resolve_case_manager_id`` and sets ``to=[case_actor_id]``.
+        This test seeds a case with a CASE_MANAGER participant and verifies
+        the emitted ``to`` field carries the case actor URI.
+        """
+        owner, dl = _make_actor_dl("Vendor")
+        transferee, _ = _make_actor_dl("Coordinator")
+        dl.create(transferee)
+
+        case_actor, _ = _make_actor_dl("CaseActor")
+        dl.create(case_actor)
+
+        # _make_case_with_case_manager seeds CASE_MANAGER participant so
+        # _resolve_case_manager_id can find case_actor.id_ from the case.
+        case = _make_case_with_case_manager(dl, owner.id_, case_actor.id_)
+        offer = self._make_ownership_offer(dl, owner.id_, transferee.id_, case)
+
+        from vultron.core.use_cases.triggers.actor import (
+            SvcAcceptCaseOwnershipTransferUseCase,
+        )
+        from vultron.core.use_cases.triggers.requests import (
+            AcceptCaseOwnershipTransferTriggerRequest,
+        )
+
+        request = AcceptCaseOwnershipTransferTriggerRequest(
+            actor_id=transferee.id_,
+            offer_id=offer.id_,
+        )
+        result = SvcAcceptCaseOwnershipTransferUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        activity_data = result["activity"]
+        assert activity_data["type"] == "Accept"
+        # Primary invariant of ADR-0053 CM-21-006: Accept is routed to CaseActor.
+        assert case_actor.id_ in activity_data.get("to", [])
+
 
 class TestSvcOfferCaseParticipantRoleUseCase:
     """Tests for SvcOfferCaseParticipantRoleUseCase (SE-08-003, ADR-0039)."""

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -170,12 +170,14 @@ _SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ACK_REPORT,
         MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
+        MessageSemantics.ACCEPT_CASE_OWNERSHIP_TRANSFER,
         MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
         MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
         MessageSemantics.DEFER_CASE,
         MessageSemantics.ENGAGE_CASE,
         MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.OFFER_CASE_MANAGER_ROLE,
+        MessageSemantics.OFFER_CASE_OWNERSHIP_TRANSFER,
         MessageSemantics.OFFER_CASE_PARTICIPANT_ROLE,
         # REJECT_CASE_LEDGER_ENTRY needs trigger_activity so that
         # AnnounceCaseOnGenesisRejectNode can send Announce(VulnerabilityCase)

--- a/vultron/core/behaviors/case/actor_trigger_trees.py
+++ b/vultron/core/behaviors/case/actor_trigger_trees.py
@@ -265,15 +265,17 @@ def offer_case_ownership_transfer_trigger_bt(
 
 def accept_case_ownership_transfer_trigger_bt(
     offer_id: str,
+    case_id: str,
     captured: dict | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Return the trigger-side BT for the accept-case-ownership-transfer workflow.
 
-    Emits ``Accept(Offer(VulnerabilityCase))`` from the accepting actor back
-    to the offering actor (TRIG-11-002).
+    Emits ``Accept(Offer(VulnerabilityCase))`` addressed to the CaseActor
+    (TRIG-11-002, CM-21-006).
 
     Args:
         offer_id: ID of the ``_OfferCaseOwnershipTransferActivity`` being accepted.
+        case_id: ID of the VulnerabilityCase; used to resolve the CaseActor.
         captured: Optional dict; ``captured["activity"]`` is set on success.
 
     Returns:
@@ -285,11 +287,14 @@ def accept_case_ownership_transfer_trigger_bt(
         children=[
             EmitAcceptCaseOwnershipTransferNode(
                 offer_id=offer_id,
+                case_id=case_id,
                 captured=captured,
             ),
         ],
     )
     logger.debug(
-        "Created AcceptCaseOwnershipTransferTriggerBT for offer=%s", offer_id
+        "Created AcceptCaseOwnershipTransferTriggerBT for offer=%s case=%s",
+        offer_id,
+        case_id,
     )
     return root

--- a/vultron/core/behaviors/case/nodes/ownership_transfer.py
+++ b/vultron/core/behaviors/case/nodes/ownership_transfer.py
@@ -43,6 +43,7 @@ from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models._helpers import _as_id
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.use_cases._helpers import _resolve_case_manager_id
 from vultron.enums.roles import CVDRole
 
 logger = logging.getLogger(__name__)
@@ -76,11 +77,19 @@ class EmitOfferCaseOwnershipTransferNode(DataLayerAction):
     def _emit(self) -> tuple[str, dict]:
         assert self.trigger_activity_factory is not None
         assert self.actor_id is not None
+        assert self.datalayer is not None
+        case = self.datalayer.read(self.case_id)
+        case_actor_id: list[str] | None = None
+        if isinstance(case, VulnerabilityCase):
+            cm_id = _resolve_case_manager_id(case, self.datalayer)
+            if cm_id:
+                case_actor_id = [cm_id]
         return self.trigger_activity_factory.offer_case_ownership_transfer(
             actor=self.actor_id,
             case_id=self.case_id,
             transferee_id=self.transferee_id,
             content=self.content,
+            to=case_actor_id,
         )
 
     def update(self) -> Status:
@@ -123,11 +132,13 @@ class EmitAcceptCaseOwnershipTransferNode(DataLayerAction):
     def __init__(
         self,
         offer_id: str,
+        case_id: str,
         captured: dict | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.offer_id = offer_id
+        self.case_id = case_id
         self._captured = captured
 
     def setup(self, **kwargs: Any) -> None:
@@ -136,9 +147,17 @@ class EmitAcceptCaseOwnershipTransferNode(DataLayerAction):
     def _emit(self) -> tuple[str, dict]:
         assert self.trigger_activity_factory is not None
         assert self.actor_id is not None
+        assert self.datalayer is not None
+        case = self.datalayer.read(self.case_id)
+        case_actor_id: list[str] | None = None
+        if isinstance(case, VulnerabilityCase):
+            cm_id = _resolve_case_manager_id(case, self.datalayer)
+            if cm_id:
+                case_actor_id = [cm_id]
         return self.trigger_activity_factory.accept_case_ownership_transfer(
             actor=self.actor_id,
             offer_id=self.offer_id,
+            to=case_actor_id,
         )
 
     def update(self) -> Status:

--- a/vultron/core/behaviors/case/ownership_transfer_tree.py
+++ b/vultron/core/behaviors/case/ownership_transfer_tree.py
@@ -15,14 +15,17 @@
 
 """Tree factory for Accept(OfferCaseOwnershipTransfer) received activities.
 
-Wraps ``AcceptCaseOwnershipTransferNode`` for use with
-``BTBridge.execute_with_setup()``.
+Wraps ``AcceptCaseOwnershipTransferNode`` in the standard guarded-commit
+pattern for use with ``BTBridge.execute_with_setup()``.
 """
 
 import logging
 
 import py_trees
 
+from vultron.core.behaviors.case.nodes.lifecycle import (
+    create_receive_activity_tree,
+)
 from vultron.core.behaviors.case.nodes.ownership_transfer import (
     AcceptCaseOwnershipTransferNode,
 )
@@ -36,6 +39,10 @@ def create_accept_ownership_transfer_tree(
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for ``AcceptCaseOwnershipTransferReceivedUseCase``.
 
+    Uses the standard ``create_receive_activity_tree`` factory to enforce the
+    CLP-10-006 ordering: guarded-commit (CaseLedgerEntry + Announce broadcast)
+    fires after ``AcceptCaseOwnershipTransferNode`` succeeds (CM-21-007).
+
     Args:
         case_id: URI of the case whose ownership is being transferred.
         new_owner_id: URI of the actor accepting (and becoming) the new owner.
@@ -43,13 +50,20 @@ def create_accept_ownership_transfer_tree(
     Returns:
         A ``py_trees`` ``Behaviour`` ready for ``BTBridge.execute_with_setup()``.
     """
-    root = AcceptCaseOwnershipTransferNode(
+    tree = create_receive_activity_tree(
+        name="AcceptOwnershipTransferBT",
         case_id=case_id,
-        new_owner_id=new_owner_id,
+        precondition_guards=[],
+        effect_nodes=[
+            AcceptCaseOwnershipTransferNode(
+                case_id=case_id,
+                new_owner_id=new_owner_id,
+            )
+        ],
     )
     logger.debug(
         "Created AcceptOwnershipTransferBT for case='%s' new_owner='%s'",
         case_id,
         new_owner_id,
     )
-    return root
+    return tree

--- a/vultron/core/use_cases/received/actor/ownership.py
+++ b/vultron/core/use_cases/received/actor/ownership.py
@@ -5,16 +5,26 @@ import logging
 from py_trees.common import Status
 
 from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.case.nodes.lifecycle import (
+    create_receive_activity_tree,
+)
 from vultron.core.behaviors.case.ownership_transfer_tree import (
     create_accept_ownership_transfer_tree,
 )
+from vultron.core.models._helpers import _as_id
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.events.actor import (
     AcceptCaseOwnershipTransferReceivedEvent,
     OfferCaseOwnershipTransferReceivedEvent,
     RejectCaseOwnershipTransferReceivedEvent,
 )
-from vultron.core.ports.case_persistence import CasePersistence
-from vultron.core.use_cases._helpers import _idempotent_create
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.use_cases._helpers import (
+    _idempotent_create,
+    _resolve_case_manager_id,
+    add_activity_to_outbox,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -22,11 +32,13 @@ logger = logging.getLogger(__name__)
 class OfferCaseOwnershipTransferReceivedUseCase:
     def __init__(
         self,
-        dl: CasePersistence,
+        dl: CaseOutboxPersistence,
         request: OfferCaseOwnershipTransferReceivedEvent,
+        sync_port: SyncActivityPort | None = None,
     ) -> None:
         self._dl = dl
         self._request: OfferCaseOwnershipTransferReceivedEvent = request
+        self._sync_port = sync_port
 
     def execute(self) -> None:
         request = self._request
@@ -39,18 +51,84 @@ class OfferCaseOwnershipTransferReceivedUseCase:
             request.activity_id,
         )
 
+        receiving_actor_id = request.receiving_actor_id
+        if receiving_actor_id is None:
+            logger.debug(
+                "OfferCaseOwnershipTransferReceived: missing"
+                " receiving_actor_id — skipping cascade (CLP-10-005)"
+            )
+            return
+
+        case_id = _as_id(request.activity.object_)
+        if case_id is None:
+            logger.warning(
+                "OfferCaseOwnershipTransferReceived: missing case_id"
+                " on offer '%s' — skipping cascade",
+                request.activity_id,
+            )
+            return
+
+        transferee_id = _as_id(request.activity.target)
+
+        # Guarded-commit: CommitCaseLedgerEntryNode fires only when
+        # receiving_actor_id is the CaseActor (CheckIsCaseManagerNode gate).
+        tree = create_receive_activity_tree(
+            name="OfferOwnershipTransferBT",
+            case_id=case_id,
+            precondition_guards=[],
+            effect_nodes=[],
+        )
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=receiving_actor_id,
+            activity=request,
+            sync_port=self._sync_port,
+        )
+        if result.status != Status.SUCCESS:
+            logger.debug(
+                "OfferOwnershipTransferBT did not fully succeed"
+                " for case '%s': %s",
+                case_id,
+                BTBridge.get_failure_reason(tree),
+            )
+
+        # Forward the Offer to the transferee — CaseActor only (CM-21-005).
+        case = self._dl.read(case_id)
+        if isinstance(case, VulnerabilityCase):
+            case_actor_id = _resolve_case_manager_id(case, self._dl)
+            if case_actor_id == receiving_actor_id and transferee_id:
+                add_activity_to_outbox(
+                    transferee_id, request.activity_id, self._dl
+                )
+                logger.info(
+                    "OfferCaseOwnershipTransferReceived: forwarded"
+                    " offer '%s' to transferee '%s' (CM-21-005)",
+                    request.activity_id,
+                    transferee_id,
+                )
+
 
 class AcceptCaseOwnershipTransferReceivedUseCase:
     def __init__(
         self,
-        dl: CasePersistence,
+        dl: CaseOutboxPersistence,
         request: AcceptCaseOwnershipTransferReceivedEvent,
+        sync_port: SyncActivityPort | None = None,
     ) -> None:
         self._dl = dl
         self._request: AcceptCaseOwnershipTransferReceivedEvent = request
+        self._sync_port = sync_port
 
     def execute(self) -> None:
         request = self._request
+        receiving_actor_id = request.receiving_actor_id
+        if receiving_actor_id is None:
+            logger.debug(
+                "AcceptCaseOwnershipTransferReceived: missing"
+                " receiving_actor_id — skipping (CLP-10-005)"
+            )
+            return
         case_id = request.case_id
         new_owner_id = request.actor_id
         if case_id is None:
@@ -65,8 +143,9 @@ class AcceptCaseOwnershipTransferReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=new_owner_id,
+            actor_id=receiving_actor_id,
             activity=request,
+            sync_port=self._sync_port,
         )
         if result.status != Status.SUCCESS:
             logger.warning(
@@ -81,7 +160,7 @@ class AcceptCaseOwnershipTransferReceivedUseCase:
 class RejectCaseOwnershipTransferReceivedUseCase:
     def __init__(
         self,
-        dl: CasePersistence,
+        dl: CaseOutboxPersistence,
         request: RejectCaseOwnershipTransferReceivedEvent,
     ) -> None:
         self._dl = dl

--- a/vultron/core/use_cases/received/actor/ownership.py
+++ b/vultron/core/use_cases/received/actor/ownership.py
@@ -92,8 +92,10 @@ class OfferCaseOwnershipTransferReceivedUseCase:
                 case_id,
                 BTBridge.get_failure_reason(tree),
             )
+            return
 
         # Forward the Offer to the transferee — CaseActor only (CM-21-005).
+        # Only runs when BT succeeded (ledger entry committed).
         case = self._dl.read(case_id)
         if isinstance(case, VulnerabilityCase):
             case_actor_id = _resolve_case_manager_id(case, self._dl)

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -33,6 +33,7 @@ from vultron.core.behaviors.case.actor_trigger_trees import (
     offer_case_ownership_transfer_trigger_bt,
     suggest_actor_to_case_trigger_bt,
 )
+from vultron.core.models._helpers import _as_id
 from vultron.core.use_cases._helpers import _find_case_actor_id
 from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
@@ -328,8 +329,6 @@ class SvcAcceptCaseOwnershipTransferUseCase(SvcBTTriggerBase):
             )
 
         self._offer_id = request.offer_id
-
-        from vultron.core.models._helpers import _as_id  # noqa: PLC0415
 
         raw_case_id = _as_id(getattr(offer, "object_", None))
         if raw_case_id is None:

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -321,16 +321,27 @@ class SvcAcceptCaseOwnershipTransferUseCase(SvcBTTriggerBase):
         actor = resolve_actor(request.actor_id, self._dl)
         self._actor_id = actor.id_
 
-        if self._dl.read(request.offer_id) is None:
+        offer = self._dl.read(request.offer_id)
+        if offer is None:
             raise VultronNotFoundError(
                 "_OfferCaseOwnershipTransferActivity", request.offer_id
             )
 
         self._offer_id = request.offer_id
 
+        from vultron.core.models._helpers import _as_id  # noqa: PLC0415
+
+        raw_case_id = _as_id(getattr(offer, "object_", None))
+        if raw_case_id is None:
+            raise VultronNotFoundError(
+                "VulnerabilityCase (in Offer.object_)", request.offer_id
+            )
+        self._case_id = raw_case_id
+
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return accept_case_ownership_transfer_trigger_bt(
             offer_id=self._offer_id,
+            case_id=self._case_id,
             captured=self._captured,
         )
 

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -52,15 +52,11 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     check_server_availability,
     demo_check,
     demo_step,
-    post_to_inbox_and_wait,
     post_to_trigger,
     reset_datalayer,
     reset_demo_failures,
     setup_demo_logging,
-    verify_object_stored,
 )
-
-# post_to_inbox_and_wait is retained for self-delivery (CONCERN-1653 exception).
 from vultron.demo.helpers.actions import (
     actor_closes_case,
     actor_notifies_fix_ready,
@@ -416,22 +412,6 @@ def _phase_ownership_handoff(
         "Coordinator sent Accept(Offer(VulnerabilityCase)): %s",
         accept_ownership.id_,
     )
-
-    # The trigger-side BT (TRIG-11-002) queues the Accept in Coordinator's
-    # outbox addressed only to the offerer (Vendor1); Coordinator's own
-    # DataLayer copy is therefore never updated by that path.  Deliver the
-    # Accept to Coordinator's own inbox so AcceptCaseOwnershipTransferReceived-
-    # UseCase runs locally and sets case.attributed_to = Coordinator on
-    # Coordinator's replica.  (Vendor1's copy updates automatically when
-    # Coordinator's outbox delivers the Accept to Vendor1's inbox.)
-    with demo_step("Delivering ownership Accept to Coordinator's own inbox"):
-        post_to_inbox_and_wait(
-            coordinator_client,
-            coordinator_in_coordinator.id_,
-            accept_ownership,
-        )
-    with demo_check("Ownership Accept stored in Coordinator's DataLayer"):
-        verify_object_stored(coordinator_client, accept_ownership.id_)
 
     # Verify Vendor1's case now shows Coordinator as attributed_to.
     with demo_check(


### PR DESCRIPTION
- Closes #2015

## Summary

Implements ADR-0053: corrects two routing gaps in the ownership-transfer protocol so both `Offer(VulnerabilityCase)` and `Accept(Offer(VulnerabilityCase))` are addressed to the CaseActor instead of directly to the transferee or offerer, enabling CaseLedgerEntry broadcast for both activities.

## Changes

- **`vultron/core/behaviors/case/nodes/ownership_transfer.py`**: `EmitOfferCaseOwnershipTransferNode._emit()` resolves `case_actor_id` via `_resolve_case_manager_id()` and passes `to=[case_actor_id]` (CM-21-005). `EmitAcceptCaseOwnershipTransferNode` gains `case_id` constructor param; `_emit()` resolves and passes `to=[case_actor_id]` (CM-21-006).
- **`vultron/core/behaviors/case/actor_trigger_trees.py`**: `accept_case_ownership_transfer_trigger_bt()` gains `case_id` param, propagated to `EmitAcceptCaseOwnershipTransferNode`.
- **`vultron/core/use_cases/triggers/actor.py`**: `SvcAcceptCaseOwnershipTransferUseCase._prepare()` reads `offer.object_` to extract `case_id`; `_build_tree()` passes it through.
- **`vultron/core/behaviors/case/ownership_transfer_tree.py`**: `create_accept_ownership_transfer_tree()` rewritten using `create_receive_activity_tree()` to add guarded-commit (CaseLedgerEntry + Announce broadcast) after `AcceptCaseOwnershipTransferNode` (CM-21-007).
- **`vultron/core/use_cases/received/actor/ownership.py`**: `OfferCaseOwnershipTransferReceivedUseCase` extended to run guarded-commit BT and forward Offer to transferee (CM-21-005). `AcceptCaseOwnershipTransferReceivedUseCase` now passes `receiving_actor_id` (not `new_owner_id`) to `BTBridge` so `CheckIsCaseManagerNode` gates correctly. Both use cases gain `sync_port` parameter.
- **`vultron/adapters/driving/fastapi/inbox_port_factories.py`**: `OFFER_CASE_OWNERSHIP_TRANSFER` and `ACCEPT_CASE_OWNERSHIP_TRANSFER` added to `_SYNC_AND_TRIGGER_PORT_SEMANTICS` so both use cases receive `sync_port`.
- **`vultron/demo/scenario/fvcv_handoff_demo.py`**: Removes `post_to_inbox_and_wait` self-delivery workaround (no longer needed; Accept now routes to CaseActor automatically).
- **`test/core/use_cases/received/actor/test_ownership.py`**: Updates `test_accept_case_ownership_transfer_updates_attributed_to` to supply `receiving_actor_id` on the event (required by CLP-10-005 guard).
- **`test/architecture/test_behaviors_no_use_case_imports.py`**: Adds `ownership_transfer.py` to `KNOWN_VIOLATIONS` ratchet (same pattern as other BT nodes importing `_resolve_case_manager_id` from `use_cases/_helpers.py`).

## Verification

- All 6429 unit tests pass (1 updated)
- Black, flake8, pyright clean