### PR TITLE
fix(demo): correct case closure ordering in fvcv_extension and fccv_handoff scenarios

### DIFF
--- a/plan/history/2608/implementation/ISSUE-2025.md
+++ b/plan/history/2608/implementation/ISSUE-2025.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-2025
+timestamp: '2026-08-06T18:25:39.453722+00:00'
+title: 'fix(demo): correct case closure ordering in fvcv_extension and fccv_handoff'
+type: implementation
+---
+
+## Issue #2025 — fix(demo): correct case closure ordering in fvcv_extension and fccv_handoff scenarios
+
+Fixed the case-owner-closes-last ordering violation in two demo scenarios:
+
+- `fvcv_extension_demo.py`: moved Vendor1 (CASE_OWNER throughout) to close last
+- `fccv_handoff_demo.py`: moved C2 (CASE_OWNER post-handoff) to close last
+
+Added regression tests to both test files mirroring the pattern established in PR #2021.
+
+DEFER: pre-existing c1_client used as authoritative ledger source post-handoff in fccv_handoff — tracked in #2043.
+
+PR: <https://github.com/CERTCC/Vultron/pull/2045>

--- a/test/demo/test_fccv_handoff_demo.py
+++ b/test/demo/test_fccv_handoff_demo.py
@@ -707,3 +707,68 @@ class TestFccvHandoffMilestoneAssertions:
                 case=case,
             )
         mock_m7.assert_called()
