### PR TITLE
docs: plan concern #2181 — causal gating in demo scenarios

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -564,6 +564,19 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   required: one on failure (file/update a `ci:main-failure` issue, CISEC-05-001)
   and one on success (close the issue for recovery visibility, CISEC-05-002).
   *Source: CONCERN-2132*
+- **Demo Steps Must Be Gated on Their Cause, Not Their Position in the Script** —
+  a scenario step that depends on an asynchronous effect MUST gate on the
+  committed state of the actor that *produces* that effect, read from that actor's
+  own container. An HTTP 202 return, elapsed time, and step order are not
+  evidence; neither is an observable that resolves synchronously during the
+  triggering request (ISSUE-2134). Discover a forwarded object by discriminator
+  scan, never by the sender's original ID (ISSUE-2178). Use `demo_gate` (stops
+  dependent steps) for preconditions and `demo_check` (advisory) for assertions,
+  and never patch either out with `nullcontext` in tests. See EDF-06, DEMOMA-22,
+  DEMOCI-01-007, ADR-0058,
+  [notes/event-driven-control-flow.md](notes/event-driven-control-flow.md)
+  § "Temporal Sequence vs. Causal Sequence", and
+  [`vultron/demo/AGENTS.md`](vultron/demo/AGENTS.md). *Source: CONCERN-2181*
 
 ---
 

--- a/docs/adr/0058-causal-gating-in-demo-scenarios.md
+++ b/docs/adr/0058-causal-gating-in-demo-scenarios.md
@@ -63,8 +63,10 @@ observe before advancing, and where should that requirement live?
   cannot simply convert gates into hard aborts.
 - Nine scenario modules totalling roughly 9,700 lines already exist; a solution
   requiring all of them to be rewritten in a new form is unlikely to be finished.
