### PR TITLE
fix(ci): repair demo-integration startup failure; add actionlint gate

### DIFF
--- a/.github/demo-scenarios.json
+++ b/.github/demo-scenarios.json
@@ -1,0 +1,47 @@
+[
+  {
+    "demo": "fv",
+    "test_file": "test/ci/invariants/test_fv_invariants.py",
+    "full_suite_only": false
+  },
+  {
+    "demo": "fvcv-handoff",
+    "test_file": "test/ci/invariants/test_fvcv_handoff_invariants.py",
+    "full_suite_only": false
+  },
+  {
+    "demo": "fcvcv",
+    "test_file": "test/ci/invariants/test_fcvcv_invariants.py",
+    "full_suite_only": false
+  },
+  {
+    "demo": "fcv-reject",
+    "test_file": "test/ci/invariants/test_fcv_reject_invariants.py",
+    "full_suite_only": false
+  },
+  {
+    "demo": "fvv",
+    "test_file": "test/ci/invariants/test_fvv_invariants.py",
+    "full_suite_only": true
+  },
+  {
+    "demo": "fvcv-extension",
+    "test_file": "test/ci/invariants/test_fvcv_extension_invariants.py",
+    "full_suite_only": true
+  },
+  {
+    "demo": "fccv-extension",
+    "test_file": "test/ci/invariants/test_fccv_extension_invariants.py",
+    "full_suite_only": true
+  },
+  {
+    "demo": "fccv-handoff",
+    "test_file": "test/ci/invariants/test_fccv_handoff_invariants.py",
+    "full_suite_only": true
+  },
+  {
+    "demo": "fcv",
+    "test_file": "test/ci/invariants/test_fcv_invariants.py",
+    "full_suite_only": true
+  }
+]

--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -1,0 +1,113 @@
+# Workflow linter — validates the GitHub Actions workflow files themselves.
+#
+# Kept separate from python-app.yml because that workflow's path filter is
+# scoped to vultron/ and test/, so workflow-only changes would never trigger
+# it. This workflow's filter is scoped to .github/ for the same reason.
+#
+# actionlint catches errors that YAML parsing cannot: invalid context
+# references, malformed `if:` expressions, unknown action inputs, and shell
+# problems in `run:` blocks (via shellcheck).
+#
+# Motivating regression (#2118, DEMOCI-06-004): demo-integration.yml carried a job-level
+# `if:` referencing the `matrix` context. That is valid YAML — yaml.safe_load
+# accepts it — but the `matrix` context does not exist until after matrix
+# expansion, so GitHub rejected the file with a startup failure: zero jobs,
+# no logs, no annotation, and a bare red X. It went unnoticed for 116
+# consecutive runs across every branch. actionlint flags it in one line.
+
+name: Actions Lint
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/demo-scenarios.json"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/demo-scenarios.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Pinned by version + SHA256 so a compromised or retagged release cannot
+      # silently change what runs in CI.
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.7"
+          ACTIONLINT_SHA256: "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
+        run: |
+          set -euo pipefail
+          TARBALL="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL --retry 3 \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${TARBALL}" \
+            -o "$TARBALL"
+          echo "${ACTIONLINT_SHA256}  ${TARBALL}" | sha256sum --check --strict
+          tar xzf "$TARBALL" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint -version
+
+      # Default discovery walks .github/workflows/. shellcheck is preinstalled
+      # on ubuntu-latest runners, so `run:` blocks are linted too.
+      #
+      # Composite actions under .github/actions/ are NOT linted: actionlint
+      # parses any file it is handed as a workflow, so passing an action.yml
+      # yields spurious "on section is missing" errors. The push/pull_request
+      # path filters still include .github/actions/** so that a change there
+      # re-lints the workflows that consume those actions (input names and
+      # `uses:` references are validated from the workflow side).
+      - name: Run actionlint
+        run: actionlint -color
+
+      - name: Validate demo scenario matrix
+        run: |
+          set -euo pipefail
+          FILE=.github/demo-scenarios.json
+          jq -e 'type == "array" and length > 0' "$FILE" > /dev/null
+
+          # Every entry needs all three fields with the right types, or the
+          # matrix expands into jobs with empty `demo`/`test_file` values.
+          jq -e 'all(
+                   (.demo | type == "string" and length > 0) and
+                   (.test_file | type == "string" and length > 0) and
+                   (.full_suite_only | type == "boolean")
+                 )' "$FILE" > /dev/null
+
+          # Duplicate scenario names would collide on artifact names.
+          DUPES="$(jq -r '[.[].demo] | group_by(.) | map(select(length > 1) | .[0]) | .[]' "$FILE")"
+          if [ -n "$DUPES" ]; then
+            echo "::error::Duplicate scenario names in $FILE: $DUPES"
+            exit 1
+          fi
+
+          # The PR validation set must be non-empty, else pull_request runs
+          # would resolve to an empty matrix and report a vacuous success.
+          PR_COUNT="$(jq -r '[.[] | select(.full_suite_only == false)] | length' "$FILE")"
+          if [ "$PR_COUNT" -eq 0 ]; then
+            echo "::error::No scenarios with full_suite_only=false; PR runs would be vacuous."
+            exit 1
+          fi
+
+          # Referenced invariant test files must exist (DEMOCI-04-003).
+          MISSING=0
+          while read -r f; do
+            if [ ! -f "$f" ]; then
+              echo "::error file=$FILE::Referenced test file does not exist: $f"
+              MISSING=1
+            fi
+          done < <(jq -r '.[].test_file' "$FILE")
+          [ "$MISSING" -eq 0 ]
+
+          echo "Scenario matrix OK: $(jq -r length "$FILE") total, ${PR_COUNT} in PR set."

