### PR TITLE
fix(devcontainer): unify on /app, add persistent host mounts

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -7,7 +7,8 @@ There is no VS Code devcontainer.json — the script handles everything.
 
 - macOS with Docker Desktop installed and running
 - AWS credentials with Bedrock access (for Claude Code)
-- GitHub CLI auth (`gh auth login`) — only needed if you plan to push/PR from inside the container
+- GitHub CLI auth (`gh auth login`) — only needed if you plan to push/PR from
+  inside the container
 
 ## First-time setup
 
@@ -17,29 +18,28 @@ From the repo root, run:
 ./start-dev.sh <slot>
 ```
 
-Replace `<slot>` with any name you like — it's personal to you and not stored in the repo.
-On first run the script will prompt you for AWS credentials and write them to
-`.devcontainer/devcontainer.env` (git-ignored).
+Replace `<slot>` with any name you like — it's personal to you and not stored
+in the repo. On first run the script will prompt you for AWS credentials and
+write them to `.devcontainer/devcontainer.env` (git-ignored).
 
 The script will:
 
 1. Build the Docker image (cached on subsequent runs)
-2. Create a git worktree at `../<repo-name>_<slot>/` (sibling to this checkout)
-3. Create a container named `<repo-name>_<slot>` mounting that worktree
-4. Run one-time setup inside the container (`postcreate.sh`)
-5. Drop you into a zsh shell
+2. Create a container named `<repo-name>_<slot>`
+3. Run one-time setup inside the container (`postcreate.sh`)
+4. Drop you into a zsh shell at `/app`
 
-## Slot names
+## How it works
 
-A slot is just a name for a parallel dev environment. Each slot gets its own:
+Every slot container is ephemeral — it is destroyed when you exit the shell.
+The source code lives at `/app` inside the container, baked into the image at
+build time. On every startup, `poststart.sh` runs `git pull` to bring `/app`
+up to date with `origin/main`.
 
-- git worktree (`../<repo-name>_<slot>/`) — persists across container restarts
-- Docker container (`<repo-name>_<slot>`)
+Because containers are destroyed on exit, any uncommitted work in `/app` is
+lost. **Push your work before exiting.**
 
-All slots share one persistent data volume for Claude config and shell history.
-
-Choose names freely. The worktrees are siblings to the main checkout wherever
-it lives on your filesystem — no hardcoded paths.
+All slots are identical. There is no "main" slot.
 
 ## Command reference
 
@@ -47,49 +47,30 @@ it lives on your filesystem — no hardcoded paths.
 # Start (or attach to) a named slot
 ./start-dev.sh <slot>
 
-# Attach to the main checkout (no worktree)
-./start-dev.sh main
-
-# Nuke the slot's worktree and recreate it from main, then start
-./start-dev.sh <slot> --reset
-
 # Rebuild the Docker image from scratch, then start
 ./start-dev.sh <slot> --rebuild
-
-# Combine: full clean slate
-./start-dev.sh <slot> --reset --rebuild
 ```
 
-## What persists
+## What persists across container restarts
 
-A named Docker volume (`<repo-name>-data`) is shared across all slots and survives
-container removal. It holds:
+Containers are ephemeral — `/app` is rebuilt from the image each time.
+Three host directories are bind-mounted into every container to persist
+data across restarts:
 
-- `~/.claude/` — Claude Code config, sessions, settings
-- `~/.zsh_history` and `~/.bash_history`
-
-Running `--reset` or `--rebuild` removes the container but never the volume.
-Your Claude sessions and shell history survive.
-
-## WIP notes and outputs
-
-Two gitignored directories at the repo root are mounted into every container:
-
-| Dir | Mount in container | Access | Purpose |
+| Host path | Mount in container | Access | Purpose |
 |---|---|---|---|
-| `wip_notes/` | `$WIP_NOTES` (`/workspaces/wip_notes`) | read-only | Drop reference notes and context files here on the host; agents can read them during sessions |
-| `wip_outputs/` | `$WIP_OUTPUTS` (`/workspaces/wip_outputs/<slot>`) | read-write | Agents write ad-hoc reports here; each slot writes to its own subdirectory to avoid conflicts |
+| `~/.claude` | `/home/vscode/.claude` | read-write | Claude Code config, sessions, memory — shared across all slots |
+| `wip_notes/` (repo root) | `/app/wip_notes` (`$WIP_NOTES`) | read-only | Drop context files here on the host; agents can read them |
+| `wip_outputs/<slot>/` (repo root) | `/app/wip_outputs` (`$WIP_OUTPUTS`) | read-write | Agents write outputs here; each slot sees only its own subdirectory |
+| `~/dev/graphify-out/<slot>/` | `/app/graphify-out` | read-write | Per-slot graph data from `/graphify`; expensive to regenerate |
 
