### PR TITLE
fix(demo-ci): create integration branch, add workflow_dispatch ref input, re-target child PRs

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -5,9 +5,12 @@
 # concurrently on PRs.  See specs/demo-ci.yaml DEMOCI-02-001.
 #
 # Triggers:
-#   pull_request  — minimum PR validation set (4 scenarios, DEMOCI-06-002)
-#   push to main  — full 9-scenario suite (DEMOCI-06-003, DEMOCI-05-001)
-#   workflow_dispatch — full 9-scenario suite (for manual re-runs)
+#   pull_request  — minimum PR validation set (4 scenarios, DEMOCI-06-002);
+#                   targets both `main` and `fix/demo-ci` integration branches
+#   push to main/fix/demo-ci — full 9-scenario suite (DEMOCI-06-003, DEMOCI-05-001)
+#   workflow_dispatch — full 9-scenario suite; accepts optional `ref` input
+#                       so the suite can be run against any branch (e.g.
+#                       `fix/demo-ci`) without opening a PR to `main`
 #
 # Dependabot PRs are skipped — python-app.yml still guards broken deps.
 # See DEMOCI-02-002, DEMOCI-02-003, DEMOCI-02-004.
@@ -60,7 +63,8 @@ name: Demo Integration
 
 on:
   pull_request:
-    branches: ["main"]
+    # fix/demo-ci: temporary integration branch — remove when merged (#2144).
+    branches: ["main", "fix/demo-ci"]
     paths:
       - "vultron/**"
       - "!vultron/metadata/**"
@@ -78,7 +82,8 @@ on:
       # The scenario matrix itself gates which demos run.
       - ".github/demo-scenarios.json"
   push:
-    branches: ["main"]
+    # fix/demo-ci: temporary integration branch — remove when merged (#2144).
+    branches: ["main", "fix/demo-ci"]
     paths:
       - "vultron/**"
       - "!vultron/metadata/**"
@@ -92,6 +97,16 @@ on:
       - ".github/actions/build-demo-images/**"
       - ".github/demo-scenarios.json"
   workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        description: >-
+          Branch, tag, or SHA to check out and run the full demo suite against.
+          Defaults to the branch the workflow is dispatched from. Use this to
+          manually validate an integration branch (e.g. fix/demo-ci) before
+          merging it to main.
+        required: false
+        default: ""
 
 # DEMOCI-02-011: cancel superseded PR runs; never cancel on-main runs.
 concurrency:
