### PR TITLE
fix(test): stop demo config cache leaking across tests

### DIFF
--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -26,26 +26,47 @@ and fall through to Level 2 (GitHub label search).
 | Test node ID | Issue | Last blocked |
 |---|---|---|
 | `test/bt/test_vultrabot.py::MyTestCase::test_main` | — | 2026-05-05 |
-| `test/demo/test_pcr_bootstrap.py::TestBootstrapSequence::test_announce_creates_case_replica` | #2086 | 2026-08-08 |
-| `test/demo/test_pcr_bootstrap.py::TestBootstrapSequence::test_case_fields_preserved_in_replica` | #2086 | 2026-08-08 |
-| `test/demo/test_integration_script_scenarios.py::TestIntegrationScriptScenarios::test_valid_scenarios_matches_ci` | #2122 | 2026-08-08 |
-| `test/demo/test_integration_script_scenarios.py::TestIntegrationScriptScenarios::test_at_least_one_scenario_in_ci` | #2122 | 2026-08-08 |
 
-> Note: the two `test_integration_script_scenarios` entries are **hard-broken on
-> `main`, not flaky** — they fail deterministically. #2114 added a test that
+> Note: the two `test_integration_script_scenarios` entries were **hard-broken
+> on `main`, not flaky** — they failed deterministically. #2114 added a test that
 > scrapes `DEMO=` from `demo-integration.yml` while #2118/#2119 moved the
 > scenario matrix to `.github/demo-scenarios.json`, leaving nothing to scrape.
-> A semantic merge collision between two individually-correct PRs. See #2122.
+> A semantic merge collision between two individually-correct PRs. **Fixed by
+> #2123**; rows removed 2026-08-08.
 >
