### PR TITLE
fix(specs): correct three spec statements contradicted by implementation

### DIFF
--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -907,9 +907,18 @@ groups:
     kind: protocol
     statement: When the CaseActor receives `Accept(Invite)` from the invitee, it MUST (1) commit a ledger entry for the Accept,
       (2) fan out the ledger entry to ALL existing participants, (3) create a `CaseParticipant` record for the invitee at
-      `RM.ACCEPTED` with the roles from the Invite, (4) sign embargo consent if `em_state == EM.ACTIVE` (CM-10-001), (5) send
+      `RM.RECEIVED` with the roles from the Invite, (4) sign embargo consent if `em_state == EM.ACTIVE` (CM-10-001), (5) send
       `Announce(VulnerabilityCase)` with the current full case snapshot to the invitee, and (6) backfill all prior `CaseLedgerEntry`
       records to the invitee in log-index order.
+    note: >-
+      Step (3) previously read `RM.ACCEPTED`. That contradicted CM-11-001, which requires the CaseActor to record
+      `RM.RECEIVED` on `Accept(Invite)` — `Accept(Invite)` signals willingness to join, not validation of the report.
+      The implementation follows CM-11-001 (`CreateInviteeParticipantAtReceivedNode` in
+      `vultron/core/behaviors/case/accept_invite_tree.py`); this text was not updated when CM-11-001 was corrected.
+      The ordering of steps (3), (4), and (5) is load-bearing: the gate on full case delivery is admission to the
+      case plus embargo consent, NOT completion of RM triage. The invitee is created at `RM.RECEIVED` (3), embargo
+      consent is signed if an embargo is active (4), and only then is the full case snapshot sent (5). See MV-10-005
+      as corrected, and MV-10-006 for the accept-implies-consent rule.
     relationships:
     - rel_type: implements
       spec_id: CM-11-001
@@ -923,8 +932,8 @@ groups:
     statement: The invitee MUST NOT appear in the case participant list until their `Accept(Invite)` has been received and
       processed by the CaseActor. A pending invitation (Invite sent, no response yet) is tracked only as a ledger entry, not
       as a participant record.
-    rationale: A participant record implies RM.ACCEPTED state and associated permissions. Creating one before the invitee
-      has consented would grant protocol access prematurely.
+    rationale: A participant record implies an active RM state (`RM.RECEIVED` per CM-17-004) and the associated permissions.
+      Creating one before the invitee has consented would grant protocol access prematurely.
   - id: CM-17-006
     priority: MUST
     kind: protocol
@@ -941,9 +950,14 @@ groups:
     kind: protocol
     statement: 'Each participant''s embargo consent MUST be tracked as a `ParticipantEmbargoConsent` (PEC) value with five
       possible states: `NO_EMBARGO` (no embargo is in scope for this participant), `INVITED` (invite sent, awaiting response),
-      `SIGNATORY` (accepted), `LAPSED` (timer expired with no response), and `DECLINED` (explicitly refused).'
+      `SIGNATORY` (accepted the current terms), `LAPSED` (was `SIGNATORY`; the case embargo entered `REVISE`, so prior consent
+      no longer covers the revised terms), and `DECLINED` (explicitly refused, or timed out without responding).'
     rationale: 'The five-state PEC machine formalizes the "pocket veto" mechanism: a participant who is invited but never
-      responds causes the embargo to lapse rather than block progress. Source: `notes/participant-embargo-consent.md`.
+      responds is recorded as `DECLINED` when the timer fires, rather than blocking progress indefinitely.
+      Source: `notes/participant-embargo-consent.md`.
+      `LAPSED` is NOT the timer path — it is reached only from `SIGNATORY` via the `REVISE` trigger (CM-18-002, CM-18-003).
+      Confusing `LAPSED` with the pocket-veto timeout is a known documentation pitfall; both timer paths
+      (`INVITED → DECLINED`, `LAPSED → DECLINED`) terminate in `DECLINED`.
       Per ADR-0048, `NO_EMBARGO` denotes the *absence of an embargo in scope*, not a "not yet consented" pre-consent state:
       it is correct for a participant in a case with `EM.NONE`, and it is the `RESET` destination when an embargo is
       terminated. It MUST NOT be read as implying that consent is pending or that an invitation is owed.'

--- a/specs/message-validation.yaml
+++ b/specs/message-validation.yaml
@@ -132,10 +132,25 @@ groups:
     kind: protocol
     statement: >-
       A participant MUST satisfy BOTH of the following conditions before the case owner delivers
