### PR TITLE
chore(lint): exclude graphify-out/ from markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -41,6 +41,8 @@ config:
 ignores:
   - "wip_notes/**"
   - "wip_outputs/**"
+  # Generated knowledge-graph output; git-ignored, but markdownlint globs it anyway
+  - "graphify-out/**"
   - "node_modules/**"
   - ".github/**"
   - ".venv/**"

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,4 @@
 wip_notes/
 node_modules/
 .github/
+graphify-out/

--- a/mdlint.sh
+++ b/mdlint.sh
@@ -15,4 +15,4 @@
 # U.S. Patent and Trademark Office by Carnegie Mellon University
 #
 
-markdownlint-cli2 --fix --config .markdownlint-cli2.yaml "**/*.md" "#node_modules/**" "#.venv/**" "#.git/**" "#wip_notes/**"
+markdownlint-cli2 --fix --config .markdownlint-cli2.yaml "**/*.md" "#node_modules/**" "#.venv/**" "#.git/**" "#wip_notes/**" "#graphify-out/**"


### PR DESCRIPTION
## Problem

`graphify-out/` holds generated knowledge-graph artifacts, including `GRAPH_REPORT.md` files. It is git-ignored, but `markdownlint-cli2` globs the working tree directly and does **not** honor `.gitignore` — so every lint run was checking (and auto-fixing) those generated reports.

## Change

Add `graphify-out/` to all three places markdownlint reads its exclusions:

- `.markdownlintignore`
- the `ignores:` list in `.markdownlint-cli2.yaml`
- the negated globs in `mdlint.sh`

## Not changed

The Python linters (black, flake8, mypy, pyright) are already scoped to `vultron/` and `test/`, and `graphify-out/` contains no Python, so they needed no exclusion.

## Verification

`./mdlint.sh` — `graphify-out/**` now appears in the resolved glob list as an exclusion; `Summary: 0 issues in 0 files` across 1855 linted files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)