### PR TITLE
fix(sync): buffer pre-genesis Announce(CaseLedgerEntry) and drain on case seed (#2186, #2180)

### DIFF
--- a/docs/adr/0055-buffer-pre-genesis-ledger-entries.md
+++ b/docs/adr/0055-buffer-pre-genesis-ledger-entries.md
@@ -1,0 +1,170 @@
+---
+status: accepted
+date: 2026-08-11
+deciders: Allen D. Householder
+consulted: []
+informed: []
+---
+
+# Buffer Pre-Genesis `Announce(CaseLedgerEntry)` and Drain on Case Seed
+
+## Context and Problem Statement
+
+A participant replica receives the canonical recorded log from the CaseActor as
+a stream of `Announce(CaseLedgerEntry)` activities, and it receives the case
+itself as a `Create`/`Announce(VulnerabilityCase)`. Both travel over a transport
+with **no ordering guarantee** (HTTP `BackgroundTasks` fan-out), so a replica can
+receive a ledger entry *before* the case that anchors it. In that pre-genesis
+window `_reconstruct_tail_hash` cannot derive the per-case genesis hash
+(CLP-08-005): there is no local tail and no case object to seed one from.
+
+ADR-0037 buffers *forward-gap* entries — those for a case whose genesis anchor is
+already known — but its forward-gap test (`log_index > tail_index + 1`) never
+fires when there is no chain at all, so a pre-genesis entry falls straight through
+to the reject-on-missing-case path (`ReconstructOrRejectOnMissingCase`,
+SYNC-15-001) and is **dropped**, leaving convergence to the reject → replay
+round-trip.
+
+That round-trip is exactly the mechanism ADR-0037 showed does not converge under
+adversarial reordering, and it has two observed costs: transient CLP-08-005 churn
+logged during fvcv-handoff (issue #2169), and — fatally for the fcvcv V1 demo —
+the `add_report_to_case` entry being dropped so no `VultronOfferRecord` is ever
+created and the report offer 404s (issue #2180). Issue #2186 identifies the
+missing pre-genesis buffer as the root cause of #2180. How should a replica handle
+a valid ledger entry that arrives before its case?
+
+## Decision Drivers
+
+- Convergence must not depend on whether the case or its ledger entries arrive
+  first (SYNC-15, SYNC-10-004); the transport provides no ordering.
+- The fix must interoperate with unknown implementations — we cannot assume the
+  sender retries or that any recovery message is delivered in order either.
+- Must preserve the effects-before-persist invariant (SYNC-12-001) and the
+  DataLayer-presence-means-committed invariant (SYNC-13-001 / SYNC-14-005).
+- Reuse the existing `LedgerGapBuffer` machinery rather than introduce a second,
+  parallel holding area.
+- Keep the genesis `Reject` as the loss backstop (SYNC-15-001) so an entry that
+  is genuinely never delivered still triggers replay.
+
+## Considered Options
+
+- **A. Rely on the reject → replay backstop only** — keep dropping pre-genesis
+  entries; trust SYNC-15-001 + SYNC-15-003 rate-limited replay to redeliver them
+  once the case is seeded.
+- **B. Buffer pre-genesis entries and drain on case seed** — hold every entry for
+  a not-yet-seeded case in the existing `LedgerGapBuffer` (keyed by
+  `prev_log_hash`), then drain the chain the moment the case seed anchors the
+  deterministic genesis hash.
+- **C. Wait for the genesis ledger entry** — buffer, but drain only when the
+  `log_index == 0` entry is separately re-delivered, not when the case is seeded.
+- **D. Add a client-side ordering guard in the demo** — make `fcvcv_demo.py`
+  order the case seed before the report so the race cannot occur in the demo.
+
+## Decision Outcome
+
+Chosen option: **B, buffer pre-genesis entries and drain on case seed.**
+
+The genesis hash is **deterministic from the case object alone** —
+`compute_genesis_hash(case_id, created_at, case_actor_id)` runs at
+`VulnerabilityCase` construction whenever `attributed_to` is present (CLP-08) — so
+seeding the case is sufficient to anchor the chain; the replica need not wait for
+the genesis ledger entry to be re-delivered. That makes option C strictly weaker
+(it re-introduces a dependence on redelivery order) and lets B reuse the ADR-0037
+drain unchanged: a buffered genesis entry's `prev_log_hash` equals the per-case
+genesis hash, so once the case is seeded `_reconstruct_tail_hash` returns
+`(genesis_hash, -1)`, `take_next(genesis_hash)` finds it, and the rest cascade in
+hash-chain order.
+
+A new `BufferPreGenesisEntryNode` is wired as the first child of the
+`ReconstructOrRejectOnMissingCase` fallback (wrapped in `FailureIsSuccess` so the
+`Reject` still fires), mirroring the buffer-and-reject structure of
+`CheckHashOrRejectOnMismatchNode`. Unlike `BufferOutOfOrderEntryNode` it applies
+**no** forward-gap check — there is no tail in the pre-genesis window, so every
+entry for the missing case is held. The drain logic itself is extracted into a
+module-level `drain_gap_buffer(...)` reused by both the announce receive path and
+a new drain-on-seed hook in `AnnounceVulnerabilityCaseReceivedUseCase`.
+
+Option A alone is insufficient for the same reason ADR-0037 rejected repairing
+replay: the replay re-announces entries individually over the same unordered
+transport and each pre-genesis entry Rejects again, amplifying churn (#2169). We
+keep the genesis `Reject` at buffer time purely as the backstop for entries that
+are genuinely *lost*. Option D was declined: the protocol, not the demo harness,
+must converge under reordering, so the demo is left to prove the protocol fix
+end-to-end (per the "protocol fix only" decision on #2180).
+
+### Consequences
+
+- Good: a replica that receives ledger entries before its case converges as soon
+  as the case is seeded, regardless of delivery order (SYNC-15-004, SYNC-15-005);
+  #2180's dropped `add_report_to_case` entry is retained and applied.
+- Good: reuses `LedgerGapBuffer` and the ADR-0037 drain — one holding area, one
+  cascade, one effects-before-persist path.
+- Good: no new dependence on sender retry or on the genesis ledger entry being
+  re-delivered; the deterministic genesis hash anchors from the case object.
+- Good: the genesis `Reject` remains as the loss backstop (SYNC-15-001), so a
+  genuinely lost entry still triggers replay.
+- Neutral: buffered state is in-memory and lost on restart; the SYNC-10 catch-up
+  gate re-syncs any gap after restart, so no durability is required.
+- Bad: the pre-genesis hold has no forward-gap bound to distinguish "far-future"
+  from "just early", so it leans entirely on the `LedgerGapBuffer` size cap +
+  farthest-ahead eviction (recoverable via the Reject backstop).
+
+## Validation
+
+- Pre-genesis regression tests through `AnnounceLedgerEntryReceivedUseCase` and
+  `drain_gap_buffer` (`test/core/use_cases/received/test_sync.py`,
+  `TestPreGenesisAnnounceBuffering`): a pre-genesis entry is buffered not dropped
+  (with the Reject still queued), a single buffered entry drains when the case is
+  seeded, and a multi-entry chain cascade-drains on seed.
+- A use-case-level drain-on-seed test
+  (`test/core/use_cases/received/actor/test_announce.py`,
+  `TestAnnounceDrainsPreGenesisBuffer`): seeding the case via
+  `AnnounceVulnerabilityCaseReceivedUseCase` drains a pre-buffered pre-genesis
+  entry into the local ledger.
+- The fcvcv demo exercises the end-to-end path: the `add_report_to_case` entry is
+  retained across the case-seed race, so the `VultronOfferRecord` is created and
+  the report offer no longer 404s (#2180).
+
+## Pros and Cons of the Options
+
+### A. Rely on the reject → replay backstop only
+
+- Good, because it reuses the existing recovery mechanism with no new state.
+- Bad, because replay re-announces entries individually over the same unordered
+  transport, so the drop race reappears — the same failure ADR-0037 documented.
+- Bad, because it amplifies CLP-08-005 churn (#2169) and leaves #2180's dropped
+  entry unrecovered within the demo's timeout.
+
+### B. Buffer pre-genesis entries and drain on case seed
+
+- Good, because convergence becomes independent of case-vs-entry arrival order.
+- Good, because it reuses `LedgerGapBuffer` and the ADR-0037 drain unchanged.
+- Good, because the deterministic genesis hash lets the case seed alone anchor
+  the chain — no wait for the genesis ledger entry.
+- Neutral, because it introduces bounded, ephemeral per-actor state (shared with
+  the forward-gap buffer).
+- Bad, because the pre-genesis hold cannot tell "early" from "far-future" and
+  relies on the size cap for its bound.
+
+### C. Wait for the genesis ledger entry
+
+- Good, because it drains through the identical `log_index == 0` code path.
+- Bad, because it re-introduces a dependence on redelivery order — the genesis
+  entry can itself reorder or be lost — which is the whole problem.
+
+### D. Client-side ordering guard in the demo
+
+- Good, because it is a small, local change that hides the symptom for #2180.
+- Bad, because it does not fix the protocol: any real deployment under reordering
+  still drops entries. The demo must validate the protocol, not paper over it.
+
+## More Information
+
+Root-cause / symptom split and the deterministic-genesis insight are recorded in
+`plan/incoming/learnings/` (`20260811-self-healing-recovery-logged-at-error.md`,
+`20260810-clp-08-005-protocol-hardening-gap`) and issues #2186 (root cause) /
+#2180 (symptom). Builds on ADR-0037 (forward-gap buffering) and the SYNC-15
+Genesis-Unavailable requirements.
+
+Generated spec requirements: `sync-ledger-replication.yaml` SYNC-15-004 and
+SYNC-15-005.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -124,7 +124,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0052 Demo CI Job Structure: Accept Barrier + Concurrency Group Over Job Consolidation](0052-demo-ci-job-structure-barrier-accepted.md) *(provisional)*
 - [ADR-0053 Route Ownership-Transfer Offer and Accept Through the CaseActor](0053-ownership-transfer-routed-via-caseactor.md)
 - [ADR-0054 Retain plan/incoming/learnings/ as a File Queue; Do Not Migrate to GitHub Issues](0054-learnings-queue-as-files-not-issues.md)
-- [ADR-0055 Buffer Pre-Genesis Announce(CaseLedgerEntry) and Drain on Case Seed](0055-buffer-pre-genesis-ledger-entries.md)
+- [ADR-0055 Buffer Pre-Genesis `Announce(CaseLedgerEntry)` and Drain on Case Seed](0055-buffer-pre-genesis-ledger-entries.md)
 
 ## Proposed ADRs
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -124,6 +124,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0052 Demo CI Job Structure: Accept Barrier + Concurrency Group Over Job Consolidation](0052-demo-ci-job-structure-barrier-accepted.md) *(provisional)*
 - [ADR-0053 Route Ownership-Transfer Offer and Accept Through the CaseActor](0053-ownership-transfer-routed-via-caseactor.md)
 - [ADR-0054 Retain plan/incoming/learnings/ as a File Queue; Do Not Migrate to GitHub Issues](0054-learnings-queue-as-files-not-issues.md)
+- [ADR-0055 Buffer Pre-Genesis Announce(CaseLedgerEntry) and Drain on Case Seed](0055-buffer-pre-genesis-ledger-entries.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -272,6 +272,7 @@ nav:
       - Demo CI Job Structure — Accept Barrier and Concurrency Group: 'adr/0052-demo-ci-job-structure-barrier-accepted.md'
       - Route Ownership-Transfer Offer and Accept Through the CaseActor: 'adr/0053-ownership-transfer-routed-via-caseactor.md'
       - Retain plan/incoming/learnings/ as a File Queue; Do Not Migrate to GitHub Issues: 'adr/0054-learnings-queue-as-files-not-issues.md'
+      - Buffer Pre-Genesis Announce(CaseLedgerEntry) and Drain on Case Seed: 'adr/0055-buffer-pre-genesis-ledger-entries.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/sync-ledger-replication.md
+++ b/notes/sync-ledger-replication.md
@@ -451,7 +451,7 @@ from the beginning; each entry passes the `CheckLedgerEntryAlreadyStoredNode` ga
 
 This is tracked as issue #1446.
 
-## Genesis-Unavailable Reject (SYNC-15)
+## Genesis-Unavailable Buffer-and-Reject (SYNC-15)
 
 `Announce(CaseLedgerEntry)` can arrive at a participant replica before
 `Create(VulnerabilityCase)` has been processed (a delivery-order race under HTTP
@@ -476,6 +476,46 @@ the CaseActor re-announces all entries once the case is delivered.
 Selector). Spec: SYNC-15-001, SYNC-15-002. Regression test:
 `test/core/use_cases/received/test_sync.py::TestAnnounceLedgerEntryReceivedUseCase
 ::test_missing_case_queues_reject_with_empty_tail_hash`.
+
+### Pre-Genesis Buffering and Drain on Case Seed (SYNC-15-004/005)
+
+The Reject backstop above is *loss* recovery — it depends on the CaseActor
+re-announcing entries once the case lands, over the same unordered transport,
+so each pre-genesis entry Rejects again and amplifies CLP-08-005 churn (#2169).
+Worse, in the `fcvcv` V1 demo the dropped `add_report_to_case` entry meant no
+`VultronOfferRecord` was ever created and the report offer 404'd (#2180). The
+forward-gap buffer (SYNC-10-004 above) does **not** catch this: its
+`log_index > tail_index + 1` test never fires when there is no chain at all, so
+a pre-genesis entry falls straight through to the reject-on-missing-case path.
+
+**Resolution (ADR-0055, #2186): buffer pre-genesis entries and drain on case
+seed.** The per-case genesis hash is deterministic from the case object alone
+(`compute_genesis_hash` runs at `VulnerabilityCase` construction when
+`attributed_to` is present, CLP-08), so seeding the case is sufficient to anchor
+the chain — no need to wait for the genesis ledger entry to be re-delivered.
+
+- `BufferPreGenesisEntryNode`
+  (`vultron/core/behaviors/sync/nodes/receive.py`) is wired as the first child
+  of the `ReconstructOrRejectOnMissingCase` fallback, wrapped in
+  `FailureIsSuccess` so the genesis `Reject` still fires as the loss backstop.
+  Unlike `BufferOutOfOrderEntryNode` it applies **no** forward-gap check — there
+  is no tail in the pre-genesis window, so every entry for the missing case is
+  held in the same `LedgerGapBuffer`.
+- The ADR-0037 drain is extracted to a module-level
+  `drain_gap_buffer(...)` (`vultron/core/use_cases/received/sync.py`) reused by
+  both the announce receive path and a new drain-on-seed hook in
+  `AnnounceVulnerabilityCaseReceivedUseCase`. In the pre-genesis case the first
+  reconstructed tail is `(genesis_hash, -1)`, so a buffered genesis entry
+  (`prev_log_hash == genesis_hash`) drains first and the rest cascade in
+  hash-chain order, reusing the exact effects-before-persist path (SYNC-12-001).
+- `ANNOUNCE_VULNERABILITY_CASE` was added to `_SYNC_PORT_SEMANTICS` so the seed
+  use case receives the `sync_port` the drain needs to send a Reject on any
+  residual mismatch.
+
+Spec: SYNC-15-004 (buffer pre-genesis), SYNC-15-005 (drain on seed).
+ADR: `docs/adr/0055-buffer-pre-genesis-ledger-entries.md`. Regression tests:
+`test/core/use_cases/received/test_sync.py::TestPreGenesisAnnounceBuffering` and
+`test/core/use_cases/received/actor/test_announce.py::TestAnnounceDrainsPreGenesisBuffer`.
 
 ## Reject/Replay Amplification (SYNC-15-003)
 

--- a/plan/incoming/learnings/20260811-git-credential-helper-broken-path.md
+++ b/plan/incoming/learnings/20260811-git-credential-helper-broken-path.md
@@ -1,0 +1,47 @@
+---
+title: git push blocked by credential helper pointing at nonexistent /usr/local/bin/gh
+type: learning
+timestamp: 2026-08-11
+source: ISSUE-2186
+signal: tooling-issue
+---
+
+Pushing the fix branch for #2186/#2180 failed before the PR could be opened:
+
+```text
+/usr/local/bin/gh auth git-credential get: 1: /usr/local/bin/gh: not found
+fatal: could not read Username for 'https://github.com'
+```
+
+Root cause: the git config sets
+`credential.https://github.com.helper = !/usr/local/bin/gh auth git-credential`,
+but in this environment `gh` lives at `/usr/bin/gh` — the configured path does
+not exist. The obvious repair (`gh auth setup-git`) also failed:
+
+```text
+failed to set up git credential helper: failed to run git:
+error: could not write config file /home/vscode/.gitconfig: Device or resource busy
+```
+
+so the global gitconfig cannot be rewritten (the file is bind-mounted /
+locked). `GH_TOKEN` *is* present in the environment.
+
+**Workaround that unblocked the push** — override the helper for a single
+command using the correct `gh` path, without touching `~/.gitconfig`:
+
+```bash
+git -c credential.https://github.com.helper='!/usr/bin/gh auth git-credential' \
+    push -u origin <branch>
+```
+
+(An inline token helper — `echo password=$GH_TOKEN` — or an
+`https://x-access-token:$GH_TOKEN@github.com/...` URL are equivalent fallbacks.)
+
+**How to apply:** when a `git push`/`gh` operation fails with
+`/usr/local/bin/gh: not found`, do not try to `gh auth setup-git` (the
+gitconfig is read-only here). Instead pass a one-shot `-c
+credential.https://github.com.helper='!/usr/bin/gh auth git-credential'`
+override on the push command. This is distinct from
+`20260811-create-pr-cannot-target-integration-branch.md` (which is about the
+create-pr skill hardcoding `--base main`); both had to be worked around in the
+same session.

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -4,7 +4,7 @@ description: >-
   Requirements for the append-only canonical recorded case ledger, replication transport,
   conflict handling, per-peer state tracking, and retry semantics for distributed case
   state synchronization across Participant Actors.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -440,17 +440,24 @@ groups:
       is recoverable because SYNC-14-002 already sent a Reject, so eviction MUST NOT be relied
       upon to trigger recovery by itself.
 - id: SYNC-15
-  title: Genesis-Unavailable Reject
+  title: Genesis-Unavailable Buffer-and-Reject
   description: >-
     A participant replica receives Announce(CaseLedgerEntry) activities from the CaseActor
     over an unordered transport.  If the CaseActor delivers a ledger entry before the
-    Create(VulnerabilityCase) activity has been processed by the participant (a delivery
-    race under HTTP BackgroundTasks), the replica cannot reconstruct the per-case genesis
-    hash (CLP-08-005) and must not silently drop the entry.  Silently dropping causes the
-    entry to be permanently lost because the CaseActor never learns that delivery failed
-    and never replays.  Sending a Reject triggers the same replay backstop as the
-    hash-mismatch path (SYNC-08-005, SYNC-14-002), allowing convergence once the case is
-    delivered.
+    Create/Announce(VulnerabilityCase) activity has been processed by the participant (a
+    delivery race under HTTP BackgroundTasks), the replica cannot reconstruct the per-case
+    genesis hash (CLP-08-005) and must not silently drop the entry.  Silently dropping causes
+    the entry to be permanently lost because the CaseActor never learns that delivery failed
+    and never replays.  A pre-genesis entry is therefore held in the same non-ledger holding
+    area used for forward gaps (SYNC-14) and drained once the case seed anchors the genesis
+    hash, making convergence independent of whether the case or its ledger entries arrive
+    first (issue #2186, #2180).  A Reject is still sent as the loss backstop, triggering the
+    same replay path as the hash-mismatch case (SYNC-08-005, SYNC-14-002) for an entry that is
+    genuinely lost rather than merely early.  The forward-gap buffer of SYNC-14 alone does not
+    cover this window: it only holds entries for a case whose genesis anchor is already known,
+    so a distinct pre-genesis hold and a drain triggered by the case seed are required.
+    Rationale for the buffer-and-drain path (SYNC-15-004, SYNC-15-005): ADR-0055
+    (docs/adr/0055-buffer-pre-genesis-ledger-entries.md).
   specs:
   - id: SYNC-15-001
     priority: MUST
@@ -525,3 +532,57 @@ groups:
     - rel_type: refines
       spec_id: SYNC-15-001
       note: The genesis Reject that SYNC-15-001 mandates is the highest-volume source of no-progress replays
+  - id: SYNC-15-004
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When a participant receives a valid Announce(CaseLedgerEntry) but cannot reconstruct the
+      per-case genesis hash because the VulnerabilityCase is not yet present in its DataLayer
+      (CLP-08-005), the participant MUST NOT rely solely on the reject/replay round-trip; it
+      MUST retain the entry in the same non-ledger holding area used for forward gaps (SYNC-14),
+      keyed by its prev_log_hash, pending arrival of the case seed.  Unlike a forward gap
+      (SYNC-14-001) this hold applies without a tail_index comparison — no chain tail exists in
+      the pre-genesis window — so every entry for the missing case is held, including the
+      genesis entry (log_index 0) whose prev_log_hash equals the per-case genesis hash.
+    rationale: >-
+      The reject/replay backstop (SYNC-15-001) does not converge under adversarial reordering
+      for the same reason forward gaps are buffered (SYNC-14): replay re-announces entries
+      individually over the same unordered transport and each pre-genesis entry Rejects again,
+      amplifying churn (issue #2169) and, for the fvcv-handoff demo, dropping the
+      add_report_to_case entry so no VultronOfferRecord is ever created (issue #2180). Holding
+      the entry lets it drain deterministically once the case is seeded.
+    relationships:
+    - rel_type: depends_on
+      spec_id: SYNC-14-001
+      note: Reuses the same non-ledger holding area and prev_log_hash keying as the forward-gap buffer
+    - rel_type: depends_on
+      spec_id: SYNC-14-005
+      note: A pre-genesis entry MUST NOT be persisted as a CaseLedgerEntry while buffered
+    - rel_type: refines
+      spec_id: SYNC-15-001
+      note: The Reject is retained as the loss backstop; buffering is the primary convergence path
+  - id: SYNC-15-005
+    priority: MUST
+    kind: protocol
+    statement: >-
+      After a participant seeds the VulnerabilityCase (via Create or Announce(VulnerabilityCase)),
+      which anchors the deterministic per-case genesis hash (CLP-08), it MUST drain the holding
+      area for that case: it MUST locate the buffered entry (if any) whose prev_log_hash equals
+      the per-case genesis hash, apply-then-persist it via the same path as in-order delivery
+      (SYNC-14-004), and cascade in hash-chain order (SYNC-14-003) until no buffered entry extends
+      the current tail.
+    rationale: >-
+      The genesis hash is derivable from the case object alone (deterministic from case_id,
+      created_at, and the CaseActor id per CLP-08), so seeding the case is sufficient to anchor
+      the chain — the participant need not wait for the genesis ledger entry to be re-delivered.
+      Draining on seed is what turns the pre-genesis hold (SYNC-15-004) into convergence.
+    relationships:
+    - rel_type: depends_on
+      spec_id: SYNC-14-003
+      note: Reuses the cascading drain defined for forward gaps
+    - rel_type: depends_on
+      spec_id: SYNC-14-004
+      note: The drained entry MUST apply effects before persisting, on the same path as in-order delivery
+    - rel_type: depends_on
+      spec_id: SYNC-15-004
+      note: Drains exactly the entries that SYNC-15-004 buffered during the pre-genesis window

--- a/test/core/behaviors/case/nodes/test_issue_2134_invite_path_report.py
+++ b/test/core/behaviors/case/nodes/test_issue_2134_invite_path_report.py
@@ -296,6 +296,48 @@ class TestApplyOfferReportFromLedgerNode:
         assert offer_record.report_id == REPORT_ID
         assert offer_record.offer_actor_id == REPORTER_ACTOR_ID
 
+    def test_stores_report_object_from_ledger_snapshot_when_absent(
+        self, bridge, datalayer, case_actor
+    ) -> None:
+        """The full report object is reconstructed from the ledger snapshot.
+
+        Regression for #2180: when the report is added to the case *after* the
+        case was announced to an invited participant, the Announce(VulnerabilityCase)
+        carried no embedded report (CBT-01-007 path is empty), so the report
+        object only ever reaches the participant inside the add_report_to_case
+        ledger snapshot.  ApplyOfferReportFromLedgerNode must therefore store the
+        report object too — otherwise _reconstitute_offer 404s on the report
+        lookup even though the offer record exists.
+        """
+        from vultron.core.behaviors.sync.nodes.offer_report_effect import (
+            ApplyOfferReportFromLedgerNode,
+        )
+
+        # The report object was never seeded (no embedded report in a prior
+        # case announce) — the ledger snapshot is the only source.
+        assert datalayer.read(REPORT_ID) is None
+
+        entry = _make_offer_report_ledger_entry()
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=ApplyOfferReportFromLedgerNode(
+                name="ApplyOfferReportFromLedger"
+            ),
+            actor_id=INVITED_ACTOR_ID,
+            activity=event,
+        )
+
+        assert result.status == Status.SUCCESS
+        stored_report = datalayer.read(REPORT_ID)
+        assert stored_report is not None, (
+            "ApplyOfferReportFromLedgerNode must store the VulnerabilityReport "
+            "reconstructed from the add_report_to_case ledger snapshot when the "
+            "report was not previously seeded (#2180)"
+        )
+        assert isinstance(stored_report, VulnerabilityReport)
+        assert stored_report.id_ == REPORT_ID
+
     def test_idempotent_when_offer_record_already_exists(
         self, bridge, datalayer, case_actor
     ) -> None:

--- a/test/core/use_cases/received/actor/test_announce.py
+++ b/test/core/use_cases/received/actor/test_announce.py
@@ -17,6 +17,10 @@ from typing import Any, cast
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
+from vultron.core.models.case_ledger import HashChainLedgerRecord
+from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
+from vultron.core.models.ledger_gap_buffer import LedgerGapBuffer
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.use_cases.received.actor.announce import (
     AnnounceVulnerabilityCaseReceivedUseCase,
@@ -207,6 +211,89 @@ class TestAnnounceVulnerabilityCaseReceivedUseCase:
         AnnounceVulnerabilityCaseReceivedUseCase(dl, event).execute()
 
         assert dl.read(_CASE_ID) is None
+
+
+# ---------------------------------------------------------------------------
+# #2186 / #2180: pre-genesis Announce(CaseLedgerEntry) drains on case seed
+# ---------------------------------------------------------------------------
+
+
+def _genesis_entry_for(
+    case_id: str, genesis_hash: str
+) -> VultronCaseLedgerEntry:
+    """Build a genesis (log_index 0) entry anchored to *genesis_hash*."""
+    chain = HashChainLedgerRecord(
+        case_id=case_id,
+        log_index=0,
+        object_id="https://example.org/activities/genesis",
+        event_type="test_event",
+        payload_snapshot={"key": "value"},
+        prev_log_hash=genesis_hash,
+    )
+    return VultronCaseLedgerEntry(
+        case_id=chain.case_id,
+        log_index=chain.log_index,
+        disposition=chain.disposition,
+        term=chain.term,
+        log_object_id=chain.object_id,
+        event_type=chain.event_type,
+        payload_snapshot=dict(chain.payload_snapshot),
+        prev_log_hash=chain.prev_log_hash,
+        entry_hash=chain.entry_hash,
+    )
+
+
+class TestAnnounceDrainsPreGenesisBuffer:
+    """Seeding a VulnerabilityCase must drain any pre-genesis ledger entries.
+
+    Regression for #2186 (root cause) / #2180 (symptom): an
+    ``Announce(CaseLedgerEntry)`` that arrives before the ``VulnerabilityCase``
+    is seeded is parked in the actor-local gap buffer (SYNC-15-004) instead of
+    being permanently dropped.  Once the case seed lands — anchoring the
+    deterministic per-case genesis hash — the buffered entry MUST drain into the
+    local ledger via the same effects-before-persist path (SYNC-15-005).
+    """
+
+    @pytest.fixture()
+    def case_with_actor(self):
+        """A case whose attributed_to yields a deterministic genesis hash."""
+        return as_VulnerabilityCase(
+            id_=_CASE_ID,
+            name="DR-10 Announce Case (pre-genesis drain)",
+            attributed_to=_CASE_ACTOR_ID,
+        )
+
+    def test_pre_genesis_entry_drains_when_case_is_announced(
+        self, dl, make_payload, case_with_actor
+    ):
+        genesis_hash = case_with_actor.genesis_hash
+        assert genesis_hash, "case must expose a deterministic genesis hash"
+        entry = _genesis_entry_for(_CASE_ID, genesis_hash)
+
+        gap_buffer = LedgerGapBuffer()
+        assert gap_buffer.buffer(entry) is True
+        assert gap_buffer.depth(_CASE_ID) == 1
+        assert dl.read(entry.id_) is None  # not yet applicable — case absent
+
+        activity = announce_vulnerability_case_activity(
+            case_with_actor,
+            actor=_CASE_ACTOR_ID,
+            context=_CASE_ID,
+        )
+        event = make_payload(activity)
+
+        AnnounceVulnerabilityCaseReceivedUseCase(
+            dl,
+            event,
+            sync_port=SyncActivityAdapter(dl),
+            gap_buffer=gap_buffer,
+        ).execute()
+
+        # Case seeded ...
+        assert dl.read(_CASE_ID) is not None
+        # ... and the buffered pre-genesis entry drained into the ledger.
+        assert dl.read(entry.id_) is not None
+        assert gap_buffer.depth(_CASE_ID) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/use_cases/received/test_sync.py
+++ b/test/core/use_cases/received/test_sync.py
@@ -620,4 +620,3 @@ class TestPreGenesisAnnounceBuffering:
 
         assert all(dl.read(e.id_) is not None for e in entries)
         assert gap_buffer.depth(CASE_URI) == 0
-        assert gap_buffer.depth(CASE_URI) == 0

--- a/test/core/use_cases/received/test_sync.py
+++ b/test/core/use_cases/received/test_sync.py
@@ -28,6 +28,7 @@ from vultron.core.models.ledger_gap_buffer import LedgerGapBuffer
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.use_cases.received.sync import (
     AnnounceLedgerEntryReceivedUseCase,
+    drain_gap_buffer,
     _reconstruct_tail_hash,
 )
 from typing import cast
@@ -507,4 +508,116 @@ class TestOutOfOrderAnnounceBuffering:
             ).execute()
 
         assert self._present_indices(dl) == {0, 1, 2, 3, 4}
+
+
+class TestPreGenesisAnnounceBuffering:
+    """A pre-genesis ``Announce(CaseLedgerEntry)`` — one that arrives before the
+    ``VulnerabilityCase`` is seeded, so the per-case genesis hash is unavailable
+    (CLP-08-005) — MUST be buffered rather than permanently dropped, and MUST
+    drain into the local ledger once the case is seeded (issue #2186, #2180,
+    SYNC-15-004, SYNC-15-005).
+
+    This closes the pre-genesis race without relying on the reject/replay
+    round-trip: the forward-gap buffer (SYNC-14) only covers entries for a case
+    whose genesis anchor is already known, so a distinct pre-genesis hold is
+    required.
+    """
+
+    @pytest.fixture
+    def gap_buffer(self) -> LedgerGapBuffer:
+        return LedgerGapBuffer()
+
+    def _make_event(
+        self, entry: VultronCaseLedgerEntry
+    ) -> AnnounceLogEntryReceivedEvent:
+        wire_entry = WireCaseLedgerEntry.model_validate(
+            entry.model_dump(mode="json")
+        )
+        activity = announce_log_entry_activity(wire_entry, actor=ACTOR_URI)
+        event = cast(AnnounceLogEntryReceivedEvent, extract_event(activity))
+        return event.model_copy(update={"receiving_actor_id": RECEIVER_URI})
+
+    def test_pre_genesis_entry_is_buffered_not_dropped(self, dl, gap_buffer):
+        """With no case seeded, the entry is held in the buffer (not dropped)
+        and a Reject is still sent as the loss backstop (SYNC-15-001)."""
+        case = _make_case()  # deliberately NOT saved — pre-genesis window
+        entry = _make_entry(CASE_URI, 0, case.genesis_hash)
+        sync_port = SyncActivityAdapter(dl)
+
+        AnnounceLedgerEntryReceivedUseCase(
+            dl,
+            self._make_event(entry),
+            sync_port=sync_port,
+            gap_buffer=gap_buffer,
+        ).execute()
+
+        # Not stored — cannot validate genesis (SYNC-15-002).
+        assert dl.read(entry.id_) is None
+        # Buffered, not dropped — the #2186 fix.
+        assert gap_buffer.depth(CASE_URI) == 1
+        # Reject still queued as the backstop (SYNC-15-001).
+        assert len(dl.outbox_list_for_actor(RECEIVER_URI)) == 1
+
+    def test_buffered_pre_genesis_entry_drains_when_case_seeded(
+        self, dl, gap_buffer
+    ):
+        """Once the case is seeded, the buffered genesis entry applies via the
+        same effects-before-persist path (SYNC-15-005, SYNC-14-004)."""
+        case = _make_case()
+        entry = _make_entry(CASE_URI, 0, case.genesis_hash)
+        sync_port = SyncActivityAdapter(dl)
+
+        AnnounceLedgerEntryReceivedUseCase(
+            dl,
+            self._make_event(entry),
+            sync_port=sync_port,
+            gap_buffer=gap_buffer,
+        ).execute()
+        assert dl.read(entry.id_) is None
+        assert gap_buffer.depth(CASE_URI) == 1
+
+        # Seed the case — genesis anchor is now derivable (deterministic from
+        # attributed_to), so the buffered entry can drain.
+        dl.save(case)
+        drain_gap_buffer(
+            dl,
+            CASE_URI,
+            RECEIVER_URI,
+            gap_buffer,
+            sync_port,
+        )
+
+        assert dl.read(entry.id_) is not None
+        assert gap_buffer.depth(CASE_URI) == 0
+
+    def test_pre_genesis_cascade_drains_full_chain_on_seed(
+        self, dl, gap_buffer
+    ):
+        """Several entries arriving pre-genesis all buffer, then cascade-drain
+        in hash-chain order the moment the case is seeded."""
+        case = _make_case()
+        prev = case.genesis_hash
+        entries: list[VultronCaseLedgerEntry] = []
+        for i in range(3):
+            e = _make_entry(CASE_URI, i, prev)
+            entries.append(e)
+            prev = e.entry_hash
+        sync_port = SyncActivityAdapter(dl)
+
+        # All three arrive before the case is seeded.
+        for e in entries:
+            AnnounceLedgerEntryReceivedUseCase(
+                dl,
+                self._make_event(e),
+                sync_port=sync_port,
+                gap_buffer=gap_buffer,
+            ).execute()
+        assert gap_buffer.depth(CASE_URI) == 3
+        assert dl.read(entries[0].id_) is None
+
+        dl.save(case)
+        drain_gap_buffer(dl, CASE_URI, RECEIVER_URI, gap_buffer, sync_port)
+
+        assert all(dl.read(e.id_) is not None for e in entries)
+        assert gap_buffer.depth(CASE_URI) == 0
         assert gap_buffer.depth(CASE_URI) == 0

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -134,6 +134,13 @@ _SYNC_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ADD_EMBARGO_EVENT_TO_CASE,
         MessageSemantics.ANNOUNCE_CASE_LEDGER_ENTRY,
+        # ANNOUNCE_VULNERABILITY_CASE seeds the local VulnerabilityCase, which
+        # anchors the per-case genesis hash and lets AnnounceVulnerabilityCase-
+        # ReceivedUseCase drain any pre-genesis Announce(CaseLedgerEntry) it
+        # parked in the gap buffer.  The drain re-runs the announce receive path,
+        # which sends a Reject on any residual mismatch, so it needs sync_port
+        # (SYNC-15-005, #2186, #2180).
+        MessageSemantics.ANNOUNCE_VULNERABILITY_CASE,
         MessageSemantics.ADD_NOTE_TO_CASE,
         MessageSemantics.CLOSE_CASE,
         MessageSemantics.INVITE_ACTOR_TO_CASE,

--- a/vultron/core/behaviors/sync/announce_tree.py
+++ b/vultron/core/behaviors/sync/announce_tree.py
@@ -10,6 +10,7 @@ from vultron.core.behaviors.sync.nodes import (
     ApplyNoteFromLedgerNode,
     ApplyOfferReportFromLedgerNode,
     ApplyParticipantStatusFromLedgerNode,
+    BufferPreGenesisEntryNode,
     CheckHashOrRejectOnMismatchNode,
     CheckIsOwnCaseActorNode,
     CheckIsNotOwnCaseActorNode,
@@ -191,17 +192,34 @@ def create_announce_log_entry_tree() -> py_trees.behaviour.Behaviour:
     )
     # When the VulnerabilityCase is not yet seeded on this replica, chain tail
     # reconstruction fails and no tail_hash is available for the mismatch check.
-    # Wrap reconstruct in a Selector so that on failure we still send a Reject
-    # (with last_accepted_hash="" meaning "replay from genesis") and exit the
-    # Sequence without persisting the entry (SYNC-15-001, CLP-08-005).
+    # Wrap reconstruct in a Selector so that on failure we (1) park the entry in
+    # the actor-local gap buffer so the case-seed path can drain it once the
+    # genesis anchor is known (SYNC-15-004, #2186), and (2) still send a Reject
+    # (with last_accepted_hash="" meaning "replay from genesis") as the loss
+    # backstop, exiting the Sequence without persisting the entry (SYNC-15-001,
+    # CLP-08-005).  FailureIsSuccess lets the reject fire whether or not the
+    # entry was buffered, mirroring CheckHashOrRejectOnMismatchNode's forward-gap
+    # buffer-and-reject structure.
     reconstruct_or_reject = py_trees.composites.Selector(
         name="ReconstructOrRejectOnMissingCase",
         memory=False,
         children=[
             ReconstructChainTailNode(name="ReconstructChainTail"),
-            # Fallback: send Reject carrying the sentinel tail_hash="" that
-            # ReconstructChainTailNode wrote before failing.
-            SendRejectLogEntryNode(name="RejectOnMissingCase"),
+            py_trees.composites.Sequence(
+                name="BufferAndRejectOnMissingCase",
+                memory=False,
+                children=[
+                    py_trees.decorators.FailureIsSuccess(
+                        name="BufferIfPreGenesis",
+                        child=BufferPreGenesisEntryNode(
+                            name="BufferPreGenesisEntry"
+                        ),
+                    ),
+                    # Fallback: send Reject carrying the sentinel tail_hash=""
+                    # that ReconstructChainTailNode wrote before failing.
+                    SendRejectLogEntryNode(name="RejectOnMissingCase"),
+                ],
+            ),
         ],
     )
     process_and_store = py_trees.composites.Sequence(

--- a/vultron/core/behaviors/sync/nodes/__init__.py
+++ b/vultron/core/behaviors/sync/nodes/__init__.py
@@ -52,6 +52,7 @@ from vultron.core.behaviors.sync.nodes.conditions import (
 )
 from vultron.core.behaviors.sync.nodes.receive import (
     BufferOutOfOrderEntryNode,
+    BufferPreGenesisEntryNode,
     CheckHashMatchesNode,
     CheckHashOrRejectOnMismatchNode,
     LogDeliveryConfirmationNode,
@@ -107,6 +108,7 @@ __all__ = [
     "PersistReceivedLogEntryNode",
     "CheckHashMatchesNode",
     "BufferOutOfOrderEntryNode",
+    "BufferPreGenesisEntryNode",
     "SendRejectLogEntryNode",
     "CheckHashOrRejectOnMismatchNode",
     # chain

--- a/vultron/core/behaviors/sync/nodes/offer_report_effect.py
+++ b/vultron/core/behaviors/sync/nodes/offer_report_effect.py
@@ -110,6 +110,38 @@ class ApplyOfferReportFromLedgerNode(DataLayerAction):
             if isinstance(object_data, (str, dict))
             else None
         )
+
+        # The add_report_to_case snapshot embeds the full report inline
+        # (build_add_report_to_case_snapshot -> obj_to_inline_dict).  An invited
+        # replica never received the VulnerabilityReport object directly, so
+        # reconstruct and store it from the snapshot here — otherwise
+        # _reconstitute_offer (and SvcValidateReportUseCase) 404 on the report
+        # lookup even though the offer record exists (#2180, ADR-0035 DL-06-002).
+        if (
+            isinstance(object_data, dict)
+            and report_id
+            and self.datalayer.read(report_id) is None
+        ):
+            from vultron.core.models.report import VulnerabilityReport
+
+            try:
+                self.datalayer.save(
+                    VulnerabilityReport.model_validate(object_data)
+                )
+                self.logger.info(
+                    "%s: stored VulnerabilityReport '%s' from ledger snapshot"
+                    " for invited replica (#2180)",
+                    self.name,
+                    report_id,
+                )
+            except Exception as exc:
+                self.logger.warning(
+                    "%s: could not reconstruct VulnerabilityReport from"
+                    " add_report_to_case snapshot: %s",
+                    self.name,
+                    exc,
+                )
+
         offer_to = snapshot.get("to", [])
         if isinstance(offer_to, str):
             offer_to = [offer_to]

--- a/vultron/core/behaviors/sync/nodes/receive.py
+++ b/vultron/core/behaviors/sync/nodes/receive.py
@@ -189,6 +189,77 @@ class BufferOutOfOrderEntryNode(DataLayerAction):
         return Status.FAILURE
 
 
+class BufferPreGenesisEntryNode(DataLayerAction):
+    """Hold a ledger entry that arrived before its ``VulnerabilityCase`` seed.
+
+    This is the *pre-genesis* companion to :class:`BufferOutOfOrderEntryNode`.
+    When ``ReconstructChainTail`` cannot derive the per-case genesis hash
+    because the ``VulnerabilityCase`` is not yet present in the DataLayer
+    (CLP-08-005), the receive path would otherwise send a
+    ``Reject(CaseLedgerEntry)`` and *drop* the entry, leaving convergence to the
+    reject → replay round-trip (which can itself reorder and churn — #2169).
+
+    Because delivery is unordered, an ``Announce(CaseLedgerEntry)`` can precede
+    the ``Create``/``Announce(VulnerabilityCase)`` that seeds the case.  This
+    node parks the entry in the actor-local
+    :class:`~vultron.core.models.ledger_gap_buffer.LedgerGapBuffer` keyed by its
+    ``prev_log_hash`` so the case-seed path can drain it once the genesis anchor
+    is known (issue #2186, SYNC-15-004).
+
+    Unlike :class:`BufferOutOfOrderEntryNode`, it does **not** apply a
+    forward-gap check: there is no reconstructed tail in the pre-genesis window,
+    so *every* entry for the missing case is held — including the genesis entry
+    (``log_index == 0``), whose ``prev_log_hash`` equals the per-case genesis
+    hash and therefore drains first once the case is seeded.
+
+    Returns SUCCESS when the entry was buffered, FAILURE otherwise (buffering
+    disabled, no gap buffer injected, or the size bound dropped it).  Its status
+    only structures the enclosing tree — a ``Reject(CaseLedgerEntry)`` is sent
+    on every pre-genesis entry regardless, so the CaseActor's replay remains the
+    backstop (SYNC-15-001).  The entry is deliberately NOT persisted here; the
+    drain applies effects before persisting, honouring SYNC-12-001 / SYNC-14-005.
+    """
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._gap_buffer: LedgerGapBuffer | None = None
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="gap_buffer", access=py_trees.common.Access.READ
+        )
+
+    def initialise(self) -> None:
+        super().initialise()
+        try:
+            self._gap_buffer = cast(
+                LedgerGapBuffer, self.blackboard.gap_buffer
+            )
+        except (AttributeError, KeyError):
+            self._gap_buffer = None
+
+    def update(self) -> Status:
+        if self._gap_buffer is None:
+            return Status.FAILURE
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        if self._gap_buffer.buffer(entry):
+            self.logger.info(
+                "%s: buffered pre-genesis entry '%s' (index=%d) for case '%s' "
+                "pending VulnerabilityCase seed",
+                self.name,
+                entry.id_,
+                entry.log_index,
+                entry.case_id,
+            )
+            return Status.SUCCESS
+        return Status.FAILURE
+
+
 class SendRejectLogEntryNode(DataLayerAction):
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)

--- a/vultron/core/use_cases/received/actor/announce.py
+++ b/vultron/core/use_cases/received/actor/announce.py
@@ -1,6 +1,7 @@
 """Use cases for case actor/participant invitation and suggestion activities."""
 
 import logging
+from typing import cast
 
 from py_trees.common import Status
 
@@ -12,10 +13,19 @@ from vultron.core.models.events.actor import (
     AnnounceVulnerabilityCaseReceivedEvent,
 )
 from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.ledger_gap_buffer import (
+    LedgerGapBuffer,
+    get_ledger_gap_buffer,
+)
 from vultron.core.models.report_case_link import VultronReportCaseLink
-from vultron.core.ports.case_persistence import CasePersistence
+from vultron.core.ports.case_persistence import (
+    CaseOutboxPersistence,
+    CasePersistence,
+)
+from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.models._helpers import _as_id
 from vultron.core.use_cases._helpers import _find_case_actor_id
+from vultron.core.use_cases.received.sync import drain_gap_buffer
 
 logger = logging.getLogger(__name__)
 
@@ -53,9 +63,13 @@ class AnnounceVulnerabilityCaseReceivedUseCase:
         self,
         dl: CasePersistence,
         request: AnnounceVulnerabilityCaseReceivedEvent,
+        sync_port: SyncActivityPort | None = None,
+        gap_buffer: LedgerGapBuffer | None = None,
     ) -> None:
         self._dl = dl
         self._request = request
+        self._sync_port = sync_port
+        self._gap_buffer = gap_buffer
 
     def execute(self) -> None:
         request = self._request
@@ -125,4 +139,22 @@ class AnnounceVulnerabilityCaseReceivedUseCase:
                 " for case '%s': %s",
                 case_id,
                 BTBridge.get_failure_reason(tree),
+            )
+            return
+
+        # The case (and therefore its deterministic per-case genesis hash) is
+        # now seeded locally.  Any Announce(CaseLedgerEntry) that arrived during
+        # the pre-genesis window was parked in the actor-local gap buffer rather
+        # than dropped (SYNC-15-004, #2186); drain it now so the ledger converges
+        # without waiting on the reject → replay round-trip (SYNC-15-005, #2180).
+        gap_buffer = self._gap_buffer
+        if gap_buffer is None and request.receiving_actor_id:
+            gap_buffer = get_ledger_gap_buffer(request.receiving_actor_id)
+        if gap_buffer is not None and gap_buffer.depth(case_id) > 0:
+            drain_gap_buffer(
+                cast(CaseOutboxPersistence, self._dl),
+                case_id,
+                request.receiving_actor_id or "unknown",
+                gap_buffer,
+                self._sync_port,
             )

--- a/vultron/core/use_cases/received/sync.py
+++ b/vultron/core/use_cases/received/sync.py
@@ -63,6 +63,92 @@ def _find_local_actor_id(dl: CasePersistence) -> str | None:
     return None
 
 
+def _run_announce_bt(
+    dl: CaseOutboxPersistence,
+    request: AnnounceLogEntryReceivedEvent,
+    receiving_actor_id: str,
+    gap_buffer: LedgerGapBuffer | None,
+    sync_port: SyncActivityPort | None,
+) -> BTExecutionResult:
+    """Run the announce receive BT for *request* with the gap buffer wired."""
+    return BTBridge(datalayer=dl).execute_with_setup(
+        tree=create_announce_log_entry_tree(),
+        actor_id=receiving_actor_id,
+        activity=request,
+        sync_port=sync_port,
+        gap_buffer=gap_buffer,
+    )
+
+
+def drain_gap_buffer(
+    dl: CaseOutboxPersistence,
+    case_id: str,
+    receiving_actor_id: str,
+    gap_buffer: LedgerGapBuffer,
+    sync_port: SyncActivityPort | None = None,
+) -> None:
+    """Apply buffered entries that now extend the local chain, in order.
+
+    After each committed entry, look up the buffered successor keyed by the new
+    tail hash and run the announce BT on it — reusing the exact
+    effects-before-persist path (SYNC-12-001).  Cascades until no buffered entry
+    extends the current tail.  A drained entry that fails to apply is re-buffered
+    so a later retry (or CaseActor replay) can pick it up.
+
+    This is the shared drain used both by the ``Announce(CaseLedgerEntry)``
+    receive path (draining forward gaps once a predecessor lands, SYNC-10-004)
+    and by the ``VulnerabilityCase`` seed path (draining *pre-genesis* entries
+    once the case — and therefore the deterministic per-case genesis hash — is
+    present, SYNC-15-005 / #2186).  In the pre-genesis case the first
+    reconstructed tail is ``(genesis_hash, -1)``, so a buffered genesis entry
+    (``prev_log_hash == genesis_hash``) drains first and the rest cascade.
+
+    A synthetic :class:`AnnounceLogEntryReceivedEvent` is constructed per drained
+    entry so this function has no dependency on an inbound request being in
+    flight; ``actor_id`` is resolved to the CaseActor when known, falling back to
+    ``case_id``.
+    """
+    from vultron.core.use_cases._helpers import _find_case_actor_id
+
+    actor_id = _find_case_actor_id(dl, case_id) or case_id
+    while True:
+        try:
+            tail_hash, _ = _reconstruct_tail_hash(case_id, dl)
+        except VultronValidationError:
+            # No genesis anchor yet — nothing can be drained.
+            return
+        successor = gap_buffer.take_next(case_id, tail_hash)
+        if successor is None:
+            return
+
+        logger.info(
+            "sync: draining buffered entry '%s' (log_index=%d) for case "
+            "'%s' now that its predecessor has arrived",
+            successor.id_,
+            successor.log_index,
+            case_id,
+        )
+        drain_event = AnnounceLogEntryReceivedEvent(
+            activity_id=f"urn:vultron:sync:drain:{successor.id_}",
+            actor_id=actor_id,
+            receiving_actor_id=receiving_actor_id,
+            object_=successor,
+        )
+        result = _run_announce_bt(
+            dl, drain_event, receiving_actor_id, gap_buffer, sync_port
+        )
+        if result.status == Status.FAILURE and dl.read(successor.id_) is None:
+            # Application failed and the entry was not persisted; hold it again
+            # so a future arrival or CaseActor replay can retry.
+            gap_buffer.buffer(successor)
+            logger.warning(
+                "sync: buffered entry '%s' failed to apply on drain — "
+                "re-buffered pending retry",
+                successor.id_,
+            )
+            return
+
+
 def _update_replication_state(
     case_id: str,
     peer_id: str,
@@ -169,15 +255,25 @@ class AnnounceLedgerEntryReceivedUseCase:
             request.actor_id,
             entry.log_index,
         )
-        result = self._run_announce_bt(request, receiving_actor_id, gap_buffer)
+        result = _run_announce_bt(
+            self._dl,
+            request,
+            receiving_actor_id,
+            gap_buffer,
+            self._sync_port,
+        )
 
         # Whenever an entry is committed, its successor may already be waiting
         # in the gap buffer; drain the contiguous run keyed on the new tail
         # (SYNC-10-004).  Draining also runs after a mismatch, in case an
         # earlier-arrived predecessor is somehow already present.
         if gap_buffer is not None:
-            self._drain_buffered_successors(
-                entry.case_id, receiving_actor_id, gap_buffer
+            drain_gap_buffer(
+                self._dl,
+                entry.case_id,
+                receiving_actor_id,
+                gap_buffer,
+                self._sync_port,
             )
 
         if result.status == Status.FAILURE:
@@ -199,72 +295,6 @@ class AnnounceLedgerEntryReceivedUseCase:
                 entry.event_type,
                 entry.log_object_id,
             )
-
-    def _run_announce_bt(
-        self,
-        request: AnnounceLogEntryReceivedEvent,
-        receiving_actor_id: str,
-        gap_buffer: LedgerGapBuffer | None,
-    ) -> BTExecutionResult:
-        """Run the announce receive BT for *request* with the gap buffer wired."""
-        return BTBridge(datalayer=self._dl).execute_with_setup(
-            tree=create_announce_log_entry_tree(),
-            actor_id=receiving_actor_id,
-            activity=request,
-            sync_port=self._sync_port,
-            gap_buffer=gap_buffer,
-        )
-
-    def _drain_buffered_successors(
-        self,
-        case_id: str,
-        receiving_actor_id: str,
-        gap_buffer: LedgerGapBuffer,
-    ) -> None:
-        """Apply buffered entries that now extend the local chain, in order.
-
-        After each committed entry, look up the buffered successor keyed by the
-        new tail hash and re-run the announce BT on it — reusing the exact
-        effects-before-persist path (SYNC-12-001).  Cascades until no buffered
-        entry extends the current tail.  A drained entry that fails to apply is
-        re-buffered so a later retry (or CaseActor replay) can pick it up.
-        """
-        while True:
-            try:
-                tail_hash, _ = _reconstruct_tail_hash(case_id, self._dl)
-            except VultronValidationError:
-                # No genesis anchor yet — nothing can be drained.
-                return
-            successor = gap_buffer.take_next(case_id, tail_hash)
-            if successor is None:
-                return
-
-            logger.info(
-                "sync: draining buffered entry '%s' (log_index=%d) for case "
-                "'%s' now that its predecessor has arrived",
-                successor.id_,
-                successor.log_index,
-                case_id,
-            )
-            drain_event = self._request.model_copy(
-                update={"object_": successor}
-            )
-            result = self._run_announce_bt(
-                drain_event, receiving_actor_id, gap_buffer
-            )
-            if (
-                result.status == Status.FAILURE
-                and self._dl.read(successor.id_) is None
-            ):
-                # Application failed and the entry was not persisted; hold it
-                # again so a future arrival or CaseActor replay can retry.
-                gap_buffer.buffer(successor)
-                logger.warning(
-                    "sync: buffered entry '%s' failed to apply on drain — "
-                    "re-buffered pending retry",
-                    successor.id_,
-                )
-                return
 
 
 class RejectLedgerEntryReceivedUseCase:

--- a/vultron/core/use_cases/received/sync.py
+++ b/vultron/core/use_cases/received/sync.py
@@ -134,9 +134,24 @@ def drain_gap_buffer(
             receiving_actor_id=receiving_actor_id,
             object_=successor,
         )
-        result = _run_announce_bt(
-            dl, drain_event, receiving_actor_id, gap_buffer, sync_port
-        )
+        try:
+            result = _run_announce_bt(
+                dl, drain_event, receiving_actor_id, gap_buffer, sync_port
+            )
+        except Exception:
+            # The announce BT raised (e.g. a residual mismatch reaches
+            # SendRejectLogEntryNode with no sync_port).  The successor was
+            # already popped by take_next, so re-buffer it before aborting the
+            # cascade — otherwise the entry is silently lost — and let a future
+            # arrival or CaseActor replay retry it.
+            if dl.read(successor.id_) is None:
+                gap_buffer.buffer(successor)
+            logger.exception(
+                "sync: draining buffered entry '%s' raised — re-buffered "
+                "pending retry",
+                successor.id_,
+            )
+            return
         if result.status == Status.FAILURE and dl.read(successor.id_) is None:
             # Application failed and the entry was not persisted; hold it again
             # so a future arrival or CaseActor replay can retry.


### PR DESCRIPTION
- Closes #2186
- Contributes to #2180 (report-offer 404 resolved; invited-vendor case-seed/drain gap remains — tracked in #2180)

## Summary

Fixes the root cause (#2186) of the fcvcv V1 demo report-offer 404 (#2180):
an `Announce(CaseLedgerEntry)` that arrives **before** its `VulnerabilityCase`
is seeded was dropped instead of buffered, so the `add_report_to_case` entry
never landed, no `VultronOfferRecord` was created, and the report offer 404'd.

Ledger entries and the case itself travel over an unordered transport (HTTP
`BackgroundTasks` fan-out), so a replica can receive an entry in the pre-genesis
window where `_reconstruct_tail_hash` cannot derive the per-case genesis hash
(CLP-08-005). ADR-0037's forward-gap check (`log_index > tail_index + 1`) never
fires when there is no chain at all, so the entry fell through to the
reject-on-missing-case path and was lost, leaving convergence to a reject →
replay round-trip that does not converge under reordering (and amplifies the
CLP-08-005 churn seen in #2169).

## Fix

Buffer pre-genesis entries in the existing actor-local `LedgerGapBuffer` and
drain them the moment the case seed anchors the deterministic per-case genesis
hash (`compute_genesis_hash` runs at `VulnerabilityCase` construction when
`attributed_to` is present — the case object alone anchors the chain, no wait
for a re-delivered genesis ledger entry).

- **`BufferPreGenesisEntryNode`** — new BT node wired as the first child of the
  `ReconstructOrRejectOnMissingCase` fallback, wrapped in `FailureIsSuccess` so
  the genesis `Reject` still fires as the loss backstop. Unlike
  `BufferOutOfOrderEntryNode` it applies no forward-gap check (there is no tail
  in the pre-genesis window).
- **`drain_gap_buffer(...)`** — the ADR-0037 drain, extracted to module level and
  reused by both the announce receive path and a new drain-on-seed hook in
  `AnnounceVulnerabilityCaseReceivedUseCase`. Reuses the exact
  effects-before-persist path (SYNC-12-001). A raised announce BT re-buffers the
  already-popped entry instead of losing it.
- Added `ANNOUNCE_VULNERABILITY_CASE` to the sync-port semantics set so the seed
  use case receives the `sync_port` needed to drain.
- **Report-object backfill (#2180 residual)** — when a report is added to a case
  *after* the case was announced to an invited participant, the case announce
  carried no embedded report, so the report object only reaches the participant
  inside the `add_report_to_case` ledger snapshot (which embeds it inline).
  `ApplyOfferReportFromLedgerNode` now reconstructs and stores that report object
  alongside the `VultronOfferRecord`, so `_reconstitute_offer` /
  `SvcValidateReportUseCase` no longer 404 on the report lookup. Complements the
  `SeedAnnouncedCaseNode` embedded-report path (ADR-0035 DL-06-002).

Protocol-level fix only — no client-side demo ordering guard (per the "protocol
fix only" decision on #2180). This resolves the report-offer 404 leg of #2180;
the fcvcv demo does not yet go green end-to-end (see Testing).

## Spec & ADR

- **ADR-0055** — Buffer Pre-Genesis `Announce(CaseLedgerEntry)` and Drain on Case
  Seed (options A–D; B chosen).
- **SYNC-15** retitled "Genesis-Unavailable Buffer-and-Reject"; added MUST-level
  **SYNC-15-004** (buffer pre-genesis entry) and **SYNC-15-005** (drain on seed).

## Testing

- `TestPreGenesisAnnounceBuffering` (`test/core/use_cases/received/test_sync.py`):
  buffered-not-dropped (Reject still queued), drains-on-seed, cascade-drains.
- `TestAnnounceDrainsPreGenesisBuffer`
  (`test/core/use_cases/received/actor/test_announce.py`): seeding the case
  drains a pre-buffered pre-genesis entry into the local ledger.
- `TestApplyOfferReportFromLedgerNode::test_stores_report_object_from_ledger_snapshot_when_absent`
  (`test/core/behaviors/case/nodes/test_issue_2134_invite_path_report.py`): the
  report object is reconstructed from the ledger snapshot when it was never
  seeded via the case announce (#2180 residual).
- Blast-radius unit suites (`test/core/behaviors/sync/`,
  `test/core/use_cases/received/`) pass locally.
- **fcvcv is NOT yet green.** CI confirms this PR resolves the report-offer 404
  (validate-report returns 202, report object present via the ledger snapshot),
  but fcvcv still fails downstream: the invited vendor accepts the case invite
  yet the `VulnerabilityCase` is never seeded on it, so this PR's pre-genesis
  buffer (working as designed) never drains — the vendor's RM state stays at
  `RECEIVED` and `engage-case` 422s (`TransitionParticipantRMtoAccepted`). That
  invited-participant case-seed/drain gap is the remaining root cause of #2180
  and is likely the same defect as #2178 (a receiving actor never gets the case
  seeded → case-lookup failures). The masking `UnboundLocalError` is #2191.

Note: this PR targets the `fix/demo-ci` integration branch (CONCERN-2137), which
is intentionally red across in-flight fixes. The fvcv-handoff demo failure is a
pre-existing ownership-transfer 404 tracked separately by #2178 and is unrelated
to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
