### PR TITLE
test(case-proposal): dual-DL isolation guard in TestCreateCaseProposalReceivedBTCaseActorRecords

### DIFF
--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -416,3 +416,51 @@ fixture so `dl.read()` resolves correctly.
 **Assertion depth**: the Accept happy path emits both an Accept notification
 and an Invite (2 activities). Assert `len(outbox) >= 2`, not `>= 1`, to catch
 the case where only one of the two required activities was emitted.
+
+---
+
+## Dual-DataLayer Isolation Guard in Tests
+
+(ISSUE-1749, 2026-08-08)
+
+A single-DataLayer test cannot catch a BT node that accidentally calls
+`get_datalayer()` (the process-global singleton) instead of `self.datalayer`.
+Such a node writes records to the singleton while the injected DataLayer stays
+empty — all positive assertions on the injected DL still pass.
+
+**The dual-DL isolation pattern** uses two separate in-memory DataLayer
+instances and asserts the global singleton is empty after the BT runs:
+
+```python
+from vultron.adapters.driven.datalayer_sqlite import get_datalayer, reset_datalayer
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+@pytest.fixture(autouse=True)
+def _reset_singleton(self):
+    reset_datalayer()
+    yield
+    reset_datalayer()
+
+def test_records_on_injected_dl_not_singleton(self, make_payload):
+    case_actor_dl = SqliteDataLayer("sqlite:///:memory:")  # injected DL
+    _seed_and_run(make_payload, case_actor_dl)
+
+    assert list(case_actor_dl.list_objects("VulnerabilityCase")), \
+        "record must appear on the injected DataLayer"
+    assert not list(get_datalayer().list_objects("VulnerabilityCase")), \
+        "singleton must stay empty — a get_datalayer() call in the BT node would fail this"
+```
+
+Key points:
+- `reset_datalayer()` before **and** after each test ensures test order
+  independence — a previous test that did call `get_datalayer()` won't poison
+  the singleton check.
+- `get_datalayer()` called with no arguments returns the shared/admin singleton
+  (unscoped). It is never the same object as `SqliteDataLayer("sqlite:///:memory:")`
+  created directly — the two have independent backing stores.
+- Apply this pattern for any BT-backed use case that receives a DataLayer as a
+  constructor argument: `CreateCaseProposalReceivedUseCase`,
+  `SvcCreateCaseUseCase`, and any future CaseActor-initialisation BTs.
+
+Reference: `test/core/behaviors/case/test_case_proposal_received_tree.py`,
+class `TestCreateCaseProposalReceivedBTCaseActorRecords`.