--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -15,7 +15,8 @@
 # Concurrency: PR runs cancel in-progress superseded runs; on-main runs
 # always run to completion (DEMOCI-02-011, DEMOCI-05-002).
 #
-# Job structure per matrix entry (DEMOCI-04-001 through DEMOCI-04-003):
+# Job structure (DEMOCI-04-001 through DEMOCI-04-003):
+#   scenarios      — selects the matrix for this event; emits it as JSON
 #   demo           — builds images, runs docker-compose, uploads JSONL artifacts
 #   invariant-harness  — downloads JSONL, runs pytest; needs: demo, if: always()
 #
@@ -30,9 +31,18 @@
 #   - fcv-reject adds reject_invite_actor_to_case (RM invitation rejection)
 # Full set adds: fvv, fvcv-extension, fccv-extension, fccv-handoff, fcv
 #
-# The matrix includes a boolean `full_suite_only` field. On pull_request events
-# the job `if:` condition skips entries where full_suite_only==true, leaving
-# only the 4-scenario minimum PR set running. On push/dispatch all 9 run.
+# Scenario selection (DEMOCI-06-002, DEMOCI-06-003): the scenario list lives in
+# .github/demo-scenarios.json, one entry per scenario carrying a boolean
+# `full_suite_only` field. The `scenarios` job filters that list — dropping
+# full_suite_only entries on pull_request events — and both downstream jobs
+# expand `fromJSON()` of its output as their matrix.
+#
+# The filter MUST NOT be expressed as a job-level `if:` on the matrix field
+# (e.g. `matrix.full_suite_only != true`). Job `if:` is evaluated before matrix
+# expansion, so the `matrix` context is unavailable there; GitHub rejects the
+# whole file with a startup failure that reports zero jobs and no logs. That
+# bug silently broke this workflow for 116 consecutive runs (#2118).
+# See DEMOCI-06-004.
 
 name: Demo Integration
 
@@ -65,6 +75,8 @@ on:
       # Workflow and action changes must re-validate CI itself.
       - ".github/workflows/demo-integration.yml"
       - ".github/actions/build-demo-images/**"
+      # The scenario matrix itself gates which demos run.
+      - ".github/demo-scenarios.json"
   push:
     branches: ["main"]
     paths:
@@ -78,6 +90,7 @@ on:
       - "uv.lock"
       - ".github/workflows/demo-integration.yml"
       - ".github/actions/build-demo-images/**"
+      - ".github/demo-scenarios.json"
   workflow_dispatch:
 
 # DEMOCI-02-011: cancel superseded PR runs; never cancel on-main runs.
@@ -90,50 +103,57 @@ permissions:
   actions: write  # needed for docker buildx bake cache-to: type=gha
 
 jobs:
+  # DEMOCI-06-002, DEMOCI-06-003: resolve the scenario matrix for this event.
+  # On pull_request, full_suite_only entries are dropped, leaving the
+  # 4-scenario minimum PR validation set. On push-to-main and
+  # workflow_dispatch, all 9 scenarios run.
+  #
+  # DEMOCI-02-004: the Dependabot guard lives here, on a job with no matrix, so
+  # a Dependabot PR resolves to an empty matrix and every downstream job is
+  # skipped rather than failing (see also DEMOCI-04-005).
+  # DEMOCI-05-004: github.head_ref is empty on push events, so the guard is a
+  # no-op there and the on-main run is never inadvertently skipped.
+  scenarios:
+    name: Select scenarios
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'dependabot/')"
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Select scenario matrix
+        id: select
+        env:
+          # true on pull_request events → drop full_suite_only scenarios.
+          PR_SET_ONLY: ${{ github.event_name == 'pull_request' }}
+        run: |
+          set -euo pipefail
+          if [ "$PR_SET_ONLY" = "true" ]; then
+            FILTER='[.[] | select(.full_suite_only == false)]'
+          else
+            FILTER='.'
+          fi
+          MATRIX="$(jq -c "$FILTER" .github/demo-scenarios.json)"
+          COUNT="$(jq -r 'length' <<<"$MATRIX")"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::Scenario matrix is empty — refusing to report success." >&2
+            exit 1
+          fi
+          echo "Selected $COUNT scenario(s):"
+          jq -r '.[] | "  - \(.demo)"' <<<"$MATRIX"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   demo:
     name: "${{ matrix.demo }} Demo Integration"
     runs-on: ubuntu-latest
     # DEMOCI-02-009: 15-minute cap to prevent indefinite hangs.
     timeout-minutes: 15
-    # DEMOCI-02-004: skip Dependabot PRs; python-app.yml guards broken deps.
-    # DEMOCI-06-002: on pull_request, skip full-suite-only entries so only the
-    # minimum 4-scenario PR validation set runs.
-    if: >-
-      !startsWith(github.head_ref, 'dependabot/') &&
-      (github.event_name != 'pull_request' || matrix.full_suite_only != true)
+    needs: scenarios
     strategy:
       fail-fast: false
       matrix:
