### PR TITLE
docs: plan issue #1218 — fcv-reject demo scenario variation

### DIFF
--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -29,7 +29,7 @@ event types it exercises. Event types are those recorded as `event_type` in
 | fccv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
 | fcvcv             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
 | fcv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
-| fcv-reject        | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   | ✓ |
+| fcv-reject        | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓ |
 
 **Notes:**
 
@@ -46,10 +46,13 @@ event types it exercises. Event types are those recorded as `event_type` in
   approves a suggested participant. It fires only in scenarios that include the
   ADR-0026 suggest-actor flow: `fvcv-extension`, `fccv-extension`, and `fcvcv`.
 - `reject_invite_actor_to_case` is emitted by `RejectInviteActorToCaseReceivedUseCase`
-  on the CaseActor when an invitee sends `Reject(Invite(actor, case))`. It fires
-  only in `fcv-reject` (IDEA-1218): the Vendor accepts the invite (entering
-  RM.RECEIVED), then rejects the case as invalid (RI → RM.INVALID) and closes it
-  (RC → RM.CLOSED). No other current scenario exercises this ledger entry.
+  on the CaseActor when an invitee sends `Reject(Invite(actor, case))` — an
+  **invitation-layer** rejection (not an RM-state RI/RC message). It fires only in
+  `fcv-reject` (IDEA-1218): the Vendor receives the case invitation and sends
+  `Reject(Invite(actor, case))` to decline it, which triggers
+  `RejectInviteActorToCaseReceivedUseCase` on the CaseActor. Because the Vendor
+  rejects rather than accepts, `accept_invite_actor_to_case` does NOT appear in
+  this scenario. No other current scenario exercises this ledger entry.
 - `add_case_participant` is emitted by `AcceptInviteNode`
   (`vultron/core/behaviors/case/nodes/accept_invite.py:181`) on the CaseActor
   received-side when processing Accept(Invite). This event records the internal
@@ -97,22 +100,24 @@ advance the CVD protocol state and are recorded in the replicated case ledger.
 | `offer_case_participant` | Suggest-actor flow (ADR-0026) |
 | `accept_invite_actor_to_case` | Invitation acceptance |
 | `accept_actor_recommendation` | Recommendation approval (ADR-0026) |
+| `reject_invite_actor_to_case` | Invitation-layer rejection (`Reject(Invite(actor, case))`) |
 
 ### Dimensions covered outside Invariant 5
 
 | Dimension | Covered by | How verified |
 |---|---|---|
 | Ownership transfer | `fvcv-handoff`, `fccv-handoff` | `demo_check` assertions in scenario script (not a ledger event_type) |
-| CVD role variation | All 8 scenarios | Scenario scripts define actor roles (deployer/vendor-only/coordinator) |
+| CVD role variation | All 9 scenarios | Scenario scripts define actor roles (deployer/vendor-only/coordinator) |
 | Fix-ready / fix-deployed lifecycle (VFd vs VFD) | All scenarios run to RM closed | Invariant 7 (`test_invariant_7_log_terminates_all_rm_closed`) |
 | Multi-vendor vs single-vendor fix paths | `fvv`, `fcvcv`, `fvcv-extension` (multiple vendors) vs `fv`, `fcv` (single) | Scenario composition; covered by minimum set via `fcvcv` |
 | Embargo lifecycle phases | Scenarios with Coordinator actors | `demo_check` + EM state assertions in scenario scripts |
 
 ### Why the minimum set is sufficient
 
-The 3-scenario minimum set (`fv`, `fvcv-handoff`, `fcvcv`) covers all 8
-`event_type` columns and the ownership-transfer path. The additional dimensions
-(CVD role variation, multi-vendor fix paths, embargo phases) are either:
+The 4-scenario minimum set (`fv`, `fvcv-handoff`, `fcvcv`, `fcv-reject`) covers
+all 9 `event_type` columns and the ownership-transfer path. The additional
+dimensions (CVD role variation, multi-vendor fix paths, embargo phases) are
+either:
 
 - exercised by multiple minimum-set scenarios (multi-vendor: `fcvcv`), or
 - verified by separate invariants that do not require additional scenarios (RM
@@ -121,7 +126,9 @@ The 3-scenario minimum set (`fv`, `fvcv-handoff`, `fcvcv`) covers all 8
   of which CI tier it lands in.
 
 The 5 full-suite-only scenarios add regression depth but not breadth relative to
-the minimum set's event-type and protocol-path coverage.
+the minimum set's event-type and protocol-path coverage. (`fcv-reject` is the
+4th minimum-set member; it cannot be covered by any existing scenario since
+`reject_invite_actor_to_case` is unique to the invitation-rejection path.)
 
 ## Minimum PR Validation Set (DEMOCI-06-002)
 
