### PR TITLE
docs: plan issue #1221 — RM scenario variations (R→I→V, A→D→A)

### DIFF
--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -166,3 +166,49 @@ regression coverage without increasing PR wall-clock cost.
 
 See ADR-0052 for the accepted barrier + concurrency group design that DEMOCI-06
 finalises.
+
+## RM State-Transition Path Coverage
+
+The event-type matrix (above) captures which protocol coordination phases each
+scenario exercises, but it does not distinguish *which RM state-to-state paths*
+are taken within those phases. Because `validate_report` is emitted on both the
+linear R → V path and the non-linear R → I → V path, and `add_participant_status_to_participant`
+is emitted on both A → D and D → A, the invariant harness alone cannot verify
+non-linear RM paths. These are validated by `demo_check` assertions in the
+scenario scripts themselves.
+
+The table below maps the distinct RM state-transition paths to the scenarios
+that exercise them. "Linear" paths are those shown in a typical happy-path
+trace; "non-linear" paths are detours the RM state machine permits but that
+do not appear in any scenario unless explicitly scripted.
+
+| RM transition path | Type | Exercised by scenario |
+|---|---|---|
+| S → R (report received) | linear | all scenarios |
+| R → V (report valid) | linear | all scenarios |
+| V → A (report accepted / engaged) | linear | all scenarios |
+| A → C (case closed) | linear | all scenarios |
+| R → I (report invalid) | non-linear | `fvcv-handoff` (Var A) |
+| I → V (re-validated after rejection) | non-linear | `fvcv-handoff` (Var A) |
+| A → D (report deferred) | non-linear | `fcvcv` (Var B) |
+| D → A (resumed after deferral) | non-linear | `fcvcv` (Var B) |
+| I → C (closed from invalid) | non-linear | not yet exercised by any scenario |
+| V → D (deferred without accepting) | non-linear | not yet exercised by any scenario |
+
+**Notes:**
+
+- Variation A (`fvcv-handoff`, R → I → V): Vendor1 initially calls
+  `invalidate-report` (RI), then the Finder posts a clarifying case note and
+  Vendor1 calls `validate-report` (RV), advancing to V before engaging. The
+  `demo_check` assertion verifies Vendor1's RM state is INVALID before
+  re-validation and VALID immediately after.
+- Variation B (`fcvcv`, A → D → A): V1 calls `engage-case` (RA), then
+  `defer-case` (RD), then `engage-case` again (RV → accepted). The
+  `demo_check` assertions verify the DEFERRED state before the second
+  `engage-case` call. The RM state machine already supports `ACCEPT:
+  DEFERRED → ACCEPTED` (rm.py line 145); no new BT nodes are needed.
+- The `I → C` and `V → D` paths are valid per the RM state machine but are
+  not exercised by any current scenario. They are candidates for a future
+  scenario or scenario extension.
+
+Source: ISSUE-1221 planning (2026-08-06).

--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -1,5 +1,5 @@
 ---
-title: Demo CI Scenario Coverage Matrix and Minimum PR Validation Set
+title: Demo CI: Scenario Coverage Matrix and Minimum PR Validation Set
 status: active
 related_specs:
   - specs/demo-ci.yaml
@@ -174,39 +174,40 @@ scenario exercises, but it does not distinguish *which RM state-to-state paths*
 are taken within those phases. Because `validate_report` is emitted on both the
 linear R → V path and the non-linear R → I → V path, and `add_participant_status_to_participant`
 is emitted on both A → D and D → A, the invariant harness alone cannot verify