@@ -121,6 +136,8 @@ jobs:
       matrix: ${{ steps.select.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Select scenario matrix
         id: select
@@ -157,6 +174,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       # DEMOCI-02-007: Docker layer caching via Buildx GHA cache.
       # On push-to-main runs, write to the "demo-integration-main" scope so
@@ -248,6 +267,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       # DEMOCI-04-003: download the JSONL artifact produced by the demo job.
       - name: Download case log JSONL files

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -6,7 +6,7 @@ description: >-
   when the demo fails — closing the gap where tests pass while the demo produces
   silent failures. Includes requirements for the invariant harness to run as an
   independent CI gate so failures are visible even when the demo itself also fails.
-version: 1.5.0
+version: 1.6.0
 scope:
   - prototype
   - production
@@ -781,3 +781,58 @@ groups:
             spec_id: DEMOCI-08-001
           - rel_type: refines
             spec_id: DEMOCI-06-004
+
+  - id: DEMOCI-09
+    title: Integration Branch Support
+    specs:
+      - id: DEMOCI-09-001
+        priority: MUST
+        kind: project
+        statement: >-
+          The `workflow_dispatch` trigger in `demo-integration.yml` MUST declare
+          an optional `ref` input (`type: string`, default empty string) whose
+          description explains that it accepts a branch, tag, or SHA to check out
+          before running the full demo suite. All three `actions/checkout` steps
+          in the workflow (in the `scenarios`, `demo`, and `invariant-harness`
+          jobs) MUST unconditionally pass `ref: ${{ inputs.ref || github.ref }}`.
+          When `inputs.ref` is non-empty the suite runs against that ref; when
+          `inputs.ref` is empty or absent (all non-`workflow_dispatch` events),
+          the expression transparently falls through to `github.ref` so normal
+          `pull_request` and `push` checkouts are unaffected.
+        rationale: >-
+          When multiple related bug-fix PRs land on a shared integration branch
+          (e.g. `fix/demo-ci`) rather than racing to `main`, the full demo suite
+          needs to be runnable against that branch without opening a dummy PR to
+          `main`. A `workflow_dispatch` `ref` input enables manual full-suite
+          validation at any point during the integration window with a single
+          button click in the GitHub UI. The unconditional expression form avoids
+          a conditional `if: inputs.ref != ''` guard that would silently break
+          normal checkout behaviour.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-05-001
+
+      - id: DEMOCI-09-002
+        priority: MUST
+        kind: project
+        statement: >-
+          While a `fix/demo-ci` integration branch is active, both the
+          `pull_request` and `push` triggers in `demo-integration.yml` MUST list
+          `fix/demo-ci` alongside `main` in their `branches:` arrays, so that
+          PRs targeting and direct pushes to the integration branch receive the
+          same Demo Integration CI gate as `main`. When the integration branch is
+          merged and no longer active, the `fix/demo-ci` entries MUST be removed
+          from both `branches:` arrays. The cleanup obligation MUST be tracked as
+          a GitHub issue so it is not silently forgotten (GitHub ignores deleted
+          branches in `branches:` arrays without warning).
+        rationale: >-
+          Child fix PRs targeting an integration branch must be validated against
+          that branch — not against `main` — so that each incremental fix is
+          confirmed not to perturb scenarios already green on the integration
+          branch. The same reasoning applies to direct pushes: when a child PR
+          merges into `fix/demo-ci`, the post-merge full-suite run validates the
+          cumulative result, closing the same "two green PRs break the shared
+          branch" gap that DEMOCI-05-001 closes for `main`.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-05-001


### PR DESCRIPTION
- Closes #2139

## Summary

Implements CONCERN-2137's coordinated integration branch strategy so multiple
demo-CI bug fixes can land on `fix/demo-ci` before any reaches `main`.

## Changes

- **`fix/demo-ci` branch created** off current `main` HEAD (AC-1).
- **PR #2127 re-targeted** from `main` → `fix/demo-ci` (AC-2). Issues #2121,
  #2134, #2135 already carried "target `fix/demo-ci`" warnings in their bodies (AC-3).
- **`.github/workflows/demo-integration.yml`** (AC-4):
  - `pull_request` and `push` triggers extended to cover `fix/demo-ci` so
    each child fix PR gets the same Demo Integration gate against the integration
    branch (DEMOCI-09-002).
  - `workflow_dispatch` gains an optional `ref` input (`type: string`) so the
    full 9-scenario suite can be run against the integration branch without
    opening a dummy PR to `main` (DEMOCI-09-001).
  - All three `actions/checkout` steps updated to `ref: ${{ inputs.ref || github.ref }}`;
    on normal PR/push events the expression transparently falls through to `github.ref`.
  - Inline `# fix/demo-ci: temporary — remove when merged (#2144)` comments added
    at both `branches:` arrays as a durable reminder.
- **`specs/demo-ci.yaml`** bumped to 1.6.0; new DEMOCI-09 group added with
  DEMOCI-09-001 (ref input spec) and DEMOCI-09-002 (integration branch CI spec).
- **Cleanup issue #2144** created to remove `fix/demo-ci` entries after the
  integration branch merges.

## AC status

| AC | Status | Notes |
|---|---|---|
| AC-1 | ✅ Done | `fix/demo-ci` created via GitHub API off `main` |
| AC-2 | ✅ Done | PR #2127 base changed to `fix/demo-ci` |
| AC-3 | ✅ Already done | Issues #2121, #2134, #2135 bodies already had target warning |
| AC-4 | ✅ Done | `workflow_dispatch` `ref` input wired in all three checkout steps |
| AC-5 | ⏳ Pending | After child PRs merge to `fix/demo-ci` and full suite is green |
| AC-6 | ⏳ Pending | Verified per child PR as they land on `fix/demo-ci` |

## Verification

- 6457 unit tests pass; 1058 integration tests pass
- Black, flake8, mypy, pyright all clean
- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`