-      full case details to them: 1. `ParticipantStatus.rm_state == ACCEPTED` (participant
-      accepted the case invitation) 2. `ParticipantStatus.embargo_adherence == True` (participant
-      is a signatory to the active embargo), OR there is no active embargo (`CaseStatus.em_state
-      == NONE`)
+      full case details to them: 1. `ParticipantStatus.rm_state` is at least `RECEIVED` (the
+      participant has accepted the case invitation and been admitted to the case) 2.
+      `ParticipantStatus.embargo_adherence == True` (participant is a signatory to the active
+      embargo), OR there is no active embargo (`CaseStatus.em_state == NONE`)
+    note: >-
+      Condition 1 previously read `rm_state == ACCEPTED`. That was incorrect and mutually
+      unsatisfiable with the rest of the invitation lifecycle: CM-11-001 records an invitee at
+      `RM.RECEIVED` on `Accept(Invite)`, and CM-11-002 has them reaching `ACCEPTED` only AFTER
+      receiving the full case replica and running triage. Requiring `ACCEPTED` before delivery
+      meant a participant could never obtain the full case they need in order to reach `ACCEPTED`.
+      The condition's own parenthetical ("participant accepted the case invitation") describes
+      `RM.RECEIVED`, confirming the intent was "is admitted to the case", not "has completed triage".
+      The embargo condition (2) is the substantive gate on case content, per MV-10-006 and CM-18.
+      The implementation follows this ordering: `accept_invite_tree` creates the invitee at
+      `RM.RECEIVED`, auto-signs embargo consent when `EM.ACTIVE`, and only then emits
+      `Announce(VulnerabilityCase)` with the full snapshot.
+    relationships:
+    - rel_type: depends_on
+      spec_id: MV-10-006
   - id: MV-10-006
     priority: MUST
     kind: protocol


### PR DESCRIPTION
## Summary

Three statements in `specs/` assert behavior the implementation does not have. In each case **the code is correct and the spec text is wrong**. No code changes.

Surfaced while reviewing the draft Vultron Protocol specification (#2078) — writing the protocol behavior out as prose made the disagreements visible.

These matter disproportionately: `load-specs` / `orient-agent` hand `specs/` to agents as ground truth at the start of every task. A false spec statement propagates into new code, whereas a code bug stays put.

## The three fixes

### CM-18-001 — `LAPSED` gloss described the timer path

Read `LAPSED` as "timer expired with no response". Contradicted by CM-18-002, CM-18-003, and `vultron/core/states/participant_embargo_consent.py`: `LAPSED` is reached **only** from `SIGNATORY` via the `REVISE` trigger and is explicitly *not* timer-based. Both timer paths (`INVITED → DECLINED`, `LAPSED → DECLINED`) terminate in `DECLINED`.

The rationale committed the same conflation a second time ("causes the embargo to lapse"). `notes/participant-embargo-consent.md` names this exact confusion as a known documentation pitfall — CM-18-001 was committing it.

### CM-17-004 — step (3) said `RM.ACCEPTED`

CM-11-001 (corrected in `ca5812e2`) requires the CaseActor to record `RM.RECEIVED` on `Accept(Invite)`. The implementation follows CM-11-001 via `CreateInviteeParticipantAtReceivedNode`. CM-17-004 was not updated at that time.

Notably, the item carries `implements -> CM-11-001`, so the traceability graph asserted that a contradicting statement implements the thing it contradicted.

### MV-10-005 — condition 1 was mutually unsatisfiable

Required `rm_state == ACCEPTED` before full case delivery. But an invitee is at `RM.RECEIVED` after `Accept(Invite)`, and reaches `ACCEPTED` only *after* receiving the full replica and running triage (CM-11-002). So a participant could never obtain the case required to reach the state that gated it.

The condition's own parenthetical — "(participant accepted the case invitation)" — describes `RM.RECEIVED`, confirming the intent was *admission to the case*, not *completion of triage*.

The substantive gate on case content is **embargo consent**, per MV-10-006 and CM-18. That is what `accept_invite_tree` implements: create invitee at `RM.RECEIVED` → auto-sign consent when `EM.ACTIVE` → then `Announce(VulnerabilityCase)` with the full snapshot. The node's own docstring says "sends the full case object after embargo consent has been resolved".

This one was initially mis-diagnosed in review as an unresolved protocol gap ("circular delivery gate"). It is not a gap — the protocol is coherent and the implementation is right; three spec files simply disagreed about it. Credit to @ahouseholder for spotting that the real gate is *in the case + embargo consent*, not RM triage completion.

## Also

`CM-17-005`'s rationale rested on the stale `RM.ACCEPTED` premise ("a participant record implies RM.ACCEPTED state"). Updated. The requirement itself is unchanged.

## Test plan

- [x] `pytest test/metadata/specs/` — 237 passed
- [x] `pytest test/core/behaviors/case/` — 373 passed
- [x] Spec registry linter (pre-commit) — passed
- [x] `mkdocs build --strict` — no new warnings; the 2 warnings present are pre-existing on clean `origin/main` (verified via stash)
- [x] YAML parses for both edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)