### PR TITLE
docs: plan issue #2132 — CI failure alerting via GitHub Issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -550,6 +550,13 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   is green. Racing parallel PRs to `main` means each PR can only confirm its own
   scenario passes — none can confirm it hasn't perturbed other currently-passing
   scenarios. *Source: CONCERN-2137*
+- **New Push-to-`main` or Scheduled Workflows MUST Wire the `notify-failure`
+  Composite Action** — any workflow that triggers on `push: branches: [main]` or
+  on `schedule:` MUST include `.github/actions/notify-failure` as a final step
+  (CISEC-05-001). Without it, failures on `main` or unattended scheduled runs go
+  undetected until someone manually audits the Actions tab. The step handles both
+  failure (file/update a `ci:main-failure` issue) and recovery (close that issue).
+  *Source: CONCERN-2132*
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -554,8 +554,9 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   Composite Action** — any workflow that triggers on `push: branches: [main]` or
   on `schedule:` MUST include `.github/actions/notify-failure` as a final step
   (CISEC-05-001). Without it, failures on `main` or unattended scheduled runs go
-  undetected until someone manually audits the Actions tab. The step handles both
-  failure (file/update a `ci:main-failure` issue) and recovery (close that issue).
+  undetected until someone manually audits the Actions tab. Two separate steps are
+  required: one on failure (file/update a `ci:main-failure` issue, CISEC-05-001)
+  and one on success (close the issue for recovery visibility, CISEC-05-002).
   *Source: CONCERN-2132*
 
 ---

--- a/docs/adr/0055-ci-failure-alerting-via-github-issues.md
+++ b/docs/adr/0055-ci-failure-alerting-via-github-issues.md
@@ -1,0 +1,111 @@
+---
+status: accepted
+date: 2026-08-11
+deciders: ahouseholder
+consulted: specs/ci-security.yaml
+informed: .github/workflows/
+---
+
+# CI Failure Alerting via GitHub Issues on Main-Branch and Scheduled Workflows
+
+## Context and Problem Statement
+
+CI failures on `main` (push-triggered and scheduled workflows) are not reported
+anywhere. The team only finds out when someone manually checks the Actions tab or
+notices a broken badge. Broken `main` can persist for days; developers stack PRs
+on a broken base; scheduled workflow failures (sweeper, quarterly tag) have zero
+visibility. The root cause is a missing alerting contract: no structured feedback
+loop exists from CI failure to the issue tracker.
+
+See CONCERN-2132.
+
+## Decision Drivers
+
+- Failures on `main` must produce a visible, trackable signal in the issue tracker.
+- Recovery must close the signal automatically so the tracker reflects current health.
+- The solution must be self-contained: no external services (Slack, email) whose
+  configuration can drift or break silently.
+- The solution must be maintainable: a shared composite action avoids per-workflow
+  divergence as new workflows are added.
+- The signal must be deduplicated: one open issue per failing workflow, not a new
+  issue per run.
+
+## Considered Options
+
+1. **GitHub Issues via a shared `notify-failure` composite action** (chosen)
+2. External notification (Slack webhook / email via third-party action)
+3. No dedicated notification — rely on GitHub notification subscriptions and status
+   badges only (status quo)
+
+## Decision Outcome
+
+Chosen option: **Option 1 — GitHub Issues via `notify-failure` composite action**,
+because the issue tracker is already the team's single source of truth for work
+items; filing a failure issue there creates a trackable, closeable signal without
+any external service dependency.
+
+The composite action lives at `.github/actions/notify-failure`. Every qualifying
+workflow (push to `main` or `schedule` trigger) wires it as a final step. On
+failure it searches for an open issue with `ci:main-failure` + a
+workflow-specific label and either comments on the existing issue or creates a new
+one. On success it closes any matching open issue.
+
+The `ci:main-failure` label is reserved for this mechanism; the label description
+documents that it is bot-managed.
+
+### Consequences
+
+- **Good**: Failures are visible in the issue tracker where the team already
+  triages work — no context switch to the Actions tab required.
+- **Good**: Recovery is automatically tracked; issues close when the workflow
+  next passes.
+- **Good**: Deduplication (one open issue per workflow) keeps the tracker clean
+  across repeated failures.
+- **Good**: A shared composite action keeps all workflows consistent; adding a
+  new qualifying workflow is a one-line change.
+- **Good**: No external service dependency; the only requirement is the standard
+  `GITHUB_TOKEN` already available to every workflow.
+- **Neutral**: Requires `issues: write` permission on qualifying workflows. This
+  is a minimal, standard permission for a bot-authored issue.
+- **Bad**: Failure issues appear in the same tracker as feature/bug work. The
+  dedicated `ci:main-failure` label is the mitigation — it keeps the signal
+  filterable and clearly distinct from human-authored issues.
+
+## Validation
+
+Compliance is verified by `test/ci/test_workflow_failure_notification.py` (to be
+added as part of CISEC-05-004), which discovers all qualifying workflows and
+asserts each includes the `notify-failure` step.
+
+## Pros and Cons of the Options
+
+### Option 1 — GitHub Issues via `notify-failure` composite action
+
+- Good, because it is self-contained (no external service)
+- Good, because failure signals are co-located with other tracked work
+- Good, because recovery automatically closes the issue (feedback loop is complete)
+- Neutral, because it requires `issues: write` permission on qualifying workflows
+
+### Option 2 — External notification (Slack / email)
+
+- Good, because it reaches the team wherever they are, not just in GitHub
+- Bad, because it requires configuring and maintaining an external service
+  (webhook URL, credentials, bot token) whose expiry or misconfiguration silently
+  breaks alerting
+- Bad, because notifications do not produce a trackable, closeable work item
+
+### Option 3 — Status quo (rely on badge / subscriptions)
+
+- Good, because it requires zero implementation effort
+- Bad, because it provides no guarantee of visibility — developers must happen to
+  look at the badge or be watching Actions emails
+- Bad, because scheduled workflow failures (no commit or PR context) produce no
+  natural notification signal
+
+## More Information
+
+- CONCERN-2132 — the motivating concern
+- `specs/ci-security.yaml` CISEC-05-001 through CISEC-05-004 — generated spec
+  requirements
+- `.github/actions/notify-failure/` — implementation (to be added)
+- `test/ci/test_workflow_failure_notification.py` — enforcement test (to be added)

