### PR TITLE
docs: plan CONCERN-2170 — codify CaseActor delegated-message contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,6 +530,17 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   `specs/` for the bare name as well as the quoted/path form, and update every spec entry
   that references it — including `statement:`, `rationale:`, and cross-reference fields.
   *Source: ISSUE-2011*
+- **Delegated-Emit Trigger Use Cases MUST Set `actor=case_actor_id`,
+  `attributed_to=requesting_actor_id`** — trigger use cases that emit an
+  Activity on behalf of the CaseActor (invite, ownership transfer, and any
+  future delegated flows) MUST set `self._actor_id = case_actor_id` and
+  `self._attributed_to = requesting_actor_id` in `_prepare()`, then queue
+  the Activity in the CaseActor's outbox (CM-24-001 through CM-24-004).
+  Setting `actor` to the requesting actor directly causes receivers to reject
+  the message (ISSUE-2142).  Use the shared `_prepare_delegated_context()`
+  helper (or equivalent) — never reconstruct the pattern inline (CM-24-005).
+  See [notes/case-communication-model.md](notes/case-communication-model.md)
+  § "Delegated-Message Pattern". *Source: CONCERN-2170*
 - **Multiple Related Fix PRs Targeting a Shared CI Suite Must Use an Integration
   Branch, Not Race to `main`** — when 3+ related bug fix PRs are open
   simultaneously and all affect the same CI suite (e.g. Demo Integration), open

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -246,6 +246,56 @@ add_activity_to_outbox(case_actor_id, activity_id, dl)   # ← Case Actor outbox
 
 ---
 
+## Delegated-Message Pattern
+
+Some case-scoped Activities are logically initiated by a participant but MUST
+be sent under the CaseActor's identity — because the protocol requires the
+CaseActor to be the recognised sender.  This is the **delegated-message
+pattern** (CM-24-001 through CM-24-005):
+
+```text
+Requesting actor calls trigger: <trigger-name>
+  → Trigger use case _prepare():
+      self._actor_id     = case_actor_id      ← CaseActor sends (CM-24-001)
+      self._attributed_to = requesting_actor_id  ← attribution preserved (CM-24-002)
+      # When no CaseActor: self._actor_id = requesting_actor_id,
+      #                     self._attributed_to = None (CM-24-003)
+  → BT runs under CaseActor identity → activity queued in CaseActor outbox (CM-24-004)
+
+Recipient receives Activity:
+  actor        = case_actor_id       ← recognisable CaseActor sender
+  attributed_to = requesting_actor_id  ← who initiated the action
+```
+
+### Reference Implementation
+
+`SvcInviteActorToCaseUseCase._prepare()` (`triggers/actor.py:146–166`) is the
+canonical reference:
+
+```python
+case_actor_id = _find_case_actor_id(self._dl, self._case.id_)
+self._actor_id = case_actor_id if case_actor_id else owner_id   # CM-24-001/003
+self._case_actor_id = case_actor_id
+self._attributed_to = owner_id if case_actor_id else None        # CM-24-002/003
+```
+
+### Delegated Flows (Exhaustive)
+
+| Trigger use case | Notes |
+|---|---|
+| `SvcInviteActorToCaseUseCase` | ✅ reference — correct |
+| `SvcOfferCaseOwnershipTransferUseCase` | ❌ as of CONCERN-2170 — tracked by #2170 impl issue |
+| Other delegated-emit trigger use cases | audit scope of the CM-24 impl issue |
+
+### Shared-Helper Requirement (CM-24-005)
+
+All delegated-message trigger use cases MUST use a shared helper to enforce
+the pattern.  No callsite may independently reconstruct `actor/attributed_to`
+assignment.  See `specs/case-management.yaml` CM-24-005 for the normative
+requirement.
+
+---
+
 ## Antipattern: Identity Spoofing in Received-Side Use Cases
 
 A received-side use case runs in one actor's DataLayer context. It MUST NOT

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -284,7 +284,7 @@ self._attributed_to = owner_id if case_actor_id else None        # CM-24-002/003
 | Trigger use case | Notes |
 |---|---|
 | `SvcInviteActorToCaseUseCase` | ✅ reference — correct |