-`start-dev.sh` creates both directories automatically if they don't exist.
-Files written by the container are owned by uid 1000 (`vscode`) on the host.
-Under Docker Desktop on macOS this is transparent and requires no extra configuration.
+`start-dev.sh` creates `wip_notes/`, `wip_outputs/`, and
+`~/dev/graphify-out/<slot>/` automatically on first use.
 
 ## Skills
 
 Claude Code loads skills from two places simultaneously:
 
 - **Project skills** — `.claude/skills/` in the repo (auto-discovered)
-- **User skills** — `~/.claude/skills/`, symlinked to `~/.agents/skills` on your Mac
-
-If you have user-level skills at `~/.agents/skills/` on your Mac, they are
-mounted read-only into every container automatically.
+- **User skills** — `~/.claude/skills/`, symlinked from `~/.agents/skills` on
+  your Mac if present

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -29,6 +29,15 @@ if ! grep -q 'local/bin' "$HOME/.zshrc" 2>/dev/null; then
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zshrc"
 fi
 
+# Auto-start tmux on login if not already inside a tmux session
+if ! grep -q 'TMUX' "$HOME/.zshrc" 2>/dev/null; then
+    cat >> "$HOME/.zshrc" <<'EOF'
+
+# Auto-start tmux on login
+if [ -z "$TMUX" ]; then exec tmux new-session -s main; fi
+EOF
+fi
+
 # --- tmux configuration ---
 cat > "$HOME/.tmux.conf" <<'EOF'
 set -g default-terminal "tmux-256color"

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -5,26 +5,6 @@ set -euo pipefail
 echo "=== Post-create setup ==="
 echo ""
 
-# --- Independent clone (non-main slots only) ---
-# main already has the host checkout bind-mounted at $PWD; every other slot
-# clones its own copy here, inside this container's own writable layer, so
-# it shares no git state with any other slot or the host. Seeded from the
-# host checkout via a read-only, one-time --reference for speed; --dissociate
-# copies the borrowed objects in immediately, so this has no ongoing
-# dependency on the mount afterward.
-if [ -n "${VULTRON_ORIGIN_URL:-}" ] && [ ! -d "$PWD/.git" ]; then
-    # Don't echo $VULTRON_ORIGIN_URL — never print a repo URL verbatim, since
-    # a differently-configured remote (this machine or another dev's) could
-    # carry embedded credentials.
-    echo "Cloning repository into $PWD ..."
-    if [ -f /mnt/main-repo.git/HEAD ]; then
-        git clone --reference /mnt/main-repo.git --dissociate "$VULTRON_ORIGIN_URL" "$PWD"
-    else
-        git clone "$VULTRON_ORIGIN_URL" "$PWD"
-    fi
-    echo ""
-fi
-
 # Update Claude Code to latest
 echo "Updating Claude Code..."
 claude update || true
@@ -44,36 +24,6 @@ prompt pure
 EOF
 fi
 
-# --- Persistent data volume ---
-DATA="$HOME/.data"
-sudo chown "$(id -u):$(id -g)" "$DATA" 2>/dev/null || true
-mkdir -p "$DATA/claude" "$DATA/shell-history"
-
-# Symlink ~/.claude to persistent volume
-if [ -d "$HOME/.claude" ] && [ ! -L "$HOME/.claude" ]; then
-    if [ -z "$(ls -A "$DATA/claude" 2>/dev/null)" ]; then
-        cp -a "$HOME/.claude/." "$DATA/claude/"
-    fi
-    rm -rf "$HOME/.claude"
-fi
-ln -sfn "$DATA/claude" "$HOME/.claude"
-
-# Persist ~/.claude.json on the volume
-if [ ! -f "$HOME/.claude/claude.json" ]; then
-    echo '{}' > "$HOME/.claude/claude.json"
-fi
-ln -sf "$HOME/.claude/claude.json" "$HOME/.claude.json"
-
-# --- Persistent shell history ---
-touch "$DATA/shell-history/.bash_history" "$DATA/shell-history/.zsh_history"
-
-if ! grep -q 'HISTFILE=.*\.data' "$HOME/.bashrc" 2>/dev/null; then
-    echo 'export HISTFILE="$HOME/.data/shell-history/.bash_history"' >> "$HOME/.bashrc"
-fi
-if [ -f "$HOME/.zshrc" ] && ! grep -q 'HISTFILE=.*\.data' "$HOME/.zshrc" 2>/dev/null; then
-    echo 'export HISTFILE="$HOME/.data/shell-history/.zsh_history"' >> "$HOME/.zshrc"
-fi
-
 # Claude Code installs to ~/.local/bin and registers it in .bashrc, but we use zsh
 if ! grep -q 'local/bin' "$HOME/.zshrc" 2>/dev/null; then
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zshrc"
@@ -89,12 +39,8 @@ set -g mouse on
 set -g default-shell /bin/zsh
 EOF
 
