### PR TITLE
Implement GitHub comment output mode in append-history

### DIFF
--- a/.agents/skills/archive-history/SKILL.md
+++ b/.agents/skills/archive-history/SKILL.md
@@ -38,30 +38,52 @@ The caller provides four pieces of information (see the calling skill for body f
 ### Step 1 — Pipe entry body to `append-history`
 
 ```bash
-cat <<'ENDOFENTRY' | uv run append-history <TYPE> \
+HISTORY_OUTPUT=$(cat <<'ENDOFENTRY' | uv run append-history <TYPE> \
     --title "<TITLE>" \
     --source "<SOURCE>"
 
 <Full entry body — include PR URL, impl issue links, and outcome summary>
 
 ENDOFENTRY
+)
 ```
 
-The tool writes `plan/history/YYMM/<type>/<source>.md` and regenerates
-`plan/history/YYMM/README.md` locally (the README is gitignored).
+Capture the output in `HISTORY_OUTPUT`. The tool either:
 
-### Step 2 — Lint the new history files
+- **File mode**: writes `plan/history/YYMM/<type>/<source>.md`, regenerates
+  the local `plan/history/YYMM/README.md` (gitignored), and prints the file
+  path to stdout.
+- **GitHub comment mode** (`implementation`/`idea` with `--source ISSUE-N`):
+  posts a comment on the issue and prints the comment URL to stdout
+  (starts with `https://`). No file is written.
+
+### Step 2 — Check output mode
+
+```bash
+if [[ "$HISTORY_OUTPUT" == https://* ]]; then
+    echo "Posted as GitHub comment: $HISTORY_OUTPUT"
+    # Skip Steps 3–5 (no file was written).
+    exit 0
+fi
+```
+
+If the output is a URL, the entry was posted as a GitHub comment — skip
+all `git` steps (HM-08-004). Record the URL for the caller's reference.
+
+### Step 3 — Lint the new history files
+
+Only reached when a file was written:
 
 ```bash
 markdownlint-cli2 --fix --config .markdownlint-cli2.yaml \
   "plan/history/$(date +%y%m)/**/*.md"
 ```
 
-### Step 3 — Stage and commit
+### Step 4 — Stage and commit
 
 ```bash
 git add plan/history/
-uv run git commit -m "history: archive <TYPE> <SOURCE> — <TITLE>
+git commit -m "history: archive <TYPE> <SOURCE> — <TITLE>
 
 Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ```
@@ -69,7 +91,7 @@ Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"
 The `Co-authored-by` trailer is **required** on this commit just as on all
 others — the history commit is the most commonly missing it.
 
-### Step 4 — Push
+### Step 5 — Push
 
 ```bash
 git push "https://x-access-token:$(gh auth token)@github.com/CERTCC/Vultron.git" HEAD
@@ -81,6 +103,8 @@ git push "https://x-access-token:$(gh auth token)@github.com/CERTCC/Vultron.git"
 
 - **Always call after PR creation** — include the PR URL in the entry body.
 - **One entry per invocation** — for multiple entries, call this skill in a loop.
-- **Do not call `git push` separately** — this skill always pushes as its final step.
+- **Skip git steps when output is a URL** — GitHub comment mode writes no file;
+  `git add`, commit, and push are not needed (HM-08-004, HM-08-006).
+- **Do not call `git push` separately** — this skill always pushes as its final step (file mode only).
 - **Do not amend** — open a new commit via a fresh invocation rather than amending.
 - History files are **immutable** once pushed.

--- a/test/metadata/test_append_history.py
+++ b/test/metadata/test_append_history.py
@@ -3,7 +3,8 @@
 Covers: HM-03-001 through HM-03-006 (entry creation, README regeneration,
 type validation, stdin mode, --file mode), HM-06-001 through HM-06-005
 (timestamp field, future-date rejection), HM-07-001 through HM-07-003
-(--title, --source CLI params).
+(--title, --source CLI params), HM-08-001 through HM-08-005 (GitHub comment
+output mode).
 """
 
 from __future__ import annotations
@@ -745,3 +746,196 @@ class TestSignalFlag:
         assert result.returncode == 0
         content = Path(result.stdout.strip()).read_text()
         assert "signal: spec-gap" in content
+
+
+class TestResolveIssueNumber:
+    """Unit tests for _resolve_issue_number (HM-08-001, HM-08-003)."""
+
+    def test_issue_prefix_resolves(self) -> None:
+        from vultron.metadata.history.cli import _resolve_issue_number
+
+        assert _resolve_issue_number("ISSUE-2159") == 2159
+
+    def test_issue_prefix_case_insensitive(self) -> None:
+        from vultron.metadata.history.cli import _resolve_issue_number
+
+        assert _resolve_issue_number("issue-42") == 42
+
+    def test_bare_integer_resolves(self) -> None:
+        from vultron.metadata.history.cli import _resolve_issue_number
+
+        assert _resolve_issue_number("123") == 123
+
+    def test_idea_source_returns_none(self) -> None:
+        from vultron.metadata.history.cli import _resolve_issue_number
+
+        assert _resolve_issue_number("IDEA-26042702") is None
+
+    def test_task_source_returns_none(self) -> None:
+        from vultron.metadata.history.cli import _resolve_issue_number
+
+        assert _resolve_issue_number("TASK-BTND5") is None
+
+    def test_zero_returns_none(self) -> None:
+        from vultron.metadata.history.cli import _resolve_issue_number
+
+        assert _resolve_issue_number("0") is None
+
+    def test_negative_returns_none(self) -> None:
+        from vultron.metadata.history.cli import _resolve_issue_number
+
+        assert _resolve_issue_number("-1") is None
+
+    def test_empty_string_returns_none(self) -> None:
+        from vultron.metadata.history.cli import _resolve_issue_number
+
+        assert _resolve_issue_number("") is None
+
+    def test_alphanumeric_source_returns_none(self) -> None:
+        from vultron.metadata.history.cli import _resolve_issue_number
+
+        assert _resolve_issue_number("CONCERN-507") is None
+
+
+class TestGitHubCommentMode:
+    """HM-08-001 through HM-08-005: GitHub comment output mode."""
+
+    def _run_with_mock_gh(
+        self,
+        entry_type: str,
+        source: str,
+        body: str = "Entry body.\n",
+        title: str = "Test Title",
+        gh_returncode: int = 0,
+        gh_stdout: str = "https://github.com/CERTCC/Vultron/issues/2159#issuecomment-9999",
+        gh_stderr: str = "",
+    ) -> _RunResult:
+        """Run append-history with a mocked ``gh`` subprocess call."""
+        from unittest.mock import MagicMock
+
+        mock_result = MagicMock()
+        mock_result.returncode = gh_returncode
+        mock_result.stdout = gh_stdout
+        mock_result.stderr = gh_stderr
+
+        with patch(
+            "vultron.metadata.history.cli.subprocess.run",
+            return_value=mock_result,
+        ):
+            return _run_append(
+                entry_type, body=body, title=title, source=source
+            )
+
+    def test_implementation_issue_source_posts_comment(
+        self, fake_repo: Path
+    ) -> None:
+        """implementation + ISSUE-N source posts a comment (HM-08-001)."""
+        result = self._run_with_mock_gh("implementation", "ISSUE-2159")
+        assert result.returncode == 0
+
+    def test_idea_issue_source_posts_comment(self, fake_repo: Path) -> None:
+        """idea + ISSUE-N source posts a comment (HM-08-001)."""
+        result = self._run_with_mock_gh("idea", "ISSUE-42")
+        assert result.returncode == 0
+
+    def test_prints_comment_url_to_stdout(self, fake_repo: Path) -> None:
+        """Comment URL is printed to stdout (HM-08-002)."""
+        url = "https://github.com/CERTCC/Vultron/issues/2159#issuecomment-9999"
+        result = self._run_with_mock_gh(
+            "implementation", "ISSUE-2159", gh_stdout=url
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == url
+
+    def test_bare_integer_source_posts_comment(self, fake_repo: Path) -> None:
+        """Bare integer source is treated as an issue number (HM-08-001)."""
+        result = self._run_with_mock_gh("implementation", "2159")
+        assert result.returncode == 0
+
+    def test_non_issue_source_writes_file(self, fake_repo: Path) -> None:
+        """Non-ISSUE-N source falls back to file mode (HM-08-003)."""
+        result = _run_append(
+            "implementation",
+            body=_IMPL_BODY,
+            title=_IMPL_TITLE,
+            source="TASK-BTND5",
+        )
+        assert result.returncode == 0
+        written = Path(result.stdout.strip())
+        assert written.exists()
+        assert written.suffix == ".md"
+
+    def test_idea_non_issue_source_writes_file(self, fake_repo: Path) -> None:
+        """idea + non-ISSUE source falls back to file mode (HM-08-003)."""
+        result = _run_append(
+            "idea",
+            body=_IDEA_BODY,
+            title=_DEFAULT_TITLE,
+            source="IDEA-26042702",
+        )
+        assert result.returncode == 0
+        assert Path(result.stdout.strip()).exists()
+
+    def test_learning_issue_source_writes_file(self, fake_repo: Path) -> None:
+        """learning type always writes a file regardless of source (HM-08-001)."""
+        result = _run_append(
+            "learning",
+            body=_IDEA_BODY,
+            title="Learning entry",
+            source="ISSUE-123",
+        )
+        assert result.returncode == 0
+        written = Path(result.stdout.strip())
+        assert written.exists()
+        assert written.suffix == ".md"
+
+    def test_comment_body_has_heading(self, fake_repo: Path) -> None:
+        """Comment body is prefixed with **History: <type> — <title>** (HM-08-005)."""
+        from unittest.mock import MagicMock
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = (
+            "https://github.com/CERTCC/Vultron/issues/2159#issuecomment-9999"
+        )
+        mock_result.stderr = ""
+
+        with patch(
+            "vultron.metadata.history.cli.subprocess.run",
+            return_value=mock_result,
+        ) as mock_run:
+            _run_append(
+                "implementation",
+                body="My implementation summary.\n",
+                title="Fix demo config cache leak",
+                source="ISSUE-2159",
+            )
+
+        assert mock_run.called
+        _, kwargs = mock_run.call_args
+        args_passed = mock_run.call_args[0][0]
+        body_idx = args_passed.index("--body") + 1
+        posted_body = args_passed[body_idx]
+        assert posted_body.startswith(
+            "**History: implementation — Fix demo config cache leak**"
+        )
+        assert "My implementation summary." in posted_body
+
+    def test_gh_failure_exits_nonzero(self, fake_repo: Path) -> None:
+        """A non-zero exit from gh causes append-history to exit non-zero."""
+        result = self._run_with_mock_gh(
+            "implementation",
+            "ISSUE-2159",
+            gh_returncode=1,
+            gh_stderr="authentication required",
+        )
+        assert result.returncode != 0
+
+    def test_no_file_written_on_comment_mode(self, fake_repo: Path) -> None:
+        """GitHub comment mode must NOT write a file under plan/history/."""
+        self._run_with_mock_gh("implementation", "ISSUE-2159")
+        history_dir = fake_repo / "plan" / "history"
+        md_files = (
+            list(history_dir.rglob("*.md")) if history_dir.exists() else []
+        )
+        assert not md_files, "No files should be written in comment mode"

--- a/vultron/metadata/history/cli.py
+++ b/vultron/metadata/history/cli.py
@@ -44,6 +44,8 @@ from __future__ import annotations
 
 import argparse
 import datetime
+import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import NoReturn
@@ -344,6 +346,75 @@ def append_history_entry(
     return entry_file
 
 
+_ISSUE_NUMBER_RE = re.compile(r"^(?:ISSUE-)?(\d+)$", re.IGNORECASE)
+
+_GITHUB_COMMENT_TYPES = frozenset(
+    {HistoryEntryType.implementation, HistoryEntryType.idea}
+)
+
+
+def _resolve_issue_number(source: str) -> int | None:
+    """Return a GitHub issue number if *source* resolves to one, else None.
+
+    Accepts ``ISSUE-N`` (case-insensitive) or a bare positive integer.
+    Returns ``None`` for all other formats (HM-08-001, HM-08-003).
+    """
+    m = _ISSUE_NUMBER_RE.match(source.strip())
+    if m is None:
+        return None
+    n = int(m.group(1))
+    return n if n > 0 else None
+
+
+def _post_github_comment(
+    issue_number: int,
+    entry_type: HistoryEntryType,
+    title: str,
+    body: str,
+) -> str:
+    """Post a GitHub comment and return the comment URL.
+
+    The comment body is prefixed with a heading line per HM-08-005:
+    ``**History: <type> — <title>**``
+
+    Args:
+        issue_number: GitHub issue number.
+        entry_type: History entry type (``implementation`` or ``idea``).
+        title: Entry title from ``--title``.
+        body: Entry body text (no frontmatter).
+
+    Returns:
+        The URL of the newly created comment.
+
+    Raises:
+        RuntimeError: If the ``gh`` CLI invocation fails.
+    """
+    heading = f"**History: {entry_type.value} — {title}**"
+    comment_body = f"{heading}\n\n{body}"
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            "CERTCC/Vultron",
+            "--body",
+            comment_body,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh issue comment failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+    # ``gh issue comment`` prints the comment URL to stdout.
+    url = result.stdout.strip()
+    return url
+
+
 def _fail(message: str, *, exit_code: int = 1) -> NoReturn:
     print(f"Error: {message}", file=sys.stderr)
     sys.exit(exit_code)
@@ -460,17 +531,8 @@ def _handle_from_file_mode(source_path: Path) -> None:
     print(str(entry_file))
 
 
-def main() -> None:
-    """Entry point for ``uv run append-history``."""
-    parser = _build_parser()
-    args = parser.parse_args()
-
-    if args.from_file is not None:
-        _check_from_file_conflicts(args)
-        _handle_from_file_mode(Path(args.from_file))
-        return
-
-    # Normal mode — require entry_type, --title, --source.
+def _handle_normal_mode(args: argparse.Namespace) -> None:
+    """Execute the normal (non-from-file) append-history flow."""
     if not args.entry_type:
         _fail(
             "entry type is required when --from-file is not provided. "
@@ -485,6 +547,20 @@ def main() -> None:
     body = _read_body(args.file)
     timestamp = _parse_timestamp(args.timestamp)
     signal = _parse_signal(args.signal, entry_type)
+
+    # GitHub comment mode: implementation/idea with an ISSUE-N source (HM-08-001).
+    if (
+        entry_type in _GITHUB_COMMENT_TYPES
+        and (issue_number := _resolve_issue_number(args.source)) is not None
+    ):
+        try:
+            url = _post_github_comment(
+                issue_number, entry_type, args.title, body
+            )
+        except RuntimeError as exc:
+            _fail(str(exc))
+        print(url)
+        return
 
     try:
         content = _build_content(
@@ -505,6 +581,19 @@ def main() -> None:
         _fail(str(exc))
 
     print(str(entry_file))
+
+
+def main() -> None:
+    """Entry point for ``uv run append-history``."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.from_file is not None:
+        _check_from_file_conflicts(args)
+        _handle_from_file_mode(Path(args.from_file))
+        return
+
+    _handle_normal_mode(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Closes #2159

## Summary

Implements HM-08 spec: `append-history implementation/idea --source ISSUE-N` now posts the entry body as a `gh issue comment` on the corresponding issue instead of writing a file, and prints the comment URL to stdout. All other source formats and entry types continue to write files unchanged.

## Changes

- **`vultron/metadata/history/cli.py`**: add `_resolve_issue_number()` (ISSUE-N and bare-int detection), `_post_github_comment()` (calls `gh issue comment`, returns URL, raises on failure), `_handle_normal_mode()` (extracted from `main()` to reduce C901 complexity, contains the comment-mode branch); `main()` simplified to dispatch
- **`.agents/skills/archive-history/SKILL.md`**: capture `append-history` output; skip `git add`/commit/push when output starts with `https://` (HM-08-004, HM-08-006)
- **`test/metadata/test_append_history.py`**: add `TestResolveIssueNumber` (9 cases) and `TestGitHubCommentMode` (10 cases) covering HM-08-001 through HM-08-005

## Verification

- All 78 unit tests in `test/metadata/test_append_history.py` pass (19 new)
- Full unit suite: 6476 passed, 362 skipped, 2 xfailed
- Integration suite: 1058 passed
- Black, flake8, mypy, pyright all clean