@@ -132,7 +139,7 @@ the minimum set's event-type and protocol-path coverage.
 | fv | ✓ (member) | 2-actor baseline; covers all 4 universal event types with no invitation phases |
 | fvcv-handoff | ✓ (member) | Adds `invite_actor_to_case` + `accept_invite_actor_to_case` + ownership-transfer protocol path |
 | fcvcv | ✓ (member) | Adds `offer_case_participant` + `accept_actor_recommendation` + ≥3-actor invite/accept chains |
-| fcv-reject | ✓ (member) | Adds `reject_invite_actor_to_case` — the only scenario exercising the RM:R→I→C rejection path |
+| fcv-reject | ✓ (member) | Adds `reject_invite_actor_to_case` — the only scenario where the Vendor sends `Reject(Invite(actor, case))` (invitation-layer rejection) |
 | fvv | covered by fvcv-handoff | Same invite+accept coverage; no additional phases |
 | fvcv-extension | covered by fcvcv | Same offer+invite+accept coverage; no additional phases |
 | fccv-extension | covered by fcvcv | Same offer+invite+accept coverage; no additional phases |

--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -8,26 +8,28 @@ related_specs:
 
 # Demo CI: Scenario Coverage Matrix and Minimum PR Validation Set
 
-Spec: DEMOCI-06. Analysis performed as part of ISSUE-1996.
+Spec: DEMOCI-06. Analysis performed as part of ISSUE-1996; updated for
+`fcv-reject` (IDEA-1218).
 
 ## Coverage Matrix
 
-The table below maps each of the 8 demo scenarios to the distinct protocol
+The table below maps each of the 9 demo scenarios to the distinct protocol
 event types it exercises. Event types are those recorded as `event_type` in
 `CaseLedgerEntry` and validated by Invariant 5
 (`test_invariant_5_expected_event_types_present`) in each scenario's
 `test/ci/invariants/test_XXX_invariants.py` file.
 
-| Scenario | validate_report | add_participant_status_to_participant | close_case | add_note_to_case | invite_actor_to_case | offer_case_participant | accept_invite_actor_to_case | accept_actor_recommendation |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| fv                | ✓ | ✓ | ✓ | ✓ |   |   |   |   |
-| fvv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |
-| fvcv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| fvcv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |
-| fccv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| fccv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |
-| fcvcv             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| fcv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |
+| Scenario | validate_report | add_participant_status_to_participant | close_case | add_note_to_case | invite_actor_to_case | offer_case_participant | accept_invite_actor_to_case | accept_actor_recommendation | reject_invite_actor_to_case |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| fv                | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |
+| fvv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
+| fvcv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
+| fvcv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
+| fccv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
+| fccv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
+| fcvcv             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
+| fcv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
+| fcv-reject        | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   | ✓ |
 
 **Notes:**
 
@@ -43,11 +45,16 @@ event types it exercises. Event types are those recorded as `event_type` in
   (`vultron/core/behaviors/case/nodes/suggest_actor/emit.py:283`) when an actor
   approves a suggested participant. It fires only in scenarios that include the
   ADR-0026 suggest-actor flow: `fvcv-extension`, `fccv-extension`, and `fcvcv`.
+- `reject_invite_actor_to_case` is emitted by `RejectInviteActorToCaseReceivedUseCase`
+  on the CaseActor when an invitee sends `Reject(Invite(actor, case))`. It fires
+  only in `fcv-reject` (IDEA-1218): the Vendor accepts the invite (entering
+  RM.RECEIVED), then rejects the case as invalid (RI → RM.INVALID) and closes it
+  (RC → RM.CLOSED). No other current scenario exercises this ledger entry.
 - `add_case_participant` is emitted by `AcceptInviteNode`
   (`vultron/core/behaviors/case/nodes/accept_invite.py:181`) on the CaseActor
   received-side when processing Accept(Invite). This event records the internal
   participant-list bookkeeping rather than a protocol-visible coordination action.
