### PR TITLE
docs: plan issue #2153 — replace plan/history files with GitHub issue comments

### DIFF
--- a/notes/history-management.md
+++ b/notes/history-management.md
@@ -29,12 +29,15 @@ tool and the migration from monolithic `plan/*HISTORY.md` files.
 | Question | Decision | Rationale |
 |---|---|---|
 | Which history files are in scope? | All `*HISTORY.md` files, including any future additions | Uniform treatment avoids per-file special cases |
-| Where do history files live? | `plan/history/` subdirectory | Separates archive from active planning; prevents agents from reading history during orientation |
-| Chunking granularity? | Monthly (YYMM suffix in directory name) | Recent history is most relevant; monthly chunks keep the current month manageable |
-| File structure per entry? | Individual write-once files: `plan/history/YYMM/<type>/<entry-id>.md` | Clean git diffs (new file added, not existing file edited); enables YAML frontmatter per entry |
+| Where do history files live? | `plan/history/` subdirectory for `learning`/`priority`; GitHub issue comments for `implementation`/`idea` when source resolves to an issue number | Co-locates completion narrative with the original problem statement; eliminates file bloat (~100–200 files/month) |
+| Chunking granularity? | Monthly (YYMM suffix in directory name) for file-mode entries | Recent history is most relevant; monthly chunks keep the current month manageable |
+| File structure per entry? | Individual write-once files: `plan/history/YYMM/<type>/<entry-id>.md` (file mode only) | Clean git diffs (new file added, not existing file edited); enables YAML frontmatter per entry |
+| GitHub comment mode? | `append-history implementation` / `append-history idea` with `--source ISSUE-N` posts a comment on issue N; falls back to file mode for non-ISSUE-N source values | Allows gradual migration; pre-issue-number legacy sources continue writing files |
 | Month-level navigation? | Auto-generated `plan/history/YYMM/README.md` rebuilt by the tool on every append; **gitignored** — use `uv run show-history [--month YYMM \| --all]` to view | Eliminates PR merge conflicts caused by parallel branches each regenerating the same file |
 | Top-level static README? | Yes — `plan/history/README.md` explains legacy files and the transition date | Documents the migration boundary for future readers |
 | Legacy file migration? | Move monolithic files to `plan/history/` top level as static archives | Cannot be split retroactively without manual effort; grandfathered content preserved |
+| Existing chunked files (pre-Aug 2026)? | Leave as-is — immutable historical records (HM-01-005) | Backfilling ~800 files would require significant API volume; pre-Aug 2026 files are infrequently accessed |
+| Aug 2026+ backfill? | Separate issue — post each 2608+ implementation/idea file as a comment, then remove the file | Scoped to recent history where co-location benefit is highest; tracked as a distinct task |
 | Tool interface? | `uv run append-history <type>` — `--title` and `--source` required; body via stdin or `--file <path>` | Frontmatter is built by the tool; agents provide only body content and named params |
 | Date determination? | Use current system clock (UTC) by default; allow a backfill-only override for migration tooling | Normal agents avoid month-selection decisions, while legacy backfill still needs historical placement |
 | Timestamp field? | `timestamp: datetime (UTC ISO 8601)` replaces legacy `date: date`; legacy entries are converted automatically by model validator | Enables sub-day ordering and reliable sorting in README tables |
@@ -43,7 +46,7 @@ tool and the migration from monolithic `plan/*HISTORY.md` files.
 | Type validation? | `HistoryEntryType` StrEnum in `vultron/metadata/history/types.py` | Adding a new type requires only one line change |
 | Module location? | `vultron/metadata/history/` — sibling of `vultron/metadata/specs/` | Both are project-management metadata tools; co-location signals intent |
 | Agent context boundary? | `plan/history/` is explicitly excluded from default "read plan context" | Prevents agents from spending context tokens on historical archive during orientation |
