### PR TITLE
Link BTC-03-001 rationale to 'The Tree Is the Documentation' invariant

### DIFF
--- a/notes/use-case-behavior-trees.md
+++ b/notes/use-case-behavior-trees.md
@@ -6,6 +6,7 @@ description: >
   trees; documents where each concern belongs.
 related_specs:
   - specs/code-style.yaml
+  - specs/bt-composability.yaml
 related_notes:
   - notes/bt-integration.md
   - notes/domain-model-separation.md
@@ -38,7 +39,9 @@ BT node or subtree, it is **invisible to analysis, audit, and explainability
 tools**.
 
 This is not a style preference. It is the design invariant that makes
-Vultron's process inspectable without reading implementation code.
+Vultron's process inspectable without reading implementation code. The
+enforceable form of this invariant is `BTC-03-001` in
+`specs/bt-composability.yaml`.
 
 ### Procedural Glue vs. Domain Logic
 

--- a/plan/history/2608/implementation/ISSUE-2163.md
+++ b/plan/history/2608/implementation/ISSUE-2163.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-2163
+timestamp: '2026-08-10T21:01:05.660363+00:00'
+title: Link BTC-03 spec to tree-is-documentation invariant
+type: implementation
+---
+
+## Issue #2163 — Link BTC-03-001 rationale to 'The Tree Is the Documentation' invariant
+
+Added bidirectional cross-references between `specs/bt-composability.yaml` (BTC-03-001) and `notes/use-case-behavior-trees.md`.
+
+- Extended `BTC-03-001.rationale` with a "See also" pointer to the note section
+- Added `specs/bt-composability.yaml` to `related_specs` frontmatter in the note
+- Added one sentence in the note body citing `BTC-03-001` as the enforceable form
+
+PR: <https://github.com/CERTCC/Vultron/pull/2164>

--- a/specs/bt-composability.yaml
+++ b/specs/bt-composability.yaml
@@ -77,7 +77,9 @@ groups:
     statement: Behavioral logic that belongs inside a BT MUST be expressed using BT composite idioms (Sequence, Selector/Fallback,
       Decorator) rather than procedural `if`/`else` chains.
     rationale: BT idioms make logic auditable, extractable, and explainable by anyone who can read the tree structure, without
-      reading implementation code. Procedural logic inside `update()` is opaque.
+      reading implementation code. Procedural logic inside `update()` is opaque. See also
+      notes/use-case-behavior-trees.md section "The Tree Is the Documentation" for the
+      design invariant that gives this rule its purpose.
     relationships:
     - rel_type: refines
       spec_id: BT-06-001


### PR DESCRIPTION
- Closes #2163

## Summary

Adds bidirectional cross-references between `specs/bt-composability.yaml` (BTC-03-001) and `notes/use-case-behavior-trees.md` (§ "The Tree Is the Documentation").

## Changes

- **`specs/bt-composability.yaml`**: extends `BTC-03-001.rationale` with a "See also" pointer to the note section. The `relationships` field cannot hold external file references (`spec_id` is validated against `SpecIdStr` pattern `^[A-Z]{2,8}(-\d{2}(-\d{3})?)?$`), so prose is the only schema-valid path.
- **`notes/use-case-behavior-trees.md`**: adds `specs/bt-composability.yaml` to `related_specs` frontmatter, and adds one sentence in the invariant section body citing `BTC-03-001` as the enforceable form.

## Verification

- `PYTHONPATH= uv run spec-dump` — succeeds (YAML valid, schema valid)
- `uv run pre-commit run validate-notes-frontmatter` — Passed
- `uv run pytest --tb=short` — passed
- All linters clean (black, flake8, mypy, pyright)