### PR TITLE
docs: plan issue #1222 — rcv-embargo and rcvv-embargo scenario variations

### DIFF
--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -16,8 +16,9 @@ related_notes:
 
 Scenarios are named by the sequence of actor roles involved:
 
-- **F** = Finder, **V** = Vendor, **C** = Coordinator, **D** = Deployer
+- **R** = Reporter (preferred; replaces the older **F** = Finder convention for new scenarios), **V** = Vendor, **C** = Coordinator, **D** = Deployer
 - Numbers distinguish multiple actors of the same role (V1, V2, C1, C2)
+- Existing scenario names that use **F** (FV, FCV, FCVCV, etc.) are not renamed retroactively; new scenarios use **R**
 
 ## Implemented scenarios
 
@@ -71,13 +72,21 @@ the design decisions reached in the #1178 planning session.
 | Case split/merge | #1229 | Parent/child/sibling case relationships |
 | Multi-reporter | #1231 | Two Finders, one C consolidates into one case |
 
+### Embargo lifecycle scenarios
+
+| Scenario | Issue | Description | Status |
+|----------|-------|-------------|--------|
+| RCV-embargo | #1222 | R+C+V; post-submission negotiation (variation b) + deliberate termination (variation e); EP→EA→ET arc | planned — `rcv-embargo` CLI command + CI job (DEMOMA-20, DEMOCI-07) |
+| RCVV-embargo | #1222 | R+C+V1+V2; variations b+c+f+d; EP→EA→EV→EJ→auto-collapse via CS.P; V2 late-invite | planned — `rcvv-embargo` CLI command + CI job (DEMOMA-21, DEMOCI-07) |
+| Pre-submission negotiation | *(new Idea, child of epic #1083)* | EP before report submission (variation a); blocked by EP-04-003 protocol gap — no mechanism for reporter to include embargo proposal with/before report; see `notes/embargo-default-semantics.md` | idea-stage |
+
 ### Cross-cutting variations (composable with any scenario)
 
 | Variation | Issue | Description |
 |-----------|-------|-------------|
 | Invitation rejection | #1218 | Invited actor transitions RM:R→I→C |
 | Tentative rejection | #1221 | Invited actor transitions RM:R→I→V (reconsiders) |
-| Embargo variations | #1222 | Negotiation, collapse, deliberate delay |
+| Embargo variations | #1222 | Negotiation, collapse, deliberate delay (see embargo lifecycle scenarios above) |
 | CVD recipe injects | #1223 | Twists from the CERT Guide to CVD cvd_recipes |
 
 ### Pre-case ACK flow (`auto_create_case=False`)

--- a/plan/history/2608/idea/IDEA-1222.md
+++ b/plan/history/2608/idea/IDEA-1222.md
@@ -1,0 +1,53 @@
+---
+source: IDEA-1222
+timestamp: '2026-08-07T15:04:25.652419+00:00'
+title: 'Demo scenario variation: embargo negotiation, collapse, and deliberate notification
+  delay'
+type: idea
+---
+
+Planned two embargo lifecycle demo scenarios covering the composable variations
+from issue #1222.
+
+## Outcome
+
+- **DEMOMA-20 (rcv-embargo)**: 3-party scenario (R+C+V) exercising variations
+  (b) post-submission negotiation and (e) deliberate early termination.
+  EP→EA→ET arc; all three parties reach emConsentState=SIGNATORY.
+- **DEMOMA-21 (rcvv-embargo)**: 4-party scenario (R+C+V1+V2) exercising
+  variations (b)+(c)+(f)+(d): propose → activate → revise → re-activate →
+  late V2 invite → accidental collapse via CS.P.
+- **DEMOCI-07**: CI registration for both scenarios with `full_suite_only: false`
+  (minimum PR set from day one) plus SHOULD-priority coverage re-eval spec.
+- **notes/demo-future-ideas.md**: R-for-Reporter naming convention, embargo
+  lifecycle scenarios table, deferred variation (a) entry.
+
+## Variation (a) deferred
+
+Pre-submission embargo negotiation is blocked by EP-04-003 protocol gap — no
+mechanism for a reporter to include an embargo proposal with/before the initial
+report. Deferred to new Idea #2075 under epic #1083. See
+`notes/embargo-default-semantics.md` for the EP-04-003 documentation.
+
+## Key design decisions
+
+- Two scenarios required because variations (d) and (e) are mutually exclusive
+  terminators on a single case.
+- `trigger_accept_embargo` covers both EA (initial activation) and EJ (revision
+  acceptance) — `AcceptEmbargoLifecycleNode` handles both PROPOSED and REVISE
+  states; no new endpoint needed.
+- New scenarios use R (Reporter) naming; existing scenario names not renamed.
+- Both scenarios default to CI minimum PR set (add-now/remove-later policy).
+
+## Implementation issues
+
+- #2070 — exchange helpers (propose/activate/terminate/revise)
+- #2071 — rcv-embargo scenario file + CLI registration
+- #2072 — rcvv-embargo scenario file + CLI registration
+- #2073 — CI invariant harnesses + demo-integration matrix wiring
+- #2074 — coverage model re-evaluation (blocked by #2073)
+- #2075 — [Idea] pre-submission embargo negotiation (variation a, deferred)
+
+## PR
+
+<https://github.com/CERTCC/Vultron/pull/2069>

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -632,18 +632,25 @@ groups:
           and `rcvv-embargo` are implemented and passing in CI. The analysis
           MUST evaluate whether the 3-scenario minimum PR set defined in
           DEMOCI-06-002 requires expansion to preserve full embargo lifecycle
-          protocol coverage, and MUST update `notes/demo-ci-scenario-coverage.md`
-          and DEMOCI-06-002 accordingly. If the embargo scenarios introduce
-          protocol event types not covered by `fv`, `fvcv-handoff`, or `fcvcv`,
-          the minimum PR set MUST be expanded.
+          protocol coverage, and MUST update `notes/demo-ci-scenario-coverage.md`,
+          DEMOCI-06-002, and DEMOCI-06-003 accordingly. If the embargo scenarios
+          introduce protocol event types not covered by `fv`, `fvcv-handoff`, or
+          `fcvcv`, the minimum PR set MUST be expanded. DEMOCI-06-003 names the
+          full scenario suite explicitly; it MUST be updated to include
+          `rcv-embargo` and `rcvv-embargo` when they are wired into CI.
         rationale: >-
           DEMOCI-06-002 defined the minimum PR set before embargo-lifecycle
           scenarios existed. The embargo protocol messages (EP, EA, EV, EJ, ET)
           are not exercised by any scenario in the current minimum set.
-          This SHOULD-priority spec creates an explicit obligation to revisit
-          the coverage model rather than letting the gap go unnoticed.
+          DEMOCI-06-003 was updated in this PR to list exactly 8 scenarios by
+          name; after #2073 adds rcv-embargo and rcvv-embargo to the CI matrix
+          that count becomes 10, so DEMOCI-06-003 must be updated in the same
+          pass. This SHOULD-priority spec creates an explicit obligation to
+          revisit both coverage specs rather than letting either gap go unnoticed.
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-06-001
           - rel_type: refines
             spec_id: DEMOCI-06-002
+          - rel_type: refines
+            spec_id: DEMOCI-06-003

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -564,3 +564,86 @@ groups:
             spec_id: DEMOCI-06-002
           - rel_type: refines
             spec_id: DEMOCI-05-001
+
+  - id: DEMOCI-07
+    title: Embargo Lifecycle Scenario CI Registration (rcv-embargo, rcvv-embargo)
+    specs:
+      - id: DEMOCI-07-001
+        priority: MUST
+        kind: project
+        statement: >-
+          The `rcv-embargo` scenario MUST be added to the CI demo-integration
+          matrix in `.github/workflows/demo-integration.yml` with
+          `DEMO=rcv-embargo`, `full_suite_only: false`, and the actor services
+          `finder` (reporter role), `coordinator`, `vendor`, and `case-actor`
+          as container dependencies. The `test_file` matrix entry MUST point to
+          `test/ci/invariants/test_rcv_embargo_invariants.py`. The devlogs
+          directory for the CI run MUST use scenario-role names: `reporter`,
+          `coordinator`, `vendor`, `case-actor`.
+        rationale: >-
+          Adding both embargo scenarios with `full_suite_only: false` places
+          them in the PR validation set immediately, consistent with the
+          add-now/remove-later policy established in issue #1222 planning
+          (rather than the deferred approach that required a DEMOCI-06
+          amendment for earlier scenarios). The four actor-service names match
+          the scenario-role naming convention used by all post-DEMOMA-12
+          scenarios; CI log directories use these names so that invariant
+          harnesses can load devlogs by role rather than docker service name.
+        lint_suppress:
+          - phantom_path_ref
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-04-001
+          - rel_type: refines
+            spec_id: DEMOMA-20-005
+
+      - id: DEMOCI-07-002
+        priority: MUST
+        kind: project
+        statement: >-
+          The `rcvv-embargo` scenario MUST be added to the CI demo-integration
+          matrix in `.github/workflows/demo-integration.yml` with
+          `DEMO=rcvv-embargo`, `full_suite_only: false`, and the actor services
+          `finder` (reporter role), `coordinator`, `vendor`, `vendor2`, and
+          `case-actor` as container dependencies. The `test_file` matrix entry
+          MUST point to `test/ci/invariants/test_rcvv_embargo_invariants.py`.
+          The devlogs directory for the CI run MUST use scenario-role names:
+          `reporter`, `coordinator`, `vendor`, `vendor2`, `case-actor`.
+        rationale: >-
+          The rcvv-embargo scenario requires a fourth actor container (`vendor2`)
+          beyond the three used by rcv-embargo. Listing `vendor2` as a service
+          dependency ensures CI spins it up before the scenario runner starts.
+          Scenario-role names in devlogs match scenario code, making log
+          archaeology easier and consistent with the FCVCV pattern
+          (DEMOMA-19-007).
+        lint_suppress:
+          - phantom_path_ref
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-04-001
+          - rel_type: refines
+            spec_id: DEMOMA-21-006
+
+      - id: DEMOCI-07-003
+        priority: SHOULD
+        kind: project
+        statement: >-
+          A follow-up coverage analysis SHOULD be performed after `rcv-embargo`
+          and `rcvv-embargo` are implemented and passing in CI. The analysis
+          MUST evaluate whether the 3-scenario minimum PR set defined in
+          DEMOCI-06-002 requires expansion to preserve full embargo lifecycle
+          protocol coverage, and MUST update `notes/demo-ci-scenario-coverage.md`
+          and DEMOCI-06-002 accordingly. If the embargo scenarios introduce
+          protocol event types not covered by `fv`, `fvcv-handoff`, or `fcvcv`,
+          the minimum PR set MUST be expanded.
+        rationale: >-
+          DEMOCI-06-002 defined the minimum PR set before embargo-lifecycle
+          scenarios existed. The embargo protocol messages (EP, EA, EV, EJ, ET)
+          are not exercised by any scenario in the current minimum set.
+          This SHOULD-priority spec creates an explicit obligation to revisit
+          the coverage model rather than letting the gap go unnoticed.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-06-001
+          - rel_type: refines
+            spec_id: DEMOCI-06-002

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -2387,3 +2387,382 @@ groups:
       spec_id: DEMOMA-03-003
     - rel_type: refines
       spec_id: DEMOMA-19-003
+
+- id: DEMOMA-20
+  title: RCV Embargo Scenario (Reporter + Coordinator + Vendor, deliberate termination)
+  description: >-
+    Specifies the rcv-embargo demo scenario: a 3-party CVD case with Reporter
+    (R), Coordinator (C), and Vendor (V), exercising embargo lifecycle variations
+    (b) post-submission negotiation and (e) deliberate early termination. After
+    report submission and case setup, R proposes an embargo (EP); C accepts (EA),
+    advancing EM to ACTIVE with all three parties as SIGNATORY. The fix lifecycle
+    then proceeds. Before the natural embargo window expires, C deliberately
+    terminates the embargo (ET), advancing EM to EXITED. The case continues to
+    the normal P-transition and closure sequence. This scenario is the first to
+    exercise: (a) embargo proposal initiated after report submission (variation
+    b), (b) the full EP→EA→ET arc (propose, activate, terminate without revision),
+    (c) PEC transitions from NO_EMBARGO through INVITED → SIGNATORY for all three
+    parties.
+  specs:
+  - id: DEMOMA-20-001
+    priority: MUST
+    kind: project
+    statement: >-
+      The rcv-embargo scenario file MUST be implemented at
+      `vultron/demo/scenario/rcv_embargo_demo.py`. It MUST be structured with
+      the following phases executed in order: (1) report_submission — R submits
+      report to C, C validates, C creates the case, C invites R and V; (2)
+      embargo_proposal — R proposes an embargo (EP trigger), C accepts (EA
+      trigger), all three parties reach `emConsentState=SIGNATORY` and
+      `em_state=ACTIVE`; (3) fix_lifecycle — V advances through the fix-ready
+      path (VFd); (4) embargo_termination — C posts the terminate-embargo
+      trigger (ET), advancing `em_state` to EXITED; (5) publication — C
+      triggers the P-transition (CS.P); (6) case_closure — all participants
+      close; (7) dump_case_ledgers — devlog output. After each phase the
+      scenario MUST assert the expected EM state before proceeding to the
+      next phase.
+    rationale: >-
+      The phased structure mirrors prior FCV/FVCV scenarios while inserting
+      embargo lifecycle phases between report setup and fix-lifecycle. Asserting
+      EM state at phase boundaries catches regressions where an embargo trigger
+      silently fails and the scenario continues in an unexpected state.
+      Variation (b) places the EP message after report submission, consistent
+      with the protocol definition: R already has an established case before
+      proposing embargo terms.
+    lint_suppress:
+    - phantom_path_ref
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+    - rel_type: refines
+      spec_id: DEMOMA-12-001
+
+  - id: DEMOMA-20-002
+    priority: MUST
+    kind: project
+    statement: >-
+      An exchange helper function `demo_propose_and_activate_embargo` MUST be
+      added to `vultron/demo/exchange/`. It MUST accept `(reporter_client,
+      coordinator_client, vendor_client, case_id)` arguments and execute the
+      following sequence: (1) reporter posts `trigger_propose_embargo` with a
+      valid embargo event (deadline, sequence); (2) coordinator polls for the
+      EP message and posts `trigger_accept_embargo`; (3) vendor polls for the
+      EA message. After step 3, the helper MUST assert `em_state == EM.ACTIVE`
+      on the coordinator's case replica and `emConsentState == SIGNATORY` for
+      all three participants. The helper MUST use `demo_step` and `demo_check`
+      for all assertions, consistent with existing exchange helpers.
+    rationale: >-
+      Extracting the propose-and-activate sequence as a reusable exchange
+      helper follows DEMOMA-17-001 (DRY for demo code). The three-party
+      propose→accept→active flow is a composable unit that both rcv-embargo
+      and rcvv-embargo scenarios require; a single helper prevents duplication
+      and ensures both scenarios exercise identical protocol steps.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-17-001
+
+  - id: DEMOMA-20-003
+    priority: MUST
+    kind: project
+    statement: >-
+      An exchange helper function `demo_terminate_embargo` MUST be added to
+      `vultron/demo/exchange/`. It MUST accept `(terminating_client, case_id)`
+      arguments — where `terminating_client` is any SIGNATORY participant
+      authorized to terminate — and post `trigger_terminate_embargo`. After
+      delivery, the helper MUST assert `em_state == EM.EXITED` on the
+      terminating actor's case replica using `demo_check`. The helper MUST NOT
+      assert PEC states for other participants; PEC propagation is asynchronous
+      and belongs in scenario-level phase assertions, not in the exchange helper.
+    rationale: >-
+      The terminate-embargo exchange is a single-actor trigger that can be
+      reused by any scenario exercising variation (e). Keeping it in
+      `vultron/demo/exchange/` (not inline in the scenario file) satisfies
+      DEMOMA-17-001. Restricting assertions to the terminating actor's EM state
+      keeps the helper side-effect-free with respect to peer-replica polling,
+      which varies by scenario topology.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-17-001
+    - rel_type: refines
+      spec_id: DEMOMA-20-002
+
+  - id: DEMOMA-20-004
+    priority: MUST
+    kind: project
+    statement: >-
+      The rcv-embargo scenario MUST be registered as the `rcv-embargo`
+      sub-command in `vultron/demo/cli.py`, consistent with the naming
+      convention of existing scenario commands.
+    rationale: >-
+      The CLI is the single entry point for all demo scenarios (DC-01-001).
+      The `rcv-embargo` name makes the embargo-lifecycle focus explicit and
+      distinguishes this scenario from the base `rcv` scenario if one is
+      ever added.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+
+  - id: DEMOMA-20-005
+    priority: MUST
+    kind: project
+    statement: >-
+      The rcv-embargo scenario MUST be added to the CI demo-integration matrix
+      in `.github/workflows/demo-integration.yml` with `DEMO=rcv-embargo` and
+      `full_suite_only: false` (runs on every PR). The CI devlogs directory for
+      the run MUST use the scenario-role naming convention: `reporter`,
+      `coordinator`, `vendor`, `case-actor`.
+    rationale: >-
+      CI coverage of the embargo lifecycle from day one avoids the deferred-add
+      pattern that required a later DEMOCI-06 amendment for earlier scenarios.
+      `full_suite_only: false` places the scenario in the minimum PR set,
+      consistent with the decision recorded in issue #1222 planning: default to
+      add-now/remove-later rather than deferred adds.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-04-001
+
+  - id: DEMOMA-20-006
+    priority: MUST
+    kind: project
+    statement: >-
+      An invariant harness file MUST be created at
+      `test/ci/invariants/test_rcv_embargo_invariants.py`. It MUST define
+      `_DEMO_NAME = "rcv-embargo"`, `_CHAIN_ACTORS` covering `reporter`,
+      `coordinator`, `vendor`, and `case-actor`, and the full set of universal
+      invariants (Invariants 1–15) following the pattern in
+      `test_fcv_invariants.py`. It MUST additionally include the following
+      scenario-specific invariant tests: (a) an embargo-propose event type is
+      present in the log (variation b: EP message delivered); (b) an
+      embargo-accept event type is present (EA message delivered, EM reached
+      ACTIVE); (c) an embargo-terminate event type is present (ET message
+      delivered, variation e exercised); (d) `emConsentState` transitions
+      through INVITED and SIGNATORY are observable in at least one participant's
+      `add_participant_status_to_participant` entries. The exact event type
+      strings for (a)–(c) MUST be confirmed from the case-ledger output of a
+      first successful local run and recorded in the harness as a comment
+      referencing the spec ID that required them.
+    rationale: >-
+      The scenario-specific invariants confirm that all three embargo protocol
+      messages (EP, EA, ET) were recorded in the ledger — not just that the
+      scenario ran without crashing. The PEC consent-state check verifies that
+      participant embargo consent transitions were emitted and recorded, which
+      is the minimal proof that the PEC state machine was exercised. Requiring
+      event-type confirmation from a first live run prevents the harness from
+      silently passing with wrong or missing event type strings.
+    lint_suppress:
+    - phantom_path_ref
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-04-001
+    - rel_type: refines
+      spec_id: DEMOMA-16-009
+    - rel_type: refines
+      spec_id: DEMOMA-20-001
+
+- id: DEMOMA-21
+  title: RCVV Embargo Scenario (Reporter + Coordinator + V1 + V2, revision and accidental collapse)
+  description: >-
+    Specifies the rcvv-embargo demo scenario: a 4-party CVD case with Reporter
+    (R), Coordinator (C), Vendor1 (V1), and Vendor2 (V2), exercising embargo
+    lifecycle variations (b) post-submission negotiation, (c) revision during
+    active embargo (EV→ER→EJ), (f) deliberate notification delay for V2
+    (late invitation simulating a short-deadline vendor), and (d) accidental
+    collapse via CS.P. After R proposes and C accepts an initial embargo (EP→EA),
+    EM reaches ACTIVE with R, C, and V1 as SIGNATORY. C then proposes a
+    revision (EV), V1 accepts (EJ), and EM returns to ACTIVE with updated terms.
+    V2 is not invited until after the revision is accepted, simulating a
+    coordinator holding off on inviting a short-deadline vendor until the
+    embargo window is near its close. V2 accepts the case invite and becomes
+    SIGNATORY. Finally, R publishes (CS.P fires), triggering
+    `PublicDisclosureBranchNode` which auto-terminates the embargo (EM→EXITED).
+    This scenario is the first to exercise: (a) an embargo revision cycle
+    (EV→ER/EJ arc), (b) a late-invitee V2 joining an active embargo (PEC
+    INVITED→SIGNATORY after EM.ACTIVE), (c) accidental embargo collapse via
+    external P-event rather than deliberate termination.
+  specs:
+  - id: DEMOMA-21-001
+    priority: MUST
+    kind: project
+    statement: >-
+      The rcvv-embargo scenario file MUST be implemented at
+      `vultron/demo/scenario/rcvv_embargo_demo.py`. It MUST be structured with
+      the following phases executed in order: (1) report_submission — R submits
+      report to C, C validates and creates the case, C invites R and V1; (2)
+      embargo_proposal — R proposes an embargo (EP), C accepts (EA), R and V1
+      reach `emConsentState=SIGNATORY` and `em_state=ACTIVE`; (3)
+      embargo_revision — C proposes a revision (EV, `em_state→REVISE`), V1
+      accepts the revision (EJ, `em_state→ACTIVE`); (4) v2_late_invite — C
+      invites V2 to the case; V2 accepts the case invite and the in-force
+      embargo (`emConsentState→SIGNATORY`); (5) fix_lifecycle — V1 and V2 each
+      advance through their fix-ready paths; (6) accidental_collapse — R
+      publishes (`actor_notifies_published`), triggering CS.P and causing
+      CaseActor to auto-terminate the embargo (`em_state→EXITED`) via
+      `PublicDisclosureBranchNode`; (7) case_closure — all participants close;
+      (8) dump_case_ledgers — devlog output. After phases 2, 3, 4, and 6 the
+      scenario MUST assert the expected EM state before proceeding.
+    rationale: >-
+      The phased ordering reflects the temporal constraints of the embargo
+      protocol: revision requires an ACTIVE embargo (phase 3 must follow
+      phase 2); V2 late-invite after revision simulates a short-deadline vendor
+      pattern (variation f); accidental collapse via CS.P must come after both
+      vendors have progressed through the fix lifecycle so the ledger contains
+      a complete picture of fix-ready states before collapse. Phase-boundary
+      assertions catch silent failures.
+    lint_suppress:
+    - phantom_path_ref
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+    - rel_type: refines
+      spec_id: DEMOMA-12-001
+
+  - id: DEMOMA-21-002
+    priority: MUST
+    kind: project
+    statement: >-
+      An exchange helper function `demo_propose_embargo_revision` MUST be added
+      to `vultron/demo/exchange/`. It MUST accept `(proposing_client,
+      accepting_client, case_id)` arguments and execute the following sequence:
+      (1) `proposing_client` posts `trigger_propose_embargo_revision`
+      (`em_state: ACTIVE → REVISE`); (2) `accepting_client` polls for the EV
+      message and posts `trigger_accept_embargo` (`em_state: REVISE → ACTIVE`).
+      After step 2, the helper MUST assert `em_state == EM.ACTIVE` on the
+      accepting client's case replica using `demo_check`. The function MUST be
+      importable from `vultron/demo/exchange/` and MUST NOT duplicate the
+      propose-and-activate logic already in `demo_propose_and_activate_embargo`
+      (DEMOMA-20-002).
+    rationale: >-
+      The revision exchange (EV→EJ) is a self-contained composable unit that
+      can be reused if future scenarios add multiple revision cycles. Accepting
+      from REVISE state uses the same `trigger_accept_embargo` endpoint as
+      accepting from PROPOSED, because `AcceptEmbargoLifecycleNode` handles
+      both states (confirmed in `vultron/core/behaviors/embargo/trigger_tree.py`
+      and `vultron/core/behaviors/embargo/nodes/proposal.py`). No new endpoint
+      is needed.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-17-001
+    - rel_type: refines
+      spec_id: DEMOMA-20-002
+
+  - id: DEMOMA-21-003
+    priority: MUST
+    kind: project
+    statement: >-
+      The v2_late_invite phase of rcvv-embargo MUST invite V2 to the case only
+      after the embargo revision (phase 3) is complete and `em_state` is
+      confirmed ACTIVE. On receiving the case invite, V2 MUST also receive the
+      current embargo event and accept it, reaching `emConsentState=SIGNATORY`.
+      The scenario MUST assert that V2's `emConsentState` is SIGNATORY before
+      proceeding to the fix_lifecycle phase. The scenario MUST use polling
+      helpers (not `post_to_inbox_and_wait`) to detect the invite in V2's
+      inbox, consistent with the no-mail-carrying rule (DEMOMA-03-003).
+    rationale: >-
+      Inviting V2 after the revision is complete — rather than before — is the
+      defining characteristic of variation (f): the coordinator delays
+      notification of a short-deadline vendor until the embargo terms are
+      settled. Asserting V2's SIGNATORY state before fix_lifecycle ensures that
+      V2 is fully enrolled in the embargo before it is accidentally collapsed by
+      CS.P, making the ledger record unambiguous about V2's consent at time of
+      collapse.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-03-003
+    - rel_type: refines
+      spec_id: DEMOMA-21-001
+
+  - id: DEMOMA-21-004
+    priority: MUST
+    kind: project
+    statement: >-
+      The accidental_collapse phase of rcvv-embargo MUST trigger the P-transition
+      by calling `actor_notifies_published` on the reporter's client, which posts
+      to the `demo/notify-published` endpoint. The scenario MUST then poll for
+      CaseActor to emit the embargo teardown (the EM.EXITED transition driven by
+      `PublicDisclosureBranchNode`) before asserting `em_state == EM.EXITED` on
+      the coordinator's replica. The scenario MUST NOT call
+      `trigger_terminate_embargo` directly for this phase; the collapse MUST
+      arrive as an automatic consequence of CS.P, not a deliberate termination.
+    rationale: >-
+      Variation (d) specifically exercises the accidental/automatic embargo
+      collapse path rather than the deliberate termination (ET) path.
+      `PublicDisclosureBranchNode` fires when CS.P is detected on the CaseActor,
+      emitting the EM termination activity automatically. Using `actor_notifies_published`
+      from `vultron/demo/helpers/actions.py` exercises this code path end-to-end.
+      Calling `trigger_terminate_embargo` directly would test variation (e)
+      instead and would not exercise `PublicDisclosureBranchNode`.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-21-001
+    - rel_type: refines
+      spec_id: DEMOMA-07-003
+
+  - id: DEMOMA-21-005
+    priority: MUST
+    kind: project
+    statement: >-
+      The rcvv-embargo scenario MUST be registered as the `rcvv-embargo`
+      sub-command in `vultron/demo/cli.py`, consistent with the naming
+      convention of existing scenario commands.
+    rationale: >-
+      The CLI is the single entry point for all demo scenarios (DC-01-001).
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+
+  - id: DEMOMA-21-006
+    priority: MUST
+    kind: project
+    statement: >-
+      The rcvv-embargo scenario MUST be added to the CI demo-integration matrix
+      in `.github/workflows/demo-integration.yml` with `DEMO=rcvv-embargo` and
+      `full_suite_only: false` (runs on every PR). The CI devlogs directory for
+      the run MUST use the scenario-role naming convention: `reporter`,
+      `coordinator`, `vendor`, `vendor2`, `case-actor`.
+    rationale: >-
+      CI coverage from day one, consistent with the decision recorded in issue
+      #1222 planning: default to add-now/remove-later rather than deferred adds.
+      `full_suite_only: false` places the scenario in the minimum PR set.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-04-001
+
+  - id: DEMOMA-21-007
+    priority: MUST
+    kind: project
+    statement: >-
+      An invariant harness file MUST be created at
+      `test/ci/invariants/test_rcvv_embargo_invariants.py`. It MUST define
+      `_DEMO_NAME = "rcvv-embargo"`, `_CHAIN_ACTORS` covering `reporter`,
+      `coordinator`, `vendor`, `vendor2`, and `case-actor`, and the full set of
+      universal invariants (Invariants 1–15). It MUST additionally include the
+      following scenario-specific invariant tests: (a) an embargo-propose event
+      type is present (variation b, EP delivered); (b) an embargo-accept event
+      type is present at least twice — once for the initial activation (EA) and
+      once for the revision acceptance (EJ); (c) an embargo-revise event type is
+      present (EV delivered, variation c); (d) `invite_actor_to_case` appears at
+      least twice (V1 and V2 each receive an invite); (e) V2 is a late joiner —
+      V2's replica MUST contain all ledger entries present in the coordinator
+      replica (backfill check, following the FCV late-joiner pattern); (f) a
+      CS.P-triggered EM termination is observable — `em_state=EXITED` is
+      present in the final snapshot without a corresponding explicit ET message
+      (or with CaseActor as the terminating actor, confirming auto-collapse).
+      The exact event type strings MUST be confirmed from a first successful
+      local run and recorded as a comment referencing the spec ID.
+    rationale: >-
+      The scenario-specific invariants confirm all four embargo-variation
+      protocol paths were exercised and recorded: EP (b), EV (c), EJ (c), and
+      auto-collapse via CS.P (d). The late-joiner backfill check for V2
+      verifies that the ledger synchronization worked correctly when V2 joined
+      mid-scenario after an embargo revision. Invariant (f) distinguishes
+      accidental collapse from deliberate termination, ensuring the scenario
+      exercised the correct code path.
+    lint_suppress:
+    - phantom_path_ref
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-04-001
+    - rel_type: refines
+      spec_id: DEMOMA-16-009
+    - rel_type: refines
+      spec_id: DEMOMA-21-001


### PR DESCRIPTION
- Closes #1222

## Summary

Plans GitHub issue #1222 (Idea): Demo scenario variations for embargo lifecycle
— negotiation, collapse, and deliberate notification delay.

## Changes

- **`specs/multi-actor-demo.yaml`**: Added DEMOMA-20 (`rcv-embargo`, 6 specs)
  and DEMOMA-21 (`rcvv-embargo`, 7 specs). DEMOMA-20 covers embargo variations
  (b) post-submission negotiation and (e) deliberate early termination (EP→EA→ET
  arc). DEMOMA-21 covers variations (b)+(c)+(f)+(d): propose → activate → revise
  → re-activate → late V2 invite → accidental collapse via CS.P.
- **`specs/demo-ci.yaml`**: Added DEMOCI-07 (3 specs) registering both new
  scenarios in CI (`full_suite_only: false`, minimum PR set from day one) plus a
  SHOULD-priority follow-up spec for coverage-model re-evaluation.
- **`notes/demo-future-ideas.md`**: Added R-for-Reporter naming convention note;
  added embargo lifecycle scenarios table with RCV-embargo, RCVV-embargo, and the
  deferred pre-submission negotiation (variation a, blocked by EP-04-003 protocol
  gap); updated cross-cutting variations row for #1222.

### Design decisions recorded

- Variation (a) (pre-submission embargo proposal) deferred — EP-04-003 protocol
  gap prevents a reporter from including an embargo proposal with or before the
  initial report. A separate Idea issue will be filed under epic #1083.
- Two scenarios required (not one) because variations (d) accidental collapse and
  (e) deliberate termination are mutually exclusive terminators on a single case.
- RCVV-embargo uses `trigger_accept_embargo` for both initial acceptance (EA) and
  revision acceptance (EJ) — `AcceptEmbargoLifecycleNode` already handles both
  PROPOSED and REVISE states; no new endpoint needed.
- Both scenarios added to CI with `full_suite_only: false` immediately, consistent
  with add-now/remove-later policy.
- New scenarios use R (Reporter) naming instead of F (Finder); existing scenario
  names are not renamed.

## Implementation Issues

- #2070 — exchange helpers (propose/activate/terminate/revise)
- #2071 — rcv-embargo scenario file + CLI registration
- #2072 — rcvv-embargo scenario file + CLI registration
- #2073 — CI invariant harnesses + demo-integration matrix wiring
- #2074 — coverage model re-evaluation (blocked by #2073)
- #2075 — [Idea] pre-submission embargo negotiation (variation a, deferred)