+
+    def test_phase_case_closure_c2_closes_last(self):
+        """C2 (case owner post-handoff) must close after C1, Vendor, and Finder."""
+        import contextlib
+
+        finder_client = self._client()
+        c1_client = self._client()
+        c2_client = self._client()
+        vendor_client = self._client()
+        c1_in_c1 = self._actor("urn:test:c1")
+        c2_in_c2 = self._actor("urn:test:c2")
+        finder_in_finder = self._actor("urn:test:finder")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        case = self._case()
+        case.id_ = "urn:test:case"
+        c1_client.get.return_value = {
+            "e0": {
+                "case_id": case.id_,
+                "log_index": 0,
+                "entry_hash": "h0",
+                "event_type": "close_case",
+            }
+        }
+
+        mock_close = MagicMock()
+
+        with (
+            patch.object(demo, "actor_closes_case", mock_close),
+            patch.object(demo, "wait_for_all_participants_rm_closed"),
+            patch.object(demo, "verify_case_closed"),
+            patch.object(demo, "wait_for_event_type_in_ledger"),
+            patch.object(demo, "wait_for_contiguous_ledger_coverage"),
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            demo._phase_case_closure(
+                finder_client=finder_client,
+                c1_client=c1_client,
+                c2_client=c2_client,
+                vendor_client=vendor_client,
+                c1=self._actor("urn:test:c1"),
+                c1_in_c1=c1_in_c1,
+                c2=self._actor("urn:test:c2"),
+                c2_in_c2=c2_in_c2,
+                finder=self._actor("urn:test:finder"),
+                finder_in_finder=finder_in_finder,
+                vendor=self._actor("urn:test:vendor"),
+                vendor_in_vendor=vendor_in_vendor,
+                case=case,
+            )
+
+        actors_closed = [
+            call.kwargs["actor"].id_ for call in mock_close.call_args_list
+        ]
+        assert (
+            actors_closed[-1] == c2_in_c2.id_
+        ), "C2 (case owner post-handoff) must close last; got order: " + str(
+            actors_closed
+        )
+        assert actors_closed.index(finder_in_finder.id_) < actors_closed.index(
+            c2_in_c2.id_
+        ), "Finder must close before C2"

--- a/test/demo/test_fccv_handoff_demo.py
+++ b/test/demo/test_fccv_handoff_demo.py
@@ -670,7 +670,7 @@ class TestFccvHandoffMilestoneAssertions:
         vendor_in_vendor = self._actor("urn:test:vendor")
         case = self._case()
         case.id_ = "urn:test:case"
-        c1_client.get.return_value = {
+        c2_client.get.return_value = {
             "e0": {
                 "case_id": case.id_,
                 "log_index": 0,
@@ -722,7 +722,7 @@ class TestFccvHandoffMilestoneAssertions:
         vendor_in_vendor = self._actor("urn:test:vendor")
         case = self._case()
         case.id_ = "urn:test:case"
-        c1_client.get.return_value = {
+        c2_client.get.return_value = {
             "e0": {
                 "case_id": case.id_,
                 "log_index": 0,

--- a/test/demo/test_fvcv_extension_demo.py
+++ b/test/demo/test_fvcv_extension_demo.py
@@ -623,3 +623,68 @@ class TestFvcvExtensionMilestoneAssertions:
                 case=case,
             )
         mock_m7.assert_called()
+
+    def test_phase_case_closure_vendor1_closes_last(self):
+        """Vendor1 (case owner) must close after Vendor2, Coordinator, and Finder."""
+        import contextlib
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        coordinator_client = self._client()
+        vendor2_client = self._client()
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        vendor2_in_vendor2 = self._actor("urn:test:vendor2")
+        finder_in_finder = self._actor("urn:test:finder")
+        coordinator_in_coordinator = self._actor("urn:test:coordinator")
+        case = self._case()
+        case.id_ = "urn:test:case"
+        vendor_client.get.return_value = {
+            "e0": {
+                "case_id": case.id_,
+                "log_index": 0,
+                "entry_hash": "h0",
+                "event_type": "close_case",
+            }
+        }
+
+        mock_close = MagicMock()
+
+        with (
+            patch.object(demo, "actor_closes_case", mock_close),
+            patch.object(demo, "wait_for_all_participants_rm_closed"),
+            patch.object(demo, "verify_case_closed"),
+            patch.object(demo, "wait_for_event_type_in_ledger"),
+            patch.object(demo, "wait_for_contiguous_ledger_coverage"),
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            demo._phase_case_closure(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                coordinator_client=coordinator_client,
+                vendor2_client=vendor2_client,
+                vendor=self._actor("urn:test:vendor"),
+                vendor_in_vendor=vendor_in_vendor,
+                vendor2=self._actor("urn:test:vendor2"),
+                vendor2_in_vendor2=vendor2_in_vendor2,
+                finder=self._actor("urn:test:finder"),
+                finder_in_finder=finder_in_finder,
+                coordinator=self._actor("urn:test:coordinator"),
+                coordinator_in_coordinator=coordinator_in_coordinator,
+                case=case,
+            )
+
+        actors_closed = [
+            call.kwargs["actor"].id_ for call in mock_close.call_args_list
+        ]
+        assert (
+            actors_closed[-1] == vendor_in_vendor.id_
+        ), "Vendor1 (case owner) must close last; got order: " + str(
+            actors_closed
+        )
+        assert actors_closed.index(finder_in_finder.id_) < actors_closed.index(
+            vendor_in_vendor.id_
+        ), "Finder must close before Vendor1"

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -848,11 +848,6 @@ def _phase_case_closure(
         case_id=case.id_,
     )
     actor_closes_case(
-        client=c2_client,
-        actor=c2_in_c2,
-        case_id=case.id_,
-    )
-    actor_closes_case(
         client=vendor_client,
         actor=vendor_in_vendor,
         case_id=case.id_,
@@ -860,6 +855,12 @@ def _phase_case_closure(
     actor_closes_case(
         client=finder_client,
         actor=finder_in_finder,
+        case_id=case.id_,
+    )
+    # C2 is the case owner post-handoff (TRIG-11-002) and closes last.
+    actor_closes_case(
+        client=c2_client,
+        actor=c2_in_c2,
         case_id=case.id_,
     )
 

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -866,7 +866,7 @@ def _phase_case_closure(
 
     with demo_check("All participants RM.CLOSED on all replicas"):
         wait_for_all_participants_rm_closed(
-            client=c1_client,
+            client=c2_client,
             case_id=case.id_,
         )
         wait_for_all_participants_rm_closed(
@@ -874,38 +874,38 @@ def _phase_case_closure(
             case_id=case.id_,
         )
         verify_case_closed(
-            receiver_client=c1_client,
+            receiver_client=c2_client,
             reporter_client=finder_client,
             case_id=case.id_,
         )
 
-    with demo_check("close_case entry present on authoritative actor (c1)"):
+    with demo_check("close_case entry present on authoritative actor (c2)"):
         wait_for_event_type_in_ledger(
-            client=c1_client,
+            client=c2_client,
             case_id=case.id_,
             event_type="close_case",
         )
-    c1_entries = _get_log_entries_for_case(c1_client, case.id_)
-    if c1_entries:
-        c1_tail = max(c1_entries, key=lambda e: e["log_index"])
-        c1_tail_index: int = c1_tail["log_index"]
-        c1_tail_hash: str = c1_tail["entry_hash"]
+    c2_entries = _get_log_entries_for_case(c2_client, case.id_)
+    if c2_entries:
+        c2_tail = max(c2_entries, key=lambda e: e["log_index"])
+        c2_tail_index: int = c2_tail["log_index"]
+        c2_tail_hash: str = c2_tail["entry_hash"]
         logger.info(
-            "Waiting for replicas to receive C1 tail after closure"
+            "Waiting for replicas to receive C2 tail after closure"
             " (hash=%s… index=%d)",
-            c1_tail_hash[:16],
-            c1_tail_index,
+            c2_tail_hash[:16],
+            c2_tail_index,
         )
         for replica_client, label in [
             (finder_client, "Finder"),
-            (c2_client, "C2"),
+            (c1_client, "C1"),
             (vendor_client, "Vendor"),
         ]:
             with demo_check(f"{label} ledger coverage (close phase)"):
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
-                    expected_tail_index=c1_tail_index,
+                    expected_tail_index=c2_tail_index,
                 )
 
 

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -758,11 +758,6 @@ def _phase_case_closure(
     logger.info("─" * 80)
 
     actor_closes_case(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-    actor_closes_case(
         client=vendor2_client,
         actor=vendor2_in_vendor2,
         case_id=case.id_,
@@ -775,6 +770,12 @@ def _phase_case_closure(
     actor_closes_case(
         client=finder_client,
         actor=finder_in_finder,
+        case_id=case.id_,
+    )
+    # Vendor1 is the case owner (CASE_OWNER throughout) and closes last.
+    actor_closes_case(
+        client=vendor_client,
+        actor=vendor_in_vendor,
         case_id=case.id_,
     )
 


### PR DESCRIPTION
- Closes #2025
- Closes #2043

## Summary

Fixes the case-owner-closes-last ordering violation in two demo scenarios,
applying the same reorder pattern from PR #2021 (ISSUE-1759 / fvcv_handoff).
Also updates `fccv_handoff_demo._phase_case_closure` to use `c2_client` as
the authoritative ledger source for post-closure sync (C2 is `CASE_OWNER`
post-handoff via TRIG-11-002).

## Changes

- **`vultron/demo/scenario/fvcv_extension_demo.py`**: move Vendor1 (`CASE_OWNER`
  throughout) to close last; previously closed first.
- **`vultron/demo/scenario/fccv_handoff_demo.py`**: move C2 (`CASE_OWNER`
  post-handoff via TRIG-11-002) to close last; previously closed second.
  Also switch authoritative ledger source from `c1_client` to `c2_client`
  for post-closure sync and ledger-coverage checks.
- **`test/demo/test_fvcv_extension_demo.py`**: add
  `test_phase_case_closure_vendor1_closes_last` regression test.
- **`test/demo/test_fccv_handoff_demo.py`**: add
  `test_phase_case_closure_c2_closes_last` regression test; update
  `test_phase_case_closure_calls_verify_case_closed` to seed `c2_client`.

Both new tests assert `actors_closed[-1] == owner.id_` and that Finder precedes
the owner, mirroring `test_phase_case_closure_coordinator_closes_last` in
`test_fvcv_handoff_demo.py`.

## Verification

- 1038 demo tests pass (2 new)
- Black, flake8, mypy, pyright clean