### PR TITLE
docs: plan concern #2091 — embargo_adherence derived vs stored

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,6 +530,12 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   `specs/` for the bare name as well as the quoted/path form, and update every spec entry
   that references it — including `statement:`, `rationale:`, and cross-reference fields.
   *Source: ISSUE-2011*
+- **`embargo_adherence` Is a `@computed_field`, Not a Settable Field** —
+  `ParticipantStatus.embargo_adherence` is derived from `consent.state`
+  (`True` iff `PEC.SIGNATORY`). Do NOT set it directly or declare it as a
+  stored field. To change the value, apply a PEC trigger via
+  `CaseParticipant.apply_pec_transition()`. See CM-18-008, ADR-0056.
+  *Source: CONCERN-2091*
 - **Delegated-Emit Trigger Use Cases MUST Set `actor=case_actor_id`,
   `attributed_to=requesting_actor_id`** — trigger use cases that emit an
   Activity on behalf of the CaseActor (invite, ownership transfer, and any

--- a/docs/adr/0056-embargo-adherence-computed-field.md
+++ b/docs/adr/0056-embargo-adherence-computed-field.md
@@ -1,0 +1,103 @@
+---
+status: accepted
+date: 2026-08-11
+deciders: [adh, Claude Sonnet 4.6]
+---
+
+# ADR-0056: `embargo_adherence` Is a Computed Property Derived from PEC State
+
+## Context and Problem Statement
+
+`ParticipantStatus.embargo_adherence: bool` was declared as a stored field
+defaulting to `True`. The draft protocol specification (§6.4.6) defined it as
+a derived property — `True` iff PEC state is `SIGNATORY`, `False` otherwise
+— but flagged the derived-vs.-stored choice as unresolved (open question 14).
+
+Two risks followed from the stored implementation:
+
+1. **Drift.** The field can disagree with the PEC state it is meant to project.
+   `_sync_latest_status_metadata()` updated `ParticipantStatus.consent` on
+   every PEC write, but never updated `embargo_adherence`. A participant who
+   transitioned from `SIGNATORY` to `LAPSED` still carried
+   `embargo_adherence=True`.
+
+2. **Fail-open default.** The default `True` means a freshly constructed
+   `ParticipantStatus` — with `consent=None` or `consent.state=NO_EMBARGO` —
+   reads as "is a signatory". The MV-10-005 full-case-delivery gate depends
+   on this field; a wrong default bypasses the gate silently.
+
+The question is: **should `embargo_adherence` be a stored field or a computed
+property, and what is the enforcement point?**
+
+## Decision Drivers
+
+- `embargo_adherence` has exactly one correct value for any given PEC state;
+  there is no scenario in which it should differ
+- A stored field that can be set independently of PEC provides no value and
+  creates two sources of truth for the same fact
+- The fail-open default is a correctness hazard at the MV-10-005 gate
+- Pydantic v2 `@computed_field` makes the derived nature explicit and
+  serialization-compatible, requiring no changes to DataLayer consumers
+
+## Considered Options
+
+1. **`@computed_field` derived from `consent.state`** (chosen): remove the
+   stored field; add a `@computed_field` that returns
+   `self.consent is not None and self.consent.state == PEC.SIGNATORY`.
+   The wire projection (`as_ParticipantStatus.from_core()`) computes the value
+   instead of copying it.
+
+2. **Stored field + `model_validator(mode='after')`**: keep the stored field;
+   add a validator that sets it from `consent.state` on every construction.
+   Guards initial construction, but still allows a caller to write the field
+   after construction via direct assignment.
+
+3. **Stored field + fix `_sync_latest_status_metadata`**: update the sync
+   method to also write `embargo_adherence`. Does not guard initial
+   construction; a freshly constructed `ParticipantStatus` still starts `True`.
+
+## Decision Outcome
+
+**Chosen option: `@computed_field` derived from `consent.state` (Option 1).**
+
+### Consequences
+
+- `ParticipantStatus.embargo_adherence` becomes a Pydantic `@computed_field`.
+  It appears in `model_dump()` output and the Pydantic schema, exactly as a
+  regular field, but it cannot be set directly.
+- The default is effectively `False` — a participant with `consent=None` is
+  not a signatory. This is fail-closed.
+- `as_ParticipantStatus.from_core()` computes the value as
+  `core_obj.consent is not None and core_obj.consent.state == PEC.SIGNATORY`.
+  The stored wire field default changes from `True` to `False`.
+- Departed participants who were `SIGNATORY` when they left will transition to
+  `LAPSED` on embargo revision (the normal PEC machine path). The computed field
+  correctly reflects `False` for `LAPSED`.
+- Good, because drift is eliminated permanently.
+- Good, because the fail-open default is replaced with a fail-closed one.
+- Good, because the MV-10-005 full-case-delivery gate is now correctly
+  enforced for all construction paths, not just those that call
+  `apply_pec_transition()`.
+- Bad, because callers that previously set `embargo_adherence` directly will
+  fail at the Pydantic validation layer. Any such site must instead change
+  the PEC state via `apply_pec_transition()`. (A grep sweep at
+  implementation time will surface these sites — expected count: zero in
+  production code, as CM-18-005 already requires all consent writes to go
+  through `apply_pec_transition()`.)
+
+## Validation
+
+- Unit tests confirm `embargo_adherence` is `True` when `consent.state==SIGNATORY`
+  and `False` for all other PEC states and for `consent=None`.
+- Existing tests that assert `embargo_adherence is True` for a SIGNATORY
+  participant continue to pass.
+- Wire round-trip: `as_ParticipantStatus.from_core(core_status).to_core()`
+  produces the correct `embargo_adherence` value.
+
+## More Information
+
+- Closes open question 14 in `docs/reference/draft-vultron-spec.md` (§6.4.6).
+- Builds on ADR-0048 (PEC NO\_EMBARGO is absence of embargo) and ADR-0036
+  (per-machine dimension objects).
+- Generated spec requirements: `specs/case-management.yaml` CM-18-008.
+- Source: Concern #2091.

--- a/docs/adr/0056-embargo-adherence-computed-field.md
+++ b/docs/adr/0056-embargo-adherence-computed-field.md
@@ -87,12 +87,15 @@ property, and what is the enforcement point?**
 
 ## Validation
 
-- Unit tests confirm `embargo_adherence` is `True` when `consent.state==SIGNATORY`
-  and `False` for all other PEC states and for `consent=None`.
+When implemented (tracked in #2189), the following MUST hold:
+
+- Unit tests MUST confirm `embargo_adherence` is `True` when
+  `consent.state==SIGNATORY` and `False` for all other PEC states and for
+  `consent=None`.
 - Existing tests that assert `embargo_adherence is True` for a SIGNATORY
-  participant continue to pass.
+  participant MUST continue to pass.
 - Wire round-trip: `as_ParticipantStatus.from_core(core_status).to_core()`
-  produces the correct `embargo_adherence` value.
+  MUST produce the correct `embargo_adherence` value.
 
 ## More Information
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -125,6 +125,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0053 Route Ownership-Transfer Offer and Accept Through the CaseActor](0053-ownership-transfer-routed-via-caseactor.md)
 - [ADR-0054 Retain plan/incoming/learnings/ as a File Queue; Do Not Migrate to GitHub Issues](0054-learnings-queue-as-files-not-issues.md)
 - [ADR-0055 CI Failure Alerting via GitHub Issues on Main-Branch and Scheduled Workflows](0055-ci-failure-alerting-via-github-issues.md)
+- [ADR-0056 `embargo_adherence` Is a Computed Property Derived from PEC State](0056-embargo-adherence-computed-field.md)
 
 ## Proposed ADRs
 

--- a/docs/reference/draft-vultron-spec.md
+++ b/docs/reference/draft-vultron-spec.md
@@ -800,6 +800,8 @@ be a stored field that can drift from the PEC state it projects.
 Consent changes MUST be applied as a PEC trigger through the validated
 transition path (ADR-0048, ADR-0056).
 
+- *Source: `specs/case-management.yaml` CM-18-008; ADR-0056*
+
 #### 6.4.7 Gating Full Case Delivery
 
 Before the Case Actor delivers full case content

--- a/docs/reference/draft-vultron-spec.md
+++ b/docs/reference/draft-vultron-spec.md
@@ -794,16 +794,11 @@ Neither `LAPSED` nor `DECLINED` is terminal — both can be re-invited.
 `embargo_adherence` is the boolean projection of PEC state: `True` iff
 PEC = `SIGNATORY`, `False` otherwise.
 
-!!! note "Derived vs. stored: unresolved"
-    This specification states `embargo_adherence` as a derived property. The
-    current implementation carries it as a stored boolean field on
-    `ParticipantStatus`, defaulting to `True`. A stored field can drift from the
-    PEC state it is meant to project, and the fail-open default differs from what
-    a derived value would yield at initial `NO_EMBARGO`.
-
-    Implementations MUST NOT record a consent change by assigning this field
-    directly. Consent changes MUST be applied as a PEC trigger through the
-    validated transition path, which fails closed on an illegal transition.
+The implementation MUST expose `embargo_adherence` as a computed property
+(e.g., Pydantic `@computed_field`) derived from `consent.state`. It MUST NOT
+be a stored field that can drift from the PEC state it projects.
+Consent changes MUST be applied as a PEC trigger through the validated
+transition path (ADR-0048, ADR-0056).
 
 #### 6.4.7 Gating Full Case Delivery
 
@@ -1375,10 +1370,9 @@ canonical-write-before-side-effects rule of §6.5.1 being the clearest case.
     third-party assertion ("I notified this Vendor"), which raises questions about
     who may assert, whether the subject may dispute, and whether transport-level
     delivery success suffices. Filed as a Concern.
-14. **`embargo_adherence` derived vs. stored** — §6.4.6. Specified here as
-    derived from PEC state; implemented as a stored boolean defaulting to `True`.
-    Needs a decision, and if it stays stored, an invariant and an enforcement
-    point.
+14. **`embargo_adherence` derived vs. stored** — §6.4.6. Resolved by ADR-0056:
+    `embargo_adherence` is a computed property derived from PEC state.
+    Implementation issue tracked separately.
 15. **Negative acknowledgement** — §5.6. Error message types are deliberately
     unmodelled (ADR-0049), and unprocessable inbound messages are dead-lettered
     with no sender notification. Whether the protocol needs an error-reply facet

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -273,6 +273,7 @@ nav:
       - Route Ownership-Transfer Offer and Accept Through the CaseActor: 'adr/0053-ownership-transfer-routed-via-caseactor.md'
       - Retain plan/incoming/learnings/ as a File Queue; Do Not Migrate to GitHub Issues: 'adr/0054-learnings-queue-as-files-not-issues.md'
       - CI Failure Alerting via GitHub Issues on Main-Branch and Scheduled Workflows: 'adr/0055-ci-failure-alerting-via-github-issues.md'
+      - embargo_adherence Is a Computed Property Derived from PEC State: 'adr/0056-embargo-adherence-computed-field.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/participant-embargo-consent.md
+++ b/notes/participant-embargo-consent.md
@@ -211,11 +211,11 @@ notes with sensitive information) is gated on `embargo_adherence=True`.
 - The machine name is `ParticipantEmbargoConsent`
 - Define states and triggers in a new module:
   `vultron/core/states/participant_embargo_consent.py`