--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -452,6 +452,7 @@ def test_records_on_injected_dl_not_singleton(self, make_payload):
 ```
 
 Key points:
+
 - `reset_datalayer()` before **and** after each test ensures test order
   independence — a previous test that did call `get_datalayer()` won't poison
   the singleton check.

--- a/plan/history/2608/implementation/ISSUE-1749.md
+++ b/plan/history/2608/implementation/ISSUE-1749.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1749
+timestamp: '2026-08-08T01:35:24.980187+00:00'
+title: 'test(case-proposal): dual-DL isolation guard'
+type: implementation
+---
+
+## Issue #1749 — test(case-proposal): use dual-DataLayer setup in TestCreateCaseProposalReceivedBTCaseActorRecords
+
+Added `TestCreateCaseProposalReceivedBTCaseActorRecords` to `test/core/behaviors/case/test_case_proposal_received_tree.py`. The class contains 4 tests that run `CreateCaseProposalReceivedUseCase` against an injected `case_actor_dl` and then assert the global singleton returned by `get_datalayer()` is empty for `VulnerabilityCase`, `CaseParticipant`, `CaseLedgerEntry`, and `actor_participant_index`. This catches the regression class where a BT node calls `get_datalayer()` instead of `self.datalayer`, which prior single-DL tests could not detect.
+
+PR: <https://github.com/CERTCC/Vultron/pull/2124>

--- a/test/core/behaviors/case/test_case_proposal_received_tree.py
+++ b/test/core/behaviors/case/test_case_proposal_received_tree.py
@@ -1703,3 +1703,140 @@ class TestAllParticipantsRMClosedIncludesCaseActor:
             "AllParticipantsRMClosed must return SUCCESS when all participants"
             " including the CaseActor are at RM.CLOSED (ADR-0051)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Dual-DataLayer isolation: records land on the injected DL, not on the
+# global singleton.  Verifies the AC-2/AC-1 isolation invariant from
+# issue #1749.
+#
+# The regression this guards against: a BT node that calls get_datalayer()
+# (the process-global singleton) instead of self.datalayer would write records
+# to the singleton rather than to the DataLayer passed into the use case.
+# Each test resets the singleton before running (via the root conftest's
+# reset_datalayer fixture), then checks the singleton is still empty after the
+# BT completes — confirming all writes landed on the injected case_actor_dl.
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCaseProposalReceivedBTCaseActorRecords:
+    """Records land on the injected DataLayer, not on the global singleton.
+
+    The CreateCaseProposalReceivedUseCase receives a single DataLayer
+    (``case_actor_dl``).  All writes (VulnerabilityCase, CaseParticipant,
+    CaseLedgerEntry, …) must appear in ``case_actor_dl``; the global
+    singleton returned by ``get_datalayer()`` must remain empty for those
+    types.
+
+    Without this test, a BT node that accidentally calls ``get_datalayer()``
+    instead of ``self.datalayer`` would write records to the singleton and
+    the existing single-DL tests would still pass.
+    """
+
+    def _run(self, make_payload, case_actor_dl):
+        """Run the full BT against *case_actor_dl*; seed report there too."""
+        _seed_report(case_actor_dl)
+        _run_full_bt(make_payload, case_actor_dl)
+
+    def test_vulnerability_case_on_injected_dl_not_singleton(
+        self, make_payload
+    ):
+        """VulnerabilityCase is written to case_actor_dl only (AC-1).
+
+        If any node leaks to the singleton via get_datalayer(), the singleton
+        would be non-empty after the run.
+        """
+        from vultron.adapters.driven.datalayer_sqlite import get_datalayer
+
+        case_actor_dl = SqliteDataLayer("sqlite:///:memory:")
+        self._run(make_payload, case_actor_dl)
+
+        cases_on_injected = list(
+            case_actor_dl.list_objects("VulnerabilityCase")
+        )
+        cases_on_singleton = list(
+            get_datalayer().list_objects("VulnerabilityCase")
+        )
+
+        assert (
+            cases_on_injected
+        ), "VulnerabilityCase must be created on the injected DataLayer (AC-1)"
+        assert not cases_on_singleton, (
+            "VulnerabilityCase must NOT appear on the global singleton —"
+            " a BT node called get_datalayer() instead of self.datalayer"
+        )
+
+    def test_case_participants_on_injected_dl_not_singleton(
+        self, make_payload
+    ):
+        """CaseParticipant records land on case_actor_dl, not the singleton."""
+        from vultron.adapters.driven.datalayer_sqlite import get_datalayer
+
+        case_actor_dl = SqliteDataLayer("sqlite:///:memory:")
+        self._run(make_payload, case_actor_dl)
+
+        participants_on_injected = list(
+            case_actor_dl.list_objects("CaseParticipant")
+        )
+        participants_on_singleton = list(
+            get_datalayer().list_objects("CaseParticipant")
+        )
+
+        assert (
+            participants_on_injected
+        ), "CaseParticipant records must be created on the injected DataLayer"
+        assert (
+            not participants_on_singleton
+        ), "CaseParticipant records must NOT appear on the global singleton"
+
+    def test_ledger_entries_on_injected_dl_not_singleton(self, make_payload):
+        """CaseLedgerEntry records land on case_actor_dl, not the singleton."""
+        from vultron.adapters.driven.datalayer_sqlite import get_datalayer
+
+        case_actor_dl = SqliteDataLayer("sqlite:///:memory:")
+        self._run(make_payload, case_actor_dl)
+
+        entries_on_injected = list(
+            case_actor_dl.list_objects("CaseLedgerEntry")
+        )
+        entries_on_singleton = list(
+            get_datalayer().list_objects("CaseLedgerEntry")
+        )
+
+        assert entries_on_injected, (
+            "CaseLedgerEntry records must be created on the injected DataLayer"
+            " (ADR-0041)"
+        )
+        assert (
+            not entries_on_singleton
+        ), "CaseLedgerEntry records must NOT appear on the global singleton"
+
+    def test_vendor_participant_index_on_injected_dl(self, make_payload):
+        """Vendor appears in case_actor_dl's actor_participant_index, not in the singleton.
+
+        This is the sharpest regression guard: a node that accidentally routes
+        the VulnerabilityCase write through get_datalayer() would put the
+        vendor in the singleton's case index and leave case_actor_dl empty.
+        """
+        from vultron.adapters.driven.datalayer_sqlite import get_datalayer
+        from vultron.core.models.case import VulnerabilityCase
+
+        case_actor_dl = SqliteDataLayer("sqlite:///:memory:")
+        self._run(make_payload, case_actor_dl)
+
+        cases_on_injected = list(
+            case_actor_dl.list_objects("VulnerabilityCase")
+        )
+        assert (
+            cases_on_injected
+        ), "VulnerabilityCase must exist on case_actor_dl"
+        case = cases_on_injected[0]
+        assert isinstance(case, VulnerabilityCase)
+        assert (
+            _VENDOR_URI in case.actor_participant_index
+        ), "Vendor must be in actor_participant_index on the injected DL"
+
+        assert not list(get_datalayer().list_objects("VulnerabilityCase")), (
+            "VulnerabilityCase must not appear on the global singleton — the"
+            " case-actor creates the case on the injected DL only (AC-1)"
+        )

--- a/test/core/behaviors/case/test_case_proposal_received_tree.py
+++ b/test/core/behaviors/case/test_case_proposal_received_tree.py
@@ -1713,8 +1713,8 @@ class TestAllParticipantsRMClosedIncludesCaseActor:
 # The regression this guards against: a BT node that calls get_datalayer()
 # (the process-global singleton) instead of self.datalayer would write records
 # to the singleton rather than to the DataLayer passed into the use case.
-# Each test resets the singleton before running (via the root conftest's
-# reset_datalayer fixture), then checks the singleton is still empty after the
+# Each test resets the singleton before running (via the _reset_singleton
+# autouse fixture), then checks the singleton is still empty after the
 # BT completes — confirming all writes landed on the injected case_actor_dl.
 # ---------------------------------------------------------------------------
 
@@ -1732,6 +1732,14 @@ class TestCreateCaseProposalReceivedBTCaseActorRecords:
     instead of ``self.datalayer`` would write records to the singleton and
     the existing single-DL tests would still pass.
     """
+
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        from vultron.adapters.driven.datalayer_sqlite import reset_datalayer
+
+        reset_datalayer()
+        yield
+        reset_datalayer()
 
     def _run(self, make_payload, case_actor_dl):
         """Run the full BT against *case_actor_dl*; seed report there too."""


### PR DESCRIPTION
- Closes #1749
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Adds `TestCreateCaseProposalReceivedBTCaseActorRecords` — four tests that verify all writes from `CreateCaseProposalReceivedUseCase` land on the injected DataLayer and not on the global singleton returned by `get_datalayer()`.

## Changes

- **`test/core/behaviors/case/test_case_proposal_received_tree.py`**: New test class with 4 tests checking `VulnerabilityCase`, `CaseParticipant`, `CaseLedgerEntry`, and `actor_participant_index` isolation. Each test runs the full BT against an injected `case_actor_dl`, then asserts the global singleton is empty for the relevant record type.

## What this guards against

The previous single-DL tests could not catch a regression where a BT node called `get_datalayer()` (the process-global singleton) instead of `self.datalayer`. Such a node would write to the singleton while `case_actor_dl` stayed empty — all prior positive assertions would still pass. The new singleton-emptiness assertions catch that class of isolation violation (the AC-2/AC-1 isolation invariant described in issue #1749).

## Verification

- 4 new tests pass; full file: 55 → 59 tests, all passing
- Black, flake8, mypy, pyright clean
- Unit suite: 6457 passed, 0 failures
- Integration suite: 4 pre-existing failures (confirmed present on clean `origin/main`)