### PR TITLE
fix(demo): gate Vendor RM triage on Finder having case replica (Bug #2135)

### DIFF
--- a/plan/history/2608/implementation/ISSUE-2135.md
+++ b/plan/history/2608/implementation/ISSUE-2135.md
@@ -1,0 +1,22 @@
+---
+source: ISSUE-2135
+timestamp: '2026-08-10T21:13:37.393493+00:00'
+title: 'fix(demo): gate Vendor RM triage on Finder having case replica (Bug #2135)'
+type: implementation
+---
+
+Closes #2135. The `fcv` demo scenario failed with CLP-08-005 (`ReconstructChainTail`) on
+the Finder because `_phase_invite_vendor()` called `run_invite_path_rm_triage()` for Vendor
+before confirming the Finder's DataLayer had the `VulnerabilityCase` genesis seed. When
+Vendor's RM triage broadcasts `Announce(CaseLedgerEntry)` to all participants, the Finder
+received entries before `dl.read(case_id)` could return the case — making the genesis hash
+unavailable (CLP-08-005, fail-closed).
+
+Fix: add `wait_for_case_on_container(finder_client, case.id_)` before
+`run_invite_path_rm_triage` in `_phase_invite_vendor()`, and thread `finder_client` as a
+new parameter. Matches the pattern from PR #2127 for `fcvcv_demo.py`.
+
+Added `TestFinderCaseReplicaWaitBeforeVendorTriage` regression class (3 tests) verifying
+the ordering invariant (spec CLP-08-005).
+
+PR: <https://github.com/CERTCC/Vultron/pull/2166>

--- a/plan/history/2608/implementation/ISSUE-2135.md
+++ b/plan/history/2608/implementation/ISSUE-2135.md
@@ -16,7 +16,7 @@ Fix: add `wait_for_case_on_container(finder_client, case.id_)` before
 `run_invite_path_rm_triage` in `_phase_invite_vendor()`, and thread `finder_client` as a
 new parameter. Matches the pattern from PR #2127 for `fcvcv_demo.py`.
 
-Added `TestFinderCaseReplicaWaitBeforeVendorTriage` regression class (3 tests) verifying
+Added `TestFinderCaseReplicaWaitBeforeVendorTriage` regression class (2 tests) verifying
 the ordering invariant (spec CLP-08-005).
 
 PR: <https://github.com/CERTCC/Vultron/pull/2166>

--- a/plan/incoming/learnings/20260810-clp-08-005-protocol-hardening-gap.md
+++ b/plan/incoming/learnings/20260810-clp-08-005-protocol-hardening-gap.md
@@ -1,0 +1,31 @@
+---
+title: Protocol gap — no buffering for Announce(CaseLedgerEntry) when case not yet seeded
+type: learning
+timestamp: 2026-08-10
+source: ISSUE-2135
+signal: concern
+---
+
+During Bug #2135 (fcv demo CLP-08-005 race), the root cause analysis revealed
+a deeper protocol gap: the implementation has no recovery path for
+`Announce(CaseLedgerEntry)` arriving before the actor's `VulnerabilityCase`
+genesis seed (i.e. `dl.read(case_id)` returns `None`).
+
+ADR-0037 (`LedgerGapBuffer`) handles out-of-order entries among entries for a
+known case, but it does not address the pre-genesis window where the case
+object itself is absent.  The current behavior is fail-closed (CLP-08-005 /
+`VultronValidationError`), which is correct but lossy: the entry is dropped
+and the Finder must rely on a `Reject → replay` loop to recover.
+
+In the demo, this is fixed with a `wait_for_case_on_container` ordering guard.
+In production, however, the race window is a real protocol gap: a participant
+who receives `Announce(CaseLedgerEntry)` before their `Create(VulnerabilityCase)`
+(e.g. due to delivery reordering) silently drops the entry and may diverge.
+
+**Suggested approach**: extend `LedgerGapBuffer` (or add a parallel
+"pre-genesis buffer") to hold `Announce(CaseLedgerEntry)` activities when
+`dl.read(case_id)` returns `None`, and drain them once the
+`Create(VulnerabilityCase)` handler seeds the case.  This would close the
+race completely without relying on demo-level polling guards.
+
+A GitHub Bug/Concern issue should be filed to track this.

--- a/test/demo/test_fcv_demo.py
+++ b/test/demo/test_fcv_demo.py
@@ -513,3 +513,132 @@ class TestFcvMilestoneAssertions:
                 case=case,
             )
         mock_m7.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for Bug #2135: CLP-08-005 unanchored chain bootstrap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spec("CLP-08-005")