-- `VultronParticipantStatus.embargo_adherence: bool` should become a
-  `@property` that returns `self._consent_state == "SIGNATORY"` (or equivalent)
-- Alternatively, retain `embargo_adherence: bool` as a plain stored field for
-  backward compatibility, but enforce transitions via use-case logic
-- The stored field value should mirror the derived property on every update
+- `ParticipantStatus.embargo_adherence` is a `@computed_field` (Pydantic v2)
+  that returns `self.consent is not None and self.consent.state == PEC.SIGNATORY`.
+  It MUST NOT be declared as a stored field. Consent writes go through
+  `apply_pec_transition()` on `CaseParticipant`; the computed field reflects the
+  result automatically. Decision: ADR-0056.
 
 ---
 

--- a/plan/history/2608/learning/CONCERN-2091.md
+++ b/plan/history/2608/learning/CONCERN-2091.md
@@ -1,0 +1,28 @@
+---
+source: CONCERN-2091
+timestamp: '2026-08-11T18:13:28.941708+00:00'
+title: embargo_adherence specified as derived but implemented as stored fail-open
+  field
+type: learning
+---
+
+`embargo_adherence: bool = True` on `ParticipantStatus` is a stored field that
+can drift from the PEC state it projects, and its fail-open default (`True`)
+reads as "is a signatory" even when consent has never been recorded.
+
+**Root cause**: `_sync_latest_status_metadata()` updates `consent`
+(`PecDimension`) on every PEC write but never touches `embargo_adherence`.
+No code sets `embargo_adherence = False`; no construction path derives it.
+
+**Decision**: `embargo_adherence` is strictly derived from PEC state —
+`True` iff `PEC.SIGNATORY`, `False` otherwise (draft spec §6.4.6, ADR-0056).
+Implement as a Pydantic `@computed_field` on `ParticipantStatus`. Wire layer
+(`as_ParticipantStatus.from_core()`) computes from `consent.state` rather than
+copying. Wire default changes from `True` to `False`.
+
+**Out of scope**: `apply_pec_trigger` fail-open on invalid triggers → #1871.
+
+**Resolved**: 2026-08-11 — implementation tracked in #2189.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2188>.
+Spec: `specs/case-management.yaml` CM-18-008.
+ADR: `docs/adr/0056-embargo-adherence-computed-field.md`.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -1037,8 +1037,28 @@ groups:
     relationships:
     - rel_type: depends_on
       spec_id: CM-18-005