-- ADR-0037 and ADR-0055 already moved one class of ordering problem into
-  actor-side buffering. A harness rule must not contradict that.
+- ADR-0037 and the pre-genesis ledger-entry buffering decision (ADR-0055 *on the
+  `fix/demo-ci` branch*, not the ADR-0055 on `main`; it is subject to renumbering
+  when that branch merges under #2143) already moved one class of ordering problem
+  into actor-side buffering. A harness rule must not contradict that.
 
 ## Considered Options
 
@@ -177,8 +179,9 @@ around it.
 
 ### Push all ordering into the actors
 
-- Good, because it fixes the production protocol, not just the demo — which
-  ADR-0055 showed is sometimes the real defect.
+- Good, because it fixes the production protocol, not just the demo — which the
+  pre-genesis buffering decision on `fix/demo-ci` showed is sometimes the real
+  defect.
 - Good, because a harness that never needs to sequence is the simplest harness.
 - Neutral, because it is already the chosen approach for the specific case of
   pre-genesis ledger entries.
@@ -216,7 +219,8 @@ machines and BT nodes ... are likely already correct. The gap is in the *demo
 harness* ... not in the actor logic itself." Post-concern evidence shows the same
 causal gap exists in the protocol layer: #2169's fan-out race is server-side and
 a client-side demo wait cannot prevent it, #2186 was consequently fixed in the
-protocol (ADR-0055), and #2194 — a bare-string `Accept.object_` that trips the
+protocol (the pre-genesis buffering ADR on `fix/demo-ci`), and #2194 — a
+bare-string `Accept.object_` that trips the
 MV-09-001 outbox gate so the activity is never delivered — is squarely an actor
 logic bug. The pattern this ADR addresses is real and well-attested, but it is
 not exclusively a harness problem, and this decision does not green Epic #2136 on
@@ -227,6 +231,14 @@ Related decisions: ADR-0037 (buffer out-of-order ledger entries), ADR-0055 on
 the `fix/demo-ci` branch (buffer pre-genesis ledger entries — the production-side
 counterpart of this decision), ADR-0041 (`log_index` order is causal order),
 ADR-0052 (demo CI job structure).
+
+> **Note on the ADR-0055 number.** Two distinct ADRs currently hold the number
+> 0055: on `main` it is "CI Failure Alerting via GitHub Issues", and on
+> `fix/demo-ci` it is "Buffer Pre-Genesis Ledger Entries". Every reference to
+> pre-genesis buffering in this ADR and in the accompanying notes means the
+> `fix/demo-ci` one. That ADR must be renumbered when `fix/demo-ci` merges
+> (#2143), the way ADR-0056 was renumbered to ADR-0057 for the same reason — so
+> prefer the title over the number when citing it.
 
 Source concern: CONCERN-2181. Evidence: the Epic #2136 sub-issues ISSUE-2120,
 ISSUE-2134, ISSUE-2135, ISSUE-2141, ISSUE-2169, ISSUE-2178, ISSUE-2180, and

--- a/docs/adr/0058-causal-gating-in-demo-scenarios.md
+++ b/docs/adr/0058-causal-gating-in-demo-scenarios.md
@@ -1,0 +1,237 @@
+---
+status: accepted-provisional
+date: 2026-08-11
+deciders: Vultron maintainers
+consulted: CONCERN-2181, Epic #2136 bug triage history
+informed: Vultron contributors, demo scenario authors
+---
+
+# Gate Demo Scenario Steps on Causal Preconditions, Not Temporal Order
+
+## Context and Problem Statement
+
+Vultron's multi-actor demo scenarios are written as temporal sequences: a phase
+function calls step A, then step B, then step C. But the system underneath is
+asynchronous — a trigger endpoint returns HTTP 202 and the protocol effect is
+committed later by a `BackgroundTasks` job on a different container. Writing
+"A and then B" when the truth is "B is only possible because A completed" makes
+every step boundary a race.
+
+This is not a theoretical concern. Of the nineteen sub-issues of Epic #2136
+("Demo CI: restore green main"), seven were the same defect in a different
+scenario: a step proceeded before the event that would enable it had propagated.
+Two more were partially this. Each was fixed locally — a wait inserted here, a
+different observable polled there — and the shared cause was never addressed, so
+the next scenario rediscovered it. Bug #2178's own triage comment states the
+diagnosis plainly: *"the demo treated async causal steps as sequential (x then y)
+rather than causally linked (x therefore y)."*
+
+Three symptoms show the problem is structural rather than a run of bad luck:
+
+1. **The specs duplicated the workaround instead of stating the rule.** Seven
+   scenario-specific requirements (DEMOMA-06-006, -11-009, -12-004, -19-005,
+   -19-009, -21-003, -21-004) each say "poll here before proceeding" for one
+   scenario. DEMOMA-11-009 states the general rule correctly but is scoped to
+   FVCV-handoff alone.
+
+2. **The gates did not gate.** Both `demo_step` and `demo_check` record the
+   failure and continue — "no re-raise", by their own docstrings and by
+   DEMOCI-01-003. So a precondition written with `demo_check` is advisory: it
+   reads like a gate in review and does nothing at runtime, and the dependent step
+   proceeds on state that was never established. The concrete instance is the
+   `RM.VALID`-before-`engage-case` gate added by the #2134 fix on the
+   `fix/demo-ci` branch, whose regression test passes only because it patches
+   `demo_check` out with `contextlib.nullcontext`. That test idiom is not
+   isolated: seven demo test modules on `main` patch these context managers out
+   the same way, so no test in the suite exercises their real control flow.
+
+3. **Which observable proves the cause landed was guesswork.** The gate before
+   `validate-report` in `run_invite_path_rm_triage` was re-picked three times in
+   one week: a ledger `submit_report` entry, then a `VultronOfferRecord` object,
+   then a ledger `add_report_to_case` entry.
+
+The question this ADR answers: what should the demo harness be required to
+observe before advancing, and where should that requirement live?
+
+## Decision Drivers
+
+- The same defect class must not be able to recur in the next scenario written.
+- The prototype's observability is limited: an actor having *processed* a
+  delivery leaves no completion record, so not every precondition is directly
+  observable.
+- Demo CI must keep reporting every failure in a run (DEMOCI-01-003), so a fix
+  cannot simply convert gates into hard aborts.
+- Nine scenario modules totalling roughly 9,700 lines already exist; a solution
+  requiring all of them to be rewritten in a new form is unlikely to be finished.
+- ADR-0037 and ADR-0055 already moved one class of ordering problem into
+  actor-side buffering. A harness rule must not contradict that.
+
+## Considered Options
+
+- **Causal gates in shared helpers, plus domain narratives as a conformance
+  oracle** — state the rule once, express preconditions with a gating primitive
+  that actually stops dependent work, and check the intended causal chain against
+  the observed one.
+- **Keep per-scenario polling with tuned timeouts** — the status quo: continue
+  adding scenario-specific wait requirements and raising timeouts as CI reveals
+  races.
+- **Push all ordering into the actors** — extend the ADR-0037/0055 buffering
+  approach until the harness never needs to sequence around delivery at all.
+- **Declarative scenario dependency graph with static validation** — replace
+  imperative phase functions with declared causal edges validated before a run.
+
+## Decision Outcome
+
+Chosen option: **causal gates in shared helpers, plus domain narratives as a
+conformance oracle.**
+
+The rule is stated once, at the conceptual layer that already governs demo
+scripts (`EDF-06`), and generalized across scenarios in `DEMOMA-22`. Concretely:
+
+- A step that depends on an asynchronous effect is gated on positive evidence
+  that the effect was **committed by the actor that produces it**, read from
+  **that actor's own container**. Elapsed time, step position, and an HTTP 202
+  return are not evidence.
+- Gating on an observable that resolves *synchronously* during the triggering
+  request is prohibited — that observable proves the cause started, not that it
+  finished. This is the #2134 defect.
+- A causally derived object (one created by a received-side use case forwarding a
+  new activity) is discovered by scanning the recipient's state for semantic
+  properties — type, target, object — never by polling for the sender's original
+  identifier. This is the #2178 defect.
+- Preconditions are expressed with a new `demo_gate` context manager that
+  accumulates the failure exactly as `demo_check` does but additionally stops the
+  steps that depend on it. `demo_check` stays advisory. This resolves the tension
+  with DEMOCI-01-003 by separating reporting from control flow rather than
+  choosing between them.
+- Waits that are irreducibly temporal — liveness probes, embargo deadlines,
+  transport backoff — are identified as temporal and are not counted as causal
+  gates.
+
+Each scenario additionally gets a narrative page under `docs/topics/scenarios/`
+describing the case's progress in CVD domain terms with each step's antecedent
+named, carrying a machine-readable list of causal edges. The invariant harness
+asserts every declared edge appears in the observed case ledger with the
+antecedent's `log_index` preceding the consequent's. Because `log_index` order is
+causal order (ADR-0041) and the harness already reads per-scenario ledger dumps,
+this needs no new instrumentation.
+
+The narrative is the part of this decision that does work the gates cannot. A
+gate enforces that *the harness waited for the right thing*. The narrative
+states, independently of the implementation, *what the protocol is supposed to
+cause* — so it can disagree with the code. That is what makes it an oracle
+rather than a restatement.
+
+**Status is `accepted-provisional`, not `accepted`:** the direction is ratified
+but nothing here has been validated by implementation yet. The shape of the
+gating primitive and the causal-edge schema are expected to converge after the
+first two or three scenarios are migrated. Refine this ADR rather than working
+around it.
+
+### Consequences
+
+- Good, because the rule lives in one place, so a new scenario inherits it
+  instead of rediscovering it.
+- Good, because `demo_gate` makes a failed precondition stop the work that
+  depends on it, which removes the cascade of secondary failures that buried the
+  real cause in #2180 and #2195.
+- Good, because the narrative check fails when the demo and the intended
+  protocol disagree, which no existing invariant detects.
+- Good, because it composes with ADR-0037/0055 rather than competing: where the
+  actor buffers, the harness needs no gate, and some of the 26
+  `wait_for_case_on_container` sites may now be removable.
+- Bad, because migrating nine scenarios and roughly 20 gate call sites is
+  substantial mechanical work, and the timeout constants are hand-tuned per site.
+- Bad, because some preconditions are not observable today. "The receiver
+  processed activity X" has no completion record, so those gates remain
+  inferential — they observe a downstream effect and assume the antecedent
+  caused it.
+- Bad, because narratives are a new artifact class that can rot; DEMOMA-22-006
+  requires updating them with the flow they describe, which is a review burden.
+
+## Validation
+
+- `spec-lint` enforces the requirement structure and ADR cross-references.
+- The invariant harness enforces DEMOMA-22-005 per scenario: declared causal
+  edges must appear in the observed ledger in causal order.
+- A migration audit confirms every scenario's asynchronous boundaries use
+  `demo_gate` and that no scenario module defines its own polling loop
+  (DEMOMA-22-002).
+- The `demo_gate` regression tests must exercise the real context manager. A test
+  that patches it out with `nullcontext` does not validate gating behaviour —
+  that is exactly how the current gap went unnoticed.
+
+## Pros and Cons of the Options
+
+### Keep per-scenario polling with tuned timeouts
+
+- Good, because it requires no new mechanism and no migration.
+- Good, because it is how the current scenarios already work, so it is proven to
+  produce a green run when the timeouts are large enough.
+- Bad, because it is the status quo that produced seven instances of the same
+  bug, and it scales the defect with the number of scenarios.
+- Bad, because timeouts encode load assumptions, so the suite gets slower and
+  flakier as scenarios are added.
+- Bad, because it leaves "which observable proves the cause landed" as a
+  per-author judgement call.
+
+### Push all ordering into the actors
+
+- Good, because it fixes the production protocol, not just the demo — which
+  ADR-0055 showed is sometimes the real defect.
+- Good, because a harness that never needs to sequence is the simplest harness.
+- Neutral, because it is already the chosen approach for the specific case of
+  pre-genesis ledger entries.
+- Bad, because it cannot cover the harness's own ordering obligations. A demo
+  still has to know that an actor must reach `RM.VALID` before it can engage a
+  case; buffering does not make that step unnecessary.
+- Bad, because it treats every ordering assumption as a protocol defect, which
+  over-generates protocol work for what are sometimes genuine harness errors.
+
+### Declarative scenario dependency graph with static validation
+
+- Good, because declared edges could be validated before a run rather than
+  during it, catching an authoring error without spending CI time.
+- Good, because it makes causality the primary structure of a scenario rather
+  than a constraint layered onto it.
+- Bad, because it is a large new mechanism replacing nine working scenario
+  modules, for a prototype whose scenario set is still changing.
+- Bad, because static validation cannot check the part that actually breaks —
+  whether the running system honours the declared edge.
+- Neutral, because the causal-edge list adopted here is a step toward it: if the
+  edge declarations prove valuable, promoting them from documentation to the
+  scenario's primary structure remains open.
+
+## More Information
+
+The narrative artifact came from a specific observation during planning: the
+concern's own framing — "B does Y **because** A did X" — is a statement about the
+CVD process, not about Python. Writing that statement down in domain terms gives
+both the demo and the reader the same causal spine, and makes the places where
+the demo has no reason for its ordering visible.
+
+One claim in CONCERN-2181 is contradicted by the evidence and is recorded here so
+it is not inherited. The concern states that "the underlying protocol state
+machines and BT nodes ... are likely already correct. The gap is in the *demo
+harness* ... not in the actor logic itself." Post-concern evidence shows the same
+causal gap exists in the protocol layer: #2169's fan-out race is server-side and
+a client-side demo wait cannot prevent it, #2186 was consequently fixed in the
+protocol (ADR-0055), and #2194 — a bare-string `Accept.object_` that trips the
+MV-09-001 outbox gate so the activity is never delivered — is squarely an actor
+logic bug. The pattern this ADR addresses is real and well-attested, but it is
+not exclusively a harness problem, and this decision does not green Epic #2136 on
+its own: #2194 and #2195 are delivery and serialization defects that causal
+gating would not have prevented.
+
+Related decisions: ADR-0037 (buffer out-of-order ledger entries), ADR-0055 on
+the `fix/demo-ci` branch (buffer pre-genesis ledger entries — the production-side
+counterpart of this decision), ADR-0041 (`log_index` order is causal order),
+ADR-0052 (demo CI job structure).
+
+Source concern: CONCERN-2181. Evidence: the Epic #2136 sub-issues ISSUE-2120,
+ISSUE-2134, ISSUE-2135, ISSUE-2141, ISSUE-2169, ISSUE-2178, ISSUE-2180, and
+ISSUE-2186.
+
+Generated spec requirements: `event-driven-control-flow.yaml` EDF-06-001 through
+EDF-06-007; `multi-actor-demo.yaml` DEMOMA-22-001 through DEMOMA-22-006;
+`demo-ci.yaml` DEMOCI-01-007.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -127,6 +127,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0055 CI Failure Alerting via GitHub Issues on Main-Branch and Scheduled Workflows](0055-ci-failure-alerting-via-github-issues.md)
 - [ADR-0056 `embargo_adherence` Is a Computed Property Derived from PEC State](0056-embargo-adherence-computed-field.md)
 - [ADR-0057 Rename `CVDRole.OTHER` to `CVDRole.OBSERVER` and Define Observer Participant Semantics](0057-observer-participant-role.md)
+- [ADR-0058 Gate Demo Scenario Steps on Causal Preconditions, Not Temporal Order](0058-causal-gating-in-demo-scenarios.md) *(provisional)*
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -275,6 +275,7 @@ nav:
       - CI Failure Alerting via GitHub Issues on Main-Branch and Scheduled Workflows: 'adr/0055-ci-failure-alerting-via-github-issues.md'
       - embargo_adherence Is a Computed Property Derived from PEC State: 'adr/0056-embargo-adherence-computed-field.md'
       - Rename CVDRole.OTHER to CVDRole.OBSERVER and Define Observer Participant Semantics: 'adr/0057-observer-participant-role.md'
+      - Gate Demo Scenario Steps on Causal Preconditions, Not Temporal Order: 'adr/0058-causal-gating-in-demo-scenarios.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/event-driven-control-flow.md
+++ b/notes/event-driven-control-flow.md
@@ -6,10 +6,13 @@ description: >
   patterns and design rationale.
 related_specs:
   - specs/event-driven-control-flow.yaml
+  - specs/multi-actor-demo.yaml
+  - specs/demo-ci.yaml
 related_notes:
   - notes/bt-integration.md
   - notes/bt-composability.md
   - notes/protocol-event-cascades.md
+  - notes/demo-ci-diagnostics.md
 relevant_packages:
   - vultron/bt
   - vultron/core
@@ -117,6 +120,124 @@ flow?"* Those are the primary events. Everything else should happen
 automatically. If the demo must manually inject an intermediate step, that is
 a signal that a cascade is not yet automated — a gap to fix, not a demo
 pattern to copy.
+
+---
+
+## Temporal Sequence vs. Causal Sequence
+
+(CONCERN-2181, ADR-0058. Normative requirements: `specs/event-driven-control-flow.yaml`
+EDF-06; `specs/multi-actor-demo.yaml` DEMOMA-22.)
+
+A scenario script is a list of steps, so it is natural to write it as a temporal
+sequence: *A, and then B, and then C*. The protocol it drives is not temporal —
+it is causal: *A, **therefore** B, **therefore** C*. Every place those two
+readings differ is a race, because a trigger endpoint returns HTTP 202 and the
+effect is committed later, by a `BackgroundTasks` job, on a different container.
+
+The distinction is not stylistic. Seven of the nineteen sub-issues of Epic #2136
+were the same defect in a different scenario: a step ran before the event that
+would enable it had propagated. Bug #2178's triage put it exactly: *"the demo
+treated async causal steps as sequential (x then y) rather than causally linked
+(x therefore y)."*
+
+### The chain each step sits in
+
+A cross-actor step is never one event. It is a chain, and a gate can be placed
+at any link — but only the last link proves the step's precondition:
+
+```text
+A addresses → A sends → delivered to B's inbox → B processes → B commits → B replies
+                     ↑                        ↑                        ↑
+              "sent" (sender-side)     "delivered"            "committed" ← gate here
+```
+
+Gating on an earlier link is the recurring error. `notes/demo-ci-diagnostics.md`
+names the same three layers — Sent, Received, Committed — for reading a failed
+run; the gate belongs at Committed.
+
+### Three rules that follow
+
+1. **Gate on the effect, observed where it lands.** The predicate must be a
+   property of the actor that *commits* the effect, read from that actor's own
+   container. A sender-side observation proves only that the sender emitted
+   something (EDF-06-002).
+
+2. **A synchronous observable is not evidence of an asynchronous effect.** In
+   #2134, `engage-case` was gated on "the case object exists" — which resolves
+   synchronously during `validate-report` — instead of "this participant reached
+   `RM.VALID`", which commits after the 202 returns. The first is a proxy for the
+   cause having *started* (EDF-06-003).
+
+3. **Find a caused object by what it is, not by the ID of its cause.** When a
+   received-side use case forwards a *new* activity, the consequent has a new
+   identity. In #2178 the demo polled for the original Offer ID; the Coordinator
+   only ever held the forwarded Offer, with a different ID (CM-21-005). Scan for
+   semantic properties — type, target, object — as `find_case_invite_for_actor`
+   and `find_cp_offer_for_case` do (EDF-06-004). The #2178 fix adds
+   `find_ownership_transfer_offer_for_actor` in the same shape; it arrives with
+   the `fix/demo-ci` integration branch.
+
+### A gate must actually gate
+
+Expressing a precondition with an advisory check is worse than having none: it
+reads like a gate in review and does nothing at runtime. `demo_check` records a
+failure and returns, so the dependent step runs anyway on state that was never
+established, and the resulting cascade of secondary failures buries the real one.
+
+Use `demo_gate` for a causal precondition and `demo_check` for a verification
+assertion. `demo_gate` accumulates identically — DEMOCI-01-003's
+report-everything contract is preserved — and additionally stops the steps that
+depend on the unmet precondition (DEMOCI-01-007, EDF-06-005).
+
+When writing tests for a gate, exercise the real context manager. Patching it out
+with `contextlib.nullcontext` makes the assertion propagate and the test pass
+while proving nothing about gating. This idiom is currently used in seven demo
+test modules, so no test in the suite exercises the real control flow of these
+context managers — which is how the advisory `RM.VALID` gate before `engage-case`
+went unnoticed.
+
+### Not every wait is a defect
+
+Some waits are irreducibly temporal and must stay: service liveness probes,
+protocol deadlines such as embargo expiry, and transport retry backoff. Name them
+as temporal at the call site so they are not "fixed" into meaningless causal
+gates, and so the causal-gate inventory stays honest (EDF-06-006).
+
+Some preconditions are not observable at all today. An actor having *processed* a
+delivery leaves no completion record — the inbox receipt log records arrival, and
+processing happens in a background task. Every "processed" gate is therefore
+inferential: it observes a downstream effect and assumes the antecedent caused it.
+When a precondition cannot be expressed as an observable predicate, record that
+gap rather than substituting a `sleep` (EDF-06-007).
+
+### Where this stops being a harness problem
+
+Harness-side gating cannot fix a cause that never becomes observable. #2169's
+finder race is server-side fan-out, and a client-side wait cannot prevent it; the
+real fix was actor-side buffering (ADR-0037, and ADR-0055 for the pre-genesis
+window). Where the actor buffers, the harness needs no gate at all — so some
+existing `wait_for_case_on_container` sites may be removable.
+
+The test for which side owns a race: if the effect is *eventually* guaranteed by
+a wired recovery path, the harness may wait for it. If the effect can be *lost*,
+the protocol must buffer it, and a demo guard is papering over a production bug.
+
+### Scenario narratives as a conformance oracle
+
+A gate enforces that the harness waited for the right thing. It cannot tell you
+whether the ordering the scenario encodes is the ordering the CVD process
+actually requires — the script is the only statement of intent, so it cannot
+disagree with itself.
+
+That is what the narratives under `docs/topics/scenarios/` are for: one page per
+scenario describing the case's progress in domain terms, with each step's
+antecedent named and no reference to endpoints, helpers, or containers. Because it
+is written independently of the implementation, it can contradict it. Each
+narrative carries a machine-readable list of causal edges, and the invariant
+harness asserts every declared edge appears in the observed case ledger with the
+antecedent's `log_index` before the consequent's — `log_index` order is causal
+order (ADR-0041), and the harness already reads the ledger dumps
+(DEMOMA-22-003 through DEMOMA-22-006).
 
 ---
 

--- a/notes/event-driven-control-flow.md
+++ b/notes/event-driven-control-flow.md
@@ -214,8 +214,10 @@ gap rather than substituting a `sleep` (EDF-06-007).
 
 Harness-side gating cannot fix a cause that never becomes observable. #2169's
 finder race is server-side fan-out, and a client-side wait cannot prevent it; the
-real fix was actor-side buffering (ADR-0037, and ADR-0055 for the pre-genesis
-window). Where the actor buffers, the harness needs no gate at all — so some
+real fix was actor-side buffering (ADR-0037, and the pre-genesis ledger-entry
+buffering ADR carried on the `fix/demo-ci` branch — numbered 0055 there, pending
+renumber when that branch merges under #2143; on `main`, ADR-0055 is an unrelated
+CI-alerting decision). Where the actor buffers, the harness needs no gate at all — so some
 existing `wait_for_case_on_container` sites may be removable.
 
 The test for which side owns a race: if the effect is *eventually* guaranteed by

--- a/notes/protocol-event-cascades.md
+++ b/notes/protocol-event-cascades.md
@@ -11,6 +11,7 @@ related_specs:
 related_notes:
   - notes/activitystreams-semantics.md
   - notes/bt-integration.md
+  - notes/event-driven-control-flow.md
 relevant_packages:
   - vultron/core/use_cases
   - vultron/core/behaviors
@@ -191,7 +192,9 @@ DEMOMA-22 and rationale in ADR-0058.
 The two are easy to confuse because they present the same way in CI, and the fix
 differs sharply: a missing cascade needs a BT subtree, while a harness race needs
 a gate — or, when the effect can be *lost* rather than merely delayed, actor-side
-buffering (ADR-0037, ADR-0055). Diagnose which one you have before fixing it.
+buffering (ADR-0037, and the pre-genesis buffering ADR on the `fix/demo-ci`
+branch — not `main`'s ADR-0055, which is unrelated). Diagnose which one you have
+before fixing it.
 
 ## Related
 

--- a/notes/protocol-event-cascades.md
+++ b/notes/protocol-event-cascades.md
@@ -172,8 +172,31 @@ trigger. The demo-runner calls only Step 1.
 
 ---
 
+## Actor-Side Causality vs. Harness-Side Causal Gating
+
+This note is about causality **inside** an actor: a primary event arrives and the
+actor's BT drives the consequences automatically, as subtrees rather than as
+procedural calls or manual demo triggers. Its failure mode is a *missing cascade*
+— the consequence never fires, so a demo has to trigger it by hand.
+
+There is a second, distinct causality problem on the **harness** side: the
+consequence does fire, but asynchronously, and the scenario script advances before
+it lands. Its failure mode is a *race*, not a gap. That problem — gating each
+scenario step on evidence that its antecedent was committed, rather than on step
+order or elapsed time — is covered in
+[notes/event-driven-control-flow.md](event-driven-control-flow.md)
+§ "Temporal Sequence vs. Causal Sequence", with requirements in EDF-06 and
+DEMOMA-22 and rationale in ADR-0058.
+
+The two are easy to confuse because they present the same way in CI, and the fix
+differs sharply: a missing cascade needs a BT subtree, while a harness race needs
+a gate — or, when the effect can be *lost* rather than merely delayed, actor-side
+buffering (ADR-0037, ADR-0055). Diagnose which one you have before fixing it.
+
 ## Related
 
+- `notes/event-driven-control-flow.md` (harness-side causal gating, EDF-06,
+  ADR-0058; the conceptual model this note's gap inventory sits inside)
 - `notes/bt-integration.md` (subtree map, trunk-removed branches
   model, anti-pattern examples)
 - `specs/behavior-tree-integration.yaml` BT-06-001, BT-06-005, BT-06-006

--- a/plan/history/2608/learning/CONCERN-2181.md
+++ b/plan/history/2608/learning/CONCERN-2181.md
@@ -1,0 +1,91 @@
+---
+source: CONCERN-2181
+timestamp: '2026-08-11T20:32:27.108509+00:00'
+title: Demo harness confuses temporal sequence for causal sequence
+type: learning
+---
+
+## Summary
+
+The demo's control flow is structured as a temporal sequence of events ("A
+happens, then B, then C") rather than a causal chain ("A happens, *therefore* B,
+*therefore* C"). This distinction causes race conditions, timeout failures, and
+ordering bugs — the harness waits for effects that haven't been triggered because
+their causes were never processed.
+
+## Surface Symptom vs. Underlying Problem
+
+**Surface symptom:** The demo is flaky — it times out waiting for events, actors
+reply before receiving the messages they'd need to reply to, and messages are sent
+without the required addressing step having occurred first.
+
+**Underlying problem:** The demo is designed around *temporal* sequencing rather
+than *causal* sequencing. A sound demo should enforce invariants such as "B cannot
+reply until B has received and processed A's activity". The current approach
+instead relies on timing assumptions that race against asynchronous execution.
+
+## What the investigation found
+
+Of the 19 sub-issues of Epic #2136, **7 were this same defect** in a different
+scenario (#2120, #2135, #2141, #2169, #2178, #2180, #2186) and 2 more were
+partially attributable (#2134 leg b, #2193). Bug #2178's own triage comment states
+the thesis independently: *"the demo treated async causal steps as sequential
+(x then y) rather than causally linked (x therefore y)."*
+
+Three structural findings beyond the original report:
+
+1. **The spec corpus duplicated the workaround instead of stating the rule.**
+   Seven scenario-specific requirements each said "poll here before proceeding"
+   for one scenario. DEMOMA-11-009 stated the general rule correctly but was
+   scoped to FVCV-handoff alone.
+
+2. **The existing gates did not gate.** `demo_step` and `demo_check` both record
+   a failure and continue, so a precondition written with `demo_check` is
+   advisory — the dependent step runs anyway on state that was never established.
+   Seven demo test modules patch these context managers out with
+   `contextlib.nullcontext`, so no test exercised their real control flow. This
+   is why the `RM.VALID`-before-`engage-case` gate went unnoticed.
+
+3. **Which observable proves the cause landed was guesswork.** The gate before
+   `validate-report` was re-picked three times in one week.
+
+## Correction to the original concern
+
+The concern asserted that "the underlying protocol state machines and BT nodes
+... are likely already correct. The gap is in the *demo harness* ... not in the
+actor logic itself." The evidence contradicts this and the correction is recorded
+in ADR-0058 so it is not inherited: #2169's race is server-side fan-out that a
+client-side wait cannot prevent, #2186 was consequently fixed in the protocol
+(ADR-0037/0055 lineage), and #2194 — a bare-string `Accept.object_` tripping the
+MV-09-001 outbox gate — is squarely an actor-logic bug. The pattern is real and
+well-attested, but it is not exclusively a harness problem.
+
+A rival recurring class also surfaced: outbound activities carrying bare URN
+references where fully inline typed objects are required (#2134 leg a violating
+CBT-01-007, #2194 violating MV-09-001). It is comparable in frequency among
+post-concern bugs and is tracked separately.
+
+Causal gating does **not** green Epic #2136 on its own — #2194 and #2195 are
+delivery and serialization defects it would not have prevented.
+
+## Resolution
+
+**Resolved**: 2026-08-11 — implementation tracked in #2201, #2202, #2203, #2204.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2200>.
+
+Decision: harness-side causal gating plus domain narratives as a conformance
+oracle, chosen over per-scenario tuned timeouts, pushing all ordering into
+actor-side buffering, and a declarative dependency graph with static validation.
+Recorded as ADR-0058 with status `accepted-provisional` — the gating primitive
+shape and causal-edge schema are expected to converge after the first migrations.
+
+Spec: `specs/event-driven-control-flow.yaml` EDF-06-001 through EDF-06-007;
+`specs/multi-actor-demo.yaml` DEMOMA-22-001 through DEMOMA-22-006 (generalizing
+DEMOMA-11-009 to all scenarios); `specs/demo-ci.yaml` DEMOCI-01-007 (`demo_gate`).
+
+Notes: `notes/event-driven-control-flow.md` § "Temporal Sequence vs. Causal
+Sequence"; `notes/protocol-event-cascades.md` (actor-side vs harness-side
+causality); `AGENTS.md` and `vultron/demo/AGENTS.md` pitfall entries, including a
+correction to the CONCERN-1635 guidance "the demo just needs to wait long enough",
+which embodied the very framing this concern identifies as the defect.

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -6,7 +6,7 @@ description: >-
   when the demo fails — closing the gap where tests pass while the demo produces
   silent failures. Includes requirements for the invariant harness to run as an
   independent CI gate so failures are visible even when the demo itself also fails.
-version: 1.6.0
+version: 1.7.0
 scope:
   - prototype
   - production
@@ -55,13 +55,15 @@ groups:
         priority: MUST
         kind: project
         statement: >-
-          Error detection and accumulation MUST be implemented by extending
-          the existing demo_step and demo_check context managers in
+          Error detection and accumulation MUST be implemented by the
+          demo_step, demo_check, and demo_gate context managers in
           vultron/demo/utils.py.
         rationale: >-
           All demo workflow steps and verification blocks already use these
           context managers; centralising error accumulation there minimises
-          the change surface.
+          the change surface. demo_gate was added by DEMOCI-01-007: it
+          accumulates identically, and differs only in that it also stops the
+          steps that depend on the failed precondition.
 
       - id: DEMOCI-01-005
         priority: MUST
@@ -94,6 +96,33 @@ groups:
             spec_id: DEMOCI-01-003
           - rel_type: refines
             spec_id: DEMOCI-01-004
+
+      - id: DEMOCI-01-007
+        priority: MUST
+        kind: project
+        statement: >-
+          A causal precondition MUST be expressed with a `demo_gate` context
+          manager, distinct from `demo_check`. On failure `demo_gate` MUST
+          record the failure in the accumulator exactly as `demo_check` does,
+          and MUST additionally prevent execution of the steps that depend on
+          the unmet precondition. `demo_check` MUST remain advisory: it records
+          and continues.
+        rationale: >-
+          Accumulate-and-continue is correct for verification assertions — report
+          every failed check, not just the first — and wrong for preconditions,
+          where continuing buries the real failure under secondary ones and makes
+          the gate indistinguishable from a comment. Both behaviours are needed,
+          so they need distinct names. See ADR-0058 and EDF-06-005.
+        adr:
+          - ADR-0058
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-01-003
+            note: >-
+              Constrains control flow only; the accumulation and
+              exit-code contract of DEMOCI-01-001 and DEMOCI-01-003 is unchanged.
+          - rel_type: implements
+            spec_id: EDF-06-005
 
   - id: DEMOCI-02
     title: GitHub Actions Demo Workflow

--- a/specs/event-driven-control-flow.yaml
+++ b/specs/event-driven-control-flow.yaml
@@ -2,7 +2,7 @@ id: EDF
 title: Event-Driven Control Flow
 description: 'Defines the event-driven processing model for Vultron actors: how primary events enter the system, how cascading
   consequences are produced automatically, and what constraints apply to demo scripts and integration tests.'
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -124,6 +124,12 @@ groups:
     kind: project
     statement: Demo scripts MUST verify correctness by observing externally visible system state (e.g., DataLayer contents,
       activities queued in the outbox) after the primary event and its cascades have settled.
+    rationale: '"Settled" is not a matter of elapsed time. EDF-06 defines normatively what counts as evidence that a cascade
+      has settled; read this requirement together with EDF-06-001.'
+    relationships:
+    - rel_type: refines
+      spec_id: EDF-06-001
+      note: EDF-06-001 supplies the operational definition of "settled" that this requirement assumes.
   - id: EDF-05-004
     priority: MUST_NOT
     kind: project
@@ -134,3 +140,108 @@ groups:
     kind: project
     statement: A demo that must manually trigger intermediate steps to reach its expected final state SHOULD be treated as
       evidence of a cascade automation gap that requires a BT fix, not as correct demo behavior.
+- id: EDF-06
+  title: Causal Gating in Demo Scenarios
+  specs:
+  - id: EDF-06-001
+    priority: MUST
+    kind: architecture
+    statement: A harness step that depends on an asynchronous effect MUST be gated on positive evidence that the effect has
+      been committed by the actor that produces it. Elapsed time, the step's position in the script, and the return of an
+      HTTP 202 acknowledgement MUST NOT be treated as such evidence.
+    rationale: Sequencing a scenario temporally ("A and then B") rather than causally ("A therefore B") makes every step a
+      race against asynchronous delivery. This was the shared root cause of a recurring family of demo failures under Epic
+      #2136 — see ADR-0058 and CONCERN-2181.
+    adr:
+    - ADR-0058
+    tags:
+    - demo
+    - testing
+  - id: EDF-06-002
+    priority: MUST
+    kind: project
+    statement: The gate predicate MUST be evaluated against the state of the actor that owns the awaited effect, read from
+      that actor's own container. Observing the effect on the sending actor's container MUST NOT be accepted as evidence that
+      the receiving actor committed it.
+    rationale: Each actor holds an independent DataLayer replica. A sender-side observation proves only that the sender
+      emitted the activity, not that the recipient processed it.
+    adr:
+    - ADR-0058
+    tags:
+    - demo
+    - testing
+  - id: EDF-06-003
+    priority: MUST_NOT
+    kind: project
+    statement: A gate MUST NOT be placed on an observable that becomes true synchronously during the triggering request when
+      the awaited effect is committed asynchronously after that request returns.
+    rationale: 'Bug #2134: `engage-case` was gated on "the case object exists" — which resolves synchronously during
+      `validate-report` — rather than on "this participant reached RM.VALID", which commits after the HTTP 202 returns. A
+      synchronously-available observable is a proxy for the cause having *started*, not for its having *completed*.'
+    adr:
+    - ADR-0058
+    tags:
+    - demo
+    - testing
+  - id: EDF-06-004
+    priority: MUST
+    kind: project
+    statement: When a received-side use case creates a new activity in response to a received one (the forwarding pattern),
+      the harness MUST discover the derived object by scanning the recipient's state for its semantic properties (activity
+      type, target, and object), and MUST NOT poll for the identifier of the sender's original activity.
+    rationale: 'Bug #2178: the demo polled the Coordinator''s DataLayer for the original Vendor1 Offer ID, but
+      `OfferCaseOwnershipTransferReceivedUseCase` creates a *new* forwarded Offer with a different ID (CM-21-005). Polling
+      for the antecedent''s identity can never observe the consequent.'
+    adr:
+    - ADR-0058
+    tags:
+    - demo
+    - testing
+  - id: EDF-06-005
+    priority: MUST
+    kind: project
+    statement: An unmet causal gate MUST prevent execution of the steps that depend on it. Recording the failure and
+      continuing to the dependent step is not sufficient.
+    rationale: A gate that records a failure but lets the dependent step run produces a cascade of secondary failures that
+      masks the first one, and makes the gate indistinguishable from a comment. This refines the accumulate-and-continue
+      rule of DEMOCI-01-003, which governs reporting rather than control flow.
+    adr:
+    - ADR-0058
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-01-003
+      note: Accumulation of failures is preserved; only the control flow of dependent steps is constrained.
+    tags:
+    - demo
+    - testing
+  - id: EDF-06-006
+    priority: MUST
+    kind: project
+    statement: A wait that is irreducibly temporal — service liveness probes, protocol deadlines such as embargo expiry, and
+      transport retry backoff — MUST be identified as temporal at its call site and MUST NOT be counted as a causal gate.
+    rationale: Not every wait is a defect. Naming the temporal waits explicitly keeps them from being "fixed" into
+      meaningless causal gates, and keeps the causal-gate inventory honest about what it does and does not cover.
+    adr:
+    - ADR-0058
+    tags:
+    - demo
+    - testing
+  - id: EDF-06-007
+    priority: SHOULD
+    kind: project
+    statement: A step whose causal precondition cannot be expressed as an observable predicate SHOULD be treated as evidence
+      of a missing observable or an unautomated cascade, and SHOULD be recorded as such rather than replaced with a timed
+      wait.
+    rationale: 'Refines EDF-05-005 to the harness side: where EDF-05-005 detects missing cascade automation from a needed
+      manual trigger, this detects it from an ungateable precondition. Some preconditions are genuinely unobservable today
+      (an actor having *processed* a delivery leaves no completion record); those gaps belong in the record, not behind a
+      `sleep`.'
+    adr:
+    - ADR-0058
+    relationships:
+    - rel_type: refines
+      spec_id: EDF-05-005
+      note: Same diagnostic principle applied to harness gating rather than to manual cascade triggering.
+    tags:
+    - demo
+    - testing

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -4,7 +4,7 @@ description: >-
   Requirements for multi-actor demo scenarios, Docker Compose orchestration, actor isolation,
   acceptance testing, and reproducibility. Includes per-scenario required
   event-type lists for the case-ledger invariant harness.
-version: 1.2.0
+version: 1.3.0
 scope:
 
 - prototype
@@ -978,6 +978,11 @@ groups:
       post-review fixes). Omitting any wait step causes the scenario to proceed on
       state that has not yet been committed to the target actor's DataLayer,
       producing consistent CI failures rather than intermittent flakes.
+      This requirement is now the FVCV-handoff instance of the general rule
+      DEMOMA-22-001, which applies the same constraint to every scenario. The
+      general form additionally constrains *what* the wait may observe
+      (EDF-06-001 through EDF-06-003); "a polling wait exists here" is
+      necessary but not sufficient.
     preconditions:
     - description: >-
         FVCV-handoff scenario executing; Vendor1 has just emitted the ownership-transfer
@@ -2803,3 +2808,123 @@ groups:
       spec_id: DEMOMA-16-009
     - rel_type: refines
       spec_id: DEMOMA-21-001
+- id: DEMOMA-22
+  title: Causal Gating and Scenario Narratives
+  specs:
+  - id: DEMOMA-22-001
+    priority: MUST
+    kind: project
+    statement: >-
+      Every scenario script under `vultron/demo/scenario/` MUST gate each
+      asynchronous protocol boundary on a causal precondition satisfying
+      EDF-06-001 through EDF-06-003 before driving the next trigger.
+    rationale: >-
+      This generalizes DEMOMA-11-009, which stated the rule for FVCV-handoff
+      alone. Seven of the nineteen sub-issues of Epic #2136 were the same
+      defect — a step proceeding before its enabling event had propagated —
+      reproduced in a different scenario each time. A per-scenario requirement
+      cannot prevent the next scenario from rediscovering it. See ADR-0058.
+    adr:
+    - ADR-0058
+    relationships:
+    - rel_type: refines
+      spec_id: EDF-06-001
+    - rel_type: supersedes
+      spec_id: DEMOMA-11-009
+      note: >-
+        DEMOMA-11-009 is retained as the FVCV-handoff instance; this is the
+        general rule it becomes an instance of.
+    tags:
+    - demo
+    - testing
+  - id: DEMOMA-22-002
+    priority: MUST
+    kind: project
+    statement: >-
+      Causal gate primitives MUST be defined in `vultron/demo/helpers/`.
+      Scenario modules MUST NOT define their own polling or retry loops.
+    rationale: >-
+      A MUST-level application of DEMOMA-17-001 (extract before reuse) to the
+      gating vocabulary specifically. Hand-rolled loops in scenario modules are
+      how the #2178 defect survived in `fccv_handoff_demo.py` after being fixed
+      in `fvcv_handoff_demo.py` — the fix had nowhere shared to land.
+    adr:
+    - ADR-0058
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-17-001
+    tags:
+    - demo
+    - testing
+  - id: DEMOMA-22-003
+    priority: MUST
+    kind: project
+    statement: >-
+      Each demo scenario MUST have a narrative page under
+      `docs/topics/scenarios/` that describes the case's progress through the
+      CVD process in domain terms, without reference to implementation
+      details such as endpoint names, helper functions, or container topology.
+      Each narrative step MUST state the antecedent that causes it.
+    rationale: >-
+      A narrative written in domain terms is an independent statement of what
+      the protocol is supposed to accomplish. Because it is written without
+      reference to the implementation, it can disagree with the implementation
+      — which is precisely what makes it usable as a conformance oracle rather
+      than a restatement of the code.
+    adr:
+    - ADR-0058
+    tags:
+    - demo
+    - documentation
+  - id: DEMOMA-22-004
+    priority: MUST
+    kind: project
+    statement: >-
+      Each scenario narrative MUST carry a machine-readable list of causal
+      edges. Each edge MUST name the antecedent event, the consequent event,
+      and the actor that commits the consequent.
+    rationale: >-
+      Prose alone drifts silently from the code it describes. A structured edge
+      list is the part of the narrative a test can check, and it forces the
+      author to state the causal claim precisely enough to be falsifiable.
+    adr:
+    - ADR-0058
+    tags:
+    - demo
+    - documentation
+  - id: DEMOMA-22-005
+    priority: MUST
+    kind: project
+    statement: >-
+      The invariant harness MUST assert, for each scenario, that every causal
+      edge declared in that scenario's narrative appears in the observed case
+      ledger, with the antecedent's log index preceding the consequent's.
+    rationale: >-
+      The case ledger already records `log_index` in causal order (ADR-0041)
+      and the invariant harness already reads the per-scenario ledger dumps, so
+      checking declared causality against observed causality needs no new
+      instrumentation. This is what converts the narrative from documentation
+      into a conformance check.
+    adr:
+    - ADR-0058
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-04-001
+    tags:
+    - demo
+    - testing
+  - id: DEMOMA-22-006
+    priority: MUST
+    kind: project
+    statement: >-
+      A change to a scenario's protocol flow MUST update that scenario's
+      narrative and its declared causal edges in the same pull request.
+    rationale: >-
+      Without this, the conformance check decays into a ratchet that is
+      weakened whenever it fails. Updating both together makes a deliberate
+      protocol change visible as a narrative change, which is the point.
+    adr:
+    - ADR-0058
+    tags:
+    - demo
+    - documentation

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -978,11 +978,8 @@ groups:
       post-review fixes). Omitting any wait step causes the scenario to proceed on
       state that has not yet been committed to the target actor's DataLayer,
       producing consistent CI failures rather than intermittent flakes.
-      This requirement is now the FVCV-handoff instance of the general rule
-      DEMOMA-22-001, which applies the same constraint to every scenario. The
-      general form additionally constrains *what* the wait may observe
-      (EDF-06-001 through EDF-06-003); "a polling wait exists here" is
-      necessary but not sufficient.
+      This requirement is the FVCV-handoff instance of the general rule
+      DEMOMA-22-001 (see relationships).
     preconditions:
     - description: >-
         FVCV-handoff scenario executing; Vendor1 has just emitted the ownership-transfer
@@ -1020,6 +1017,14 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-10-007
+    - rel_type: refines
+      spec_id: DEMOMA-22-001
+      note: >-
+        This requirement is the FVCV-handoff instance of the general rule
+        DEMOMA-22-001, which applies the same constraint to every scenario and
+        additionally constrains *what* the wait may observe (EDF-06-001 through
+        EDF-06-003). "A polling wait exists here" is necessary but not
+        sufficient. This requirement remains active; it is not superseded.
   - id: DEMOMA-11-010
     priority: MUST
     kind: project
@@ -2829,11 +2834,13 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: EDF-06-001
-    - rel_type: supersedes
+    - rel_type: constrains
       spec_id: DEMOMA-11-009
       note: >-
-        DEMOMA-11-009 is retained as the FVCV-handoff instance; this is the
-        general rule it becomes an instance of.
+        DEMOMA-11-009 remains active and is NOT superseded: it is retained as
+        the FVCV-handoff instance of this general rule, and additionally
+        constrained by it (the general form also governs *what* the wait may
+        observe, per EDF-06-001 through EDF-06-003).
     tags:
     - demo
     - testing
@@ -2841,18 +2848,30 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      Causal gate primitives MUST be defined in `vultron/demo/helpers/`.
-      Scenario modules MUST NOT define their own polling or retry loops.
+      Causal gate *predicates* — the reusable functions that poll or scan an
+      actor's own state to decide whether a precondition holds — MUST be defined
+      in `vultron/demo/helpers/`. Scenario modules MUST NOT define their own
+      polling or retry loops. This requirement does NOT relocate the `demo_gate`
+      context manager itself, which DEMOCI-01-007 places in
+      `vultron/demo/utils.py` alongside `demo_step` and `demo_check`.
     rationale: >-
       A MUST-level application of DEMOMA-17-001 (extract before reuse) to the
       gating vocabulary specifically. Hand-rolled loops in scenario modules are
       how the #2178 defect survived in `fccv_handoff_demo.py` after being fixed
-      in `fvcv_handoff_demo.py` — the fix had nowhere shared to land.
+      in `fvcv_handoff_demo.py` — the fix had nowhere shared to land. The split
+      is deliberate: the control-flow primitive lives with the other context
+      managers, and the observables it gates on live in the helper vocabulary.
     adr:
     - ADR-0058
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-17-001
+    - rel_type: depends_on
+      spec_id: DEMOCI-01-007
+      note: >-
+        DEMOCI-01-007 owns the location and semantics of the `demo_gate` context
+        manager; this requirement owns the location of the predicates passed to
+        it.
     tags:
     - demo
     - testing

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -248,7 +248,8 @@ Fixing them one at a time does not stop the next scenario from reintroducing it.
    call site so they are not mistaken for causal gates (EDF-06-006).
 7. **Raising a timeout is not a fix.** If a gate times out reliably, either the
    observable is wrong (see 1–3) or the effect can be *lost* rather than delayed —
-   in which case the protocol must buffer it (ADR-0037, ADR-0055) and a demo guard
+   in which case the protocol must buffer it (ADR-0037, and the pre-genesis
+   buffering ADR on `fix/demo-ci` — not `main`'s ADR-0055) and a demo guard
    would be papering over a production bug.
 
 **Testing gates:** exercise the real context manager. A test that patches

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -169,9 +169,15 @@ The distinction that matters:
 **Root cause of the pattern:** The inbox endpoint returns 202 immediately
 (`BackgroundTasks`) before the activity is fully processed. Naive polling
 after a trigger timed out, so mail-carrying was added as a workaround. The
-correct fix is to use a polling helper with a sufficient timeout — the real
-HTTP delivery path (`HttpDeliveryAdapter`) with its retry/backoff will
-complete; the demo just needs to wait long enough.
+correct fix is to gate on the effect the delivery causes — the real HTTP
+delivery path (`HttpDeliveryAdapter`) with its retry/backoff will complete.
+
+> **Amended (CONCERN-2181):** this section previously ended "the demo just needs
+> to wait long enough." That framing is what the causal-gating rule corrects. A
+> long-enough timeout is not the fix; observing the *right thing* is. Choose the
+> observable per EDF-06-002 and EDF-06-003 — the committed state of the actor
+> that produces the effect, read from its own container — and express it with
+> `demo_gate`, not a raised timeout. See the next section.
 
 **How to apply:**
 
@@ -198,6 +204,64 @@ pattern to eliminate; CONCERN-1653's self-delivery pattern is orthogonal and
 remains correct.
 
 <!-- Source: CONCERN-1635 -->
+
+---
+
+### Gate Each Step on Its Cause, Not on Its Position in the Script
+
+A scenario is a list of steps, so it is tempting to write it as "A, and then B."
+The protocol is causal: "A, **therefore** B." Where those differ you have a race,
+because triggers return HTTP 202 and the effect commits later, in a background
+task, on another container.
+
+**Why:** Seven of the nineteen sub-issues of Epic #2136 were this same defect in
+a different scenario — a step ran before the event enabling it had propagated.
+Fixing them one at a time does not stop the next scenario from reintroducing it.
+
+**How to apply:**
+
+1. **Gate on the committed effect, read where it commits.** The predicate must be
+   a property of the actor that commits the effect, fetched from *that actor's own
+   client*. Observing it on the sender proves only that the sender emitted
+   something (EDF-06-002).
+2. **Never gate on a synchronously-available proxy.** If the observable resolves
+   during the triggering request while the effect commits after the 202, it proves
+   the cause *started*, not that it finished. Bug #2134: `engage-case` gated on
+   "case exists" instead of the receiver's own `RM.VALID` (EDF-06-003).
+3. **Discover a caused object by its properties, not its cause's ID.** When a
+   received-side use case forwards a *new* activity, the consequent has a new
+   identity. Use a discriminator scan — `find_case_invite_for_actor`,
+   `find_cp_offer_for_case`, and (arriving with the `fix/demo-ci` branch)
+   `find_ownership_transfer_offer_for_actor` — not
+   `wait_for_object_stored(obj_id=<sender's original id>)`, which silently times
+   out. Bug #2178 (EDF-06-004).
+4. **Use `demo_gate`, not `demo_check`, for a precondition.** `demo_check` records
+   the failure and returns, so the dependent step runs anyway on state that was
+   never established. `demo_gate` accumulates identically but stops the dependent
+   steps (DEMOCI-01-007, EDF-06-005).
+5. **Put the gate in `vultron/demo/helpers/`.** Scenario modules MUST NOT define
+   their own polling loops — that is how the #2178 fix landed in
+   `fvcv_handoff_demo.py` but not `fccv_handoff_demo.py` (DEMOMA-22-002,
+   DEMOMA-17-001).
+6. **Label irreducibly temporal waits as such.** Liveness probes, embargo
+   deadlines, and transport backoff are legitimately time-based; say so at the
+   call site so they are not mistaken for causal gates (EDF-06-006).
+7. **Raising a timeout is not a fix.** If a gate times out reliably, either the
+   observable is wrong (see 1–3) or the effect can be *lost* rather than delayed —
+   in which case the protocol must buffer it (ADR-0037, ADR-0055) and a demo guard
+   would be papering over a production bug.
+
+**Testing gates:** exercise the real context manager. A test that patches
+`demo_check`/`demo_gate` out with `contextlib.nullcontext` makes the assertion
+propagate and passes while proving nothing — that is precisely how the missing
+gate before `engage-case` escaped notice.
+
+See `specs/event-driven-control-flow.yaml` EDF-06, `specs/multi-actor-demo.yaml`
+DEMOMA-22, ADR-0058, and
+[notes/event-driven-control-flow.md](../../notes/event-driven-control-flow.md)
+§ "Temporal Sequence vs. Causal Sequence".
+
+<!-- Source: CONCERN-2181 -->
 
 ---
 


### PR DESCRIPTION
- Closes #2181

## Summary

Concern #2181 reported that the demo harness sequences scenario steps temporally
("A and then B") instead of causally ("A therefore B"). Investigation confirmed
the pattern and found it accounts for 7 of the 19 sub-issues of Epic #2136, with
2 more partially attributable. This PR codifies a causality-first rule for
scenario authoring, records the decision, and corrects the existing guidance that
embodied the temporal framing.

Two findings changed the plan's shape:

1. **The existing gates do not gate.** `demo_step` and `demo_check` both record a
   failure and continue, so a precondition written with `demo_check` is advisory —
   the dependent step runs anyway on state that was never established. Seven demo
   test modules patch these context managers out with `contextlib.nullcontext`, so
   no test exercises their real control flow.
2. **The concern's localization is wrong.** #2181 asserts actor logic is "likely
   already correct" and the gap is harness-only. Post-concern evidence contradicts
   this: #2169's race is server-side fan-out, #2186 was consequently fixed in the
   protocol (ADR-0037/0055 lineage), and #2194 is an actor-side serialization bug.
   The correction is recorded in ADR-0058 so it is not inherited.

This plan does not green Epic #2136 on its own — #2194 and #2195 are delivery and
serialization defects that causal gating would not have prevented.

## Changes

- **`specs/event-driven-control-flow.yaml`**: new `EDF-06` group (7 requirements)
  defining what counts as evidence that a cause was committed — gate on the
  producing actor's committed state read from its own container, never on a
  synchronously-resolving proxy, discover forwarded objects by discriminator scan,
  unmet gates must stop dependent steps, and temporal waits must be labelled.
  `EDF-05-003` gains a rationale pointing at `EDF-06-001` for the operational
  definition of "settled", the vague clause the concern attacked.
- **`specs/multi-actor-demo.yaml`**: new `DEMOMA-22` group generalizing
  `DEMOMA-11-009` from FVCV-handoff to all scenarios, plus the scenario-narrative
  requirements (domain-terms narrative per scenario, machine-readable causal edge
  list, invariant-harness validation against the observed ledger, update-together
  rule). `DEMOMA-11-009` is retained and marked as an instance of the general rule.
- **`specs/demo-ci.yaml`**: `DEMOCI-01-007` introduces `demo_gate`, which
  accumulates exactly as `demo_check` does but additionally stops dependent steps —
  resolving the tension with `DEMOCI-01-003` by separating reporting from control
  flow rather than choosing between them. `DEMOCI-01-004` amended to admit it.
- **`docs/adr/0058-causal-gating-in-demo-scenarios.md`**: records why harness-side
  causal gating plus narrative conformance was chosen over per-scenario tuned
  timeouts, pushing all ordering into actor-side buffering, and a declarative
  dependency graph with static validation. Status `accepted-provisional` — the
  gating primitive and edge schema are expected to converge after the first
  migrations. Honest limits are stated: "the receiver processed X" is not
  observable today, so those gates remain inferential.
- **`docs/adr/index.md`, `mkdocs.yml`**: ADR-0058 registered in both.
- **`notes/event-driven-control-flow.md`**: new "Temporal Sequence vs. Causal
  Sequence" section — the send/deliver/commit chain and where the gate belongs,
  the three gating rules with their originating bugs, why a gate must actually
  gate, which waits are legitimately temporal, and the test for when a race stops
  being the harness's problem and becomes the protocol's.
- **`notes/protocol-event-cascades.md`**: distinguishes actor-side causality
  (missing cascade) from harness-side gating (race) so the two notes do not drift.
- **`AGENTS.md`, `vultron/demo/AGENTS.md`**: pitfall entries. The existing
  CONCERN-1635 guidance "the demo just needs to wait long enough" is corrected —
  that framing is the defect, not the fix.

## Verification

- `spec-lint specs/` exits 0; all 14 new requirement IDs resolve.
- `markdownlint-cli2` clean across 1832 files.
- `black --check`, `flake8`, `mypy vultron`, `pyright` all clean (no Python changed).
- `vultron.metadata.adr.index_gen --check`: ADR index and nav in sync.
- `pytest test/metadata/ test/architecture/` green (2 pre-existing xfails).

## Implementation Issues

- #2201 — Add `demo_gate` context manager and make gate tests exercise real control flow (size:M)
- #2202 — Build the shared causal-gate helper vocabulary in `vultron/demo/helpers/` (size:L)
- #2203 — Migrate all 9 demo scenarios to causal gates and fix the latent fccv-handoff defects (size:L, blocked by #2201 and #2202)
- #2204 — Write domain-terms scenario narratives and validate declared causal edges against the ledger (size:L)

All four are children of Epic #2136 and blocked by #2181.