### PR TITLE
fix(invariants): skip VFd check for fcv-reject Invariant 15

### DIFF
--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -53,6 +53,14 @@ event types it exercises. Event types are those recorded as `event_type` in
   `RejectInviteActorToCaseReceivedUseCase` on the CaseActor. Because the Vendor
   rejects rather than accepts, `accept_invite_actor_to_case` does NOT appear in
   this scenario. No other current scenario exercises this ledger entry.
+  **Invariant 15 note**: because the Vendor never participates, no actor advances
+  the VFD state machine and `vfd_state == 'VFd'` is structurally unreachable.
+  `test_invariant_15` in `test_fcv_reject_invariants.py` therefore passes
+  `check_fix_ready=False` to `check_cs_state_transitions_observed` — skipping the
+  VFd assertion while still enforcing the P-transition check. When copy-pasting
+  Invariant 15 from another harness, audit whether the target scenario has a
+  participating Vendor; if not, set `check_fix_ready=False` (DEMOCI-06-001,
+  ISSUE-2121).
 - `add_case_participant` is emitted by `AcceptInviteNode`
   (`vultron/core/behaviors/case/nodes/accept_invite.py:181`) on the CaseActor
   received-side when processing Accept(Invite). This event records the internal

--- a/plan/history/2608/implementation/ISSUE-2121.md
+++ b/plan/history/2608/implementation/ISSUE-2121.md
@@ -1,0 +1,25 @@
+---
+source: ISSUE-2121
+timestamp: '2026-08-10T19:58:55.093883+00:00'
+title: 'fix(invariants): skip VFd check for fcv-reject Invariant 15'
+type: implementation
+---
+
+Issue #2121: `test_invariant_15_cs_state_transitions_observed` in
+`test/ci/invariants/test_fcv_reject_invariants.py` was failing because the
+shared `check_cs_state_transitions_observed` helper unconditionally checked
+for `vfd_state == 'VFd'` (fix ready). In the fcv-reject scenario, Vendor
+rejects the case invitation and is never added as a participant, so no actor
+advances the VFD state machine — `VFd` is structurally unreachable.
+
+Root cause: copy-paste of `test_invariant_15` from vendor-inclusive scenarios
+(same class as DEMOCI-06-001). The invariant was added when demo CI was dark
+(#2118 startup failure), so it never had a green CI run to catch the error.
+
+Fix: added keyword-only `check_fix_ready: bool = True` to
+`check_cs_state_transitions_observed` in `common.py`; fcv-reject's Invariant
+15 now passes `check_fix_ready=False`. All 8 other scenario harnesses
+verified — each calls `actor_notifies_fix_ready` in its demo, so VFd is
+reachable there. Two regression tests added to `test_common.py`.
+
+PR: <https://github.com/CERTCC/Vultron/pull/2152>

--- a/plan/incoming/learnings/20260810-cs-invariant-15-reject-flow-no-vfd.md
+++ b/plan/incoming/learnings/20260810-cs-invariant-15-reject-flow-no-vfd.md
@@ -1,0 +1,25 @@
+---
+title: "Invariant 15 VFd check is scenario-specific, not universal"
+type: learning
+timestamp: 2026-08-10
+source: ISSUE-2121
+signal: design-question
+---
+
+`check_cs_state_transitions_observed` in `test/ci/invariants/common.py` was
+originally written as a universal check requiring both `vfd_state == 'VFd'`
+(fix ready) and a P-transition.  This assumption holds for all scenarios where
+a Vendor participates and advances the VFD state machine — but the fcv-reject
+scenario intentionally has no participating Vendor (Vendor rejects the
+invitation), so VFd is structurally unreachable there.
+
+The fix added a keyword-only `check_fix_ready: bool = True` parameter.
+Scenario-specific harnesses that cover a reject flow (no Vendor participant)
+MUST pass `check_fix_ready=False`.  All other scenarios use the default.
+
+The broader lesson: invariants in the harness are only invariant *within their
+scenario's protocol path*.  When copy-pasting invariant tests across scenarios,
+audit each one against the scenario's participant set and phase list — a check
+that is universal for vendor-inclusive scenarios may be inapplicable for
+rejection or no-vendor flows.  This is the same class of copy-paste defect
+documented in DEMOCI-06-001.

--- a/test/ci/invariants/common.py
+++ b/test/ci/invariants/common.py
@@ -610,13 +610,20 @@ def cs_observations_from_snap(snap: dict) -> tuple[bool, bool, bool]:
 
 def check_cs_state_transitions_observed(
     replicas: dict[str, list[dict]],
+    *,
+    check_fix_ready: bool = True,
 ) -> list[str]:
     """Key CS transitions observed in the authoritative log (Invariant 15).
 
-    Checks vfd_state == "VFd" (fix ready) and pxa_state starting with "P"
-    (public aware).  VFD (fix deployed) is NOT checked here because demo
-    scenarios use vendor-only actors (CVDRole.VENDOR, no CVDRole.DEPLOYER);
-    per CSB-15-002 those actors stop at VFd and never reach VFD.
+    Checks pxa_state starting with "P" (public aware) for all scenarios.
+    When ``check_fix_ready=True`` (default), also checks vfd_state == "VFd"
+    (fix ready).  Set ``check_fix_ready=False`` for scenarios where no Vendor
+    ever becomes a case participant and therefore no actor advances the VFD
+    state machine (e.g. fcv-reject: Vendor rejects the invitation).
+
+    VFD (fix deployed) is NOT checked here because demo scenarios use
+    vendor-only actors (CVDRole.VENDOR, no CVDRole.DEPLOYER); per CSB-15-002
+    those actors stop at VFd and never reach VFD.
     """
     auth = auth_entries(replicas)
     status_entries = [
@@ -637,7 +644,7 @@ def check_cs_state_transitions_observed(
         saw_published |= published
 
     missing: list[str] = []
-    if not saw_fix_ready:
+    if check_fix_ready and not saw_fix_ready:
         missing.append("vfd_state == 'VFd' (fix_ready) never observed")
     if not saw_published:
         missing.append(

--- a/test/ci/invariants/test_common.py
+++ b/test/ci/invariants/test_common.py
@@ -456,6 +456,65 @@ def test_check_cs_state_transitions_observed_detects_no_status_entries():
     assert violations
 
 
+def test_check_cs_state_transitions_observed_no_vfd_passes_without_fix_ready():
+    """check_fix_ready=False skips VFd check — reject-flow scenario regression.
+
+    Reproduces the fcv-reject Invariant 15 failure (issue #2121): a scenario
+    where Vendor never participates produces no VFd observation, which triggered
+    a spurious violation when check_fix_ready was unconditional.
+    """
+    actor_id = "https://example.org/actors/coordinator"
+    h0 = _SHA256("no-vfd:0")
+    entry = _entry(
+        0,
+        h0,
+        GENESIS_HASH,
+        event_type="add_participant_status_to_participant",
+        payload={
+            "object": {
+                "attributedTo": actor_id,
+                "rmState": "ACCEPTED",
+                "emConsentState": "SIGNATORY",
+                "cvdRole": ["COORDINATOR"],
+                "vfdState": "vfd",  # no vendor → never VFd
+                "caseStatus": {"pxaState": "Pxa"},  # P-transition present
+            }
+        },
+    )
+    replicas = {"case-actor": [entry]}
+    violations = check_cs_state_transitions_observed(
+        replicas, check_fix_ready=False
+    )
+    assert not violations
+
+
+def test_check_cs_state_transitions_observed_no_vfd_still_requires_published():
+    """check_fix_ready=False still enforces the P-transition requirement."""
+    actor_id = "https://example.org/actors/coordinator"
+    h0 = _SHA256("no-vfd-no-p:0")
+    entry = _entry(
+        0,
+        h0,
+        GENESIS_HASH,
+        event_type="add_participant_status_to_participant",
+        payload={
+            "object": {
+                "attributedTo": actor_id,
+                "rmState": "ACCEPTED",
+                "emConsentState": "SIGNATORY",
+                "cvdRole": ["COORDINATOR"],
+                "vfdState": "vfd",
+                "caseStatus": {"pxaState": "pxa"},  # no P yet
+            }
+        },
+    )
+    replicas = {"case-actor": [entry]}
+    violations = check_cs_state_transitions_observed(
+        replicas, check_fix_ready=False
+    )
+    assert violations
+
+
 # ---------------------------------------------------------------------------
 # Positive-case (happy-path) tests using conftest fixtures
 # ---------------------------------------------------------------------------

--- a/test/ci/invariants/test_fcv_reject_invariants.py
+++ b/test/ci/invariants/test_fcv_reject_invariants.py
@@ -265,8 +265,17 @@ def test_invariant_14_no_gaps_in_log_indices(
 def test_invariant_15_cs_state_transitions_observed(
     fcv_reject_replicas: dict[str, list[dict]],
 ) -> None:
-    """All three key CS transitions observed in the authoritative log."""
-    violations = check_cs_state_transitions_observed(fcv_reject_replicas)
+    """P-transition (public aware) observed; VFd check skipped for reject-flow.
+
+    In the fcv-reject scenario Vendor rejects the case invitation and is never
+    added as a participant, so no actor advances the VFD state machine.
+    ``vfd_state == 'VFd'`` (fix ready) is therefore unreachable and is excluded
+    from this scenario's Invariant 15.  The P-transition (pxa_state starts with
+    'P') is still required — Coordinator triggers CS.P during publication.
+    """
+    violations = check_cs_state_transitions_observed(
+        fcv_reject_replicas, check_fix_ready=False
+    )
     assert not violations, "Missing CS-transition observations:\n" + "\n".join(
         violations
     )


### PR DESCRIPTION
- Closes #2121

## Summary

Invariant 15 in the `fcv-reject` harness was failing because
`check_cs_state_transitions_observed` unconditionally required
`vfd_state == 'VFd'` (fix ready). In the fcv-reject scenario Vendor rejects
the invitation and is never added as a participant, so no actor advances the
VFD state machine — `VFd` is structurally unreachable. The check was
copy-pasted from vendor-inclusive scenarios (DEMOCI-06-001 class of defect).

## Changes

- **`test/ci/invariants/common.py`**: Added keyword-only
  `check_fix_ready: bool = True` parameter to
  `check_cs_state_transitions_observed`. When `False`, the VFd check is
  skipped; the P-transition check is always enforced.
- **`test/ci/invariants/test_fcv_reject_invariants.py`**: Updated
  `test_invariant_15` to pass `check_fix_ready=False` with a docstring
  explaining the reject-flow rationale (VFd unreachable, Vendor never
  became a participant).
- **`test/ci/invariants/test_common.py`**: Added two regression tests:
  - `test_check_cs_state_transitions_observed_no_vfd_passes_without_fix_ready`
    — no false violation when VFd absent and `check_fix_ready=False`
  - `test_check_cs_state_transitions_observed_no_vfd_still_requires_published`
    — P-transition still enforced when `check_fix_ready=False`

## AC Checklist

- [x] AC-1: VFd is genuinely unreachable in fcv-reject; Option 2 from issue applied.
- [x] AC-2: Invariant 15 corrected for fcv-reject via `check_fix_ready=False`;
  rationale in docstring and `plan/incoming/learnings/`.
- [x] AC-3: All 8 other scenario invariant files audited — every other scenario
  calls `actor_notifies_fix_ready` in its demo so VFd is reachable there;
  no other copy-paste defect found.
- [x] AC-4: Unit + integration suites pass; `fcv-reject Invariant Harness` CI
  job will flip green.

## Verification

- 6459 unit tests pass (2 new), 1058 integration tests pass
- Black, flake8, mypy, pyright clean