+    - rel_type: depends_on
+      spec_id: CM-18-008
     adr:
     - ADR-0048
+    - ADR-0056
+  - id: CM-18-008
+    priority: MUST
+    kind: project
+    statement: '`ParticipantStatus.embargo_adherence` MUST be implemented as a computed property (e.g., Pydantic `@computed_field`)
+      that returns `True` if and only if `consent.state == PEC.SIGNATORY`. It MUST NOT be declared as a stored field. The wire
+      projection (`as_ParticipantStatus.from_core()`) MUST derive the value from the consent state rather than copying a stored
+      field.'
+    rationale: >
+      A stored boolean field can drift from the PEC state it is meant to project and its fail-open default (`True`)
+      violates the principle that unset consent should not be treated as active consent. Making `embargo_adherence` a
+      computed property eliminates the drift risk permanently and makes the fail-closed invariant unbypassable.
+      Resolved by ADR-0056, closing the open question recorded in the draft specification §6.4.6.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-18-006
+    adr:
+    - ADR-0056
   - id: CM-18-007
     priority: MUST
     kind: project

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -1037,27 +1037,8 @@ groups:
     relationships:
     - rel_type: depends_on
       spec_id: CM-18-005
-    - rel_type: depends_on
-      spec_id: CM-18-008
     adr:
     - ADR-0048