-# --- User-level skills ---
-# Point ~/.claude/skills at the Mac host user skills mounted by start-dev.sh.
-# Project skills (.claude/skills/ in the working tree) are auto-discovered by Claude Code separately.
-if [ -d "$HOME/.agents/skills" ]; then
-    ln -sfn "$HOME/.agents/skills" "$HOME/.data/claude/skills"
-fi
+# ~/.claude is a bind-mount of the host's ~/.claude — the host manages its own
+# skills symlink. Nothing to do here.
 
 echo ""
 echo "Post-create complete. Run 'claude' to start Claude Code."

--- a/.devcontainer/poststart.sh
+++ b/.devcontainer/poststart.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
-# Runs on every container start/restart.
+# Runs on every container start.
 set -euo pipefail
 
 CONTAINER_NAME="$(hostname)"
 
-# Keep this slot's independent clone's remote-tracking refs current. Never
-# touches the working tree or local branches — just a fetch.
-if [ -d "$PWD/.git" ]; then
-    git -C "$PWD" fetch origin --quiet 2>/dev/null || true
-fi
+# Refresh /app from origin. The container is ephemeral (destroyed on exit),
+# so there are never local uncommitted changes to protect here.
+git -C /app pull --ff-only --quiet 2>&1 || echo "[warn] git pull failed — running with baked image snapshot"
 
 echo ""
 echo "=== $CONTAINER_NAME ==="

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,24 +1,19 @@
 #!/bin/bash
 # Start (or attach to) a slot-based Claude Code devcontainer from the Mac terminal.
-# Usage: ./start-dev.sh <slot> [--rebuild] [--reset]
-#   slot       Name for this dev slot (e.g. inky, pinky, main). You pick the name.
-#              "main" is special: attaches to the host checkout directly.
-#              Every other slot gets its own independent `git clone`, made
-#              entirely inside that container — no shared git state between
-#              slots, no host directory per slot.
-#   --rebuild  Remove and rebuild the Docker image from scratch.
-#   --reset    Wipe the slot's container (its clone goes with it). A fresh
-#              clone from origin/main is made on next start.
+# Usage: ./start-dev.sh <slot> [--rebuild]
+#   slot       Name for this dev slot (e.g. inky, pinky, blinky).
+#              Every slot gets its own independent container. /app is baked
+#              into the image and refreshed from origin on every startup via
+#              `git pull` in poststart.sh.
+#   --rebuild  Remove the image and rebuild from scratch.
 set -euo pipefail
 
 SLOT=""
 REBUILD=false
-RESET=false
 
 for arg in "$@"; do
     case "$arg" in
         --rebuild) REBUILD=true ;;
-        --reset)   RESET=true ;;
         --*)       echo "Unknown option: $arg"; exit 1 ;;
         *)
             if [ -n "$SLOT" ]; then
@@ -30,69 +25,48 @@ for arg in "$@"; do
 done
 
 if [ -z "$SLOT" ]; then
-    echo "Usage: ./start-dev.sh <slot> [--rebuild] [--reset]"
+    echo "Usage: ./start-dev.sh <slot> [--rebuild]"
     echo ""
-    echo "  slot       Name for this dev slot (e.g. inky, pinky, main)."
-    echo "             'main' attaches to the host checkout; every other slot"
-    echo "             gets its own independent clone, isolated in that container."
+    echo "  slot       Name for this dev slot (e.g. inky, pinky, blinky)."
     echo "  --rebuild  Remove and rebuild the Docker image from scratch."
-    echo "  --reset    Wipe the slot's container and its clone; recreated fresh"
-    echo "             from origin/main on next start."
     exit 1
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MAIN_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 MAIN_NAME="$(basename "$MAIN_DIR")"
-# Strip any embedded credentials (https://user:token@host/...) before this
-# ever reaches a container env var or a log line — auth should flow through
-# the mounted .gitconfig's credential helper (gh, using GH_TOKEN from
-# --env-file below), never through the remote URL itself.
-ORIGIN_URL="$(git -C "$MAIN_DIR" remote get-url origin | sed -E 's#://[^@/]+@#://#')"
 IMAGE_NAME="${MAIN_NAME}-image"