-  It fires in every scenario with invite/accept flows (7 of 8) but is intentionally
+  It fires in every scenario with invite/accept flows but is intentionally
   excluded from `_EXPECTED_EVENT_TYPES` lists: it is a `CaseActor`-internal
   ledger entry, not a coordination event that invariant checks should mandate.
 - `fccv-extension` spec entry DEMOMA-16-010 was added as part of ISSUE-1996;
@@ -56,6 +63,7 @@ event types it exercises. Event types are those recorded as `event_type` in
   from their `_EXPECTED_EVENT_TYPES` lists; corrected as part of ISSUE-1996 (AC-2).
 - `fcvcv`, `fvcv-extension`, and `fccv-extension` were missing
   `accept_actor_recommendation`; corrected as part of ISSUE-1996 (AC-2 follow-up).
+- `fcv-reject` (DEMOMA-16-011) was added as part of IDEA-1218 planning.
 
 ## AC-2 Corrections Applied
 
@@ -117,13 +125,14 @@ the minimum set's event-type and protocol-path coverage.
 
 ## Minimum PR Validation Set (DEMOCI-06-002)
 
-**Set: `fv`, `fvcv-handoff`, `fcvcv`**
+**Set: `fv`, `fvcv-handoff`, `fcvcv`, `fcv-reject`**
 
 | Scenario | Covered by minimum set | Rationale |
 |---|:---:|---|
 | fv | ✓ (member) | 2-actor baseline; covers all 4 universal event types with no invitation phases |
 | fvcv-handoff | ✓ (member) | Adds `invite_actor_to_case` + `accept_invite_actor_to_case` + ownership-transfer protocol path |
 | fcvcv | ✓ (member) | Adds `offer_case_participant` + `accept_actor_recommendation` + ≥3-actor invite/accept chains |
+| fcv-reject | ✓ (member) | Adds `reject_invite_actor_to_case` — the only scenario exercising the RM:R→I→C rejection path |
 | fvv | covered by fvcv-handoff | Same invite+accept coverage; no additional phases |
 | fvcv-extension | covered by fcvcv | Same offer+invite+accept coverage; no additional phases |
 | fccv-extension | covered by fcvcv | Same offer+invite+accept coverage; no additional phases |
@@ -132,7 +141,7 @@ the minimum set's event-type and protocol-path coverage.
 
 ### Coverage proof
 
-The minimum set of 3 scenarios covers all 8 distinct event types:
+The minimum set of 4 scenarios covers all 9 distinct event types:
 
 | Event type | Covered by |
 |---|---|
@@ -144,6 +153,7 @@ The minimum set of 3 scenarios covers all 8 distinct event types:
 | accept_invite_actor_to_case | fvcv-handoff |
 | offer_case_participant | fcvcv |
 | accept_actor_recommendation | fcvcv |
+| reject_invite_actor_to_case | fcv-reject |
 
 The 5 remaining scenarios (`fvv`, `fvcv-extension`, `fccv-extension`,
 `fccv-handoff`, `fcv`) produce no event type not already covered by the
@@ -155,14 +165,21 @@ regression coverage without increasing PR wall-clock cost.
 `.github/workflows/demo-integration.yml` was updated to:
 
 1. Add a `push: branches: ["main"]` trigger (implements DEMOCI-05-001 and
-   DEMOCI-06-003, which were previously unimplemented).
+   DEMOCI-06-003, which were previously unimplemented — landed in PR #2030).
 2. Mark `fv`, `fvcv-handoff`, and `fcvcv` as `full_suite_only: false` — they
