### PR TITLE
fix: run integration suite in pre-PR validation

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -180,7 +180,12 @@ that clearly belongs with it, apply the following:
    uv run black vultron/ test/
    uv run flake8 vultron/ test/ && uv run mypy && uv run pyright
    uv run pytest --tb=short 2>&1 | tail -5
+   uv run pytest -m integration --tb=short 2>&1 | tail -5
    ```
+
+   Both suites must pass. The first command covers the unit suite (integration
+   tests excluded by `addopts`); the second explicitly runs the integration
+   suite so demo-layer regressions are caught before the PR opens.
 
 2. Do not skip or delegate validation.
 3. Apply branch-ownership and pre-existing-failure rules from

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -162,7 +162,12 @@ before proceeding. Do not open a PR with lint failures.
 uv run black vultron/ test/
 uv run flake8 vultron/ test/ && uv run mypy && uv run pyright
 uv run pytest --tb=short 2>&1 | tail -5
+uv run pytest -m integration --tb=short 2>&1 | tail -5
 ```
+
+Both suites must pass. The first pytest command covers the unit suite
+(integration tests excluded by `addopts`); the second explicitly runs the
+integration suite so demo-layer regressions are caught before the PR opens.
 
 If any step fails, fix, re-validate, and continue. Do not open a PR with
 failing tests or lint errors.

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -26,10 +26,24 @@ outputs:
 | Integration | `uv run pytest -m integration --tb=short 2>&1 \| tail -5` |
 | All | `uv run pytest -m "" --tb=short 2>&1 \| tail -5` |
 
+## Pre-PR Validation (build and create-pr)
+
+Run **both** suites before opening a PR:
+
+```bash
+uv run pytest --tb=short 2>&1 | tail -5
+uv run pytest -m integration --tb=short 2>&1 | tail -5
+```
+
+The first command covers the unit suite (integration tests excluded by
+`addopts = "-m 'not integration'"`). The second explicitly runs the
+integration suite. Both must pass; a branch that only breaks integration
+tests must not reach a non-draft PR.
+
 ## Constraints
 
 - Run exactly once per validation cycle; do not use `-q` or change output formatting.
 - Do not change `tail -5`.
 - `filterwarnings = ["error"]` in `pyproject.toml` — warnings are test errors; fix root cause, do not suppress.
-- Integration tests are excluded from the default run; use `-m integration` for demo/datalayer validation.
+- Integration tests are excluded from the default interactive run; always run `-m integration` explicitly in pre-PR validation.
 - Treat all failures as branch-owned by default; clean-base proof is required before classifying as pre-existing.

--- a/plan/history/2608/implementation/ISSUE-1914.md
+++ b/plan/history/2608/implementation/ISSUE-1914.md
@@ -1,0 +1,26 @@
+---
+source: ISSUE-1914
+timestamp: '2026-08-07T20:44:48.129340+00:00'
+title: 'fix: run integration suite in pre-PR validation'
+type: implementation
+---
+
+## Issue #1914 — Pre-PR validation silently skips all integration tests
+
+Fixed the blind spot where `build` Phase 6 and `create-pr` Phase 3 both ran
+`uv run pytest --tb=short` which silently deselected all integration tests via
+`addopts = "-m 'not integration'"` in pyproject.toml.
+
+**Root cause**: validation steps hardcoded a command that relies on `addopts`
+to run everything, but `addopts` actively *excludes* integration tests. A
+branch breaking only `test/demo/` tests (all auto-marked `integration`) could
+open a non-draft PR reporting "tests pass".
+
+**Fix**: Added `uv run pytest -m integration --tb=short 2>&1 | tail -5` after
+the unit run in both `build` Phase 6 and `create-pr` Phase 3. Updated
+`run-tests/SKILL.md` to document the two-step pre-PR validation requirement.
+
+**Files changed**: `.agents/skills/build/SKILL.md`,
+`.agents/skills/create-pr/SKILL.md`, `.agents/skills/run-tests/SKILL.md`
+
+PR: <https://github.com/CERTCC/Vultron/pull/2114>


### PR DESCRIPTION
- Closes #1914

## Summary

Add an explicit `-m integration` pytest run to the pre-PR validation steps in
`build` and `create-pr`, so demo-layer regressions are caught before a PR
opens. Update `run-tests/SKILL.md` to document the two-step requirement.

## Changes

- **`.agents/skills/build/SKILL.md`**: Phase 6 now runs both
  `uv run pytest --tb=short` (unit suite) and
  `uv run pytest -m integration --tb=short` (integration suite); added
  explanatory note that both must pass.
- **`.agents/skills/create-pr/SKILL.md`**: Phase 3 implementation-PR
  validation likewise runs both suites; same explanatory note added.
- **`.agents/skills/run-tests/SKILL.md`**: New "Pre-PR Validation" section
  documents the two-step requirement; updated the Constraints line to say
  integration tests must always be run explicitly in pre-PR validation.