### PR TITLE
docs: plan concern #2137 — demo CI integration branch strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,6 +530,15 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   `specs/` for the bare name as well as the quoted/path form, and update every spec entry
   that references it — including `statement:`, `rationale:`, and cross-reference fields.
   *Source: ISSUE-2011*
+- **Multiple Related Fix PRs Targeting a Shared CI Suite Must Use an Integration
+  Branch, Not Race to `main`** — when 3+ related bug fix PRs are open
+  simultaneously and all affect the same CI suite (e.g. Demo Integration), open
+  a single `fix/<area>` integration branch off `main` and target all child PRs
+  there. Run the full CI suite against the integration branch after each child PR
+  merges into it. Merge the integration branch to `main` only when the full suite
+  is green. Racing parallel PRs to `main` means each PR can only confirm its own
+  scenario passes — none can confirm it hasn't perturbed other currently-passing
+  scenarios. *Source: CONCERN-2137*
 
 ---
 

--- a/plan/history/2608/learning/CONCERN-2137.md
+++ b/plan/history/2608/learning/CONCERN-2137.md
@@ -1,0 +1,38 @@
+---
+source: CONCERN-2137
+timestamp: '2026-08-10T18:25:05.634254+00:00'
+title: Parallel fix PRs to a shared CI suite need an integration branch as the cumulative
+  gate
+type: learning
+---
+
+## The problem
+
+There are currently 4+ distinct demo-CI failures on `main` spanning at least 2
+root-cause classes. Open PRs (#2127 and whatever follows) each target `main`
+directly. This creates a verification gap:
+
+- Each PR author can only confirm their own scenario passes.
+- None can confirm they have not perturbed the other 6 failing scenarios.
+- The last known-green Demo Integration baseline was before 2026-08-07 — over
+  3 days ago. Any PR that claims "demo CI passes" is verifying against a
+  partial picture.
+
+## Why this matters
+
+Demo Integration failures are silent by default (see #2132). Without a
+baseline, a PR that fixes its own scenario and accidentally breaks a
+currently-passing scenario (fv, fcv-reject demo) could merge undetected.
+
+## Proposed strategy: integration branch
+
+1. **Open a single `fix/demo-ci` branch** off current `main` as the integration
+   target for all child fixes of epic #2136.
+2. PRs for #2120, #2135, #2134, #2121 all target `fix/demo-ci`, not `main`.
+3. **Run Demo Integration against `fix/demo-ci`** after each child PR merges
+   into it — this is the cumulative gate.
+4. Only when all 9 Demo Integration jobs are green on `fix/demo-ci` does that
+   branch merge to `main`.
+
+**Resolved**: 2026-08-10 — implementation tracked in #2139.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2138>.


### PR DESCRIPTION
- Closes #2137

## Summary

Plans CONCERN-2137: parallel fix PRs to `main` cannot guarantee a green Demo
Integration baseline — all child fixes of epic #2136 must land on a coordinated
integration branch before merging to `main`.

**Decision**: Use a `fix/demo-ci` integration branch as the cumulative CI gate.
All open and future child fix PRs (#2127, #2135, #2134, #2121) target
`fix/demo-ci`. The integration branch merges to `main` only when all 9 Demo
Integration scenarios are green.

**Doc change**: AGENTS.md pitfall entry — when 3+ related fix PRs target the
same CI suite, use an integration branch rather than racing PRs to `main`.

## Changes

- **`AGENTS.md`**: New pitfall entry under "Common Pitfalls": use an integration
  branch as the cumulative CI gate when multiple related fix PRs target the same
  CI suite (e.g. Demo Integration); do not race parallel PRs to `main`.

## Implementation issues

(added after creation — see Phase 8)

## Implementation Issues

- #2139