-   run on every `pull_request` event.
+   run on every `pull_request` event (PR #2030).
 3. Mark the remaining 5 scenarios as `full_suite_only: true` — they run only
-   on `push` to main and `workflow_dispatch`.
+   on `push` to main and `workflow_dispatch` (PR #2030).
 4. Add a job-level `if:` condition that skips `full_suite_only: true` entries
    on `pull_request` events. Both `demo` and `invariant-harness` jobs carry the
    same gate condition so the artifact/download pairing stays consistent.
+
+When `fcv-reject` is implemented (IDEA-1218), the workflow MUST be updated in
+the same PR (DEMOCI-03-002) to:
+
+- Add `fcv-reject` as a matrix entry with `full_suite_only: false` (PR minimum
+  set member per DEMOCI-06-002).
+- Update the full-suite scenario list from 8 to 9 scenarios.
 
 See ADR-0052 for the accepted barrier + concurrency group design that DEMOCI-06
 finalises.

--- a/plan/history/2608/idea/IDEA-1218.md
+++ b/plan/history/2608/idea/IDEA-1218.md
@@ -1,0 +1,32 @@
+---
+source: IDEA-1218
+timestamp: '2026-08-06T18:31:31.171632+00:00'
+title: 'Demo scenario variation: invitation rejection (RM:R → RM:I → RM:C)'
+type: idea
+---
+
+## Summary
+
+A cross-cutting scenario variation where an invited participant outright rejects the
+invitation (RM state path: R → Invalid → Closed). This variation can be applied to any
+multi-actor scenario to demonstrate the protocol behavior when a party declines to participate.
+
+## Motivation
+
+The current demo scripts only exercise the 'happy path' where all invited actors accept.
+Rejection is a valid and common CVD protocol outcome that must be demonstrated.
+
+## Decision
+
+New dedicated `fcv_reject_demo` scenario (FCV composition: Finder + Coordinator + Vendor).
+Phase sequence: C invites V → V accepts invite (RM.RECEIVED) → V sends RI (RM.INVALID) →
+V sends RC (RM.CLOSED) → C and F exchange notes → C triggers embargo termination → F publishes
+→ C publishes → F leaves → C closes case. V receives only an invite stub; never joins fully.
+
+Added to PR minimum validation set because `reject_invite_actor_to_case` is a new
+CaseLedgerEntry event type not covered by any existing scenario.
+
+**Processed**: 2026-08-06 — implementation tracked in #2047.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2046>.
+Spec: `specs/multi-actor-demo.yaml` DEMOMA-16-011.
+Notes: `notes/demo-ci-scenario-coverage.md`.

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -513,20 +513,24 @@ groups:
         priority: MUST
         kind: project
         statement: >-
-          The minimum PR validation scenario set is `fv`, `fvcv-handoff`, and
-          `fcvcv`. Together these three scenarios cover all 8 distinct protocol
-          event types exercised by the full 8-scenario suite: the four universal
-          types plus `invite_actor_to_case`, `offer_case_participant`,
-          `accept_invite_actor_to_case`, and `accept_actor_recommendation`. The
-          `demo-integration.yml` workflow MUST use this 3-scenario set as the
-          `pull_request` matrix and run only these scenarios on every PR commit.
+          The minimum PR validation scenario set is `fv`, `fvcv-handoff`,
+          `fcvcv`, and `fcv-reject`. Together these four scenarios cover all
+          distinct protocol event types exercised by the full scenario suite:
+          the four universal types plus `invite_actor_to_case`,
+          `offer_case_participant`, `accept_invite_actor_to_case`,
+          `accept_actor_recommendation`, and `reject_invite_actor_to_case`.
+          The `demo-integration.yml` workflow MUST use this 4-scenario set as
+          the `pull_request` matrix and run only these scenarios on every PR
+          commit.
         rationale: >-
-          Running all 8 scenarios on every PR commit incurs a fan-in barrier
-          proportional to the slowest scenario. The 3-scenario minimum set
-          preserves full protocol-phase coverage while reducing PR wall-clock
-          cost. FV covers the 2-actor baseline; FVCV-handoff adds invite +
-          accept + ownership-transfer; FCVCV adds offer_case_participant,
-          accept_actor_recommendation, and ≥3-actor invite/accept chains.
+          Running all scenarios on every PR commit incurs a fan-in barrier
+          proportional to the slowest scenario. The minimum set preserves full
+          protocol-phase coverage while reducing PR wall-clock cost. FV covers
+          the 2-actor baseline; FVCV-handoff adds invite + accept +
+          ownership-transfer; FCVCV adds offer_case_participant,
+          accept_actor_recommendation, and ≥3-actor invite/accept chains;
+          FCV-reject adds reject_invite_actor_to_case (the only scenario that
+          exercises a vendor rejecting an invitation after entering RM.RECEIVED).
           Rationale recorded in `notes/demo-ci-scenario-coverage.md`. See
           ADR-0052.
         relationships:
@@ -541,9 +545,9 @@ groups:
           of which subset runs for PR validation, so that all scenario variants
           continue to generate case-log invariant signals on the default branch.
           The `demo-integration.yml` workflow MUST include a `push: branches:
-          ["main"]` trigger that runs all 8 scenarios (`fv`, `fvv`,
+          ["main"]` trigger that runs all 9 scenarios (`fv`, `fvv`,
           `fvcv-extension`, `fvcv-handoff`, `fccv-extension`, `fccv-handoff`,
-          `fcvcv`, `fcv`).
+          `fcvcv`, `fcv`, `fcv-reject`).
         rationale: >-
           The post-merge run is the safety net for cross-PR regressions; it
           must cover all scenarios to ensure no scenario silently degrades after

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -2000,6 +2000,21 @@ groups:
     - rel_type: refines
       spec_id: DEMOMA-13-001
 
+  - id: DEMOMA-16-011
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCV-reject scenario expected-event-types list MUST include
+      `invite_actor_to_case`, `accept_invite_actor_to_case`, and
+      `reject_invite_actor_to_case` in addition to the four universal types
+      (DEMOMA-16-001), because the Coordinator invites the Vendor, the Vendor
+      accepts the invitation (RM: Received), then transitions RM to Invalid and
+      Closed by sending RI then RC, producing the `reject_invite_actor_to_case`
+      ledger entry on the CaseActor.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+
 - id: DEMOMA-18
   title: In-Process Fuzz Simulation Scenario
   specs:

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -2005,12 +2005,14 @@ groups:
     kind: project
     statement: >-
       The FCV-reject scenario expected-event-types list MUST include
-      `invite_actor_to_case`, `accept_invite_actor_to_case`, and
-      `reject_invite_actor_to_case` in addition to the four universal types
-      (DEMOMA-16-001), because the Coordinator invites the Vendor, the Vendor
-      accepts the invitation (RM: Received), then transitions RM to Invalid and
-      Closed by sending RI then RC, producing the `reject_invite_actor_to_case`
-      ledger entry on the CaseActor.
+      `invite_actor_to_case` and `reject_invite_actor_to_case` in addition to
+      the four universal types (DEMOMA-16-001), because the Coordinator invites
+      the Vendor and the Vendor sends `Reject(Invite(actor, case))` (an
+      invitation-layer rejection), which triggers
+      `RejectInviteActorToCaseReceivedUseCase` on the CaseActor and produces
+      the `reject_invite_actor_to_case` ledger entry. The Vendor never sends
+      `Accept(Invite(actor, case))`, so `accept_invite_actor_to_case` does NOT
+      appear in this scenario.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001


### PR DESCRIPTION
- Closes #1218

## Summary

Plans the `fcv-reject` demo scenario: a new FCV-composition demo where the
Vendor rejects an invitation (RM: R→I→C), the remaining Finder and Coordinator
exchange notes, terminate the embargo (triggered), publish, then close the case.
Adds `fcv-reject` to the PR minimum validation set as the only scenario
exercising the `reject_invite_actor_to_case` ledger event type.

## Changes

- **`specs/multi-actor-demo.yaml`**: Add DEMOMA-16-011 — fcv-reject
  expected-event-types list (`reject_invite_actor_to_case` + invite/accept
  universals)
- **`specs/demo-ci.yaml`**: Update DEMOCI-06-002 minimum PR set from 3 to 4
  scenarios (add `fcv-reject`); update DEMOCI-06-003 full-suite count from 8
  to 9 scenarios
- **`notes/demo-ci-scenario-coverage.md`**: Expand coverage matrix from 8 to
  9 scenarios, add `reject_invite_actor_to_case` column, update minimum PR set
  and coverage proof sections, add workflow implementation notes for the
  fcv-reject addition

## Implementation Issues

- #2047