### PR TITLE
fix(ownership-transfer): forward Offer via CaseActor outbox (fix #2142)

### DIFF
--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -102,7 +102,7 @@ Extend to:
 
 1. Store the Offer object (existing behaviour — keep it).
 2. Commit a `CaseLedgerEntry` recording the offer.
-3. Forward the Offer to the transferee's inbox (new behaviour).
+3. Forward the Offer to the transferee's inbox.
 
 **Forwarded-Offer wire format** (CM-21-005, mirrors Invite-flow analogy):
 

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -104,6 +104,20 @@ Extend to:
 2. Commit a `CaseLedgerEntry` recording the offer.
 3. Forward the Offer to the transferee's inbox (new behaviour).
 
+**Forwarded-Offer wire format** (CM-21-005, mirrors Invite-flow analogy):
+
+```
+Offer(VulnerabilityCase,
+    actor        = case_actor_id,       ← CaseActor is the sender
+    attributed_to = original_actor_id,  ← Vendor1's intent carried forward
+    target       = transferee_id,
+    to           = [transferee_id],     ← MUST be set (delivery requirement)
+)
+```
+
+`attributed_to` must be threaded through `TriggerActivityPort.offer_case_ownership_transfer`
+so the factory can stamp it on the wire object.
+
 Use the guarded-commit pattern: only runs when `receiving_actor_id == case_actor_id`.
 
 ### AcceptCaseOwnershipTransferReceivedUseCase / ownership_transfer_tree.py

--- a/test/core/use_cases/received/actor/test_ownership.py
+++ b/test/core/use_cases/received/actor/test_ownership.py
@@ -103,14 +103,20 @@ class TestOwnershipTransferUseCases:
             == "https://example.org/users/coordinator"
         )
 
-    def test_offer_cascade_forwards_to_transferee_outbox(self, make_payload):
-        """OfferCaseOwnershipTransferReceivedUseCase forwards offer to transferee's outbox.
+    def test_offer_cascade_forwards_to_transferee_via_case_actor_outbox(
+        self, make_payload
+    ):
+        """CaseActor builds a new forwarded Offer and queues it in its own outbox.
 
-        When the receiving actor is the CaseActor (CASE_MANAGER), the offer is
-        recorded (idempotent_create) and then forwarded to the transferee via
-        add_activity_to_outbox (CM-21-005).  The BT guarded-commit succeeds
-        because the receiving actor holds CASE_MANAGER (ADR-0053).
+        When the receiving actor is the CaseActor (CASE_MANAGER), the use case
+        must NOT re-queue the original offer in the transferee's outbox slot.
+        Instead it builds a new Offer(VulnerabilityCase, actor=case_actor_id,
+        attributed_to=vendor_id, to=[transferee_id]) and enqueues it in the
+        CaseActor's outbox so the registered outbox monitor delivers it to
+        the transferee's inbox (CM-21-005, ADR-0053).
         """
+        from unittest.mock import MagicMock
+
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.objects.case_participant import (
             as_CaseParticipant,
@@ -121,6 +127,7 @@ class TestOwnershipTransferUseCases:
         case_actor_id = "https://example.org/actors/case-actor"
         vendor_id = "https://example.org/users/vendor"
         transferee_id = "https://example.org/users/coordinator"
+        forwarded_id = "https://example.org/activities/offer_ot4_fwd"
 
         dl = SqliteDataLayer("sqlite:///:memory:")
 
@@ -142,10 +149,6 @@ class TestOwnershipTransferUseCases:
         dl.create(case)
         dl.create(case_manager_participant)
 
-        # Pass target as an inline actor object so the semantic dispatcher
-        # correctly distinguishes this from OfferCaseManagerRole (which also
-        # matches Offer(VulnerabilityCase) but checks target_=CASE_PARTICIPANT).
-        # A bare string is permissive-matched, causing misidentification.
         transferee_actor = as_Service(id_=transferee_id, name="Coordinator")
         activity = offer_case_ownership_transfer_activity(
             case,
@@ -155,11 +158,34 @@ class TestOwnershipTransferUseCases:
         )
         event = make_payload(activity, receiving_actor_id=case_actor_id)
 
-        OfferCaseOwnershipTransferReceivedUseCase(dl, event).execute()
+        # TriggerActivityPort mock: returns (forwarded_id, {}) when called.
+        trigger_activity = MagicMock()
+        trigger_activity.offer_case_ownership_transfer.return_value = (
+            forwarded_id,
+            {},
+        )
 
-        # Offer must be forwarded to the transferee's outbox (CM-21-005).
+        OfferCaseOwnershipTransferReceivedUseCase(
+            dl, event, trigger_activity=trigger_activity
+        ).execute()
+
+        # trigger_activity.offer_case_ownership_transfer must be called with
+        # actor=case_actor_id, to=[transferee_id], attributed_to=vendor_id.
+        trigger_activity.offer_case_ownership_transfer.assert_called_once_with(
+            case_id=case.id_,
+            transferee_id=transferee_id,
+            actor=case_actor_id,
+            to=[transferee_id],
+            attributed_to=vendor_id,
+        )
+
+        # Forwarded offer must land in CaseActor's outbox (not transferee's slot).
+        case_actor_outbox = dl.clone_for_actor(case_actor_id).outbox_list()
+        assert forwarded_id in case_actor_outbox
+
+        # Original offer must NOT be in the transferee's outbox slot.
         transferee_outbox = dl.clone_for_actor(transferee_id).outbox_list()
-        assert activity.id_ in transferee_outbox
+        assert activity.id_ not in transferee_outbox
 
     def test_reject_case_ownership_transfer_logs_rejection(
         self, caplog, make_payload

--- a/test/core/use_cases/received/actor/test_ownership.py
+++ b/test/core/use_cases/received/actor/test_ownership.py
@@ -115,8 +115,6 @@ class TestOwnershipTransferUseCases:
         CaseActor's outbox so the registered outbox monitor delivers it to
         the transferee's inbox (CM-21-005, ADR-0053).
         """
