### PR TITLE
docs: plan issue #1896 — fail-closed status-write transition validation

### DIFF
--- a/notes/status-dimension-objects.md
+++ b/notes/status-dimension-objects.md
@@ -198,6 +198,45 @@ methods (`rm.is_validated()`) over the free-standing helpers
 
 ---
 
+## Write-Side Validation at BT Nodes
+
+Dimension objects that are constructed directly by target state value
+(e.g. `VfdDimension(state=target)`) rather than via `transition()` **bypass
+the transition contract** in SDO-02-002. BT write nodes that use this pattern
+MUST validate the `(current → target)` pair before persisting.
+
+The valid-transition helper functions in `vultron/core/states/` provide this:
+
+```python
+from vultron.core.states.cs import is_valid_vfd_transition, is_valid_pxa_transition
+from vultron.core.states.rm import is_valid_rm_transition
+
+# In a write node's update():
+if target_state is not None and target_state != current_state:
+    if not is_valid_vfd_transition(current_state, target_state):
+        self.feedback_message = (
+            f"Invalid VFD transition {current_state!r} → {target_state!r}"
+        )
+        return Status.FAILURE
+```
+
+Rules:
+
+- `target == current` → proceed (status confirmation; valid protocol observation)
+- `is_valid_*_transition(current, target)` is `True` → proceed
+- Otherwise → `Status.FAILURE` with a descriptive `feedback_message`
+- `None` target → skip validation (caller is preserving current state)
+
+This makes write nodes fail-closed regardless of whether an upstream guard
+is present, weak, or bypassed. See BTND-10-001, SDO-02-004, CSB-16-001/002.
+
+The primary write boundary is `CreateParticipantStatusNode` in
+`vultron/core/behaviors/case/nodes/participant/status.py` — all VFD/RM/PXA
+state-write paths in the prototype route through it or should follow the same
+pattern.
+
+---
+
 ## Relationship to EmbargoLifecycle
 
 `EmbargoLifecycle` currently mutates `em_state` and `em_consent_state` fields

--- a/plan/history/2608/learning/CONCERN-1896.md
+++ b/plan/history/2608/learning/CONCERN-1896.md
@@ -1,0 +1,42 @@
+---
+source: CONCERN-1896
+timestamp: '2026-08-07T19:01:23.985396+00:00'
+title: CreateParticipantStatusNode persists VFD/RM/PXA state without transition validation
+type: learning
+---
+
+## Concern
+
+`CreateParticipantStatusNode.update()` constructed `VfdDimension(state=target)`
+directly, bypassing `VfdDimension.transition()` and all validity checks. Any
+weak, missing, or bypassed upstream guard could allow an illegal state jump to
+be persisted. The same structural gap exists in `rm_transitions.py`.
+
+## Resolution
+
+Added spec requirements establishing that BT write nodes MUST validate
+source→target transitions before persisting, making the write path fail-closed
+regardless of upstream guard coverage.
+
+- Same-state writes (target == current) are permitted as status confirmations.
+- None targets skip validation (preserve current state).
+- Illegal jumps MUST cause the node to return `Status.FAILURE` with a
+  descriptive `feedback_message`.
+
+## Specs and Notes Updated
+
+- **BTND-10-001** (`specs/behavior-tree-node-design.yaml`): BT status-write
+  nodes MUST validate VFD/RM/PXA transitions before persisting
+- **SDO-02-004** (`specs/status-dimension-objects.yaml`): direct-construction
+  call sites MUST validate source→target; refines SDO-02-002
+- **CSB-16-001/002** (`specs/cs-behavior.yaml`): VFD and PXA write boundaries
+  MUST reject illegal jumps and backward moves
+- **`notes/status-dimension-objects.md`**: "Write-Side Validation at BT Nodes"
+  section with canonical code pattern
+
+## Implementation Issues
+
+- #2081: validate VFD/RM/PXA transitions in `CreateParticipantStatusNode` (Schedule=Focus)
+- #2082: validate RM transitions in `rm_transitions.py` (Schedule=Focus, blocked-by #2081)
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2080>

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -502,6 +502,63 @@ groups:
       spec_id: BTND-08-001
     verification: In each `Selector(Sequence(IsFoo, ApplyFoo), AlwaysSuccess)` composite, confirm the `AlwaysSuccess` node's
       `name` ends with `"Skipped"`.