-| `SvcOfferCaseOwnershipTransferUseCase` | ❌ as of CONCERN-2170 — tracked by #2170 impl issue |
+| `SvcOfferCaseOwnershipTransferUseCase` | ❌ as of CONCERN-2170 — tracked in #2173 |
 | Other delegated-emit trigger use cases | audit scope of the CM-24 impl issue |
 
 ### Shared-Helper Requirement (CM-24-005)

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -57,10 +57,10 @@ Offering actor calls trigger: offer-case-ownership-transfer
       constructs: Offer(VulnerabilityCase, target=transferee_id)
       actor:      case_actor_id                ← delegated-message contract
       attributed_to: offering_actor_id
-      addressed:  to=[transferee_id]           ← delivered directly to transferee
+      addressed:  to=[case_actor_id]           ← MUST (CM-21-005)
       queued in:  CaseActor's outbox           ← CM-24-004
 
-CaseActor self-receives the Offer (via outbox → inbox round-trip)
+CaseActor inbox receives Offer
   → OfferCaseOwnershipTransferReceivedUseCase:
       1. Records the Offer object (idempotent).
       2. Commits CaseLedgerEntry (offer-recorded).
@@ -69,8 +69,8 @@ CaseActor self-receives the Offer (via outbox → inbox round-trip)
 ```
 
 > **Correction (CONCERN-2170)**: Earlier descriptions of this flow stated the
-> Offer was "queued in: offering actor's outbox" with `actor=offering_actor`.
-> That was wrong.  Bug ISSUE-2142 confirmed the Coordinator rejects Offers
+> Offer was "queued in: offering actor's outbox" with `actor=offering_actor`
+> and no `attributed_to`.  That was wrong.  Bug ISSUE-2142 confirmed the Coordinator rejects Offers
 > whose `actor` names the Finder rather than the CaseActor.  The delegated
 > pattern (CM-24-001 through CM-24-004) is the correct model.
 

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -108,8 +108,8 @@ CaseActor inbox receives Accept
 
 - `_emit()` MUST use `actor=self.actor_id` (the CaseActor's ID) and pass
   `attributed_to=self.attributed_to` to the factory call.
-- `to` MUST be `[transferee_id]` (addressed directly to the transferee;
-  the CaseActor self-receives via the outbox→inbox round-trip).
+- `to` MUST be `[case_actor_id]` — the Offer routes through the CaseActor
+  (CM-21-005); the CaseActor processes it and forwards to the transferee.
 - The `target` field of the Offer carries `transferee_id` (as before).
 
 ### EmitAcceptCaseOwnershipTransferNode

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -50,18 +50,29 @@ Both activities MUST flow through the CaseActor.
 
 ```text
 Offering actor calls trigger: offer-case-ownership-transfer
+  → SvcOfferCaseOwnershipTransferUseCase._prepare() sets:
+      self._actor_id      = case_actor_id      ← CaseActor sends (CM-24-001)
+      self._attributed_to = offering_actor_id  ← attribution (CM-24-002)
   → EmitOfferCaseOwnershipTransferNode
       constructs: Offer(VulnerabilityCase, target=transferee_id)
-      addressed:  to=[case_actor_id]         ← MUST (CM-21-005)
-      queued in:  offering actor's outbox
+      actor:      case_actor_id                ← delegated-message contract
+      attributed_to: offering_actor_id
+      addressed:  to=[transferee_id]           ← delivered directly to transferee
+      queued in:  CaseActor's outbox           ← CM-24-004
 
