### PR TITLE
docs: plan CONCERN-1667 — CaseStatus authority model

### DIFF
--- a/docs/adr/0046-received-status-authorization.md
+++ b/docs/adr/0046-received-status-authorization.md
@@ -112,7 +112,7 @@ which is removed from `add_participant_status_tree`.
 - Unit tests: CS states outside {P, X, A} do not trigger teardown
 - Regression: CS.P path unaffected after migration of PublicDisclosureBranchNode
 
-## Outbound Emit Invariant (added 2026-08-11, from CONCERN-1667)
+## Outbound Emit Invariant
 
 The two-seam model governs **inbound** participant suggestions. A parallel
 invariant applies to the CaseActor's **own** EM and PXA state mutations:
@@ -130,9 +130,10 @@ CaseActor mutates EM/PXA state
 ```
 
 A shared `EmitCaseStatusUpdateNode` (direct write, not inbox-routed) is wired
-after every EM lifecycle BT node. This is **not** a new seam decision — it is
-the logical consequence of the CaseActor's role as single-writer authority
-(ADR-0021). The existing `EmitAddCaseStatusToSelfNode` (inbox-loopback path)
+after every EM lifecycle BT node. This is **not** a new seam decision — it
+carves a limited exception to ADR-0021's inbox-routing rule: the CaseActor's
+own outbound EM/PXA state change emissions write directly to the ledger rather
+than routing through the inbox seam. The existing `EmitAddCaseStatusToSelfNode` (inbox-loopback path)
 is a kludge that will be refactored once `EmitCaseStatusUpdateNode` is in place.
 
 ### CaseStatus Emission Authority (RSH-04)

--- a/docs/adr/0046-received-status-authorization.md
+++ b/docs/adr/0046-received-status-authorization.md
@@ -1,6 +1,7 @@
 ---
 status: accepted-provisional
 date: 2026-07-30
+updated: 2026-08-11
 deciders: Allen D. Householder
 consulted: Claude Sonnet 4.6
 informed: []
@@ -111,11 +112,46 @@ which is removed from `add_participant_status_tree`.
 - Unit tests: CS states outside {P, X, A} do not trigger teardown
 - Regression: CS.P path unaffected after migration of PublicDisclosureBranchNode
 
+## Outbound Emit Invariant (added 2026-08-11, from CONCERN-1667)
+
+The two-seam model governs **inbound** participant suggestions. A parallel
+invariant applies to the CaseActor's **own** EM and PXA state mutations:
+
+> Every CaseActor-side EM or PXA state change MUST be followed by a canonical
+> `CaseStatus` ledger write. `CaseStatus` is the only protocol channel for
+> communicating EM and PXA state to participant replicas.
+
+The correct causal order is:
+
+```text
+CaseActor mutates EM/PXA state
+  → writes CaseStatus to case.case_statuses + CaseLedgerEntry (authoritative)
+  → Announce(CaseLedgerEntry) syncs participants
+```
+
+A shared `EmitCaseStatusUpdateNode` (direct write, not inbox-routed) is wired
+after every EM lifecycle BT node. This is **not** a new seam decision — it is
+the logical consequence of the CaseActor's role as single-writer authority
+(ADR-0021). The existing `EmitAddCaseStatusToSelfNode` (inbox-loopback path)
+is a kludge that will be refactored once `EmitCaseStatusUpdateNode` is in place.
+
+### CaseStatus Emission Authority (RSH-04)
+
+Only the CaseActor (acting as CASE_MANAGER) emits `Add(CaseStatus)` directly.
+All other participants embed a suggested `CaseStatus` inside
+`Add(ParticipantStatus)`; the two-seam model decides whether to adopt it.
+
+See `specs/received-status-handling.yaml` RSH-04-001 through RSH-04-004 and
+`notes/received-status-authorization.md` § "CaseStatus Emission Authority".
+
+---
+
 ## More Information
 
 Design ratified in IDEA-1836 planning session (2026-07-30).
-Status is `accepted-provisional` — the design is the agreed direction but has
-not yet been validated by a complete implementation pass.
+Status is `accepted-provisional` — the inbound two-seam design is implemented;
+the outbound emit invariant (`EmitCaseStatusUpdateNode`) is pending
+(CONCERN-1667 implementation child issue).
 
 Generated spec requirements: `specs/received-status-handling.yaml` RSH-01
-through RSH-03.
+through RSH-04.

--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -175,9 +175,76 @@ Placed in `vultron/core/behaviors/call_out/bundles/status_authorization.py`
 
 ---
 
+## CaseStatus Emission Authority (RSH-04)
+
+### The invariant
+
+CaseStatus is the **only protocol channel** for communicating EM and PXA
+state changes to participant replicas. This means:
+
+1. **Only the CaseActor (CASE_MANAGER) emits `Add(CaseStatus)` directly.**
+   All other participants embed a suggested `CaseStatus` inside
+   `Add(ParticipantStatus)` and let the two-seam model decide whether to
+   adopt it (RSH-04-001).
+
+2. **Every CaseActor-side EM or PXA state mutation MUST be followed by a
+   canonical `CaseStatus` ledger write** (RSH-04-002, RSH-04-003). Without
+   it, all participant replicas remain stale until the next round-trip.
+
+### The emit mechanism
+
+A shared BT node, `EmitCaseStatusUpdateNode`, performs the canonical write:
+
+1. Reads the updated `CaseStatus` from the case record (post-mutation state).
+2. Appends it to `case.case_statuses` and persists.
+3. Commits a `CaseLedgerEntry` (the authoritative ledger record).
+4. The `Announce(CaseLedgerEntry)` broadcast that syncs participants to
+   the new state is handled by the existing announce mechanism downstream.
+
+This node is wired **after** every EM lifecycle node in each BT tree factory
+(Propose, Accept, Reject, Terminate, and cascade variants such as
+`RejectProposedEmbargoLifecycleNode` and `ApplyEmbargoTeardownNode`).
+
+### Causality (important)
+
+The correct causal order is:
+
+```text
+CaseActor mutates EM/PXA state
+  → writes CaseStatus to ledger (authoritative)
+  → Announce(CaseLedgerEntry) syncs participants
+```
+
+**Not** the inbox-loopback pattern that `EmitAddCaseStatusToSelfNode`
+currently uses:
+
+```text
+[kludge] EmitAddCaseStatusToSelf → inbox → add_case_status_tree → writes ledger
+```
+
+The inbox seam (Seam 1 → Seam 2) exists for evaluating **external participant
+suggestions**, not for the CaseActor recording its own authoritative state
+changes. `EmitAddCaseStatusToSelfNode` is a recognized kludge; a follow-on
+issue will refactor the inbound path to use direct ledger writes as well
+(blocked by the `EmitCaseStatusUpdateNode` impl issue).
+
+### BT nodes in scope for the emit invariant
+
+| Node / Tree | EM transition | Covered by `EmitCaseStatusUpdateNode`? |
+|---|---|---|
+| `ProposeEmbargoLifecycleNode` (trigger) | NO_EMBARGO → PROPOSED or ACTIVE → REVISE | Pending (ISSUE-1667 child) |
+| `AcceptEmbargoLifecycleNode` (trigger) | PROPOSED → ACTIVE | Pending |
+| `RejectEmbargoLifecycleNode` (trigger) | PROPOSED → NO_EMBARGO | Pending |
+| `TerminateEmbargoLifecycleNode` (trigger) | ACTIVE/REVISE → EXITED | Pending |
+| `RejectProposedEmbargoLifecycleNode` (cascade) | PROPOSED → NO_EMBARGO | Pending |
+| `ApplyEmbargoTeardownNode` (sync/announce) | ACTIVE/REVISE → EXITED | Pending |
+
+---
+
 ## References
 
 - ADR-0046: `docs/adr/0046-received-status-authorization.md`
-- Spec: `specs/received-status-handling.yaml` RSH-01 through RSH-03
+- Spec: `specs/received-status-handling.yaml` RSH-01 through RSH-04
+- Source Concern: CONCERN-1667
 - Source Idea: IDEA-1836
 - Superseded approach: `notes/bt-fuzzer-rm-threat.md` (sentinel integration context)

--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -232,7 +232,8 @@ issue will refactor the inbound path to use direct ledger writes as well
 
 | Node / Tree | EM transition | Covered by `EmitCaseStatusUpdateNode`? |
 |---|---|---|
-| `ProposeEmbargoLifecycleNode` (trigger) | NO_EMBARGO → PROPOSED or ACTIVE → REVISE | Pending (ISSUE-1667 child) |
+| `ProposeEmbargoLifecycleNode` in `propose_embargo_trigger_bt` (initial proposal) | NO_EMBARGO → PROPOSED | Pending (ISSUE-2175) |
+| `ProposeEmbargoLifecycleNode` in `propose_embargo_revision_trigger_bt` (revision, with `ValidateEmbargoRevisionStateNode` guard) | ACTIVE → REVISE | Pending (ISSUE-2175) |
 | `AcceptEmbargoLifecycleNode` (trigger) | PROPOSED → ACTIVE | Pending |
 | `RejectEmbargoLifecycleNode` (trigger) | PROPOSED → NO_EMBARGO | Pending |
 | `TerminateEmbargoLifecycleNode` (trigger) | ACTIVE/REVISE → EXITED | Pending |

--- a/plan/history/2608/learning/CONCERN-1667.md
+++ b/plan/history/2608/learning/CONCERN-1667.md
@@ -1,0 +1,65 @@
+---
+source: CONCERN-1667
+timestamp: '2026-08-11T14:59:53.464454+00:00'
+title: 'CaseStatus authority model: outbound emit invariant designed'
+type: learning
+---
+
+## Outcome
+
+CONCERN-1667 ("CaseStatus authority model is undesigned") is resolved at the
+design level. The two-seam inbound authorization model (ADR-0046 / IDEA-1836)
+was already fully implemented. The remaining gap — the outbound emit invariant
+— is now fully specified and planned.
+
+## Key decisions
+
+1. **CaseStatus is the only protocol channel for EM/PXA state changes.**
+   Every CaseActor-side EM or PXA mutation MUST be followed by a canonical
+   `CaseStatus` ledger write (RSH-04-002, RSH-04-003).
+
+2. **Only the CaseActor (CASE_MANAGER) emits `Add(CaseStatus)` directly.**
+   All other participants embed a suggested CaseStatus inside
+   `Add(ParticipantStatus)` and let the two-seam model decide adoption
+   (RSH-04-001).
+
+3. **DRY: one shared node, not N inline patches.**
+   `EmitCaseStatusUpdateNode` (new BT node in
+   `vultron/core/behaviors/status/nodes/case_status.py`) will be wired after
+   each of the 6 EM lifecycle nodes. Direct ledger write — no inbox loopback.
+
+4. **`EmitAddCaseStatusToSelfNode` is a recognized kludge.**
+   Its inbox-loopback pattern inverts causality. Refactoring it out is a
+   follow-on issue blocked-by the main impl.
+
+## Causal ordering invariant
+
+```text
+CaseActor mutates EM/PXA state
+  → writes CaseStatus to canonical ledger (authoritative)
+  → Announce(CaseLedgerEntry) syncs participants
+```
+
+NOT the inbox-loopback pattern:
+
+```text
+[kludge] EmitAddCaseStatusToSelf → inbox → add_case_status_tree → writes ledger
+```
+
+## Docs produced
+
+- `specs/received-status-handling.yaml`: RSH-04 group added (RSH-04-001–004)
+- `notes/received-status-authorization.md`: § "CaseStatus Emission Authority"
+- `docs/adr/0046-received-status-authorization.md`: Outbound Emit Invariant section
+
+## Implementation issues spawned
+
+- #2175 (size:M): implement `EmitCaseStatusUpdateNode`; wire after all 6 EM
+  lifecycle BT nodes; satisfies RSH-04-002 through RSH-04-004
+- #2176 (size:S): refactor `EmitAddCaseStatusToSelfNode` to direct ledger
+  write; blocked-by #2175
+
+## Reference
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2174>
+Parent epic: #1935

--- a/specs/received-status-handling.yaml
+++ b/specs/received-status-handling.yaml
@@ -135,3 +135,75 @@ groups:
       The node belongs in the tree that writes canonical state. Its presence
       in `add_participant_status_tree` predates the two-seam design and must
       be migrated as part of implementing RSH-01 and RSH-02.
+
+- id: RSH-04
+  title: CaseStatus Emission Authority and Outbound Emit Invariant
+  description: >
+    Specifies which actors may emit Add(CaseStatus) directly and mandates that
+    every CaseActor-side EM or PXA state mutation is followed by a canonical
+    CaseStatus ledger write. CaseStatus is the only protocol channel for
+    communicating EM and PXA state changes across actors; omitting the emit
+    leaves all participant replicas stale until the next round-trip.
+  specs:
+  - id: RSH-04-001
+    priority: MUST
+    kind: protocol
+    statement: >
+      Only the CaseActor (acting as CASE_MANAGER) MUST emit `Add(CaseStatus)`
+      directly. All other participants MUST embed a suggested `CaseStatus`
+      inside `Add(ParticipantStatus)` rather than sending `Add(CaseStatus)`
+      independently.
+    rationale: >
+      CaseStatus encodes shared EM and PXA state for the entire case. Only the
+      CaseActor holds the CASE_MANAGER role and is the authoritative writer of
+      canonical case state (ADR-0046, CLP-09). Allowing participants to emit
+      Add(CaseStatus) directly would bypass the two-seam authorization model.
+  - id: RSH-04-002
+    priority: MUST
+    kind: protocol
+    statement: >
+      Every BT node or tree that mutates EM state (Propose, Accept, Reject,
+      Terminate, and all cascade variants) MUST immediately follow the
+      state-mutation step with a write of the updated `CaseStatus` to the
+      canonical case ledger.
+    rationale: >
+      EM state changes are only observable to remote actors via `CaseStatus`
+      entries in `Announce(CaseLedgerEntry)` messages. A mutation without a
+      subsequent ledger write leaves participant replicas with a stale EM state
+      (observed in fv/fcv/fvv CI scenarios — see CONCERN-1667).
+  - id: RSH-04-003
+    priority: MUST
+    kind: protocol
+    statement: >
+      Every BT node or tree that mutates PXA state (public awareness, exploit
+      public, attacks observed) MUST immediately follow the state-mutation step
+      with a write of the updated `CaseStatus` to the canonical case ledger.
+    rationale: >
+      PXA state is participant-agnostic and shared across the case. The
+      rationale mirrors RSH-04-002: omitting the ledger write leaves replicas
+      stale and breaks the Avoid Surprise principle.
+  - id: RSH-04-004
+    priority: MUST
+    kind: protocol
+    statement: >
+      The CaseStatus ledger write described in RSH-04-002 and RSH-04-003 MUST
+      be implemented as a shared BT node (`EmitCaseStatusUpdateNode`) that
+      writes the new `CaseStatus` directly to `case.case_statuses` and commits
+      a canonical `CaseLedgerEntry`, then emits `Announce(CaseLedgerEntry)` for
+      participant replica sync. It MUST NOT route through the inbox
+      authorization seam (`add_case_status_tree`) — the CaseActor is always the
+      authority for its own outbound state changes.
+    rationale: >
+      The inbox seam (Seam 1 → Seam 2) exists for evaluating external
+      participant suggestions. The CaseActor writing its own EM/PXA transition
+      is not a suggestion — it is an authoritative state change. Routing through
+      the inbox loopback (as `EmitAddCaseStatusToSelfNode` does) inverts
+      causality: the ledger write should precede the announce, not be triggered
+      by a self-addressed inbox message. DRY: one shared node, not N inline
+      patches per BT tree factory.
+    notes: >
+      Implementation tracked in ISSUE-1667's implementation child issue.
+      The `EmitAddCaseStatusToSelfNode` kludge (inbound path) is acknowledged
+      as a parallel refactor target: once `EmitCaseStatusUpdateNode` is in
+      place, `EmitAddCaseStatusToSelfNode` should be refactored to use direct
+      ledger writes as well. That refactor is blocked-by the impl issue.

--- a/specs/received-status-handling.yaml
+++ b/specs/received-status-handling.yaml
@@ -202,7 +202,9 @@ groups:
       by a self-addressed inbox message. DRY: one shared node, not N inline
       patches per BT tree factory.
     notes: >
-      Implementation tracked in ISSUE-1667's implementation child issue.
+      Implementation tracked in ISSUE-2175 (implement EmitCaseStatusUpdateNode,
+      size:M). A follow-on refactor of `EmitAddCaseStatusToSelfNode` is tracked
+      in ISSUE-2176 (size:S, blocked-by ISSUE-2175).
       The `EmitAddCaseStatusToSelfNode` kludge (inbound path) is acknowledged
       as a parallel refactor target: once `EmitCaseStatusUpdateNode` is in
       place, `EmitAddCaseStatusToSelfNode` should be refactored to use direct


### PR DESCRIPTION
- Closes #1667

## What this PR does

Plans CONCERN-1667 ("CaseStatus authority model is undesigned") by documenting
the agreed design direction and spawning a concrete implementation issue.

The two-seam inbound authorization design (ADR-0046 / IDEA-1836) is already
fully implemented. This PR documents the **complementary outbound invariant**:
every CaseActor-side EM or PXA state mutation must be followed by a canonical
`CaseStatus` ledger write (the only protocol channel for communicating EM/PXA
state changes to participant replicas).

## Changes

- **`specs/received-status-handling.yaml`** — adds RSH-04 group (RSH-04-001
  through RSH-04-004): CaseStatus emission authority (only CASE_MANAGER emits
  `Add(CaseStatus)` directly) and the outbound emit invariant for every
  EM/PXA state mutation.
- **`notes/received-status-authorization.md`** — documents the outbound emit
  pattern, correct causal ordering (mutation → ledger write → Announce), the
  `EmitCaseStatusUpdateNode` design, and the table of BT nodes in scope.
- **`docs/adr/0046-received-status-authorization.md`** — adds Outbound Emit
  Invariant section and RSH-04 cross-reference; status remains
  `accepted-provisional` (inbound implemented; outbound pending).

## Implementation issues spawned

(See below — added after issue creation.)

## Implementation Issues

- #2175 — impl: add EmitCaseStatusUpdateNode; wire after all EM lifecycle BT nodes (size:M, blocked-by #1667)
- #2176 — refactor: replace EmitAddCaseStatusToSelfNode inbox-loopback with direct ledger write (size:S, blocked-by #2175)