-        from unittest.mock import MagicMock
-
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.objects.case_participant import (
             as_CaseParticipant,
@@ -186,6 +184,66 @@ class TestOwnershipTransferUseCases:
         # Original offer must NOT be in the transferee's outbox slot.
         transferee_outbox = dl.clone_for_actor(transferee_id).outbox_list()
         assert activity.id_ not in transferee_outbox
+
+    def test_offer_cascade_warns_when_trigger_activity_absent(
+        self, make_payload, caplog
+    ):
+        """Warns when trigger_activity port is absent after BT commit.
+
+        Seeds a full case with a CASE_MANAGER participant so the guarded-commit
+        BT can succeed, then omits trigger_activity. The use case must emit a
+        WARNING and leave all outboxes empty (CM-21-005 forwarding skipped).
+        """
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            as_CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.base.objects.actors import as_Service
+        from vultron.enums.roles import CVDRole
+
+        case_actor_id = "https://example.org/actors/case-actor-w"
+        vendor_id = "https://example.org/users/vendor-w"
+        transferee_id = "https://example.org/users/coordinator-w"
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        case = as_VulnerabilityCase(
+            id_="https://example.org/cases/case_ot5",
+            name="OT Warning Case",
+            attributed_to=vendor_id,
+        )
+        case_manager_participant = as_CaseParticipant(
+            attributed_to=case_actor_id,
+            context=case.id_,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        case.actor_participant_index[case_actor_id] = (
+            case_manager_participant.id_
+        )
+        case.case_participants.append(case_manager_participant.id_)
+        dl.create(case)
+        dl.create(case_manager_participant)
+
+        transferee_actor = as_Service(id_=transferee_id, name="Coordinator-W")
+        activity = offer_case_ownership_transfer_activity(
+            case,
+            target=transferee_actor,
+            actor=vendor_id,
+            id_="https://example.org/activities/offer_ot5",
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor_id)
+
+        with caplog.at_level("WARNING"):
+            OfferCaseOwnershipTransferReceivedUseCase(
+                dl,
+                event,
+                # trigger_activity intentionally omitted
+            ).execute()
+
+        assert any("no trigger_activity" in r.message for r in caplog.records)
+        # No activity should have landed in any outbox.
+        case_actor_outbox = dl.clone_for_actor(case_actor_id).outbox_list()
+        assert len(case_actor_outbox) == 0
 
     def test_reject_case_ownership_transfer_logs_rejection(
         self, caplog, make_payload

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -632,6 +632,7 @@ class _ActorsMixin:
         actor: str,
         content: str | None = None,
         to: list[str] | None = None,
+        attributed_to: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Offer(VulnerabilityCase)`` ownership transfer.
 
@@ -646,6 +647,8 @@ class _ActorsMixin:
         }
         if content is not None:
             extra["content"] = content
+        if attributed_to is not None:
+            extra["attributed_to"] = attributed_to
         activity = offer_case_ownership_transfer_activity(
             case=case,
             target=transferee_id,

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -621,6 +621,7 @@ class TriggerActivityPort(Protocol):
         actor: str,
         content: str | None = None,
         to: list[str] | None = None,
+        attributed_to: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Offer(VulnerabilityCase)`` ownership-transfer activity.
 

--- a/vultron/core/use_cases/received/actor/ownership.py
+++ b/vultron/core/use_cases/received/actor/ownership.py
@@ -44,6 +44,7 @@ class OfferCaseOwnershipTransferReceivedUseCase:
         self._dl = dl
         self._request: OfferCaseOwnershipTransferReceivedEvent = request
         self._sync_port = sync_port
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -101,17 +102,41 @@ class OfferCaseOwnershipTransferReceivedUseCase:
 
         # Forward the Offer to the transferee — CaseActor only (CM-21-005).
         # Only runs when BT succeeded (ledger entry committed).
+        # CaseActor builds a NEW Offer: actor=case_actor_id,
+        # attributed_to=original_offerer, to=[transferee_id].
+        # Queued in CaseActor's own outbox so the registered outbox monitor
+        # delivers it to the transferee's inbox.
+        if self._trigger_activity is None:
+            logger.warning(
+                "OfferCaseOwnershipTransferReceived: no trigger_activity"
+                " port — cannot forward offer to transferee (CM-21-005)"
+            )
+            return
         case = self._dl.read(case_id)
         if isinstance(case, VulnerabilityCase):
             case_actor_id = _resolve_case_manager_id(case, self._dl)
-            if case_actor_id == receiving_actor_id and transferee_id:
-                add_activity_to_outbox(
-                    transferee_id, request.activity_id, self._dl
+            original_actor_id = request.actor_id
+            if (
+                case_actor_id is not None
+                and case_actor_id == receiving_actor_id
+                and transferee_id
+                and original_actor_id is not None
+            ):
+                forwarded_id, _ = (
+                    self._trigger_activity.offer_case_ownership_transfer(
+                        case_id=case_id,
+                        transferee_id=transferee_id,
+                        actor=case_actor_id,
+                        to=[transferee_id],
+                        attributed_to=original_actor_id,
+                    )
                 )
+                add_activity_to_outbox(case_actor_id, forwarded_id, self._dl)
                 logger.info(
                     "OfferCaseOwnershipTransferReceived: forwarded"
-                    " offer '%s' to transferee '%s' (CM-21-005)",
-                    request.activity_id,
+                    " offer '%s' (as '%s') to transferee '%s' (CM-21-005)",
+                    forwarded_id,
+                    case_actor_id,
                     transferee_id,
                 )
 


### PR DESCRIPTION
- Closes #2142
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

`OfferCaseOwnershipTransferReceivedUseCase` was re-queuing the original Offer object in Coordinator's outbox slot on the CaseActor container; Coordinator is not a registered actor there so no outbox monitor fired, causing the `fvcv-handoff` demo to stall at the offer-delivery polling timeout.

## Changes

- **`notes/ownership-transfer.md`**: Document forwarded-Offer wire format — `actor=case_actor_id`, `attributed_to=vendor_id`, `to=[transferee_id]` — per ADR-0053 Invite-flow analogy.
- **`vultron/core/ports/trigger_activity.py`**: Add `attributed_to` parameter to `offer_case_ownership_transfer`.
- **`vultron/adapters/driven/trigger_activity_adapter/actors.py`**: Wire `attributed_to` through to the wire factory.
- **`vultron/core/use_cases/received/actor/ownership.py`**: Store `trigger_activity` port; replace broken `add_activity_to_outbox(transferee_id, original_offer_id)` with a new `Offer(VulnerabilityCase, actor=case_actor_id, attributed_to=vendor_id, to=[transferee_id])` queued in CaseActor's own outbox so the registered monitor delivers it to Coordinator's inbox (CM-21-005).
- **`test/core/use_cases/received/actor/test_ownership.py`**: Update `test_offer_cascade_forwards_to_transferee_via_case_actor_outbox` to assert the new activity lands in CaseActor's outbox with correct `actor`/`attributed_to`/`to` args; assert original offer is NOT in transferee's outbox slot.

## Verification

- 6459 unit tests pass (1 new / 1 updated)
- Black, flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)