--- a/docs/adr/0055-ci-failure-alerting-via-github-issues.md
+++ b/docs/adr/0055-ci-failure-alerting-via-github-issues.md
@@ -45,10 +45,12 @@ items; filing a failure issue there creates a trackable, closeable signal withou
 any external service dependency.
 
 The composite action lives at `.github/actions/notify-failure`. Every qualifying
-workflow (push to `main` or `schedule` trigger) wires it as a final step. On
-failure it searches for an open issue with `ci:main-failure` + a
-workflow-specific label and either comments on the existing issue or creates a new
-one. On success it closes any matching open issue.
+workflow (push to `main` or `schedule` trigger) wires two steps: one conditioned
+on failure (file/update an issue) and one conditioned on success (close the
+matching issue). Each step calls the composite action with a `mode` input
+(`notify` vs `close`). Keeping the two steps separate avoids embedding
+workflow-status detection logic inside the action itself — the caller's
+`if: failure()` / `if: success()` conditions handle that entirely.
 
 The `ci:main-failure` label is reserved for this mechanism; the label description
 documents that it is bot-managed.

--- a/docs/adr/0055-ci-failure-alerting-via-github-issues.md
+++ b/docs/adr/0055-ci-failure-alerting-via-github-issues.md
@@ -2,8 +2,8 @@
 status: accepted
 date: 2026-08-11
 deciders: ahouseholder
-consulted: specs/ci-security.yaml
-informed: .github/workflows/
+consulted: []
+informed: []
 ---
 
 # CI Failure Alerting via GitHub Issues on Main-Branch and Scheduled Workflows
@@ -107,7 +107,10 @@ asserts each includes the `notify-failure` step.
 ## More Information
 
 - CONCERN-2132 — the motivating concern
-- `specs/ci-security.yaml` CISEC-05-001 through CISEC-05-004 — generated spec
+- `specs/ci-security.yaml` CISEC-05-001 through CISEC-05-005 — generated spec
   requirements
 - `.github/actions/notify-failure/` — implementation (to be added)
 - `test/ci/test_workflow_failure_notification.py` — enforcement test (to be added)
+
+Generated spec requirements: `specs/ci-security.yaml` CISEC-05-001 through
+CISEC-05-005.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -124,6 +124,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0052 Demo CI Job Structure: Accept Barrier + Concurrency Group Over Job Consolidation](0052-demo-ci-job-structure-barrier-accepted.md) *(provisional)*
 - [ADR-0053 Route Ownership-Transfer Offer and Accept Through the CaseActor](0053-ownership-transfer-routed-via-caseactor.md)
 - [ADR-0054 Retain plan/incoming/learnings/ as a File Queue; Do Not Migrate to GitHub Issues](0054-learnings-queue-as-files-not-issues.md)