-DATA_VOLUME="${MAIN_NAME}-data"
 ENV_FILE="$SCRIPT_DIR/.devcontainer/devcontainer.env"
+CONTAINER_NAME="${MAIN_NAME}_${SLOT}"
+WORKSPACE="/app"
 
 # First-run: collect credentials
 if [ ! -f "$ENV_FILE" ]; then
     bash "$SCRIPT_DIR/.devcontainer/setup.sh"
 fi
 
-if [ "$SLOT" = "main" ]; then
-    CONTAINER_NAME="${MAIN_NAME}_main"
-    WORKSPACE="/workspaces/${MAIN_NAME}"
-else
-    CONTAINER_NAME="${MAIN_NAME}_${SLOT}"
-    WORKSPACE="/workspaces/${MAIN_NAME}_${SLOT}"
-fi
-
 # Ensure wip_notes/ and wip_outputs/ exist on the host (both gitignored)
-_created_wip=false
 if [ ! -d "$MAIN_DIR/wip_notes" ]; then
     mkdir -p "$MAIN_DIR/wip_notes"
-    _created_wip=true
+    echo "Created wip_notes/ (read-only agent input). Gitignored."
 fi
 if [ ! -d "$MAIN_DIR/wip_outputs" ]; then
     mkdir -p "$MAIN_DIR/wip_outputs"
-    _created_wip=true
-fi
-if [ "$_created_wip" = true ]; then
-    echo "Created wip_notes/ (read-only agent input) and/or wip_outputs/ (agent output files). Both are gitignored."
+    echo "Created wip_outputs/ (agent output files). Gitignored."
 fi
 mkdir -p "$MAIN_DIR/wip_outputs/$SLOT"
+WIP_OUTPUTS_SLOT="$MAIN_DIR/wip_outputs/$SLOT"
 
-# --rebuild or --reset: remove existing container first. A slot's clone lives
-# entirely inside its own container's writable layer, so removing the
-# container is the whole reset — there's nothing else on the host to clean up.
-if [ "$REBUILD" = true ] || [ "$RESET" = true ]; then
+# Ensure per-slot graphify-out dir exists on the host
+GRAPHIFY_HOST="$HOME/dev/graphify-out/$SLOT"
+mkdir -p "$GRAPHIFY_HOST"
+
+# --rebuild: remove container and image
+if [ "$REBUILD" = true ]; then
     if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
         echo "Removing container '$CONTAINER_NAME'..."
         docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
     fi
-fi
-
-# --rebuild: also remove the image
-if [ "$REBUILD" = true ]; then
     echo "Removing image '$IMAGE_NAME'..."
     docker rmi -f "$IMAGE_NAME" >/dev/null 2>&1 || true
 fi
@@ -114,23 +88,7 @@ if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     exit 0
 fi
 
-# Container exists but stopped — restart it. Its clone lives on the
-# container's own writable layer and survives stop/start; only `docker rm`
-# (via --reset or --rebuild) discards it.
-if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
-    echo "Starting stopped container '$CONTAINER_NAME'..."
-    trap _cleanup EXIT
-    docker start "$CONTAINER_NAME"
-    docker exec -u vscode -w "$WORKSPACE" "$CONTAINER_NAME" \
-        bash -l .devcontainer/poststart.sh
-    _exec_shell
-    exit 0
-fi
-
-# First create: build image (cached layers reused if unchanged), create
-# container, run setup. All slots build from the main checkout's Dockerfile —
-# there's no per-slot host directory anymore to source an in-progress
-# Dockerfile from; test Dockerfile changes via the main checkout + --rebuild.
+# Build image (cached layers reused if unchanged)
 echo "Building image '$IMAGE_NAME'..."
 docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/docker/Dockerfile" --target dev "$SCRIPT_DIR"
 
@@ -144,31 +102,14 @@ DOCKER_ARGS=(
     -e LC_ALL=C.UTF-8
     -e TERM=xterm-256color
     -e VULTRON_MAIN_NAME="$MAIN_NAME"
-    -v "${DATA_VOLUME}:/home/vscode/.data"
-    -v "$MAIN_DIR:/workspaces/${MAIN_NAME}"
+    -e WIP_NOTES=/app/wip_notes
+    -e WIP_OUTPUTS=/app/wip_outputs
+    -v "$HOME/.claude:/home/vscode/.claude"
+    -v "$MAIN_DIR/wip_notes:/app/wip_notes:ro"
+    -v "$WIP_OUTPUTS_SLOT:/app/wip_outputs"
+    -v "$GRAPHIFY_HOST:/app/graphify-out"
     -w "$WORKSPACE"
 )