+class TestFinderCaseReplicaWaitBeforeVendorTriage:
+    """_phase_invite_vendor must confirm the Finder has the case replica
+    before calling run_invite_path_rm_triage for Vendor (Bug #2135).
+
+    Vendor's RM triage broadcasts Announce(CaseLedgerEntry) to all
+    participants including the Finder.  If the Finder's DataLayer does not
+    yet hold the VulnerabilityCase (genesis hash unavailable), the chain
+    bootstrap fails with CLP-08-005.
+    """
+
+    @staticmethod
+    def _actor(id_: str = "urn:test:actor"):
+        a = MagicMock()
+        a.id_ = id_
+        return a
+
+    @staticmethod
+    def _case(id_: str = "urn:test:case"):
+        c = MagicMock()
+        c.id_ = id_
+        return c
+
+    @staticmethod
+    def _client():
+        c = MagicMock()
+        c.get.return_value = {}
+        return c
+
+    def test_finder_client_in_signature(self):
+        """_phase_invite_vendor must accept finder_client as a parameter."""
+        import inspect
+
+        sig = inspect.signature(demo._phase_invite_vendor)
+        assert "finder_client" in sig.parameters, (
+            "_phase_invite_vendor must accept finder_client to gate Vendor RM "
+            "triage on the Finder having the case replica (Bug #2135)"
+        )
+
+    def test_finder_wait_before_vendor_triage(self):
+        """wait_for_case_on_container(finder_client) precedes run_invite_path_rm_triage."""
+        import contextlib
+
+        finder_client = self._client()
+        coordinator_client = self._client()
+        vendor_client = self._client()
+        coordinator_in_coordinator = self._actor("urn:test:coordinator")
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        finder = self._actor("urn:test:finder")
+        case = self._case("urn:test:case")
+
+        call_order: list[str] = []
+
+        def _wait_for_case(client, case_id, **_kwargs):
+            if client is finder_client:
+                call_order.append("finder_wait")
+
+        def _triage(**_kwargs):
+            call_order.append("triage")
+
+        with (
+            patch.object(
+                demo, "wait_for_case_on_container", side_effect=_wait_for_case
+            ),
+            patch.object(
+                demo, "run_invite_path_rm_triage", side_effect=_triage
+            ),
+            patch.object(
+                demo,
+                "post_to_trigger",
+                return_value={
+                    "activity": {"id": "urn:test:act", "type": "Offer"}
+                },
+            ),
+            patch.object(demo, "wait_for_case_participants"),
+            patch.object(demo, "find_case_invite_for_actor"),
+            patch.object(
+                demo, "get_actor_by_id", return_value=vendor_in_vendor
+            ),
+            patch.object(demo, "as_TransitiveActivity") as mock_ta,
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+            patch.object(
+                demo,
+                "demo_step",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            mock_ta.model_validate.return_value = MagicMock(
+                id_="urn:test:invite"
+            )
+            demo._phase_invite_vendor(
+                coordinator_client=coordinator_client,
+                vendor_client=vendor_client,
+                finder_client=finder_client,
+                coordinator_in_coordinator=coordinator_in_coordinator,
+                vendor=vendor,
+                case=case,
+                offer=MagicMock(id_="urn:test:offer"),
+                report=MagicMock(),
+                finder=finder,
+            )
+
+        assert (
+            "finder_wait" in call_order
+        ), "wait_for_case_on_container(finder_client) was never called before Vendor triage"
+        assert (
+            "triage" in call_order
+        ), "run_invite_path_rm_triage was never called"
+        finder_idx = next(
+            i for i, v in enumerate(call_order) if v == "finder_wait"
+        )
+        triage_idx = next(i for i, v in enumerate(call_order) if v == "triage")
+        assert finder_idx < triage_idx, (
+            f"Finder case-replica wait (index {finder_idx}) must come BEFORE "
+            f"run_invite_path_rm_triage (index {triage_idx}). "
+            f"Call order: {call_order} — Bug #2135 (CLP-08-005)"
+        )

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -259,6 +259,7 @@ def _phase_report_submission(
 def _phase_invite_vendor(
     coordinator_client: DataLayerClient,
     vendor_client: DataLayerClient,
+    finder_client: DataLayerClient,
     coordinator_in_coordinator: as_Actor,
     vendor: as_Actor,
     case: as_VulnerabilityCase,
@@ -325,6 +326,16 @@ def _phase_invite_vendor(
         timeout_seconds=20.0,
     )
     logger.info("✓ M2: Vendor joined case (4 participants)")
+
+    # Gate: Finder must have the case replica before Vendor's RM triage
+    # broadcasts Announce(CaseLedgerEntry) to all participants (CLP-08-005).
+    with demo_check("Finder's DataLayer received case replica"):
+        wait_for_case_on_container(
+            client=finder_client,
+            case_id=case.id_,
+            timeout_seconds=20.0,
+        )
+    logger.info("Finder received case replica")
 
     # CM-11-002: Vendor joined via invite-accept — run standard RM triage cycle.
     run_invite_path_rm_triage(
@@ -790,6 +801,7 @@ def run_fcv_demo(
     vendor_in_vendor = _phase_invite_vendor(
         coordinator_client=coordinator_client,
         vendor_client=vendor_client,
+        finder_client=finder_client,
         coordinator_in_coordinator=coordinator_in_coordinator,
         vendor=vendor_obj,
         case=case,


### PR DESCRIPTION
- Closes #2135

## Summary

`_phase_invite_vendor()` in `fcv_demo.py` called `run_invite_path_rm_triage()` for Vendor without first confirming the Finder had received its `VulnerabilityCase` genesis seed. When Vendor's RM triage broadcasts `Announce(CaseLedgerEntry)` to all participants, the Finder received entries before `dl.read(case_id)` could return the case object — making the genesis hash unavailable and raising CLP-08-005 (unanchored chain bootstrap, fail-closed).

## Changes

- **`vultron/demo/scenario/fcv_demo.py`**: Add `finder_client` parameter to `_phase_invite_vendor()`; add `wait_for_case_on_container(finder_client, case.id_)` before `run_invite_path_rm_triage()`; thread `finder_client` through from `run_fcv_demo()` call site
- **`test/demo/test_fcv_demo.py`**: Add `TestFinderCaseReplicaWaitBeforeVendorTriage` regression class with 2 tests verifying the ordering invariant (spec CLP-08-005)

## Verification

- 24 integration tests pass (2 new in `TestFinderCaseReplicaWaitBeforeVendorTriage`)
- 6361 unit tests pass
- Black, flake8, mypy, pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)