### PR TITLE
docs: plan issue #1806 — spec-to-test traceability gap

### DIFF
--- a/plan/history/2608/learning/CONCERN-1806.md
+++ b/plan/history/2608/learning/CONCERN-1806.md
@@ -1,0 +1,17 @@
+---
+source: CONCERN-1806
+timestamp: '2026-08-07T20:55:19.948587+00:00'
+title: 'Spec-to-test traceability gap: ~1% of requirements carry @pytest.mark.spec;
+  audit, decorate, and ratchet'
+type: learning
+---
+
+Only ~15 of ~2,215 spec requirements (well under 1%) carry a `@pytest.mark.spec` marker linking a test to the requirement it verifies. This makes spec→test coverage effectively invisible: we cannot mechanically answer "is requirement XX-NN-NNN verified by any test?" for 99% of the spec registry.
+
+**Surface symptom vs. underlying problem:** This is primarily a **traceability** gap, not (only) a testing gap. The reference implementation has a large, mature test suite; the issue is that the vast majority of those tests are **not decorated** with the `@pytest.mark.spec("XX-NN-NNN")` marker that ties them back to the requirements they exercise. Coverage exists but is not *attributable*.
+
+**Root cause:** SR-05-004 was a SHOULD with no enforcement mechanism, allowing adoption to drift toward near-zero with no signal.
+
+**Resolution:** 2026-08-07 — implementation tracked in #2116, #2117.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2115>.
+Spec: `specs/spec-registry.yaml` (SR-05-004 upgraded to MUST for protocol-kind; SR-05-005 added for CI floor).

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -275,10 +275,26 @@ groups:
     kind: project
     statement: The pytest integration SHOULD load the registry once per session (not per test) to avoid I/O overhead.
   - id: SR-05-004
-    priority: SHOULD
+    priority: MUST
     kind: project
-    statement: Tests SHOULD use `@pytest.mark.spec` to assert which requirement they verify, enabling coverage reporting by
-      spec ID.
+    statement: >-
+      Tests that verify a protocol-tier requirement (spec items with kind equal to "protocol") MUST carry
+      `@pytest.mark.spec("<ID>")` linking the test to the requirement it exercises. Tests for other requirement kinds
+      SHOULD use the marker to enable coverage reporting by spec ID.
+    rationale: >-
+      Protocol-kind requirements are conformance-critical. Without a marker, coverage for those requirements is
+      unverifiable and the CI floor ratchet (SR-05-005) cannot enforce it. The SHOULD for non-protocol kinds preserves
+      opt-in adoption for lower-stakes requirements.
+  - id: SR-05-005
+    priority: MUST
+    kind: project
+    statement: >-
+      CI MUST enforce a minimum `@pytest.mark.spec` coverage floor for protocol-tier requirements and fail the build if
+      coverage drops below the configured threshold, preventing marker adoption from drifting back toward zero.
+    rationale: >-
+      A SHOULD-only rule (the former SR-05-004) produced near-zero adoption with no enforcement signal. A CI-enforced
+      floor is the minimum mechanism that guarantees the ratchet cannot be accidentally broken by future commits that add
+      protocol requirements without linking tests.
 - id: SR-06
   title: Pre-commit Hook
   specs:


### PR DESCRIPTION
- Closes #1806

## Summary

Upgrades SR-05-004 from SHOULD to MUST for protocol-tier requirements and adds
SR-05-005 requiring a CI coverage floor, establishing the spec foundation for
the spec-to-test traceability implementation work.

## Changes

- **`specs/spec-registry.yaml`**: Tightened SR-05-004 — tests verifying
  protocol-kind requirements MUST carry `@pytest.mark.spec`; added rationale
  explaining the near-zero adoption failure mode. Added SR-05-005 requiring a
  CI-enforced coverage floor for protocol-tier markers with rationale.

## Implementation Issues

- #2116
- #2117