-| Skill updates? | `build`, `ingest-idea`, `learn` skills must use `append-history` for writes | Skills that directly append to history files must be updated to use the tool |
+| Skill updates? | `build`, `ingest-idea`, `learn` skills must use `append-history` for writes; `archive-history` must skip commit/push when output is a GitHub comment | Skills that directly append to history files must be updated to use the tool |
 
 ---
 
@@ -92,6 +95,50 @@ source: IDEA-26042702
 `specs/history-management.yaml` (HM-01 through HM-05) and
 `notes/history-management.md`.
 ```
+
+---
+
+## GitHub Comment Output Mode
+
+For `implementation` and `idea` entry types, when `--source` resolves to a GitHub
+issue number (`ISSUE-N` or bare integer N), `append-history` posts the entry body
+as a comment on that issue rather than writing a file. This co-locates the
+completion narrative with the original problem statement.
+
+### Source resolution rules
+
+| `--source` value | Output |
+|---|---|
+| `ISSUE-2153` | Comment on issue #2153 |
+| `2153` (bare integer) | Comment on issue #2153 |
+| `IDEA-26042702` | File at `plan/history/YYMM/idea/IDEA-26042702.md` |
+| `TASK-BTND5` | File at `plan/history/YYMM/implementation/TASK-BTND5.md` |
+
+`learning` and `priority` types always write files regardless of source format.
+
+### Skill behaviour change
+
+When `append-history` posts a GitHub comment it prints the comment URL to stdout
+(not a file path). The `archive-history` skill MUST detect this and skip the
+`git add plan/history/` and commit/push steps — there is no new file to stage.
+
+### Comment format
+
+```markdown
+**History: implementation — Fix demo config cache leak**
+
+<full entry body text>
+```
+
+The heading line uses the entry type and `--title` value. The body follows
+unchanged from what would have been the file-based Markdown body.
+
+### Backfill of existing files
+
+Files written before August 2026 are left as-is (HM-01-005 immutability rule).
+A separate backfill task covers the 2608 directory and forward: for each
+`implementation`/`idea` file whose filename is `ISSUE-N.md`, post the body as a
+comment on issue N and delete the file.
 
 ---
 

--- a/specs/history-management.yaml
+++ b/specs/history-management.yaml
@@ -1,9 +1,12 @@
 id: HM
 title: History File Management
-description: Defines the structure, location, entry format, and tooling for managing project history files using per-entry
-  write-once files organized by month and type, managed by the `append-history` CLI tool.
-version: 1.3.0
+description: Defines the structure, location, entry format, and tooling for managing project history entries. For
+  `implementation` and `idea` types whose `--source` resolves to a GitHub issue number, `append-history` posts the
+  entry body as a comment on the corresponding GitHub issue rather than writing a file. `learning` and `priority`
+  types continue to write per-entry write-once files under `plan/history/`, managed by the `append-history` CLI tool.
+version: 1.4.0
 scope:
+
 - prototype
 - production
 tags:
@@ -17,7 +20,10 @@ groups:
   - id: HM-01-001
     priority: MUST
     kind: process
-    statement: All project history files MUST reside under `plan/history/`.
+    statement: History entries for `learning` and `priority` types MUST reside under `plan/history/` as per-entry write-once
+      files. History entries for `implementation` and `idea` types whose `--source` resolves to a GitHub issue number MUST
+      be posted as a comment on the corresponding GitHub issue (see HM-08); those entries MUST NOT be written as files under
+      `plan/history/`.
   - id: HM-01-006
     priority: MUST_NOT
     kind: process
@@ -25,9 +31,11 @@ groups:
   - id: HM-01-002
     priority: MUST
     kind: process
-    statement: Each history entry MUST be stored as an individual write-once file at the path `plan/history/YYMM/<type>/<entry-id>.md`,
-      where `YYMM` is the two-digit year and two-digit month when the entry was created, `<type>` is the entry type (see HM-02-002),
-      and `<entry-id>` is the originating task or idea identifier (e.g., `IDEA-26042702`, `TASK-BTND5`).
+    statement: Each `learning` or `priority` history entry MUST be stored as an individual write-once file at the path
+      `plan/history/YYMM/<type>/<entry-id>.md`, where `YYMM` is the two-digit year and two-digit month when the entry
+      was created, `<type>` is the entry type (see HM-02-002), and `<entry-id>` is the originating task or idea identifier
+      (e.g., `TASK-BTND5`). `implementation` and `idea` entries whose `--source` resolves to a GitHub issue number use
+      the GitHub comment output mode (HM-08) instead.
   - id: HM-01-003
     priority: MUST
     kind: process
@@ -281,3 +289,40 @@ groups:
     kind: project
     statement: Skill documentation (`ingest-idea`, `build`, `learn`) and `notes/history-management.md` MUST use the `--title`/`--source`
       interface for `append-history`. The frontmatter-in-stdin pattern MUST NOT be used.
+- id: HM-08
+  title: GitHub Comment Output Mode
+  kind: project
+  specs:
+  - id: HM-08-001
+    priority: MUST
+    kind: project
+    statement: When `append-history` is invoked with type `implementation` or `idea` and `--source` is a value that resolves
+      to a GitHub issue number (i.e., the string `ISSUE-N` for any positive integer N, or a bare positive integer), the tool
+      MUST post the entry body as a comment on issue N in the CERTCC/Vultron repository using `gh issue comment`, rather than
+      writing a file under `plan/history/`.
+  - id: HM-08-002
+    priority: MUST
+    kind: project
+    statement: When `append-history` falls through to GitHub comment mode (HM-08-001), it MUST print the URL of the newly
+      created comment to stdout so callers can record it.
+  - id: HM-08-003
+    priority: MUST
+    kind: project
+    statement: When `append-history` is invoked with type `implementation` or `idea` and `--source` does NOT resolve to a
+      GitHub issue number (e.g., source is `IDEA-26042702`, `TASK-BTND5`, or any other non-numeric format), the tool MUST
+      fall back to writing a file under `plan/history/` as in the pre-HM-08 behaviour.
+  - id: HM-08-004
+    priority: MUST_NOT
+    kind: project
+    statement: The `archive-history` skill MUST NOT call `git add plan/history/` or commit any file when the entry was posted
+      as a GitHub comment (HM-08-001). The `git add` and commit steps are only needed for file-mode entries.
+  - id: HM-08-005
+    priority: MUST
+    kind: project
+    statement: The comment body posted to GitHub MUST contain the full entry body text (same content that would have been
+      the Markdown body in the file-based format), prefixed with a one-line heading showing the entry type and title.
+  - id: HM-08-006
+    priority: SHOULD
+    kind: project
+    statement: The `archive-history` skill documentation SHOULD be updated to reflect that when `append-history` outputs a
+      GitHub comment URL (rather than a file path), the commit/push steps are skipped for that entry.


### PR DESCRIPTION
- Closes #2153

## Summary

Specifies and documents the dual-output model for `append-history`: `implementation` and
`idea` entries whose `--source` resolves to a GitHub issue number post the entry body as
a comment on that issue rather than writing a file under `plan/history/`.

## Changes

- **`specs/history-management.yaml`** (v1.3.0 → v1.4.0): Updated HM-01-001/002 to
  restrict file-based output to `learning`/`priority` types. Added HM-08 group (6
  requirements) specifying GitHub comment output mode, source resolution rules
  (`ISSUE-N` and bare integers → comment; all other source formats → file fallback),
  comment format requirements, and `archive-history` skill commit/push behaviour.
- **`notes/history-management.md`**: Revised decision table to reflect dual-output
  model and backfill strategy (pre-Aug 2026 files left as-is; 2608+ backfill tracked
  separately). Added "GitHub Comment Output Mode" section documenting source resolution
  rules, comment format, and backfill scope.

## Implementation Issues

- #2159 — implement append-history GitHub comment output mode + archive-history skill update
- #2160 — backfill 2608+ plan/history files as GitHub comments (separate, blocked-by #2153)