-CaseActor inbox receives Offer
+CaseActor self-receives the Offer (via outbox → inbox round-trip)
   → OfferCaseOwnershipTransferReceivedUseCase:
       1. Records the Offer object (idempotent).
       2. Commits CaseLedgerEntry (offer-recorded).
       3. Announce(CaseLedgerEntry) → all participants.   ← CM-21-005 rationale
       4. Forwards Offer to transferee's inbox.
 ```
+
+> **Correction (CONCERN-2170)**: Earlier descriptions of this flow stated the
+> Offer was "queued in: offering actor's outbox" with `actor=offering_actor`.
+> That was wrong.  Bug ISSUE-2142 confirmed the Coordinator rejects Offers
+> whose `actor` names the Finder rather than the CaseActor.  The delegated
+> pattern (CM-24-001 through CM-24-004) is the correct model.
 
 ### Accept flow
 
@@ -84,10 +95,21 @@ CaseActor inbox receives Accept
 
 ## Implementation Checklist
 
+### SvcOfferCaseOwnershipTransferUseCase._prepare()
+
+- MUST call `_find_case_actor_id()` and set `self._actor_id = case_actor_id`
+  (CM-24-001).
+- MUST set `self._attributed_to = offering_actor_id` (CM-24-002).
+- When no CaseActor exists: `self._actor_id = offering_actor_id`,
+  `self._attributed_to = None` (CM-24-003).
+- Pass `attributed_to` through to the BT builder (CM-24-004).
+
 ### EmitOfferCaseOwnershipTransferNode
 
-- `_emit()` MUST resolve `case_actor_id` from the DataLayer and set
-  `to=[case_actor_id]`.  Do not use the `transferee_id` as the `to` field.
+- `_emit()` MUST use `actor=self.actor_id` (the CaseActor's ID) and pass
+  `attributed_to=self.attributed_to` to the factory call.
+- `to` MUST be `[transferee_id]` (addressed directly to the transferee;
+  the CaseActor self-receives via the outbox→inbox round-trip).
 - The `target` field of the Offer carries `transferee_id` (as before).
 
 ### EmitAcceptCaseOwnershipTransferNode

--- a/plan/history/2608/learning/CONCERN-2170.md
+++ b/plan/history/2608/learning/CONCERN-2170.md
@@ -1,0 +1,20 @@
+---
+source: CONCERN-2170
+timestamp: '2026-08-11T14:30:51.885962+00:00'
+title: actor/attributedTo contract for CaseActor-delegated messages is unspecified
+  and not factory-enforced
+type: learning
+---
+
+When CaseActor emits an Activity on behalf of CaseOwner (ownership transfer, actor invitation, embargo announcement), the correct assignment of `actor` (who is sending) vs. `attributedTo` (whose intent is carried) is established by one reference callsite but is not codified in specs, notes, or enforced by a shared factory. Each new callsite must reconstruct the pattern independently.
+
+**Surface symptom:** `SvcOfferCaseOwnershipTransferUseCase` sets `actor` to the requesting actor directly and never sets `attributed_to`, while `SvcInviteActorToCaseUseCase` correctly routes through the CaseActor identity.
+
+**Underlying problem:** The delegated-message pattern (`actor=case_actor_id`, `attributed_to=requesting_actor_id`) exists only as an implicit convention demonstrated in one reference node (`SvcInviteActorToCaseUseCase._prepare()`). There is no spec section, no notes guidance, and no shared factory enforcing it.
+
+**Severity:** High — all delegated-message flows (ownership transfer, embargo announcement, actor invitations) are affected. Bug ISSUE-2142 (fvcv-handoff ownership-transfer offer delivery timeout) is direct evidence: the Coordinator rejected an Offer whose `actor` field named the Finder rather than the CaseActor.
+
+**Resolved:** 2026-08-11 — implementation tracked in #2173.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2172>.
+Spec: `specs/case-management.yaml` (CM-24-001..005).
+Notes: `notes/case-communication-model.md` § "Delegated-Message Pattern".

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -5,7 +5,6 @@ description: Requirements for VulnerabilityCase lifecycle management, CaseActor 
   state, case initialization sequencing, embargo acceptance ownership, and the invitation acceptance lifecycle.
 version: 1.2.0
 scope:
-
 - prototype
 - production
 tags:
@@ -1582,7 +1581,7 @@ groups:
       spec_id: CM-24-001
   - id: CM-24-004
     priority: MUST
-    kind: implementation
+    kind: architecture
     statement: >-
       Trigger use cases that emit delegated Activities MUST queue the
       constructed Activity in the CaseActor's outbox, not in the requesting
@@ -1598,7 +1597,7 @@ groups:
       spec_id: CM-24-001
   - id: CM-24-005
     priority: MUST
-    kind: implementation
+    kind: architecture
     statement: >-
       All trigger use cases that emit delegated Activities MUST use a shared
       helper (e.g. _prepare_delegated_context() or equivalent) that enforces

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -5,6 +5,7 @@ description: Requirements for VulnerabilityCase lifecycle management, CaseActor 
   state, case initialization sequencing, embargo acceptance ownership, and the invitation acceptance lifecycle.
 version: 1.2.0
 scope:
+
 - prototype
 - production
 tags:
@@ -1522,3 +1523,91 @@ groups:
       spec_id: CM-02-009
     adr:
     - ADR-0051
+
+- id: CM-24
+  title: CaseActor-Delegated Activity Authorship Contract
+  description: >-
+    Requirements for how trigger use cases assign `actor` and `attributed_to`
+    when the CaseActor emits an Activity on behalf of a requesting participant
+    (delegated message).  The reference implementation is
+    SvcInviteActorToCaseUseCase._prepare().  Codified from CONCERN-2170.
+  specs:
+  - id: CM-24-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When a trigger use case causes the CaseActor to emit a protocol Activity
+      on behalf of a requesting participant (delegated message), the `actor`
+      field of the emitted Activity MUST be set to the CaseActor's actor ID,
+      not the requesting participant's actor ID.
+    rationale: >-
+      Receiving actors authenticate messages by matching the `actor` field
+      against known case participants.  An Activity whose `actor` names a
+      non-CaseActor participant is not recognised as a CaseActor-authorised
+      delegation and may be rejected or misrouted.  Bug ISSUE-2142
+      (ownership-transfer offer delivery timeout) is direct evidence:
+      the Coordinator rejected an Offer whose `actor` named the Finder.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-02-009
+  - id: CM-24-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When a delegated Activity is emitted by the CaseActor, the
+      `attributed_to` field MUST be set to the requesting participant's actor
+      ID so that receivers can recover the originating identity.
+    rationale: >-
+      `attributed_to` is the AS2-standard field for recording who delegated an
+      action.  Without it, the intent of the message cannot be attributed to the
+      correct participant, and audit trails are incomplete.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-24-001
+  - id: CM-24-003
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When no dedicated CaseActor exists for a case (no participant with
+      CVDRole.CASE_MANAGER in the actor_participant_index), the Activity is sent
+      directly by the requesting participant.  In this case `actor` MUST be the
+      requesting participant's actor ID and `attributed_to` MUST be None.
+    rationale: >-
+      Without a CaseActor the delegation channel does not exist.  Forcing
+      `actor=None` or a fallback CaseActor ID would produce an invalid wire
+      message.  The SvcInviteActorToCaseUseCase reference implementation
+      demonstrates this fallback at actor.py:160-166.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-24-001
+  - id: CM-24-004
+    priority: MUST
+    kind: implementation
+    statement: >-
+      Trigger use cases that emit delegated Activities MUST queue the
+      constructed Activity in the CaseActor's outbox, not in the requesting
+      participant's outbox.  self._actor_id MUST be set to case_actor_id in
+      _prepare() so that the BT bridge runs under the CaseActor's identity.
+    rationale: >-
+      The CaseActor's outbox is the delivery path to other participants.
+      Queuing a delegated Activity in the requesting actor's outbox bypasses
+      the CaseActor as the authoritative intermediary and breaks the
+      CaseLedgerEntry audit trail.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-24-001
+  - id: CM-24-005
+    priority: MUST
+    kind: implementation
+    statement: >-
+      All trigger use cases that emit delegated Activities MUST use a shared
+      helper (e.g. _prepare_delegated_context() or equivalent) that enforces
+      the CM-24-001 through CM-24-004 invariants.  No callsite may independently
+      reconstruct the delegated-authorship pattern without going through this
+      shared helper.
+    rationale: >-
+      Independent reconstruction of the actor/attributed_to assignment at each
+      callsite is structurally fragile.  CONCERN-2170 documents two callsites
+      that deviated: SvcOfferCaseOwnershipTransferUseCase (wrong actor, no
+      attributed_to) proved the pattern is re-broken every time a new callsite
+      is added.  A shared helper eliminates the entire class of defect.


### PR DESCRIPTION
- Closes #2170

## Summary

Codifies the delegated-message authorship contract (actor=case_actor_id,
attributed_to=requesting_actor_id) that CaseActor-delegated trigger use cases
must follow, and corrects the ownership-transfer notes to match the confirmed
protocol behaviour.

## Changes

- **`specs/case-management.yaml`**: add CM-24 group (CM-24-001..005) defining
  the delegated-message contract as normative requirements
- **`notes/case-communication-model.md`**: add "Delegated-Message Pattern"
  section with reference implementation, table of delegated flows, and
  shared-helper requirement
- **`notes/ownership-transfer.md`**: correct the Offer flow — actor MUST be
  case_actor_id (delegated pattern, CM-24-001), not offering_actor; annotates
  ISSUE-2142 as direct evidence
- **`AGENTS.md`**: add "Delegated-Emit Trigger Use Cases MUST Set
  actor=case_actor_id" pitfall entry (CONCERN-2170)

## Implementation Issues

- #2173