+- id: BTND-10
+  title: BT Status-Write Node Transition Validation
+  specs:
+  - id: BTND-10-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      A BT node that persists a ParticipantStatus snapshot containing a non-None
+      VFD, RM, or PXA state MUST validate that (current_state → target_state) is
+      a permitted transition before constructing or saving the new dimension object.
+      A same-state write (target == current) is permitted as a status confirmation.
+      An illegal jump (e.g. vfd → VFD, skipping Vfd) or a backward move MUST cause
+      the node to return Status.FAILURE with a descriptive feedback_message.
+    rationale: >-
+      The dimension objects' transition() machinery (SDO-02-002) and the
+      is_valid_*_transition() helpers in vultron/core/states/ enforce forward-only
+      state machine rules, but constructing VfdDimension(state=target) directly
+      bypasses them. A BT guard upstream is necessary but not sufficient: if the
+      guard is too weak (as in issue #1825) or absent (as in the trigger path),
+      an illegal state jump reaches the write boundary unchecked. Validating at
+      the write node makes illegal transitions fail-closed regardless of guard
+      coverage. Same-state writes are permitted because a ParticipantStatus
+      snapshot records current state; confirming "still at VFd" is a legitimate
+      protocol observation, not a transition error.
+    testable: true
+    preconditions:
+    - description: A non-None target VFD, RM, or PXA state is passed to the write node
+    steps:
+    - order: 1
+      actor: write_node
+      action: >-
+        Read the participant's current state for the dimension being written
+        (e.g. resolve_participant_state_from_dl)
+      expected: Current state available
+    - order: 2
+      actor: write_node
+      action: >-
+        If target == current, proceed (status confirmation). If
+        is_valid_*_transition(current, target) is True, proceed. Otherwise
+        return Status.FAILURE with a feedback_message identifying the illegal
+        source→target pair.
+      expected: Only valid forward transitions or same-state writes reach the
+        DataLayer persist step; invalid jumps return FAILURE.
+    postconditions:
+    - description: No ParticipantStatus record with an illegal state jump is persisted
+    relationships:
+    - rel_type: implements
+      spec_id: SDO-02-002
+      note: Write-node compliance with the transition() validation contract
+    - rel_type: implements
+      spec_id: BTND-09-001
+      note: Validation failure returns FAILURE from update(), consistent with error handling contract
+    verification: >-
+      Unit tests: (1) invalid backward/skip jump returns Status.FAILURE and sets
+      feedback_message; (2) valid forward transition succeeds; (3) same-state write
+      succeeds; (4) None target skips validation.
+
 - id: BTND-09
   title: BT Error Handling Contract
   specs:

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -502,6 +502,24 @@ groups:
       spec_id: BTND-08-001
     verification: In each `Selector(Sequence(IsFoo, ApplyFoo), AlwaysSuccess)` composite, confirm the `AlwaysSuccess` node's
       `name` ends with `"Skipped"`.
+- id: BTND-09
+  title: BT Error Handling Contract
+  specs:
+  - id: BTND-09-001
+    priority: MUST
+    kind: project
+    statement: 'BT helper functions MUST raise exceptions on error — they MUST NOT catch exceptions and return a sentinel
+      value. The `update()` method of the owning leaf node is the sole try/except boundary: it calls helpers, catches any
+      exceptions they raise, writes to the error result channel (BTND-03-006), and returns `FAILURE`.'
+    rationale: If helpers catch their own errors and return sentinels (e.g., `None`, `False`), the leaf's `update()` method
+      cannot distinguish a legitimate `None` return from a hidden failure. All error information travels via Python's exception
+      mechanism so that the single boundary point (`update()`) has complete diagnostic context.
+    relationships:
+    - rel_type: implements
+      spec_id: BTND-03-006
+    - rel_type: implements
+      spec_id: EH-02-001
+
 - id: BTND-10
   title: BT Status-Write Node Transition Validation
   specs:
@@ -558,21 +576,3 @@ groups:
       Unit tests: (1) invalid backward/skip jump returns Status.FAILURE and sets
       feedback_message; (2) valid forward transition succeeds; (3) same-state write
       succeeds; (4) None target skips validation.
-
-- id: BTND-09
-  title: BT Error Handling Contract
-  specs:
-  - id: BTND-09-001
-    priority: MUST
-    kind: project
-    statement: 'BT helper functions MUST raise exceptions on error — they MUST NOT catch exceptions and return a sentinel
-      value. The `update()` method of the owning leaf node is the sole try/except boundary: it calls helpers, catches any
-      exceptions they raise, writes to the error result channel (BTND-03-006), and returns `FAILURE`.'
-    rationale: If helpers catch their own errors and return sentinels (e.g., `None`, `False`), the leaf's `update()` method
-      cannot distinguish a legitimate `None` return from a hidden failure. All error information travels via Python's exception
-      mechanism so that the single boundary point (`update()`) has complete diagnostic context.
-    relationships:
-    - rel_type: implements
-      spec_id: BTND-03-006
-    - rel_type: implements
-      spec_id: EH-02-001

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -1368,3 +1368,88 @@ groups:
       note: >-
         P event trigger must not imply D event; separates participant-agnostic
         public awareness from participant-specific fix deployment
+
+- id: CSB-16
+  title: CS Write-Boundary Transition Validation
+  description: >-
+    Requirements for CS state write paths (VFD and PXA) to validate
+    source→target transition validity before persisting a ParticipantStatus
+    snapshot. Complements CSB-15 (trigger-side role preconditions) and
+    SDO-02-002 (dimension object transition contract) by requiring that
+    the BT write node itself is fail-closed regardless of upstream guard
+    coverage.
+  specs:
+  - id: CSB-16-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      A BT node or helper that writes a VFD state (CS_vfd) to a ParticipantStatus
+      snapshot MUST validate that the (current_vfd_state → target_vfd_state)
+      transition is permitted by the VFD state machine before persisting.
+      A same-state write is permitted (status confirmation). A backward move or
+      illegal jump (e.g. vfd → VFD skipping Vfd) MUST cause the node to return
+      Status.FAILURE without writing to the DataLayer.
+    rationale: >-
+      Upstream BT guards (e.g. CheckCSFixNotYetDeployed) are necessary but
+      insufficient: a guard that is too weak, missing, or bypassed allows an
+      invalid VFD state jump to reach the write node unchecked. Validating at
+      the write boundary makes illegal VFD transitions fail-closed regardless
+      of guard coverage. Source: concern #1896, which surfaced when the
+      CheckCSFixNotYetDeployed guard was too weak in issue #1825.
+    testable: true
+    preconditions:
+    - description: A non-None CS_vfd target state is passed to a ParticipantStatus write node
+    steps:
+    - order: 1
+      actor: write_node
+      action: Read the participant's current VFD state from the DataLayer
+      expected: Current CS_vfd state available
+    - order: 2
+      actor: write_node
+      action: >-
+        If target == current, proceed. If is_valid_vfd_transition(current, target)
+        is True, proceed. Otherwise return Status.FAILURE.
+      expected: Only valid transitions or same-state writes reach the DataLayer
+    postconditions:
+    - description: No ParticipantStatus with an illegal VFD jump is persisted
+    relationships:
+    - rel_type: implements
+      spec_id: SDO-02-004
+    - rel_type: refines
+      spec_id: BTND-10-001
+
+  - id: CSB-16-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      A BT node or helper that writes a PXA state (CS_pxa) to a CaseStatus or
+      ParticipantStatus snapshot MUST validate that the (current_pxa_state →
+      target_pxa_state) transition is permitted by the PXA state machine before
+      persisting. A same-state write is permitted. A backward move MUST cause
+      the node to return Status.FAILURE without writing to the DataLayer.
+    rationale: >-
+      PXA state transitions are forward-only (p→P, x→X, a→A). An invalid
+      backward PXA write would produce a misleading public-disclosure regression
+      in the case record. The same fail-closed boundary that protects VFD applies
+      equally to PXA. Source: concern #1896.
+    testable: true
+    preconditions:
+    - description: A non-None CS_pxa target state is passed to a ParticipantStatus write node
+    steps:
+    - order: 1
+      actor: write_node
+      action: Read the participant's current PXA state
+      expected: Current CS_pxa state available
+    - order: 2
+      actor: write_node
+      action: >-
+        If target == current, proceed. If is_valid_pxa_transition(current, target)
+        is True, proceed. Otherwise return Status.FAILURE.
+      expected: Only valid transitions or same-state writes reach the DataLayer
+    postconditions:
+    - description: No ParticipantStatus with an illegal PXA regression is persisted
+    relationships:
+    - rel_type: implements
+      spec_id: SDO-02-004
+    - rel_type: refines
+      spec_id: BTND-10-001

--- a/specs/rm-behavior.yaml
+++ b/specs/rm-behavior.yaml
@@ -1404,3 +1404,53 @@ groups:
       note: >-
         SHOULD communicate intent to adhere or terminate compliance when closing
         during an active embargo
+
+- id: RMB-15
+  title: RM Write-Boundary Transition Validation
+  description: >-
+    Requirements for RM state write paths to validate source→target transition
+    validity before persisting a ParticipantStatus snapshot. Complements
+    CSB-16 (VFD/PXA write-boundary validation) and SDO-02-002 (dimension
+    object transition contract) by requiring that the BT write node itself
+    is fail-closed regardless of upstream guard coverage.
+  specs:
+  - id: RMB-15-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      A BT node or helper that writes an RM state to a ParticipantStatus
+      snapshot MUST validate that the (current_rm_state → target_rm_state)
+      transition is permitted by the RM state machine using
+      is_valid_rm_transition() before persisting. A same-state write is
+      permitted (status confirmation). An illegal jump or backward move
+      MUST cause the node to return Status.FAILURE without writing to the
+      DataLayer.
+    rationale: >-
+      ParticipantStatus.rm_state is written via direct-construction
+      (e.g. RmDimension(state=target)) at sites such as rm_transitions.py,
+      bypassing the transition() contract in SDO-02-002. Upstream BT guards
+      are necessary but insufficient: a weak or missing guard allows an
+      invalid RM state jump to reach the write node unchecked. Validating
+      at the write boundary makes illegal RM transitions fail-closed
+      regardless of guard coverage. Source: concern #1896.
+    testable: true
+    preconditions:
+    - description: A non-None RM target state is passed to a ParticipantStatus write node
+    steps:
+    - order: 1
+      actor: write_node
+      action: Read the participant's current RM state from the DataLayer
+      expected: Current RM state available
+    - order: 2
+      actor: write_node
+      action: >-
+        If target == current, proceed. If is_valid_rm_transition(current, target)
+        is True, proceed. Otherwise return Status.FAILURE.
+      expected: Only valid transitions or same-state writes reach the DataLayer
+    postconditions:
+    - description: No ParticipantStatus with an illegal RM state jump is persisted
+    relationships:
+    - rel_type: implements
+      spec_id: SDO-02-004
+    - rel_type: refines
+      spec_id: BTND-10-001

--- a/specs/status-dimension-objects.yaml
+++ b/specs/status-dimension-objects.yaml
@@ -71,6 +71,27 @@ groups:
     rationale: Mutation of embedded Pydantic models is fragile and inconsistent with the append-only history model. See ADR-0036.
     adr:
     - ADR-0036
+  - id: SDO-02-004
+    priority: MUST
+    kind: protocol
+    statement: >-
+      Any code path that constructs a new dimension object by target state value
+      (e.g. VfdDimension(state=target)) rather than calling transition() MUST
+      first validate that (current_state → target_state) is a permitted transition
+      using is_valid_*_transition() or equivalent. A same-state write (target ==
+      current) is permitted. A None target (preserve current) requires no validation.
+      An illegal jump MUST NOT be persisted.
+    rationale: >-
+      Constructing a dimension object by target state bypasses the transition()
+      validation contract established in SDO-02-001/SDO-02-002. BT write nodes
+      that build snapshots this way must apply the same validity check themselves.
+      See issue #1896 and BTND-10-001.
+    relationships:
+    - rel_type: refines
+      spec_id: SDO-02-002
+      note: Extends the transition() contract to direct-construction call sites
+    - rel_type: refines
+      spec_id: BTND-10-001
 - id: SDO-03
   title: CaseStatus and ParticipantStatus Field Shape
   specs:


### PR DESCRIPTION
- Closes #1896

## Summary

Adds spec requirements and design guidance establishing that BT write nodes
constructing `ParticipantStatus` snapshots MUST validate source→target state
transitions before persisting, making the write path fail-closed regardless
of upstream guard coverage.

## Changes

- **`specs/behavior-tree-node-design.yaml`**: Add BTND-10 group (BTND-10-001)
  — BT status-write nodes MUST validate VFD/RM/PXA transitions before
  persisting; same-state writes permitted; illegal jumps return FAILURE
- **`specs/status-dimension-objects.yaml`**: Add SDO-02-004 — direct-construction
  call sites that build dimension objects by target state MUST validate the
  source→target pair; refines SDO-02-002 (transition() contract)
- **`specs/cs-behavior.yaml`**: Add CSB-16 group (CSB-16-001, CSB-16-002) —
  VFD and PXA write boundaries MUST reject illegal jumps and backward moves;
  complements CSB-15 (trigger-side role preconditions)
- **`notes/status-dimension-objects.md`**: Add "Write-Side Validation at BT
  Nodes" section with canonical code pattern and cross-references to new specs

## Implementation Issues

- #2081
- #2082