-> Note: the two `TestBootstrapSequence` entries are **genuinely
-> nondeterministic**. They pass reliably in isolation (`[0,0,0]` over 3 runs)
-> but running the whole `test/demo/` directory gives `[2,0,2]` failures over 3
-> identical invocations — so `-p no:randomly` does NOT stabilise them. No single
-> preceding file reproduces the failure when paired with the target (all 27
-> checked), meaning the trigger is cumulative accumulated state plus a
-> nondeterministic interaction, not a single polluting module. File-level
-> bisection cannot converge because clean results are false negatives. Verified
-> pre-existing on clean `origin/main`. See #2086 for the full data.
+> Note: the two `TestBootstrapSequence` entries were **deterministic
+> cross-module config leakage, not nondeterminism** — root-caused and **fixed by
+> #2126**; rows removed 2026-08-08.
+>
+> An earlier revision of this note claimed they were "genuinely
+> nondeterministic" because `pytest -m "" test/demo/` gave `[2,0,2]` bootstrap
+> failures over three identical runs. That reading was an artifact of the
+> measurement. `timeout = 5` with `timeout_method = "thread"`
+> (`pyproject.toml:123`) kills the **whole pytest process**, not just the slow
+> test, so a run that trips it emits no summary line and never reaches
+> `test_pcr_bootstrap.py` at all — scoring a phantom `0`. Re-running the same
+> command with a driver that records the `+++ Timeout +++` marker reproduces
+> `[2,0,2]` and shows the `0` run aborted mid-session.
+>
+> At any granularity that actually runs both modules to completion, the failure
+> is deterministic on clean `origin/main`:
+>
+> | Invocation (`-p no:randomly`, 3× each) | Bootstrap failures |
+> |---|---|
+> | `test_fvcv_handoff_demo.py` + `test_pcr_bootstrap.py` | `[2, 2, 2]` |
+> | `...::TestOwnershipTransferAnnounceReachesFinderAC5c` + bootstrap | `[2, 2, 2]` |
+> | `test_pcr_bootstrap.py` alone | `[0, 0, 0]` |
+>
+> The earlier pairwise bisect that found "no single polluting file (all 27
+> checked)" disagrees with the first row above; treat that sweep as unreliable.
+> The cause was `reload_config()` running before `monkeypatch.undo()` in four
+> demo fixture teardowns, pinning a fake CaseActor host into the module-level
+> config cache for the rest of the session. See #2086 and PR #2126.
+>
+> **Lesson for future triage here**: a pytest run that aborts on the global
+> thread-method timeout looks identical to a clean pass if you only count
+> `FAILED` lines. Always check for a summary line and the `+++ Timeout +++`
+> marker before concluding a test is nondeterministic.
 >
 > Note: `test_vultrabot` shows `SUBFAILED` in the full suite due to py_trees
 > blackboard global-state ordering, but exit code stays 0 (unittest subtest

--- a/plan/history/2608/implementation/ISSUE-2086.md
+++ b/plan/history/2608/implementation/ISSUE-2086.md
@@ -1,0 +1,73 @@
+---
+source: ISSUE-2086
+timestamp: '2026-08-08T01:49:37.124299+00:00'
+title: Fix demo config cache leak causing flaky bootstrap validate-report
+type: implementation
+---
+
+**Issue**: [#2086](https://github.com/CERTCC/Vultron/issues/2086) — Flaky CI:
+`TestBootstrapSequence.test_announce_creates_case_replica` /
+`test_case_fields_preserved_in_replica` — `SvcValidateReportUseCase` no
+routable recipients.
+
+**PR**: [#2126](https://github.com/CERTCC/Vultron/pull/2126)
+
+## Symptoms
+
+Two `test/demo/test_pcr_bootstrap.py` tests failed intermittently in CI with
+`SvcValidateReportUseCase: no routable recipients`. Secondary symptom:
+`EnsureEmbargoExists` reporting no active embargo. Passed in isolation.
+
+## Root cause
+
+Not a race and not a production defect. `vultron/config/app.py` keeps a
+process-global `_config_cache`; `reload_config()` clears it and re-reads the
+environment. Pytest's `monkeypatch` fixture undoes env changes *after* the
+requesting fixture's teardown body runs, so a teardown that calls
+`reload_config()` before the undo re-caches the still-patched value for the
+remainder of the session.
+
+Four demo fixtures had that order, repointing `VULTRON_SERVER__BASE_URL` and
+`VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL` at fake hosts. Every later demo test
+then derived its CaseActor ID from the leaked host (e.g.
+`http://coordinator-otc.test`), which no `_TestClientRouter` registers.
+`_TestClientRouter.emit` silently dropped the `Create(CaseProposal)` at DEBUG
+level, so the CaseActor never created the canonical case with its
+`CASE_MANAGER` participant and embargo, and `trigger/validate-report` failed
+three steps downstream. Because it only affects tests running after the
+offender and `pytest-randomly` reseeds order per run, it read as flakiness.
+
+## Fix
+
+- Reordered teardown to `monkeypatch.undo()` before `reload_config()` in
+  `test_fvcv_handoff_demo.py`, `test_pcr_late_joiner.py`,
+  `test_case_proposal_round_trip.py`, `test_pcr_engage_case.py`.
+  `test_fv_demo.py` already avoided the trap via an explicit `MonkeyPatch()`.
+- Added `config_url_snapshot()` / `restore_config_if_leaked()` plus an autouse
+  `restore_case_actor_url_after_each_test` fixture in `test/demo/conftest.py`
+  that snapshots the two URLs around every demo test and reloads on drift.
+- Added `test/demo/test_config_leak_guard.py` (5 tests) covering both teardown
+  orderings, the guard helpers, and the demo session's baseline CaseActor URL.
+
+No production code changed.
+
+## Discarded approach
+
+An initial fix made `_compute_report_addressees` fall through to the offer
+actor when a case had no `CASE_MANAGER`. It was reverted: it broke the
+fail-closed routing invariant from issue #1854 AC-2, asserted by
+`test_close_report_raises_when_case_exists_without_case_manager`.
+
+## Verification
+
+Deterministic repro with `-p no:randomly`; 16/16 pass after the fix. Unit
+suite 6453 passed. Integration suite 1050 passed, with 2 pre-existing
+`test_integration_script_scenarios.py` failures reproduced on a clean
+`origin/main` worktree and tracked by
+[#2122](https://github.com/CERTCC/Vultron/issues/2122). Black, flake8, mypy,
+pyright clean.
+
+## Learnings
+
+- `20260808-silent-delivery-drop-masks-config-leak.md` (`signal: concern`)
+- `20260808-module-level-config-cache-fragile-in-tests.md` (`signal: concern`)

--- a/plan/incoming/learnings/20260808-module-level-config-cache-fragile-in-tests.md
+++ b/plan/incoming/learnings/20260808-module-level-config-cache-fragile-in-tests.md
@@ -1,0 +1,47 @@
+---
+title: "Module-level config cache makes reload_config() order-sensitive in test teardown"
+type: learning
+timestamp: "2026-08-08"
+source: ISSUE-2086
+signal: concern
+---
+
+`vultron/config/app.py` holds a module-level `_config_cache`. `get_config()`
+lazily populates it; `reload_config()` clears it and re-reads the environment.
+That makes the *cache* process-global while the *environment* it derives from is
+per-test — and pytest's `monkeypatch` fixture undoes env changes **after** the
+requesting fixture's teardown body runs.
+
+So this order is a latent session-wide leak:
+
+```python
+# teardown
+reload_config()      # re-caches the still-patched fake host
+# ... monkeypatch's own undo runs here, too late
+```
+
+and this order is correct:
+
+```python
+monkeypatch.undo()
+reload_config()
+```
+
+Four demo fixtures had the buggy order (`test_fvcv_handoff_demo.py`,
+`test_pcr_late_joiner.py`, `test_case_proposal_round_trip.py`,
+`test_pcr_engage_case.py`). One (`test_fv_demo.py`) had already hit this and
+worked around it by using an explicit `MonkeyPatch()` instead of the fixture,
+with a comment explaining why — the knowledge existed but was local to one file
+and never generalized.
+
+Because the leak only bites tests that run *after* the offender, and
+`pytest-randomly` reseeds order each run, it presented as CI flakiness rather
+than a deterministic failure.
+
+**Suggested follow-up**: the durable fix is to stop reaching for a module-level
+singleton in tests — e.g. expose config via a FastAPI dependency that tests
+override, or provide a `config_override()` context manager in
+`vultron/config/app.py` that owns both the env patch and the cache invalidation
+so callers cannot get the order wrong. The current fix (source fixes plus an
+autouse snapshot/restore guard in `test/demo/conftest.py`) contains the blast
+radius but does not remove the footgun.

--- a/plan/incoming/learnings/20260808-pytest-thread-timeout-fakes-nondeterminism.md
+++ b/plan/incoming/learnings/20260808-pytest-thread-timeout-fakes-nondeterminism.md
@@ -1,0 +1,45 @@
+---
+title: "Global pytest thread-timeout aborts look like passing runs and fake nondeterminism"
+type: learning
+timestamp: "2026-08-08"
+source: ISSUE-2086
+signal: tooling-issue
+---
+
+`pyproject.toml` sets `timeout = 5` with `timeout_method = "thread"`. The thread
+method cannot cancel a single test — it kills the **entire pytest process**. The
+run then emits no `N passed / N failed` summary line and simply stops wherever it
+was.
+
+If a triage script counts `FAILED` lines to score a run, an aborted run scores
+**zero failures** — indistinguishable from a clean pass. When the abort happens
+before the suspect test is even reached, the test appears to have passed.
+
+This produced a false conclusion on #2086. Three identical
+`pytest -m "" test/demo/` runs gave `[2, 0, 2]` bootstrap failures, which was
+read as proof the failures were "genuinely nondeterministic" and that
+`-p no:randomly` did not stabilize them. Re-running with a driver that also
+recorded the `+++ Timeout +++` marker and the presence of a summary line
+reproduced `[2, 0, 2]` — and showed the middle run had `timeout=True` with no
+summary. It never ran `test_pcr_bootstrap.py`.
+
+At every granularity that runs both modules to completion, the failure was
+deterministic (`[2, 2, 2]`), and the cause was ordinary cross-module config
+leakage. Chasing phantom nondeterminism (dict iteration order, UUID collisions,
+BackgroundTasks races) cost real time.
+
+**How to measure a suspected flake reliably**:
+
+- Require a summary line. Its absence means the run is void, not green.
+- Grep for `+++ Timeout +++` and treat any hit as void.
+- Don't infer pass/fail from exit code alone — an abort and a real failure both
+  give non-zero.
+- Drive repeated invocations from a Python `subprocess` list, not a shell
+  variable holding a file list; word-splitting differences between `bash` and
+  `zsh` silently turned an earlier bisect into exit-4 no-ops.
+
+**Related**: `20260803-pytest-full-suite-timeout.md` recorded the same 5s
+thread-timeout firing under load. The recurring cost suggests either raising
+`timeout` for the integration/demo suites or switching to
+`timeout_method = "signal"` so a slow test fails alone instead of voiding the
+session.

--- a/plan/incoming/learnings/20260808-silent-delivery-drop-masks-config-leak.md
+++ b/plan/incoming/learnings/20260808-silent-delivery-drop-masks-config-leak.md
@@ -1,0 +1,47 @@
+---
+title: "_TestClientRouter silently drops unroutable deliveries, masking config leaks as flaky failures"
+type: learning
+timestamp: "2026-08-08"
+source: ISSUE-2086
+signal: concern
+---
+
+`_TestClientRouter.emit` (`test/demo/conftest.py`) drops a delivery when no
+client is registered for the recipient's base URL, logging only at `DEBUG`:
+
+```python
+client = self._clients.get(base)
+if client is None:
+    logger.debug("... dropping delivery to %s", recipient_id)
+    continue
+```
+
+This is deliberate — demo tests address fictional external URLs
+(`https://vultron.example/users/...`) that must not become real HTTP requests
+(#527). But the same silence swallows *unintentional* misrouting.
+
+In #2086 a leaked `VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL` caused every
+subsequent demo test's `Create(CaseProposal)` to be addressed to
+`http://coordinator-otc.test` — a host no router registered. The delivery
+vanished, the CaseActor never created the canonical case, and the failure
+surfaced three steps downstream as `SvcValidateReportUseCase: no routable
+recipients`. Nothing in the failure output named the actual cause.
+
+**Why this cost time**: the observable symptom pointed at
+`_compute_report_addressees` (a fail-closed routing check in production code)
+rather than at test infrastructure. An initial hypothesis of an async race in
+the CaseActor proposal chain was wrong, and a candidate production fix that
+made `_compute_report_addressees` fall through to the offer actor broke the
+fail-closed invariant from issue #1854 AC-2, asserted by
+`test_close_report_raises_when_case_exists_without_case_manager`. Only reading
+the CI logs (delivery target `coordinator-otc.test`, a string appearing in
+exactly one test module) identified the real cause.
+
+**Suggested follow-up**: distinguish expected drops from unexpected ones —
+e.g. an allowlist of known-fictional hosts (`vultron.example`) that keeps
+`DEBUG`, with anything else logged at `WARNING`. A dropped delivery to a
+`.test` host that a sibling module registers is almost always a bug.
+
+**Related**: the config-cache leak itself (`reload_config()` before
+`monkeypatch.undo()`) is fixed at the source in four demo modules plus an
+autouse guard in `test/demo/conftest.py`.

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -50,6 +50,61 @@ why. Do not use it to paper over slow tests.
 
 ---
 
+### `monkeypatch.undo()` MUST Precede `reload_config()` in Fixture Teardown
+
+`vultron/config/app.py` keeps a process-global `_config_cache`.
+`reload_config()` clears it and re-reads the environment. Pytest undoes
+`monkeypatch` env changes **after** the requesting fixture's teardown body
+runs, so this order pins the patched value into the cache for the rest of the
+session:
+
+```python
+# WRONG — re-caches the still-patched env
+yield
+reload_config()
+
+# RIGHT — undo first, then reload from the clean env
+yield
+monkeypatch.undo()
+reload_config()
+```
+
+Any fixture that both patches a `VULTRON_*` env var and calls
+`reload_config()` in teardown is affected, not just `test/demo/`. Clearing the
+cache without reloading (`_cfg_module._config_cache = None`, as in
+`test/adapters/driven/test_get_datalayer.py`) is an equally valid fix.
+
+`test/demo/conftest.py` has an autouse guard that detects and repairs such
+leaks, and records them on `config_leak_ledger` so
+`test_config_leak_guard.py::TestNoFixtureLeakedConfig` fails rather than
+silently masking the regression. That guard is **function-scoped only** — a
+module-, class-, or session-scoped fixture pollutes the cache before the guard
+snapshots it, so higher-scoped fixtures must get the order right themselves.
+Nothing outside `test/demo/` is guarded at all.
+
+Source: #2086 / PR #2126.
+
+---
+
+### A Test That Needs `VULTRON_*` Config MUST Set It Itself
+
+The flip side of the rule above: fixing a leak removes config that downstream
+tests may have been silently borrowing. `test_create_tree.py` and
+`nodes/test_communication.py` both run `ResolveCaseActorUrlsNode` (via
+`CreateCaseActorNode` / `CreateCaseBT`), which returns FAILURE when
+`case_actor_service_url` is None (CP-08-002/003) — yet neither module set it.
+They passed only because another module leaked the value into the process-global
+cache first, and failed in isolation or in a subset run (#1897).
+
+Each module that depends on a `VULTRON_*` setting needs its own autouse fixture
+setting it, using the `monkeypatch.undo()`-then-`reload_config()` teardown order
+above. Verify with a targeted run, not just the full suite — a module that only
+passes in a full-suite run is order-dependent, not passing.
+
+Source: #1897 / PR #2126.
+
+---
+
 ### Pytest `filterwarnings = ["error"]` Does Not Catch All Warnings
 
 `filterwarnings = ["error"]` converts `warnings.warn()` to errors, but does NOT

--- a/test/core/behaviors/case/nodes/test_case_setup.py
+++ b/test/core/behaviors/case/nodes/test_case_setup.py
@@ -77,6 +77,10 @@ def configure_case_actor_url(monkeypatch):
 
     reload_config()
     yield
+    # Undo the env patch BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URL into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
     reload_config()
 
 

--- a/test/core/behaviors/case/nodes/test_communication.py
+++ b/test/core/behaviors/case/nodes/test_communication.py
@@ -45,9 +45,36 @@ from vultron.core.models.vultron_types import (
 )
 from test.core.behaviors.bt_harness import BTTestScenario
 
+# The URL used by tests as the CaseActor service base URL (CP-08-001).
+_CASE_ACTOR_SERVICE_URL = "http://case-actor:7999/api/v2"
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def configure_case_actor_url(monkeypatch):
+    """Set VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL for this module.
+
+    ``CreateCaseActorNode`` runs ``ResolveCaseActorUrlsNode``, which returns
+    FAILURE when ``case_actor_service_url`` is None (CP-08-002/003).  This
+    module used to inherit the value leaked into the module-level config cache
+    by another test's fixture, so it failed whenever it ran in isolation or in
+    a subset (#1897).  Configuring it here makes the module self-sufficient.
+    """
+    from vultron.config.app import reload_config
+
+    monkeypatch.setenv(
+        "VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL", _CASE_ACTOR_SERVICE_URL
+    )
+    reload_config()
+    yield
+    # Undo the env patch BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URL into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
+    reload_config()
 
 
 @pytest.fixture

--- a/test/core/behaviors/case/test_bug_26040902_regression.py
+++ b/test/core/behaviors/case/test_bug_26040902_regression.py
@@ -53,6 +53,10 @@ def configure_case_actor_url(monkeypatch):
 
     reload_config()
     yield
+    # Undo the env patch BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URL into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
     reload_config()
 
 

--- a/test/core/behaviors/case/test_create_tree.py
+++ b/test/core/behaviors/case/test_create_tree.py
@@ -39,6 +39,33 @@ from vultron.core.models.vultron_types import (
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.create_tree import create_create_case_tree
 
+# The URL used by tests as the CaseActor service base URL (CP-08-001).
+_CASE_ACTOR_SERVICE_URL = "http://case-actor:7999/api/v2"
+
+
+@pytest.fixture(autouse=True)
+def configure_case_actor_url(monkeypatch):
+    """Set VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL for this module.
+
+    ``CreateCaseBT`` runs ``ResolveCaseActorUrlsNode``, which returns FAILURE
+    when ``case_actor_service_url`` is None (CP-08-002/003).  This module used
+    to inherit the value leaked into the module-level config cache by another
+    test's fixture, so it failed whenever it ran in isolation or in a subset
+    (#1897).  Configuring it here makes the module self-sufficient.
+    """
+    from vultron.config.app import reload_config
+
+    monkeypatch.setenv(
+        "VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL", _CASE_ACTOR_SERVICE_URL
+    )
+    reload_config()
+    yield
+    # Undo the env patch BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URL into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
+    reload_config()
+
 
 @pytest.fixture
 def datalayer():

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -63,6 +63,10 @@ def configure_case_actor_url(monkeypatch):
 
     reload_config()
     yield
+    # Undo the env patch BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URL into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
     reload_config()
 
 

--- a/test/core/use_cases/received/test_ack_validate_report_received.py
+++ b/test/core/use_cases/received/test_ack_validate_report_received.py
@@ -55,6 +55,10 @@ def configure_case_actor_url(monkeypatch):
 
     reload_config()
     yield
+    # Undo the env patch BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URL into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
     reload_config()
 
 

--- a/test/core/use_cases/received/test_submit_report_received.py
+++ b/test/core/use_cases/received/test_submit_report_received.py
@@ -43,6 +43,10 @@ def configure_case_actor_url(monkeypatch):
 
     reload_config()
     yield
+    # Undo the env patch BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URL into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
     reload_config()
 
 

--- a/test/core/use_cases/test_validate_report_ledger_routing.py
+++ b/test/core/use_cases/test_validate_report_ledger_routing.py
@@ -160,6 +160,10 @@ def _configure_case_actor_url(monkeypatch):
 
     reload_config()
     yield
+    # Undo the env patch BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URL into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
     reload_config()
 
 

--- a/test/demo/conftest.py
+++ b/test/demo/conftest.py
@@ -244,6 +244,69 @@ def configure_case_actor_url_for_demo():
         reload_config()
 
 
+def config_url_snapshot() -> tuple[str, str]:
+    """Return the currently cached ``(server.base_url, case_actor_service_url)``.
+
+    These are the two settings demo tests repoint at their own fake hosts, and
+    the pair whose leakage caused #2086.
+    """
+    from vultron.config import get_config
+
+    cfg = get_config()
+    return (
+        str(cfg.server.base_url),
+        str(cfg.actor.case_actor_service_url),
+    )
+
+
+def restore_config_if_leaked(before: tuple[str, str]) -> bool:
+    """Reload the module-level config if the URL snapshot drifted from *before*.
+
+    Args:
+        before: Snapshot from :func:`config_url_snapshot` taken before the
+            code under test ran.
+
+    Returns:
+        ``True`` if a leak was detected and the config was reloaded.
+    """
+    from vultron.config.app import reload_config
+
+    after = config_url_snapshot()
+    if after == before:
+        return False
+    logger.warning(
+        "Demo test leaked config (server.base_url / "
+        "actor.case_actor_service_url): %s -> %s; reloading (#2086)",
+        before,
+        after,
+    )
+    reload_config()
+    return True
+
+
+@pytest.fixture(autouse=True)
+def restore_case_actor_url_after_each_test():
+    """Restore the session's CaseActor/server config after every demo test.
+
+    Guards against config leakage between demo tests (#2086).  Several demo
+    tests point ``VULTRON_SERVER__BASE_URL`` and
+    ``VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL`` at their own fake hosts and then
+    call ``reload_config()``.  If such a test reloads while its env patches are
+    still applied, the polluted values are cached in the module-level config for
+    the remainder of the session.  Every later test then addresses its
+    ``Create(CaseProposal)`` to a host no ``_TestClientRouter`` knows about, the
+    delivery is silently dropped, the CaseActor never creates the canonical
+    case, and ``validate-report`` fails with "no routable recipients".
+
+    Because that depends on test *order*, it presented as CI flakiness.  This
+    fixture snapshots the two URLs before each test and reloads config after if
+    they changed, so a leak cannot outlive the test that caused it.
+    """
+    before = config_url_snapshot()
+    yield
+    restore_config_if_leaked(before)
+
+
 @pytest.fixture(scope="module", autouse=True)
 def reset_datalayer_between_modules():
     """Reset all cached DataLayer instances before each demo test module.

--- a/test/demo/conftest.py
+++ b/test/demo/conftest.py
@@ -244,11 +244,25 @@ def configure_case_actor_url_for_demo():
         reload_config()
 
 
+def config_snapshot() -> dict:
+    """Return the full currently-cached config as a plain dict.
+
+    Snapshotting every field rather than a hand-picked pair means a fixture
+    that leaks something other than the two #2086 URLs (e.g.
+    ``VULTRON_ACTOR__DEFAULT_CASE_ROLES``) is still detected.
+    """
+    from vultron.config import get_config
+
+    return get_config().model_dump(mode="json")
+
+
 def config_url_snapshot() -> tuple[str, str]:
     """Return the currently cached ``(server.base_url, case_actor_service_url)``.
 
     These are the two settings demo tests repoint at their own fake hosts, and
-    the pair whose leakage caused #2086.
+    the pair whose leakage caused #2086.  Kept as a narrow, readable accessor
+    for tests that assert specifically on those URLs;
+    :func:`config_snapshot` is what the leak guard compares.
     """
     from vultron.config import get_config
 
@@ -259,28 +273,84 @@ def config_url_snapshot() -> tuple[str, str]:
     )
 
 
-def restore_config_if_leaked(before: tuple[str, str]) -> bool:
-    """Reload the module-level config if the URL snapshot drifted from *before*.
+class ConfigLeakLedger:
+    """Session-wide record of config leaks the guard had to repair.
+
+    The guard repairs leaks so that one misordered teardown cannot cascade into
+    unrelated failures.  That repair also hides the leak, which would leave the
+    ``monkeypatch.undo()``-before-``reload_config()`` fixes in the demo modules
+    unenforced by any test.  Recording each detection here keeps the repair
+    while still giving :mod:`test.demo.test_config_leak_guard` something that
+    fails when a fixture teardown regresses (#2086).
+    """
+
+    def __init__(self) -> None:
+        self.leaks: list[str] = []
+
+    def record(self, before: dict, after: dict) -> None:
+        self.leaks.append(f"{_describe_drift(before, after)}")
+
+    def reset(self) -> None:
+        self.leaks.clear()
+
+
+#: Session-wide ledger; asserted on by ``test_config_leak_guard.py``.
+config_leak_ledger = ConfigLeakLedger()
+
+
+def _describe_drift(before: dict, after: dict) -> str:
+    """Summarise which config keys changed, for logs and assertion messages."""
+    drifted = sorted(
+        f"{key}: {before.get(key)!r} -> {after.get(key)!r}"
+        for key in set(before) | set(after)
+        if before.get(key) != after.get(key)
+    )
+    return "; ".join(drifted)
+
+
+def restore_config_if_leaked(before: dict) -> bool:
+    """Reload the module-level config if it drifted from the *before* snapshot.
+
+    The repair is :func:`reload_config`, which re-reads ``os.environ``.  That
+    only helps if the offending fixture also undid its env patches, so the
+    post-reload state is verified rather than assumed: a reload that fails to
+    restore *before* raises instead of reporting a success it did not achieve
+    (ARCH-15-001 — a fake success is the same bug as a silent ``None``).
 
     Args:
-        before: Snapshot from :func:`config_url_snapshot` taken before the
-            code under test ran.
+        before: Snapshot from :func:`config_snapshot` taken before the code
+            under test ran.
 
     Returns:
-        ``True`` if a leak was detected and the config was reloaded.
+        ``True`` if a leak was detected and successfully repaired, ``False``
+        if the config never drifted.
+
+    Raises:
+        RuntimeError: if the config drifted and the reload did not restore it,
+            which means the environment itself is still polluted.
     """
     from vultron.config.app import reload_config
 
-    after = config_url_snapshot()
+    after = config_snapshot()
     if after == before:
         return False
+
+    drift = _describe_drift(before, after)
     logger.warning(
-        "Demo test leaked config (server.base_url / "
-        "actor.case_actor_service_url): %s -> %s; reloading (#2086)",
-        before,
-        after,
+        "Demo test leaked config (%s); reloading (#2086)",
+        drift,
     )
+    config_leak_ledger.record(before, after)
     reload_config()
+
+    repaired = config_snapshot()
+    if repaired != before:
+        raise RuntimeError(
+            "Config leak could not be repaired by reload_config(): the "
+            "environment is still polluted. A fixture mutated the "
+            "environment without undoing it (see #2086). Residual drift: "
+            f"{_describe_drift(before, repaired)}"
+        )
     return True
 
 
@@ -299,10 +369,20 @@ def restore_case_actor_url_after_each_test():
     case, and ``validate-report`` fails with "no routable recipients".
 
     Because that depends on test *order*, it presented as CI flakiness.  This
-    fixture snapshots the two URLs before each test and reloads config after if
-    they changed, so a leak cannot outlive the test that caused it.
+    fixture snapshots the config before each test and reloads after if it
+    drifted.
+
+    **Scope limitation**: this fixture is function-scoped, so it only catches
+    *function-scoped* offenders.  A module-, class-, or session-scoped fixture
+    pollutes the cache *before* this guard takes its ``before`` snapshot, so
+    the drift is invisible here and that fixture's teardown runs after this
+    one's finalizer.  Higher-scoped fixtures must therefore still order
+    ``monkeypatch.undo()`` before ``reload_config()`` themselves — the guard is
+    not a substitute.  Any repair performed here is recorded on
+    :data:`config_leak_ledger` so ``test_config_leak_guard.py`` fails rather
+    than silently masking the regression.
     """
-    before = config_url_snapshot()
+    before = config_snapshot()
     yield
     restore_config_if_leaked(before)
 

--- a/test/demo/test_case_proposal_round_trip.py
+++ b/test/demo/test_case_proposal_round_trip.py
@@ -187,6 +187,10 @@ def two_app_setup(monkeypatch):
     configure_default_emitter(previous_emitter)  # type: ignore[arg-type]
     vendor_iso.dl.close()
     reporter_iso.dl.close()
+    # Undo the env patches BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URLs into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
     reload_config()
 
 

--- a/test/demo/test_config_leak_guard.py
+++ b/test/demo/test_config_leak_guard.py
@@ -30,16 +30,21 @@ reseeds each run), this presented as CI flakiness in
 
 These tests pin both halves of the fix:
 
-* teardown must undo env patches *before* reloading (the source fix), and
+* teardown must undo env patches *before* reloading (the source fix), enforced
+  by :class:`TestNoFixtureLeakedConfig` asserting the guard never had to repair
+  anything during the session, and
 * the autouse ``restore_case_actor_url_after_each_test`` guard must detect and
   repair a leak if any fixture gets the order wrong again (defense in depth).
 """
 
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 from vultron.config.app import reload_config
 from test.demo.conftest import (
     _CASE_ACTOR_SERVICE_URL,
+    config_leak_ledger,
+    config_snapshot,
     config_url_snapshot,
     restore_config_if_leaked,
 )
@@ -47,11 +52,31 @@ from test.demo.conftest import (
 _FAKE_HOST = "http://leaky-host.invalid/api/v2"
 
 
-def _repoint_config_at_fake_host(mp: MonkeyPatch) -> None:
-    """Apply the env patches that demo fixtures apply, and cache them."""
+def _patch_env_at_fake_host(mp: MonkeyPatch) -> None:
+    """Apply the env patches that demo fixtures apply, without reloading.
+
+    Kept separate from the reload so each test below can perform the
+    reload/undo sequence in the order it is actually testing.
+    """
     mp.setenv("VULTRON_SERVER__BASE_URL", _FAKE_HOST)
     mp.setenv("VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL", _FAKE_HOST)
+
+
+def _repoint_config_at_fake_host(mp: MonkeyPatch) -> None:
+    """Apply the env patches that demo fixtures apply, and cache them."""
+    _patch_env_at_fake_host(mp)
     reload_config()
+
+
+def _discard_own_ledger_entries(baseline: int) -> None:
+    """Trim ledger entries this test deliberately caused.
+
+    The tests below leak config on purpose, so they must not leave their own
+    entries behind for :class:`TestNoFixtureLeakedConfig` to trip over.  They
+    truncate back to *baseline* rather than clearing, so genuine leaks recorded
+    by earlier fixtures survive and are still reported.
+    """
+    del config_leak_ledger.leaks[baseline:]
 
 
 class TestConfigLeakGuard:
@@ -59,24 +84,74 @@ class TestConfigLeakGuard:
 
     def test_snapshot_is_stable_when_nothing_changes(self):
         """No reload happens when the config never drifted."""
-        before = config_url_snapshot()
+        before = config_snapshot()
         assert restore_config_if_leaked(before) is False
-        assert config_url_snapshot() == before
+        assert config_snapshot() == before
 
     def test_guard_restores_config_after_a_leak(self):
         """A fixture that reloads while patched is repaired by the guard."""
-        before = config_url_snapshot()
+        baseline = len(config_leak_ledger.leaks)
+        before = config_snapshot()
         mp = MonkeyPatch()
         try:
             # The buggy teardown order: env still patched when reload runs.
             _repoint_config_at_fake_host(mp)
-            assert config_url_snapshot() != before
+            assert config_snapshot() != before
         finally:
             mp.undo()
 
         # The guard sees the drift and reloads from the (now clean) env.
         assert restore_config_if_leaked(before) is True
-        assert config_url_snapshot() == before
+        assert config_snapshot() == before
+        # The repair is recorded rather than silently swallowed, so a real
+        # fixture regression cannot hide behind the guard.
+        assert len(config_leak_ledger.leaks) == baseline + 1
+        _discard_own_ledger_entries(baseline)
+
+    def test_guard_detects_non_url_drift(self):
+        """Drift outside the two #2086 URLs is caught too."""
+        baseline = len(config_leak_ledger.leaks)
+        before = config_snapshot()
+        mp = MonkeyPatch()
+        try:
+            mp.setenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", '["VENDOR"]')
+            reload_config()
+            assert config_snapshot() != before
+        finally:
+            mp.undo()
+
+        assert restore_config_if_leaked(before) is True
+        assert config_snapshot() == before
+        _discard_own_ledger_entries(baseline)
+
+    def test_guard_raises_when_repair_is_impossible(self):
+        """An un-undone env patch must fail loudly, not report a fake repair.
+
+        Mutates ``os.environ`` directly (not via ``monkeypatch``) to simulate a
+        fixture that never undid its patch, so ``reload_config()`` cannot
+        recover the pre-test values.  The session-scoped demo patch is captured
+        and restored by hand for the same reason.
+        """
+        import os
+
+        baseline = len(config_leak_ledger.leaks)
+        env_key = "VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL"
+        original = os.environ.get(env_key)
+        before = config_snapshot()
+        os.environ[env_key] = _FAKE_HOST
+        reload_config()
+        try:
+            with pytest.raises(RuntimeError, match="still polluted"):
+                restore_config_if_leaked(before)
+        finally:
+            if original is None:
+                os.environ.pop(env_key, None)
+            else:
+                os.environ[env_key] = original
+            reload_config()
+            _discard_own_ledger_entries(baseline)
+
+        assert config_snapshot() == before
 
 
 class TestTeardownOrdering:
@@ -84,15 +159,17 @@ class TestTeardownOrdering:
 
     def test_reload_after_undo_leaves_no_leak(self):
         """The corrected order restores the cached config on its own."""
-        before = config_url_snapshot()
+        before = config_snapshot()
         mp = MonkeyPatch()
-        try:
-            _repoint_config_at_fake_host(mp)
-        finally:
-            mp.undo()
-            reload_config()
+        _patch_env_at_fake_host(mp)
+        reload_config()
+        assert config_snapshot() != before
 
-        assert config_url_snapshot() == before
+        # Corrected teardown: undo first, reload second.
+        mp.undo()
+        reload_config()
+
+        assert config_snapshot() == before
         assert restore_config_if_leaked(before) is False
 
     def test_reload_before_undo_leaks(self):
@@ -101,18 +178,46 @@ class TestTeardownOrdering:
         This is the mechanism behind #2086; asserting it keeps the comments in
         the demo fixtures honest.
         """
-        before = config_url_snapshot()
+        before = config_snapshot()
         mp = MonkeyPatch()
         try:
-            _repoint_config_at_fake_host(mp)
-            # Buggy teardown: reload first, undo second.
+            _patch_env_at_fake_host(mp)
+            # Buggy teardown: reload while the env patches are still applied.
             reload_config()
-            assert config_url_snapshot() != before
+            assert config_snapshot() != before
+            # Undoing afterwards does NOT evict the already-cached values —
+            # that is precisely why the order matters.
+            mp.undo()
+            assert config_snapshot() != before
         finally:
             mp.undo()
             reload_config()
 
-        assert config_url_snapshot() == before
+        assert config_snapshot() == before
+
+
+class TestNoFixtureLeakedConfig:
+    """No demo fixture may leak config during the session.
+
+    This is what pins the ``monkeypatch.undo()``-before-``reload_config()``
+    fixes in ``test_fvcv_handoff_demo.py``, ``test_pcr_late_joiner.py``,
+    ``test_case_proposal_round_trip.py``, and ``test_pcr_engage_case.py``.  The
+    autouse guard repairs leaks, which keeps one bad teardown from cascading —
+    but without this assertion the repair would also make a regression of those
+    four fixes invisible to CI.
+
+    Note this only observes fixtures that ran *before* this module in the
+    session, so it is order-dependent by nature: it is a ratchet that catches
+    regressions on most orderings, not a proof of absence on every ordering.
+    """
+
+    def test_guard_recorded_no_leaks(self):
+        assert config_leak_ledger.leaks == [], (
+            "A demo fixture leaked config into the module-level cache. The "
+            "autouse guard repaired it, but the offending fixture must order "
+            "monkeypatch.undo() BEFORE reload_config() in its teardown "
+            "(#2086). Recorded drift: " + " | ".join(config_leak_ledger.leaks)
+        )
 
 
 class TestDemoSessionBaseline:

--- a/test/demo/test_config_leak_guard.py
+++ b/test/demo/test_config_leak_guard.py
@@ -1,0 +1,129 @@
+#  Copyright (c) 2025-2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Regression tests for demo-suite config leakage (#2086).
+
+Several demo fixtures repoint ``VULTRON_SERVER__BASE_URL`` and
+``VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL`` at their own fake hosts and then call
+``reload_config()``.  ``reload_config()`` re-reads the environment into the
+*module-level* config cache, so the order of ``monkeypatch.undo()`` and
+``reload_config()`` in teardown determines whether the fake host outlives the
+test.
+
+When it does outlive the test, every later demo test derives its CaseActor ID
+from a host no ``_TestClientRouter`` has registered.  ``_TestClientRouter.emit``
+silently drops the ``Create(CaseProposal)`` delivery, the CaseActor never
+creates the canonical case, and ``trigger/validate-report`` fails with
+"no routable recipients".  Because it depends on test order (pytest-randomly
+reseeds each run), this presented as CI flakiness in
+``TestBootstrapSequence.test_announce_creates_case_replica``.
+
+These tests pin both halves of the fix:
+
+* teardown must undo env patches *before* reloading (the source fix), and
+* the autouse ``restore_case_actor_url_after_each_test`` guard must detect and
+  repair a leak if any fixture gets the order wrong again (defense in depth).
+"""
+
+from _pytest.monkeypatch import MonkeyPatch
+
+from vultron.config.app import reload_config
+from test.demo.conftest import (
+    _CASE_ACTOR_SERVICE_URL,
+    config_url_snapshot,
+    restore_config_if_leaked,
+)
+
+_FAKE_HOST = "http://leaky-host.invalid/api/v2"
+
+
+def _repoint_config_at_fake_host(mp: MonkeyPatch) -> None:
+    """Apply the env patches that demo fixtures apply, and cache them."""
+    mp.setenv("VULTRON_SERVER__BASE_URL", _FAKE_HOST)
+    mp.setenv("VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL", _FAKE_HOST)
+    reload_config()
+
+
+class TestConfigLeakGuard:
+    """The conftest guard detects and repairs a leaked config snapshot."""
+
+    def test_snapshot_is_stable_when_nothing_changes(self):
+        """No reload happens when the config never drifted."""
+        before = config_url_snapshot()
+        assert restore_config_if_leaked(before) is False
+        assert config_url_snapshot() == before
+
+    def test_guard_restores_config_after_a_leak(self):
+        """A fixture that reloads while patched is repaired by the guard."""
+        before = config_url_snapshot()
+        mp = MonkeyPatch()
+        try:
+            # The buggy teardown order: env still patched when reload runs.
+            _repoint_config_at_fake_host(mp)
+            assert config_url_snapshot() != before
+        finally:
+            mp.undo()
+
+        # The guard sees the drift and reloads from the (now clean) env.
+        assert restore_config_if_leaked(before) is True
+        assert config_url_snapshot() == before
+
+
+class TestTeardownOrdering:
+    """``monkeypatch.undo()`` must precede ``reload_config()`` in teardown."""
+
+    def test_reload_after_undo_leaves_no_leak(self):
+        """The corrected order restores the cached config on its own."""
+        before = config_url_snapshot()
+        mp = MonkeyPatch()
+        try:
+            _repoint_config_at_fake_host(mp)
+        finally:
+            mp.undo()
+            reload_config()
+
+        assert config_url_snapshot() == before
+        assert restore_config_if_leaked(before) is False
+
+    def test_reload_before_undo_leaks(self):
+        """The buggy order pins the fake host into the module-level cache.
+
+        This is the mechanism behind #2086; asserting it keeps the comments in
+        the demo fixtures honest.
+        """
+        before = config_url_snapshot()
+        mp = MonkeyPatch()
+        try:
+            _repoint_config_at_fake_host(mp)
+            # Buggy teardown: reload first, undo second.
+            reload_config()
+            assert config_url_snapshot() != before
+        finally:
+            mp.undo()
+            reload_config()
+
+        assert config_url_snapshot() == before
+
+
+class TestDemoSessionBaseline:
+    """The demo session's CaseActor URL is intact when a test starts.
+
+    This is the invariant that CI violated: with pytest-randomly, this test may
+    run after any leak-prone demo module, so a surviving leak fails it here.
+    """
+
+    def test_case_actor_service_url_matches_demo_session_value(self):
+        _, case_actor_url = config_url_snapshot()
+        assert case_actor_url.rstrip("/") == _CASE_ACTOR_SERVICE_URL.rstrip(
+            "/"
+        )

--- a/test/demo/test_fvcv_handoff_demo.py
+++ b/test/demo/test_fvcv_handoff_demo.py
@@ -835,4 +835,9 @@ class TestOwnershipTransferAnnounceReachesFinderAC5c:
             vendor_iso.dl.close()
             coordinator_iso.dl.close()
             finder_iso.dl.close()
+            # Undo the env patches BEFORE reloading, otherwise the reload
+            # re-caches this test's coordinator URLs and every subsequent test
+            # in the session inherits them (#2086).  monkeypatch's own undo
+            # runs after this fixture teardown, which is too late.
+            monkeypatch.undo()
             reload_config()

--- a/test/demo/test_pcr_engage_case.py
+++ b/test/demo/test_pcr_engage_case.py
@@ -126,6 +126,10 @@ def two_app_setup(monkeypatch):
     configure_default_emitter(previous_emitter)  # type: ignore[arg-type]
     owner_iso.dl.close()
     reporter_iso.dl.close()
+    # Undo the env patches BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URLs into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
     reload_config()
 
 

--- a/test/demo/test_pcr_late_joiner.py
+++ b/test/demo/test_pcr_late_joiner.py
@@ -169,6 +169,10 @@ def three_app_setup(monkeypatch):
     owner_iso.dl.close()
     reporter_iso.dl.close()
     late_joiner_iso.dl.close()
+    # Undo the env patches BEFORE reloading: monkeypatch's own undo runs after
+    # this teardown, so reloading first would re-cache this fixture's URLs into
+    # the module-level config for the rest of the session (#2086).
+    monkeypatch.undo()
     reload_config()
 
 


### PR DESCRIPTION
- Closes #2086
- Closes #1897

## Summary

Four demo fixtures called `reload_config()` in teardown *before* `monkeypatch`
undid their env patches, pinning a fake CaseActor host into the module-level
config cache for the remainder of the pytest session. This fixes the teardown
order at the source, adds an autouse guard so a future ordering mistake cannot
outlive its test, and adds a regression module.

## Root cause

`vultron/config/app.py` keeps a process-global `_config_cache`;
`reload_config()` clears it and re-reads the environment. Pytest's
`monkeypatch` fixture undoes env changes **after** the requesting fixture's
teardown body runs, so `reload_config()` in teardown re-caches the *still
patched* value.

Every later demo test then derived its CaseActor ID from that leaked host
(e.g. `http://coordinator-otc.test`). No `_TestClientRouter` registers it, so
`emit()` silently dropped the `Create(CaseProposal)` (DEBUG log only), the
CaseActor never created the canonical case with its `CASE_MANAGER` participant,
and `trigger/validate-report` failed three steps downstream with
`SvcValidateReportUseCase: no routable recipients`.

No production code was at fault.

## The failure is deterministic, not nondeterministic

An earlier triage note on this issue concluded the failures were "genuinely
nondeterministic" because `pytest -m "" test/demo/` gave `[2, 0, 2]` bootstrap
failures over three identical runs. **That was a measurement artifact.**

`timeout = 5` with `timeout_method = "thread"` (`pyproject.toml:123`) kills the
**whole pytest process**, not just the slow test. A run that trips it emits no
summary line and never reaches `test_pcr_bootstrap.py` — scoring a phantom `0`.
Re-running the identical command with a driver that also records the
`+++ Timeout +++` marker reproduces `[2, 0, 2]` and shows the middle run
aborted mid-session with `timeout=True` and no summary.

At any granularity that actually runs both modules to completion, clean
`origin/main` (post-#2123, `1a911d30`) fails deterministically:

| Invocation (`-p no:randomly`, 3× each) | clean `origin/main` | this branch |
|---|---|---|
| `test_fvcv_handoff_demo.py` + `test_pcr_bootstrap.py` | `[2, 2, 2]` | `[0, 0, 0]` |
| `...::TestOwnershipTransferAnnounceReachesFinderAC5c` + bootstrap | `[2, 2, 2]` | — |
| `test_pcr_bootstrap.py` alone | `[0, 0, 0]` | `[0, 0, 0]` |
| full `test/demo/` (4×) | `[2, 0, 2]` | `[0, 0, 0, 0]` |

The first row contradicts the earlier pairwise sweep that reported zero failures
across all 27 preceding files; that sweep should be treated as unreliable (it
also suffered shell word-splitting no-ops). Confirmed still failing `[2,2,2]` on
post-#2123 `main`, so #2123 fixed #2122 — not this.

## Changes

- **`test/demo/test_fvcv_handoff_demo.py`**, **`test/demo/test_pcr_late_joiner.py`**,
  **`test/demo/test_case_proposal_round_trip.py`**, **`test/demo/test_pcr_engage_case.py`**:
  call `monkeypatch.undo()` before `reload_config()` in fixture teardown.
  (`test_fv_demo.py` already avoided this by using an explicit `MonkeyPatch()`.)
- **Six non-demo fixtures** — `test/core/behaviors/case/nodes/test_case_setup.py`,
  `test/core/behaviors/case/test_bug_26040902_regression.py`,
  `test/core/behaviors/case/test_receive_report_case_tree.py`,
  `test/core/use_cases/received/test_ack_validate_report_received.py`,
  `test/core/use_cases/received/test_submit_report_received.py`,
  `test/core/use_cases/test_validate_report_ledger_routing.py`: same teardown
  ordering fix. All six patch `VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL` and
  reloaded while still patched, leaking `http://case-actor:7999/api/v2` for the
  rest of the session. Nothing outside `test/demo/` is covered by the guard.
- **`test/demo/conftest.py`**: add `config_snapshot()` /
  `restore_config_if_leaked()` helpers and an autouse
  `restore_case_actor_url_after_each_test` fixture that snapshots the **full**
  config around every demo test and reloads if it drifted — so drift in a
  setting other than the two #2086 URLs is caught too. The repair verifies the
  post-reload state and raises rather than reporting a success it did not
  achieve (ARCH-15-001). Each repair is recorded on a `ConfigLeakLedger`.
- **`test/demo/test_config_leak_guard.py`** (new): 8 tests covering both
  teardown orderings, the guard helpers, non-URL drift, the
  unrepairable-pollution path, the demo session's baseline CaseActor URL, and
  `TestNoFixtureLeakedConfig` — a ratchet asserting the guard never had to
  repair anything, so the source fixes stay enforced.
- **`test/core/behaviors/case/test_create_tree.py`**,
  **`test/core/behaviors/case/nodes/test_communication.py`**: configure
  `case_actor_service_url` in their own autouse fixture (#1897). Both run
  `ResolveCaseActorUrlsNode` — which FAILs when that URL is None
  (CP-08-002/003) — without setting it, and passed only by borrowing the leak
  the change above removes.
- **`test/AGENTS.md`**: document the teardown-ordering rule, the guard's
  function-scope-only limitation, and the converse rule that a module needing a
  `VULTRON_*` setting must set it itself.
- **`notes/flaky-tests.md`**: correct the #2086 entry, drop the #2086 and #2122
  rows (the latter fixed by #2123), and document the timeout-vs-pass trap.
- **`plan/incoming/learnings/`**: three learnings — the silent
  `_TestClientRouter` drop that masked the cause, the module-level config cache
  footgun, and the thread-timeout measurement trap.

## The first revision's regression coverage was vacuous

Worth recording, because the guard was the problem. With the autouse guard in
place and **all four source fixes reverted**, `test/demo/` reported
`25 passed` — nothing failed. The guard repaired every leak so reliably that no
test could observe a regression of the fixes the PR exists to make. A
three-way experiment isolated it:

| guard | source fixes | result |
|---|---|---|
| off | present | 20 passed (control) |
| on | **reverted** | **25 passed — nothing fails** |
| off | reverted | both `TestBootstrapSequence` tests FAIL, "no routable recipients" |

`ConfigLeakLedger` + `TestNoFixtureLeakedConfig` resolve this: the guard still
repairs (so one bad teardown cannot cascade), but every repair is recorded and
asserted on. Validated by reverting two *different* fixtures in turn — each
produced a failing ratchet naming the offending host.

## Verification

Rebased onto `origin/main` @ `1a911d30` (includes #2123).

- Unit suite: `6453 passed, 362 skipped, 2 xfailed, 5552 subtests passed`.
- Full suite incl. integration and demo (`-m ""`):
  `7511 passed, 362 skipped, 3 xfailed, 1 xpassed, 5552 subtests passed` —
  **0 failures**.
- xfail ratchet: all of #1991, #1992, #1993, #1994 confirmed open.
- Black, flake8, mypy, pyright, markdownlint all clean.

### #1897 was surfaced, not caused, by this PR

Removing the leak broke 4 tests that had been depending on it
(`test_create_tree.py` ×3, `test_communication.py` ×1). Proven by matched runs
at identical fixed order (`-p no:randomly`): clean branch HEAD passes the full
suite; with the six-fixture fix applied, exactly those 4 fail. They also fail on
clean `origin/main` when run as a subset — which is #1897, filed earlier and
still open. Fixed properly here (each module configures the URL itself) rather
than by restoring the leak.

## Notes

- One of the four full-suite trials still tripped the global 5s thread timeout.
  That is pre-existing and unrelated (see also
  `20260803-pytest-full-suite-timeout.md`); the learning suggests raising the
  demo/integration timeout or switching to `timeout_method = "signal"` so a slow
  test fails alone instead of voiding the session.
- The autouse guard contains the blast radius but does not remove the footgun;
  the durable fix (a `config_override()` context manager, or config via a
  FastAPI dependency tests can override) is captured as a learning rather than
  done here, to keep this scoped to the flake.
- The guard is **function-scoped only**: a module-, class-, or session-scoped
  fixture pollutes the cache before the guard snapshots it, so higher-scoped
  fixtures must get the ordering right themselves. Documented in
  `test/AGENTS.md` and in the fixture docstring rather than fixed, since no
  current fixture is in that position.
- `TestNoFixtureLeakedConfig` only observes fixtures that ran *before* it in the
  session, so it is order-dependent by nature — a ratchet that catches
  regressions on most orderings, not a proof of absence on every one.