-non-linear RM paths. These are validated by `demo_check` assertions in the
-scenario scripts themselves.
+non-linear RM paths. Once implemented (#2050), these will be validated by
+`demo_check` assertions in the scenario scripts themselves.
 
 The table below maps the distinct RM state-transition paths to the scenarios
-that exercise them. "Linear" paths are those shown in a typical happy-path
+planned to exercise them (implementation tracked in #2050). "Linear" paths
+are those shown in a typical happy-path
 trace; "non-linear" paths are detours the RM state machine permits but that
 do not appear in any scenario unless explicitly scripted.
 
-| RM transition path | Type | Exercised by scenario |
+| RM transition path | Type | Planned scenario (#2050) |
 |---|---|---|
 | S → R (report received) | linear | all scenarios |
 | R → V (report valid) | linear | all scenarios |
 | V → A (report accepted / engaged) | linear | all scenarios |
 | A → C (case closed) | linear | all scenarios |
-| R → I (report invalid) | non-linear | `fvcv-handoff` (Var A) |
-| I → V (re-validated after rejection) | non-linear | `fvcv-handoff` (Var A) |
-| A → D (report deferred) | non-linear | `fcvcv` (Var B) |
-| D → A (resumed after deferral) | non-linear | `fcvcv` (Var B) |
+| R → I (report invalid) | non-linear | `fvcv-handoff` (Var A, planned) |
+| I → V (re-validated after rejection) | non-linear | `fvcv-handoff` (Var A, planned) |
+| A → D (report deferred) | non-linear | `fcvcv` (Var B, planned) |
+| D → A (resumed after deferral) | non-linear | `fcvcv` (Var B, planned) |
 | I → C (closed from invalid) | non-linear | not yet exercised by any scenario |
 | V → D (deferred without accepting) | non-linear | not yet exercised by any scenario |
 
 **Notes:**
 
-- Variation A (`fvcv-handoff`, R → I → V): Vendor1 initially calls
-  `invalidate-report` (RI), then the Finder posts a clarifying case note and
-  Vendor1 calls `validate-report` (RV), advancing to V before engaging. The
-  `demo_check` assertion verifies Vendor1's RM state is INVALID before
-  re-validation and VALID immediately after.
-- Variation B (`fcvcv`, A → D → A): V1 calls `engage-case` (RA), then
-  `defer-case` (RD), then `engage-case` again (RV → accepted). The
-  `demo_check` assertions verify the DEFERRED state before the second
-  `engage-case` call. The RM state machine already supports `ACCEPT:
-  DEFERRED → ACCEPTED` (rm.py line 145); no new BT nodes are needed.
+- Variation A (`fvcv-handoff`, R → I → V, planned in #2050): Vendor1 will
+  call `invalidate-report` (RI), then the Finder will post a clarifying case
+  note and Vendor1 will call `validate-report` (RV), advancing to V before
+  engaging. A `demo_check` assertion will verify Vendor1's RM state is
+  INVALID before re-validation and VALID immediately after.
+- Variation B (`fcvcv`, A → D → A, planned in #2050): V1 will call
+  `engage-case` (RA), then `defer-case` (RD), then `engage-case` again
+  (RV → accepted). A `demo_check` assertion will verify the DEFERRED state
+  before the second `engage-case` call. The RM state machine already supports
+  `ACCEPT: DEFERRED → ACCEPTED` (rm.py line 145); no new BT nodes are needed.
 - The `I → C` and `V → D` paths are valid per the RM state machine but are
   not exercised by any current scenario. They are candidates for a future
   scenario or scenario extension.

--- a/plan/history/2608/idea/IDEA-1221.md
+++ b/plan/history/2608/idea/IDEA-1221.md
@@ -1,0 +1,40 @@
+---
+source: IDEA-1221
+timestamp: '2026-08-06T20:05:28.739630+00:00'
+title: 'Demo scenario variation: tentative rejection then acceptance (RM:R → RM:I
+  → RM:V)'
+type: idea
+---
+
+## Summary
+
+Cross-cutting scenario variations for non-linear RM state paths: (a) a participant
+initially rejects then accepts after receiving additional information, and (b) a
+participant who accepted later defers and subsequently resumes.
+
+## Motivation
+
+Models two realistic CVD patterns:
+
+- A vendor initially says "this doesn't affect us" but changes position after the
+  coordinator provides more details (e.g., a proof of concept or clarifying technical context).
+- A vendor accepts, then pauses participation due to competing priorities, then resumes
+  when they are ready — demonstrating that case participation is not a one-way ratchet.
+
+## Accepted Design
+
+- **Variation A** (`fvcv-handoff`): Vendor1 invalidates report (R→I), Finder posts a
+  clarifying case note, Vendor1 re-validates (I→V), then the scenario continues normally.
+  Placed between report-receipt and the existing `receiver_validates_report` call.
+- **Variation B** (`fcvcv`): V1 engages (V→A), defers (A→D), then resumes (D→A)
+  before fix-ready. Uses the existing `defer-case` + `engage-case` trigger endpoints
+  which already support `DEFERRED → ACCEPTED` via `rm.py` line 145.
+
+No new BT nodes or trigger endpoints required. `auto_create_case=False` / `ack_report`
+path is NOT in scope for this plan — deferred as a follow-on Idea.
+
+RM state-transition coverage verified via `demo_check` assertions, not `EXPECTED_EVENT_TYPES`
+(since `validate_report` is emitted on both linear R→V and non-linear R→I→V paths).
+
+**Processed**: 2026-08-06 — implementation tracked in #2050.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2049>.

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1899,6 +1899,15 @@ groups:
       to the four universal types (DEMOMA-16-001), because Vendor1 invites
       Coordinator, the Coordinator accepts and becomes the new CASE_OWNER,
       and Coordinator then invites Vendor2 who also accepts.
+    rationale: >-
+      In addition to the event-type coverage, FVCV-handoff is the scenario
+      that exercises the non-linear RM path R → I → V (tentative rejection
+      then acceptance): Vendor1 initially invalidates the report (RI), then
+      re-validates after the Finder provides clarifying information via a
+      case note. This RM state-transition path is verified by `demo_check`
+      assertions in the scenario script, not by `event_type` presence in the
+      invariant harness, because R → I → V produces the same `validate_report`
+      ledger event as the linear R → V path.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001
@@ -1975,6 +1984,15 @@ groups:
       vendor/coordinator invitees issue explicit accepts. Verifying these
       event types confirms the full ADR-0026 suggest-actor path and the
       multi-vendor invitation chain are exercised end-to-end.
+
+      In addition to event-type coverage, FCVCV is the scenario that exercises
+      the non-linear RM path A → D → A (accepted, then deferred, then
+      re-accepted): V1 accepts the case, defers due to competing priorities
+      (RD message), then resumes and engages again (RV message). This RM
+      state-transition path is verified by `demo_check` assertions in the
+      scenario script. The `defer-case` and `engage-case` trigger endpoints
+      both support this path without new BT nodes, since the RM state machine
+      already declares `ACCEPT: DEFERRED → ACCEPTED` as a valid transition.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1901,13 +1901,14 @@ groups:
       and Coordinator then invites Vendor2 who also accepts.
     rationale: >-
       In addition to the event-type coverage, FVCV-handoff is the scenario
-      that exercises the non-linear RM path R → I → V (tentative rejection
-      then acceptance): Vendor1 initially invalidates the report (RI), then
-      re-validates after the Finder provides clarifying information via a
-      case note. This RM state-transition path is verified by `demo_check`
-      assertions in the scenario script, not by `event_type` presence in the
-      invariant harness, because R → I → V produces the same `validate_report`
-      ledger event as the linear R → V path.
+      planned to exercise the non-linear RM path R → I → V (tentative
+      rejection then acceptance, implementation tracked in #2050): Vendor1
+      will initially invalidate the report (RI), then re-validate after the
+      Finder provides clarifying information via a case note. This RM
+      state-transition path will be verified by `demo_check` assertions in
+      the scenario script, not by `event_type` presence in the invariant
+      harness, because R → I → V produces the same `validate_report` ledger
+      event as the linear R → V path.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001
@@ -1985,14 +1986,15 @@ groups:
       event types confirms the full ADR-0026 suggest-actor path and the
       multi-vendor invitation chain are exercised end-to-end.
 
-      In addition to event-type coverage, FCVCV is the scenario that exercises
-      the non-linear RM path A → D → A (accepted, then deferred, then
-      re-accepted): V1 accepts the case, defers due to competing priorities
-      (RD message), then resumes and engages again (RV message). This RM
-      state-transition path is verified by `demo_check` assertions in the
-      scenario script. The `defer-case` and `engage-case` trigger endpoints
-      both support this path without new BT nodes, since the RM state machine
-      already declares `ACCEPT: DEFERRED → ACCEPTED` as a valid transition.
+      In addition to event-type coverage, FCVCV is the scenario planned to
+      exercise the non-linear RM path A → D → A (accepted, then deferred,
+      then re-accepted, implementation tracked in #2050): V1 will accept the
+      case, defer due to competing priorities (RD message), then resume and
+      engage again (RV message). This RM state-transition path will be
+      verified by `demo_check` assertions in the scenario script. The
+      `defer-case` and `engage-case` trigger endpoints both support this path
+      without new BT nodes, since the RM state machine already declares
+      `ACCEPT: DEFERRED → ACCEPTED` as a valid transition.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-16-001


### PR DESCRIPTION
- Closes #1221

## Summary

Documents the planning decision to exercise non-linear RM state paths
(R→I→V and A→D→A) by extending two existing PR-gated minset scenarios
rather than adding new CI slots.

## Changes

- **`specs/multi-actor-demo.yaml`**: Add `rationale:` blocks to DEMOMA-16-005
  (`fvcv-handoff`) and DEMOMA-16-009 (`fcvcv`) documenting which non-linear
  RM state-transition paths each scenario covers and how they are verified.
- **`notes/demo-ci-scenario-coverage.md`**: Add new "RM State-Transition Path
  Coverage" section with a per-scenario matrix of linear vs. non-linear RM
  paths, notes on how each non-linear path is verified (demo_check assertions),
  and identification of paths not yet exercised by any scenario.

## Implementation Issues

- #2050