-        # DEMOCI-06-002 minimum PR validation set (full_suite_only: false).
-        # DEMOCI-06-003 additional scenarios (full_suite_only: true — push/dispatch only).
-        include:
-          - demo: fv
-            test_file: test/ci/invariants/test_fv_invariants.py
-            full_suite_only: false
-          - demo: fvcv-handoff
-            test_file: test/ci/invariants/test_fvcv_handoff_invariants.py
-            full_suite_only: false
-          - demo: fcvcv
-            test_file: test/ci/invariants/test_fcvcv_invariants.py
-            full_suite_only: false
-          - demo: fcv-reject
-            test_file: test/ci/invariants/test_fcv_reject_invariants.py
-            full_suite_only: false
-          - demo: fvv
-            test_file: test/ci/invariants/test_fvv_invariants.py
-            full_suite_only: true
-          - demo: fvcv-extension
-            test_file: test/ci/invariants/test_fvcv_extension_invariants.py
-            full_suite_only: true
-          - demo: fccv-extension
-            test_file: test/ci/invariants/test_fccv_extension_invariants.py
-            full_suite_only: true
-          - demo: fccv-handoff
-            test_file: test/ci/invariants/test_fccv_handoff_invariants.py
-            full_suite_only: true
-          - demo: fcv
-            test_file: test/ci/invariants/test_fcv_invariants.py
-            full_suite_only: true
+        include: ${{ fromJSON(needs.scenarios.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -213,44 +233,18 @@ jobs:
     name: "${{ matrix.demo }} Invariant Harness"
     runs-on: ubuntu-latest
     # DEMOCI-04-002: always run after the demo job, even on demo failure.
-    # DEMOCI-02-004: skip Dependabot PRs (demo is skipped, no artifact exists).
-    # DEMOCI-06-002: mirror the demo job gate — skip full-suite-only entries on PR.
-    needs: demo
+    # DEMOCI-04-005, DEMOCI-02-004: the Dependabot guard is enforced upstream on
+    # the `scenarios` job; `always()` must not resurrect this job when that job
+    # was skipped or failed, so the condition tests the scenarios job directly
+    # rather than using a bare always().
+    needs: [scenarios, demo]
     if: >-
       always() &&
-      !startsWith(github.head_ref, 'dependabot/') &&
-      (github.event_name != 'pull_request' || matrix.full_suite_only != true)
+      needs.scenarios.result == 'success'
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - demo: fv
-            test_file: test/ci/invariants/test_fv_invariants.py
-            full_suite_only: false
-          - demo: fvcv-handoff
-            test_file: test/ci/invariants/test_fvcv_handoff_invariants.py
-            full_suite_only: false
-          - demo: fcvcv
-            test_file: test/ci/invariants/test_fcvcv_invariants.py
-            full_suite_only: false
-          - demo: fcv-reject
-            test_file: test/ci/invariants/test_fcv_reject_invariants.py
-            full_suite_only: false
-          - demo: fvv
-            test_file: test/ci/invariants/test_fvv_invariants.py
-            full_suite_only: true
-          - demo: fvcv-extension
-            test_file: test/ci/invariants/test_fvcv_extension_invariants.py
-            full_suite_only: true
-          - demo: fccv-extension
-            test_file: test/ci/invariants/test_fccv_extension_invariants.py
-            full_suite_only: true
-          - demo: fccv-handoff
-            test_file: test/ci/invariants/test_fccv_handoff_invariants.py
-            full_suite_only: true
-          - demo: fcv
-            test_file: test/ci/invariants/test_fcv_invariants.py
-            full_suite_only: true
+        include: ${{ fromJSON(needs.scenarios.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -48,7 +48,9 @@ jobs:
 
       - name: Check ADR index and nav are in sync
         run: |
-          PYTHONPATH= uv run python -m vultron.metadata.adr.index_gen --check
+          # PYTHONPATH='' (quoted) is identical in effect to PYTHONPATH= but
+          # distinguishable by shellcheck, which flags the bare form as SC1007.
+          PYTHONPATH='' uv run python -m vultron.metadata.adr.index_gen --check
 
       - name: Build Site
         run: |

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -34,4 +34,6 @@ jobs:
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-uv
       - name: Run spec-lint
-        run: PYTHONPATH= uv run spec-lint specs/
+        # PYTHONPATH='' (quoted) is identical in effect to PYTHONPATH= but
+        # distinguishable by shellcheck, which flags the bare form as SC1007.
+        run: PYTHONPATH='' uv run spec-lint specs/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,17 @@ repos:
         language_version: py313
         args: ["."]
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      # Catches GitHub Actions errors that YAML parsing cannot: invalid context
+      # references, bad `if:` expressions, unknown action inputs. A job-level
+      # `if:` referencing the `matrix` context parses as valid YAML but makes
+      # GitHub reject the whole workflow with a zero-job startup failure.
+      # Uses the golang hook (not actionlint-docker) so pre-commit provisions
+      # its own toolchain; the devcontainer has neither docker nor go on PATH.
+      - id: actionlint
+
   - repo: local
     hooks:
       - id: markdownlint-cli2

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -6,7 +6,7 @@ description: >-
   when the demo fails — closing the gap where tests pass while the demo produces
   silent failures. Includes requirements for the invariant harness to run as an
   independent CI gate so failures are visible even when the demo itself also fails.
-version: 1.4.0
+version: 1.5.0
 scope:
   - prototype
   - production
@@ -133,8 +133,9 @@ groups:
           filter, covering: vultron/** (excluding vultron/metadata/** and
           vultron/bt/**), docker/**, integration_tests/**, test/ci/**,
           pyproject.toml, uv.lock,
-          .github/workflows/demo-integration.yml, and
-          .github/actions/build-demo-images/**.
+          .github/workflows/demo-integration.yml,
+          .github/actions/build-demo-images/**, and
+          .github/demo-scenarios.json.
         rationale: >-
           These are the files whose changes can affect demo container behaviour
           or the invariant assertions that validate it. Filtering avoids running
@@ -149,6 +150,9 @@ groups:
           .github/workflows/demo-integration.yml and
           .github/actions/build-demo-images/** are included so that changes to
           the workflow or the shared build action itself trigger a validation run.
+          .github/demo-scenarios.json is included because it is the source of
+          truth for which scenarios run (DEMOCI-06-004), so a change to it
+          changes the demo matrix itself.
 
       - id: DEMOCI-02-004
         priority: MUST
@@ -391,16 +395,30 @@ groups:
         priority: MUST
         kind: project
         statement: >-
-          The invariant-harness job MUST carry the same Dependabot exclusion
-          guard as the demo job (DEMOCI-02-004): its `if:` condition MUST
-          include `!startsWith(github.head_ref, 'dependabot/')` in addition
-          to `always()`.
+          The invariant-harness job MUST NOT run for Dependabot PRs, matching
+          the demo job's exclusion (DEMOCI-02-004). The guard MUST be enforced
+          such that a bare `always()` cannot resurrect the job: because the
+          Dependabot exclusion is applied once on the upstream `scenarios` job
+          (DEMOCI-06-004), the invariant-harness `if:` MUST pair `always()`
+          with a check that the scenarios job succeeded — e.g.
+          `always() && needs.scenarios.result == 'success'`.
         rationale: >-
           Without the guard, a Dependabot PR skips the demo job (correct) but
           triggers the invariant-harness job, which immediately fails because
           `actions/download-artifact` finds no artifact — producing spurious
-          failing status checks on every Dependabot PR. The guard prevents this
-          by matching the skip condition of the upstream demo job.
+          failing status checks on every Dependabot PR.
+
+          This entry originally mandated the literal
+          `!startsWith(github.head_ref, 'dependabot/')` expression in this
+          job's own `if:`. That prescribed a mechanism rather than the outcome.
+          Once scenario selection moved into a `scenarios` job (DEMOCI-06-004),
+          duplicating the head_ref test in three places invited drift, so the
+          exclusion is now enforced once upstream and inherited via
+          `needs.scenarios.result`. The requirement is the outcome — no
+          invariant-harness run on Dependabot PRs — not the specific predicate.
+          Note that `always()` alone is insufficient: it runs the job even when
+          an upstream job was skipped, which is exactly the spurious-failure
+          case this entry exists to prevent.
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-04-002
@@ -552,7 +570,7 @@ groups:
         priority: MUST
         kind: project
         statement: >-
-          The full 8-scenario suite MUST run on push events to main, regardless
+          The full 9-scenario suite MUST run on push events to main, regardless
           of which subset runs for PR validation, so that all scenario variants
           continue to generate case-log invariant signals on the default branch.
           The `demo-integration.yml` workflow MUST include a `push: branches:
@@ -568,6 +586,51 @@ groups:
             spec_id: DEMOCI-06-002
           - rel_type: refines
             spec_id: DEMOCI-05-001
+
+      - id: DEMOCI-06-004
+        priority: MUST
+        kind: project
+        statement: >-
+          Per-event scenario selection (DEMOCI-06-002, DEMOCI-06-003) MUST be
+          implemented by resolving the matrix before matrix expansion, NOT by a
+          job-level `if:` condition that references the `matrix` context.
+          Specifically: the scenario list MUST live in a single declarative
+          source of truth (`.github/demo-scenarios.json`), each entry carrying a
+          boolean `full_suite_only` field; a `scenarios` job MUST filter that
+          list according to `github.event_name` and expose the result as a JSON
+          job output; and the `demo` and `invariant-harness` jobs MUST derive
+          their matrices via `fromJSON()` of that output.
+
+          A job-level `if:` referencing `matrix.*` MUST NOT be used to gate
+          matrix entries.
+        rationale: >-
+          GitHub evaluates job-level `if:` conditions BEFORE expanding the
+          matrix, so the `matrix` context does not exist at that point.
+          Referencing it is valid YAML — a YAML parser and `yaml.safe_load`
+          both accept the file — but GitHub rejects the entire workflow with a
+          startup failure: zero jobs scheduled, no logs, no annotations, no
+          per-job status, and a run whose `name` is reported as the file path
+          instead of the workflow name.
+
+          This failure mode is near-silent. It broke demo-integration.yml for
+          116 consecutive runs (2026-08-06 through 2026-08-07) across every
+          branch, including main. Because the same commit added the
+          push-to-main trigger, every push registered a startup failure before
+          the branch filter could be evaluated, so the red X appeared even on
+          branches the workflow was never meant to run on — which made the
+          signal read as noise rather than a real regression.
+
+          Deriving both matrices from one JSON file also removes the verbatim
+          9-entry matrix duplication between the `demo` and `invariant-harness`
+          jobs, where the two copies could silently drift apart.
+
+          Detection is delegated to `actionlint` in CI and pre-commit
+          (DEMOCI-08-001), which flags the illegal context reference directly.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-06-002
+          - rel_type: refines
+            spec_id: DEMOCI-06-003
 
   - id: DEMOCI-07
     title: Embargo Lifecycle Scenario CI Registration (rcv-embargo, rcvv-embargo)
@@ -658,3 +721,63 @@ groups:
             spec_id: DEMOCI-06-002
           - rel_type: refines
             spec_id: DEMOCI-06-003
+
+  - id: DEMOCI-08
+    title: Workflow Static Analysis (actionlint)
+    specs:
+      - id: DEMOCI-08-001
+        priority: MUST
+        kind: project
+        statement: >-
+          GitHub Actions workflow files MUST be statically analysed by
+          `actionlint` in CI, via a dedicated workflow
+          (`.github/workflows/actions-lint.yml`) whose path filter is scoped to
+          `.github/**`. The check MUST NOT be added to `python-app.yml`, whose
+          path filter is scoped to `vultron/**` and `test/**` and therefore
+          would not trigger on a workflow-only change. The same linter MUST be
+          registered as a pre-commit hook so the error is caught before push.
+          The actionlint version MUST be pinned, and the CI download MUST be
+          verified against a pinned SHA256 checksum.
+        rationale: >-
+          A workflow can be syntactically valid YAML yet be rejected by GitHub
+          at startup — the `matrix`-context-in-job-`if:` bug of DEMOCI-06-004 is
+          the motivating case. Startup failures produce no logs, no annotations,
+          and no job-level statuses, so nothing in the repository's own test or
+          lint suite can detect them and the only symptom is a bare red X.
+          `actionlint` resolves context availability per field and reports the
+          illegal reference as a one-line error with the exact position.
+
+          Pinning by version and checksum keeps CI reproducible and prevents a
+          retagged or compromised upstream release from silently altering what
+          executes in the pipeline.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-06-004
+
+      - id: DEMOCI-08-002
+        priority: MUST
+        kind: project
+        statement: >-
+          The `actions-lint.yml` workflow MUST validate
+          `.github/demo-scenarios.json` structurally: it MUST assert the file is
+          a non-empty array; that every entry has a non-empty string `demo`, a
+          non-empty string `test_file`, and a boolean (not string)
+          `full_suite_only`; that no `demo` name is duplicated; that at least
+          one entry has `full_suite_only: false`; and that every referenced
+          `test_file` exists in the repository.
+        rationale: >-
+          Once the matrix is data rather than inline YAML, malformed data
+          degrades silently instead of failing loudly. A string `"false"` is
+          truthy to `jq`'s equality test against `false` and would drop a
+          scenario from the PR set; a missing `test_file` key expands into a job
+          that runs `pytest ""`; a duplicated `demo` name collides on the
+          upload-artifact name and one scenario's logs overwrite the other's;
+          and an empty PR set would let `pull_request` runs report a vacuous
+          success with zero scenarios executed — the same false-green class of
+          failure that DEMOCI-06-004 exists to prevent. A non-existent
+          `test_file` is also caught here rather than 15 minutes into a demo run.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-08-001
+          - rel_type: refines
+            spec_id: DEMOCI-06-004


### PR DESCRIPTION
Fixes #2118

## What was broken

`demo-integration.yml` had been failing at workflow **startup** since 2026-08-06 — **116 consecutive runs** across every branch, including `main`. Zero demo or invariant-harness jobs executed in that window.

Both the `demo` and `invariant-harness` jobs carried a job-level `if:` referencing the `matrix` context:

```yaml
if: >-
  !startsWith(github.head_ref, 'dependabot/') &&
  (github.event_name != 'pull_request' || matrix.full_suite_only != true)
```

GitHub evaluates job-level `if:` **before** matrix expansion, so `matrix` does not exist there and the entire file is rejected. The result is a near-silent failure: 0s duration, zero jobs, no logs, no annotations, and `run.name` reported as the file path rather than `Demo Integration`.

The file is valid YAML — `yaml.safe_load()` accepts it — so nothing in the existing test or lint suite could catch it. Introduced in aa7b7929 (DEMOCI-06). That same commit added the `push: branches: [main]` trigger, which is what made the failure visible on *every* branch: a startup failure is registered before the branch filter is evaluated, so the red X appeared on branches the workflow never targeted. That made it read as CI noise rather than a regression, which is why it survived two days.

## The fix

Resolve the matrix **before** expansion rather than gating expanded entries:

- **`.github/demo-scenarios.json`** (new) — single source of truth for the 9 scenarios and their `full_suite_only` flags.
- **`scenarios` job** (new) — filters that list by `github.event_name`, emits it as a JSON output.
- **`demo` / `invariant-harness`** — consume `include: ${{ fromJSON(needs.scenarios.outputs.matrix) }}`.

This also eliminates the verbatim 9-entry matrix that was duplicated across both jobs, where the copies could silently drift.

Two subtleties worth a reviewer's eye:

- The Dependabot guard moved onto `scenarios` (a job with no matrix), so it's enforced **once** instead of three times. On push events `github.head_ref` is empty, so the guard is a no-op there and the on-main run is never skipped (DEMOCI-05-004).
- `invariant-harness` uses `always() && needs.scenarios.result == 'success'` rather than a bare `always()`. A bare `always()` runs the job even when an upstream job was **skipped** — which would resurrect exactly the spurious Dependabot failures that DEMOCI-04-005 exists to prevent.

## Prevention

`actionlint` added as both a CI gate (`.github/workflows/actions-lint.yml`) and a pre-commit hook, pinned by version and verified against a pinned SHA256.

It deliberately does **not** live in `python-app.yml`: that workflow's path filter is scoped to `vultron/**` and `test/**`, so a workflow-only change would never have triggered the check. The new workflow is scoped to `.github/**`.

It also structurally validates `demo-scenarios.json` — field types, duplicate scenario names, non-empty PR set, referenced test files exist — because the matrix is now *data*, which degrades quietly rather than loudly. A string `"false"` instead of a boolean would silently drop a scenario from the PR set; an empty PR set would report a vacuous green.

## Spec changes

- **DEMOCI-06-004** (new) — selection MUST resolve pre-expansion; `matrix.*` in a job-level `if:` is prohibited, with the failure mode documented.
- **DEMOCI-08** (new) — the actionlint gate and the JSON validation requirements.
- **DEMOCI-04-005** (amended) — it *mandated* the literal `!startsWith(github.head_ref, 'dependabot/')` predicate on the invariant-harness job. Hoisting the guard upstream contradicts its letter while preserving its intent, so I restated it as the required **outcome** and recorded why. Flagging for review since it's the one place I changed a MUST rather than adding one.
- **DEMOCI-06-003** — fixed a stale "8-scenario" count (it enumerates 9).
- **DEMOCI-02-003** — added the new JSON file to the enumerated path filter.

## Verification

- `actionlint` (with shellcheck) and `spec-lint` both exit 0; all five files parse.
- **The fix is verified against the actual bug, not just lint-clean**: restoring the original buggy file into a scratch workflow reproduces the error at both original line numbers, and the pre-commit hook catches it.
- Both matrices resolve correctly — 4 scenarios on `pull_request`, 9 on `push`/`dispatch`.
- All 9 referenced invariant test files exist.
- The `GITHUB_OUTPUT` write is single-line and `fromJSON`-parseable for both event types.
- The JSON validator rejects all four malformed-input cases (string-boolean, duplicate name, empty PR set, missing field) and accepts valid input.

**Caveats:**

- The demos themselves could not be run locally — no Docker in the devcontainer. The first on-main run after merge is the real proof. Note this PR's own `pull_request` run will exercise the new 4-scenario path, since the workflow's path filter includes itself.
- `actionlint` cannot lint the composite actions under `.github/actions/` — it parses any file handed to it as a workflow, so an `action.yml` yields spurious "on section is missing" errors. The path filters still include them so consuming workflows get re-linted.

## Follow-up worth tracking separately

Nothing alerted on 116 failures over two days. A required status check on `main` would have surfaced this on day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)