-    - ADR-0056
-  - id: CM-18-008
-    priority: MUST
-    kind: project
-    statement: '`ParticipantStatus.embargo_adherence` MUST be implemented as a computed property (e.g., Pydantic `@computed_field`)
-      that returns `True` if and only if `consent.state == PEC.SIGNATORY`. It MUST NOT be declared as a stored field. The wire
-      projection (`as_ParticipantStatus.from_core()`) MUST derive the value from the consent state rather than copying a stored
-      field.'
-    rationale: >
-      A stored boolean field can drift from the PEC state it is meant to project and its fail-open default (`True`)
-      violates the principle that unset consent should not be treated as active consent. Making `embargo_adherence` a
-      computed property eliminates the drift risk permanently and makes the fail-closed invariant unbypassable.
-      Resolved by ADR-0056, closing the open question recorded in the draft specification §6.4.6.
-    relationships:
-    - rel_type: refines
-      spec_id: CM-18-006
-    adr:
     - ADR-0056
   - id: CM-18-007
     priority: MUST
@@ -1078,6 +1059,23 @@ groups:
       spec_id: CM-14-003
     adr:
     - ADR-0048
+  - id: CM-18-008
+    priority: MUST
+    kind: project
+    statement: '`ParticipantStatus.embargo_adherence` MUST be implemented as a computed property (e.g., Pydantic `@computed_field`)
+      that returns `True` if and only if `consent.state == PEC.SIGNATORY`. It MUST NOT be declared as a stored field. The wire
+      projection (`as_ParticipantStatus.from_core()`) MUST derive the value from the consent state rather than copying a stored
+      field.'
+    rationale: >
+      A stored boolean field can drift from the PEC state it is meant to project and its fail-open default (`True`)
+      violates the principle that unset consent should not be treated as active consent. Making `embargo_adherence` a
+      computed property eliminates the drift risk permanently and makes the fail-closed invariant unbypassable.
+      Resolved by ADR-0056, closing the open question recorded in the draft specification §6.4.6.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-18-006
+    adr:
+    - ADR-0056
 - id: CM-19
   title: Participant Index Discipline
   specs:


### PR DESCRIPTION
- Closes #2091

## Summary

Resolves the open design question in draft spec §6.4.6: `embargo_adherence`
is a computed property derived from PEC state (`True` iff `SIGNATORY`), not
a stored field. Adds ADR-0056, updates spec and notes, and adds an AGENTS.md
pitfall.

## Changes

- **`docs/adr/0056-embargo-adherence-computed-field.md`**: new ADR deciding
  `embargo_adherence` is a `@computed_field` derived from `consent.state`
- **`docs/adr/index.md`**: add ADR-0056 to Accepted list
- **`mkdocs.yml`**: add ADR-0056 to nav
- **`docs/reference/draft-vultron-spec.md`**: replace §6.4.6 "Derived vs.
  stored: unresolved" note with the decided approach; mark open-question 14
  as resolved by ADR-0056
- **`notes/participant-embargo-consent.md`**: remove "alternatively, retain as
  stored field" language; state that `embargo_adherence` is a `@computed_field`
- **`specs/case-management.yaml`**: add CM-18-008 (computed-field requirement);
  cross-reference ADR-0056 in CM-18-006
- **`AGENTS.md`**: add pitfall — `embargo_adherence` is `@computed_field`,
  not settable directly

## Implementation Issues

- #2189