-
-# Non-main slots get their own independent `git clone`, made entirely inside
-# that container's own writable filesystem layer (see .devcontainer/postcreate.sh)
-# — never a host bind mount, never sharing a .git with any other slot or the
-# host. Nothing any container does to its own repo (commit, branch, checkout
-# someone else's PR for review, `git gc`, even `rm -rf .git`) can reach any
-# other slot's repo: that's Docker's ordinary per-container filesystem
-# isolation, not something enforced by careful mounting or locking.
-#
-# The clone is seeded from the host's main checkout via a one-time, read-only
-# `--reference --dissociate`: objects are borrowed from it for speed, then
-# immediately copied into the clone's own object store, so the clone has zero
-# ongoing dependency on this mount or on this machine's paths once created —
-# portable to any dev's machine, and safe even if the host checkout is later
-# gc'd or moved.
-if [ "$SLOT" != "main" ]; then
-    DOCKER_ARGS+=(
-        -v "$MAIN_DIR/.git:/mnt/main-repo.git:ro"
-        -e VULTRON_ORIGIN_URL="$ORIGIN_URL"
-    )
-fi
 
 # Mount user-level skills read-only if present on the host
 if [ -d "$HOME/.agents/skills" ]; then
@@ -188,33 +129,16 @@ if [ -S "/run/host-services/ssh-auth.sock" ]; then
     )
 fi
 
-# Mount wip_notes (read-only) and wip_outputs (read-write, namespaced by slot)
-DOCKER_ARGS+=(
-    -v "$MAIN_DIR/wip_notes:/workspaces/wip_notes:ro"
-    -v "$MAIN_DIR/wip_outputs:/workspaces/wip_outputs"
-    -e WIP_NOTES=/workspaces/wip_notes
-    -e WIP_OUTPUTS=/workspaces/wip_outputs/$SLOT
-)
-
 docker run -d "${DOCKER_ARGS[@]}" "$IMAGE_NAME" sleep infinity
 trap _cleanup EXIT
-
-# Docker auto-creates -w's target directory as root if it doesn't already
-# exist, regardless of the image's configured USER — so a non-main slot's
-# fresh $WORKSPACE (never bind-mounted, unlike main's) starts out root-owned
-# and the vscode user can't clone into it. Fix ownership before postcreate.sh
-# (which runs as vscode) tries to.
-if [ "$SLOT" != "main" ]; then
-    docker exec -u root "$CONTAINER_NAME" chown vscode:vscode "$WORKSPACE"
-fi
 
 echo ""
 echo "Running post-create setup (first time only)..."
 docker exec -u vscode -w "$WORKSPACE" "$CONTAINER_NAME" \
-    bash -l "/workspaces/${MAIN_NAME}/.devcontainer/postcreate.sh"
+    bash -l /app/.devcontainer/postcreate.sh
 
 echo ""
 docker exec -u vscode -w "$WORKSPACE" "$CONTAINER_NAME" \
-    bash -l "/workspaces/${MAIN_NAME}/.devcontainer/poststart.sh"
+    bash -l /app/.devcontainer/poststart.sh
 
 _exec_shell


### PR DESCRIPTION
- Closes #2177

## Summary

Simplifies the slot-based devcontainer setup by unifying on `/app` as the
canonical workspace path and adding persistent host mounts for
`graphify-out`, `~/.claude`, `wip_notes`, and `wip_outputs`.

## Changes

- **`start-dev.sh`**: Removed `main` slot, `--reset` flag, named data
  volume, and `.git` reference mount. Added `~/dev/graphify-out/<slot>/`
  mount at `/app/graphify-out`. Bind-mount host `~/.claude` directly.
  Scope `wip_outputs` mount to slot subdirectory. Update `wip_notes` target
  to `/app/wip_notes`. `WORKSPACE=/app` always. Containers are ephemeral —
  destroyed on shell exit via `trap _cleanup EXIT`.
- **`.devcontainer/postcreate.sh`**: Removed git clone, `~/.data` volume
  setup, `~/.claude` symlink, shell history persistence, and user-skills
  symlink. Kept `claude update`, pure prompt, tmux config, PATH fix.
- **`.devcontainer/poststart.sh`**: Simplified to `git pull --ff-only` with
  a warning on failure (safe — containers are always fresh).
- **`.devcontainer/README.md`**: Updated to reflect ephemeral container
  model, `/app` workspace, and new mount table.

## Verification

- `bash -n` syntax check passes on all three shell scripts
- `markdownlint-cli2` clean on README
- Black, flake8, mypy, pyright all clean (no Python changed)