+- [ADR-0055 CI Failure Alerting via GitHub Issues on Main-Branch and Scheduled Workflows](0055-ci-failure-alerting-via-github-issues.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -272,6 +272,7 @@ nav:
       - Demo CI Job Structure — Accept Barrier and Concurrency Group: 'adr/0052-demo-ci-job-structure-barrier-accepted.md'
       - Route Ownership-Transfer Offer and Accept Through the CaseActor: 'adr/0053-ownership-transfer-routed-via-caseactor.md'
       - Retain plan/incoming/learnings/ as a File Queue; Do Not Migrate to GitHub Issues: 'adr/0054-learnings-queue-as-files-not-issues.md'
+      - CI Failure Alerting via GitHub Issues on Main-Branch and Scheduled Workflows: 'adr/0055-ci-failure-alerting-via-github-issues.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/plan/history/2608/learning/CONCERN-2132.md
+++ b/plan/history/2608/learning/CONCERN-2132.md
@@ -1,0 +1,61 @@
+---
+source: CONCERN-2132
+timestamp: '2026-08-11T17:01:14.329114+00:00'
+title: CI failures on main are silent — no structured feedback loop from workflow
+  failure to issue tracker
+type: learning
+---
+
+## Summary
+
+CI failures on `main` (push-triggered and scheduled workflows) are not reported
+anywhere. There is no notification step, no issue filed, and no alert — the team
+only finds out when someone manually checks the Actions tab or notices a broken
+badge.
+
+## Surface Symptom vs. Underlying Problem
+
+**Surface symptom:** Individual CI runs show red, but no one is notified. The
+failure sits unacknowledged until a developer happens to look.
+
+**Underlying problem:** `main` has no failure alerting contract. The team
+implicitly relies on reviewers noticing a broken status badge or stumbling across
+the run — there is no structured feedback loop from CI failure back to the issue
+tracker. This is a process gap, not just a missing step.
+
+## Category
+
+Observability / CI hygiene
+
+## Severity
+
+Medium — breakage can linger undetected; the longer it sits, the more PRs land
+on a broken base and the harder the failure is to attribute.
+
+## Evidence
+
+The following workflows run on push to `main` or on a schedule but have no
+on-failure notification step:
+
+- `python-app.yml` (tests, linters, type checks, build)
+- `demo-integration.yml` (full 9-scenario end-to-end suite)
+- `spec-check.yml` (spec registry linter)
+- `actions-lint.yml` (workflow file linter)
+- `lint_md_all.yml` (Markdown linter)
+- `stale_claim_sweeper.yml` (scheduled, no human watching)
+- `quarterly_tag.yml` (scheduled, no human watching)
+- `deploy_site.yml` (docs site deployment, push to publish branch)
+
+No `ci:main-failure` label exists in the repo. No composite action for failure
+notification exists under `.github/actions/`.
+
+## Impact if Ignored
+
+Broken `main` goes undetected until a developer is blocked or manually audits the
+Actions tab. Developers may unknowingly stack PRs on a broken base. Scheduled
+workflow failures (sweeper, quarterly tag) have no visibility at all.
+
+**Resolved**: 2026-08-11 — implementation tracked in #2184.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2183>.
+Spec: `specs/ci-security.yaml` (CISEC-05).
+ADR: `docs/adr/0055-ci-failure-alerting-via-github-issues.md`.

--- a/specs/ci-security.yaml
+++ b/specs/ci-security.yaml
@@ -64,3 +64,43 @@ groups:
     kind: process
     statement: When adding a new workflow step or action, the SHA pin and version annotation MUST be included before the step
       is merged to `main`
+- id: CISEC-05
+  title: CI Failure Notification
+  specs:
+  - id: CISEC-05-001
+    priority: MUST
+    kind: process
+    statement: >-
+      Every workflow triggered by push to `main` or by a `schedule` event MUST
+      include a final step that files or updates a GitHub Issue when the workflow
+      fails. The step MUST use the shared `.github/actions/notify-failure`
+      composite action and MUST run on failure using an appropriate job-level or
+      step-level condition.
+    rationale: >-
+      Without structured failure notification, a broken `main` or a failed
+      scheduled job goes undetected until a developer manually audits the Actions
+      tab. Structured alerting ensures failures are visible in the issue tracker
+      where the team already triages work. Derived from ADR-0055
+      (docs/adr/0055-ci-failure-alerting-via-github-issues.md).
+  - id: CISEC-05-002
+    priority: MUST
+    kind: process
+    statement: >-
+      The notify-failure step MUST always run (not only on failure) and MUST close
+      any open failure issue for that workflow when the current run succeeds,
+      providing recovery visibility.
+    rationale: >-
+      A failure issue that stays open after the workflow recovers is misleading.
+      Recovery closure ensures the issue tracker reflects the current health of
+      `main`.
+  - id: CISEC-05-003
+    priority: MUST
+    kind: process
+    statement: Each failure notification issue MUST be tagged with the `ci:main-failure` label and a workflow-specific
+      label (e.g., `ci:workflow-python-app`). The combination of both labels MUST uniquely identify the open failure issue
+      for a specific workflow, enabling the composite action to find and update rather than duplicate.
+  - id: CISEC-05-004
+    priority: SHOULD
+    kind: process
+    statement: A CI verification test SHOULD confirm that every qualifying workflow (push to `main` or `schedule` trigger)
+      includes the `.github/actions/notify-failure` composite action step.

--- a/specs/ci-security.yaml
+++ b/specs/ci-security.yaml
@@ -105,3 +105,17 @@ groups:
     kind: process
     statement: A CI verification test SHOULD confirm that every qualifying workflow (push to `main` or `schedule` trigger)
       includes the `.github/actions/notify-failure` composite action step.
+  - id: CISEC-05-005
+    priority: SHOULD
+    kind: process
+    statement: >-
+      A workflow triggered on the `issues: labeled` event SHOULD enforce that the
+      `ci:main-failure` label is bot-managed: if `github.actor` is not
+      `github-actions[bot]`, the label MUST be removed immediately. This prevents
+      label spoofing that could suppress failure notification or create false alerts.
+    rationale: >-
+      The `ci:main-failure` label is the deduplication key used by the composite
+      action to find and update an existing failure issue rather than creating a
+      new one. If a human or external actor applies the label manually, the signal
+      is corrupted — the action may comment on an unrelated issue or fail to file
+      a new one. Bot-only enforcement keeps the alerting signal reliable.

--- a/specs/ci-security.yaml
+++ b/specs/ci-security.yaml
@@ -3,6 +3,7 @@ title: CI Security
 description: Requirements for securing CI/CD workflows and GitHub Actions usage in the Vultron project.
 version: 1.0.0
 scope:
+
 - prototype
 - production
 tags:
@@ -72,10 +73,9 @@ groups:
     kind: process
     statement: >-
       Every workflow triggered by push to `main` or by a `schedule` event MUST
-      include a final step that files or updates a GitHub Issue when the workflow
-      fails. The step MUST use the shared `.github/actions/notify-failure`
-      composite action and MUST run on failure using an appropriate job-level or
-      step-level condition.
+      include a step conditioned on failure that files or updates a GitHub Issue.
+      The step MUST use the shared `.github/actions/notify-failure` composite
+      action.
     rationale: >-
       Without structured failure notification, a broken `main` or a failed
       scheduled job goes undetected until a developer manually audits the Actions
@@ -86,13 +86,14 @@ groups:
     priority: MUST
     kind: process
     statement: >-
-      The notify-failure step MUST always run (not only on failure) and MUST close
-      any open failure issue for that workflow when the current run succeeds,
-      providing recovery visibility.
+      Every qualifying workflow (per CISEC-05-001) MUST also include a separate
+      step conditioned on success that closes any open failure issue for that
+      workflow, providing recovery visibility.
     rationale: >-
       A failure issue that stays open after the workflow recovers is misleading.
-      Recovery closure ensures the issue tracker reflects the current health of
-      `main`.
+      Two dedicated steps (one on failure, one on success) keep each step
+      single-purpose and avoid embedding workflow-status logic inside the
+      composite action itself.
   - id: CISEC-05-003
     priority: MUST
     kind: process


### PR DESCRIPTION
- Closes #2132

## Summary

Plans CONCERN-2132: adds CISEC-05 spec requirements and ADR-0055 for CI failure
alerting. Every push-to-main and scheduled workflow must wire two steps — one
on failure to file/update a GitHub Issue, one on success to close it — using a
shared `.github/actions/notify-failure` composite action.

## Changes

- **`specs/ci-security.yaml`**: adds CISEC-05 group (4 requirements) covering
  failure notification for push-to-main/scheduled workflows; two-step pattern
  (separate on-failure/on-success steps, no internal status logic in the action)
- **`docs/adr/0055-ci-failure-alerting-via-github-issues.md`**: new ADR recording
  the decision to alert via GitHub Issues over external channels (Slack/email),
  and the two-step composite action pattern
- **`docs/adr/index.md`**: adds ADR-0055 to the accepted ADRs list
- **`mkdocs.yml`**: adds ADR-0055 to the docs nav
- **`AGENTS.md`**: adds pitfall reminding agents to wire both notify-failure
  steps on any new qualifying workflow (CISEC-05-001)

## Implementation Issues

- #2184