### PR TITLE
fix: keep Activity-typed object_ inline on store; expand nested refs on read (#2194)

### DIFF
--- a/docs/adr/0055-buffer-pre-genesis-ledger-entries.md
+++ b/docs/adr/0055-buffer-pre-genesis-ledger-entries.md
@@ -162,8 +162,8 @@ end-to-end (per the "protocol fix only" decision on #2180).
 
 Root-cause / symptom split and the deterministic-genesis insight are recorded in
 `plan/incoming/learnings/` (`20260811-self-healing-recovery-logged-at-error.md`,
-`20260810-clp-08-005-protocol-hardening-gap`) and issues #2186 (root cause) /
-#2180 (symptom). Builds on ADR-0037 (forward-gap buffering) and the SYNC-15
+`20260810-clp-08-005-protocol-hardening-gap`) and issues #2186 (root cause) and #2180
+(symptom). Builds on ADR-0037 (forward-gap buffering) and the SYNC-15
 Genesis-Unavailable requirements.
 
 Generated spec requirements: `sync-ledger-replication.yaml` SYNC-15-004 and

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -81,8 +81,10 @@ and fall through to Level 2 (GitHub label search).
 |---|---|---|
 | `fvcv-extension` | — | 2026-07-31 |
 | `fccv-extension` | — | 2026-07-31 |
-| `fcvcv Demo Integration` | #2134 | 2026-08-10 |
-| `fcvcv Invariant Harness` | #2134 | 2026-08-10 |
+| `fcvcv Demo Integration` | #2216 | 2026-08-12 |
+| `fvcv-handoff Demo Integration` | #2216 | 2026-08-12 |
+| `fvcv-handoff Invariant Harness` | #2216 | 2026-08-12 |
+| `fcvcv Invariant Harness` | — | 2026-08-10 |
 | `fcv-reject Invariant Harness` | #2121 | 2026-08-10 |
 
 > These jobs fail intermittently due to inter-container HTTP delivery timeouts

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -106,7 +106,7 @@ Extend to:
 
 **Forwarded-Offer wire format** (CM-21-005, mirrors Invite-flow analogy):
 
-```
+```text
 Offer(VulnerabilityCase,
     actor        = case_actor_id,       ← CaseActor is the sender
     attributed_to = original_actor_id,  ← Vendor1's intent carried forward

--- a/plan/incoming/learnings/20260811-ownership-transfer-demo-causal-wait-polling.md
+++ b/plan/incoming/learnings/20260811-ownership-transfer-demo-causal-wait-polling.md
@@ -52,4 +52,4 @@ copy with a new ID.
 > the recipient's container.
 
 Related: issue #2181 (broader pattern: demos conflate sequential with causal ordering).
-Fix PR: https://github.com/CERTCC/Vultron/pull/2182
+Fix PR: <https://github.com/CERTCC/Vultron/pull/2182>

--- a/plan/incoming/learnings/20260811-permissive-target-pattern-fragility.md
+++ b/plan/incoming/learnings/20260811-permissive-target-pattern-fragility.md
@@ -1,0 +1,24 @@
+---
+title: "OfferCaseManagerRolePattern permissive string target is a silent mis-route risk"
+type: learning
+timestamp: "2026-08-11"
+source: ISSUE-2194
+signal: concern
+---
+
+`OfferCaseManagerRolePattern` uses `target_=VOtype.CASE_PARTICIPANT` but
+`ActivityPattern._match_activity_field` treats bare string URIs as
+"permissively allowed" for `target_`.  This means any
+`Offer(VulnerabilityCase)` with a string `target` matches the case-manager-role
+pattern, which precedes `OfferCaseOwnershipTransferActivityPattern` in the
+registry (SE-08-001 ordering).
+
+Correct routing therefore depends on `_rehydrate_fields` expanding the
+`target` string to its typed domain object (e.g. as_Organization) BEFORE
+pattern matching runs.  If that expansion is skipped (e.g. because the
+object is kept inline), the dispatcher silently selects the wrong use case.
+
+Consider: (a) adding a `target_strict` per-field flag to `ActivityPattern`
+so CASE_PARTICIPANT matching rejects strings, or (b) reordering registry
+entries so ownership-transfer appears before case-manager-role and does NOT
+require target discrimination.  File as a Concern issue.

--- a/plan/incoming/learnings/20260811-rehydrate-inline-recursion.md
+++ b/plan/incoming/learnings/20260811-rehydrate-inline-recursion.md
@@ -1,0 +1,22 @@
+---
+title: "_rehydrate_fields must recurse into inline BaseModel objects"
+type: learning
+timestamp: "2026-08-11"
+source: ISSUE-2194
+signal: design-question
+---
+
+When `_KEEP_INLINE_NESTED_TYPES` keeps an Activity (e.g. Offer) inline in a
+stored parent Activity (e.g. Accept), the inline object arrives at
+`_rehydrate_fields` as a `BaseModel` instance, not a bare string.  The old
+`_rehydrate_fields` only expanded string ID references, so the nested object's
+own reference fields (e.g. `target`) were never expanded from the DataLayer.
+
+Decision: extend `_rehydrate_fields` to recurse into inline `BaseModel` values
+found in `_AS_OBJECT_REF_FIELDS` slots, so the full expansion chain mirrors
+what previously happened via the dehydrate-then-read-back-separately path.
+
+Without this recursion, `target` remained a bare URI string.  Pattern
+matching in `OfferCaseManagerRolePattern` is permissive for strings, so the
+wrong semantics (`accept_case_manager_role`) were matched instead of
+`accept_case_ownership_transfer`, silently mis-routing the Accept.

--- a/plan/incoming/learnings/20260811-self-healing-recovery-logged-at-error.md
+++ b/plan/incoming/learnings/20260811-self-healing-recovery-logged-at-error.md
@@ -37,7 +37,7 @@ precisely scoped — genuine chain corruption is handled by a different node
 
 ## Root cause vs symptom
 
-#2169 fixed the symptom (log level). The underlying protocol gap — no
+Issue #2169 fixed the symptom (log level). The underlying protocol gap — no
 pre-genesis buffer for `Announce(CaseLedgerEntry)` arriving before
 `Create(VulnerabilityCase)` — is tracked as **#2186** (child of #2136, blocks
 the merge-to-main task #2143). See

--- a/test/adapters/driven/test_issue_2194_accept_object_inline.py
+++ b/test/adapters/driven/test_issue_2194_accept_object_inline.py
@@ -110,11 +110,6 @@ def test_outbox_gate_rejects_bare_string_object():
         )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#2194 — outbound Accept object_ is bare-string, trips MV-09-001;"
-    " xfail removed once emitted fully inline",
-)
 def test_stored_validate_report_accept_carries_inline_typed_object(dl):
     """Outbound validate-report ``Accept.object_`` must be a fully-inline typed
     object (not a bare ``str`` / ``as_Link``) so it passes the MV-09-001 outbox

--- a/test/adapters/driven/test_sqlite_coercion.py
+++ b/test/adapters/driven/test_sqlite_coercion.py
@@ -87,6 +87,58 @@ class TestRehydrateFields:
         assert result is not None
         assert isinstance(result.object_, str)  # type: ignore[union-attr]
 
+    def test_inline_activity_target_expanded_via_recursion(self, dl):
+        """_rehydrate_fields recurses into inline BaseModel objects.
+
+        When Accept.object_ is an inline Offer (kept inline by
+        _KEEP_INLINE_NESTED_TYPES), _rehydrate_fields must recurse into the
+        Offer and expand its own string reference fields (e.g. target) from
+        the DataLayer.  Without recursion the bare-string target causes
+        OfferCaseManagerRolePattern to permissively match any
+        Offer(VulnerabilityCase), silently mis-routing ownership-transfer
+        Accepts as accept_case_manager_role (SE-08-001, ISSUE-2194).
+        """
+        from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+        from vultron.wire.as2.vocab.base.objects.actors import as_Organization
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        org_id = "https://example.org/actors/target-org"
+        org = as_Organization(id_=org_id, name="Target Org")
+        dl.save(org)
+
+        case = as_VulnerabilityCase()
+        # target is a bare string URI — must be expanded on read-back via recursion
+        offer = as_Offer(
+            object_=case,
+            target=org_id,
+            actor="https://example.org/actors/sender",
+        )
+        accept = as_Accept(
+            object_=offer,
+            actor="https://example.org/actors/accepter",
+        )
+        # Store Accept only; the Offer is kept inline by _KEEP_INLINE_NESTED_TYPES.
+        # The org is found by _rehydrate_fields recursing into the inline Offer.
+        dl.create(accept)
+
+        stored = dl.read(accept.id_)
+
+        assert stored is not None
+        inline_offer = getattr(stored, "object_", None)
+        assert (
+            inline_offer is not None
+        ), "object_ should be present on stored Accept"
+        assert not isinstance(
+            inline_offer, str
+        ), "Accept.object_ should be the inline Offer, not a bare string"
+        assert not isinstance(inline_offer.target, str), (  # type: ignore[union-attr]
+            f"Offer.target should be the typed actor after recursion,"
+            f" not bare string {inline_offer.target!r}"  # type: ignore[union-attr]
+        )
+        assert isinstance(inline_offer.target, as_Actor)  # type: ignore[union-attr]
+
 
 # ---------------------------------------------------------------------------
 # DL-REHYDRATE: _coerce_to_semantic_class tests

--- a/test/adapters/driven/test_sqlite_coercion.py
+++ b/test/adapters/driven/test_sqlite_coercion.py
@@ -281,6 +281,58 @@ class TestCoerceToSemanticClass:
         assert result.object_.case_id == entry.case_id  # type: ignore[union-attr]
         assert result.object_.log_object_id == entry.log_object_id  # type: ignore[union-attr]
 
+    def test_retype_inline_object_refs_recurses_into_sub_activities(self):
+        """_retype_inline_object_refs recurses into re-typed inline sub-activities.
+
+        Accept(object_=Offer(object_=CaseLedgerEntry(case_id=...))) — both Offer
+        and CaseLedgerEntry are kept inline by _KEEP_INLINE_NESTED_TYPES.
+        Without recursion, re-typing the Offer via model_validate parses the inner
+        CaseLedgerEntry dict against the base as_Object union (as_Offer.object_ is
+        typed Union[as_Object, as_Link, str, CoreObject]), silently dropping
+        domain-specific fields such as case_id and event_type.  With the recursive
+        call, _retype_inline_object_refs runs again on the re-typed Offer's raw
+        sub-data and restores the CaseLedgerEntry to its specific class.
+        """
+        from vultron.adapters.driven.db_record import Record
+        from vultron.wire.as2.vocab.objects.case_ledger_entry import (
+            as_CaseLedgerEntry,
+        )
+
+        ledger_entry = as_CaseLedgerEntry(
+            case_id="https://example.org/cases/retype-recurse-1",
+            log_object_id="https://example.org/activities/obj-retype-1",
+            event_type="log_entry_committed",
+            log_index=0,
+        )
+        offer = as_Offer(
+            object_=ledger_entry,
+            actor="https://example.org/actors/sender",
+        )
+        accept = as_Accept(
+            object_=offer,
+            actor="https://example.org/actors/accepter",
+        )
+
+        record = Record.from_obj(accept)
+        result = record.to_obj()
+
+        inner_offer = getattr(result, "object_", None)
+        assert (
+            inner_offer is not None
+        ), "Accept.object_ must be the inline Offer"
+        assert not isinstance(
+            inner_offer, str
+        ), "Accept.object_ must not collapse to a bare string"
+        inner_entry = getattr(inner_offer, "object_", None)
+        assert isinstance(inner_entry, as_CaseLedgerEntry), (
+            f"Offer.object_ should be re-typed to as_CaseLedgerEntry by recursive "
+            f"_retype_inline_object_refs; got {type(inner_entry).__name__!r}"
+        )
+        assert (
+            inner_entry.case_id == "https://example.org/cases/retype-recurse-1"
+        )
+        assert inner_entry.event_type == "log_entry_committed"
+
     def test_non_activity_object_not_coerced(self, dl):
         """Non-activity objects (e.g. as_VulnerabilityReport) are returned as-is."""
         from vultron.wire.as2.vocab.objects.vulnerability_report import (

--- a/vultron/adapters/driven/datalayer_sqlite/datalayer.py
+++ b/vultron/adapters/driven/datalayer_sqlite/datalayer.py
@@ -18,7 +18,7 @@
 import logging
 from typing import Any, Callable, cast
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from sqlmodel import SQLModel
 
 from vultron.adapters.driven.db_record import (
@@ -196,23 +196,40 @@ class SqliteDataLayer:
         ``self.read()`` and replaces it with the full domain object.  If a
         referenced object is not found the string is kept and a DEBUG message
         is logged.
+
+        When a field holds an inline ``PersistableModel`` (kept inline by
+        ``_KEEP_INLINE_NESTED_TYPES`` rather than dehydrated to a bare ID),
+        this method recurses into it so that the nested object's own reference
+        fields are expanded too.  Without this recursion an inline Offer's
+        ``target`` would remain a bare string URI and break semantic dispatch
+        that relies on the resolved type (e.g. Organisation ≠ CaseParticipant
+        for ``OfferCaseManagerRolePattern`` vs ``OfferCaseOwnershipTransfer``).
         """
         updates: dict[str, object] = {}
         for field_name in _AS_OBJECT_REF_FIELDS:
             value = getattr(obj, field_name, None)
-            if not isinstance(value, str) or not value:
+            if value is None:
                 continue
-            nested = self.read(value)
-            if nested is None:
-                logger.debug(
-                    "Could not rehydrate field %r with id %r on %r;"
-                    " keeping string reference.",
-                    field_name,
-                    value,
-                    type(obj).__name__,
+            if isinstance(value, str):
+                if not value:
+                    continue
+                nested = self.read(value)
+                if nested is None:
+                    logger.debug(
+                        "Could not rehydrate field %r with id %r on %r;"
+                        " keeping string reference.",
+                        field_name,
+                        value,
+                        type(obj).__name__,
+                    )
+                    continue
+                updates[field_name] = nested
+            elif isinstance(value, BaseModel):
+                rehydrated = self._rehydrate_fields(
+                    cast(PersistableModel, value)
                 )
-                continue
-            updates[field_name] = nested
+                if rehydrated is not value:
+                    updates[field_name] = rehydrated
         if updates:
             obj = obj.model_copy(update=updates)
         return obj

--- a/vultron/adapters/driven/db_record.py
+++ b/vultron/adapters/driven/db_record.py
@@ -40,6 +40,50 @@ _AS_OBJECT_REF_FIELDS: frozenset[str] = frozenset(
     }
 )
 
+# AS2 Activity ``type_`` strings (transitive + intransitive) plus
+# ``CaseLedgerEntry``.  When a nested ``_AS_OBJECT_REF_FIELDS`` value has one
+# of these types it MUST be kept inline rather than collapsed to a bare ID
+# string: Activities may not have independent DataLayer records (e.g. a
+# reconstituted Offer in the validate-report path, a CaseLedgerEntry inside an
+# Announce envelope), so dehydrating them would make rehydration impossible on
+# read-back and cause MV-09-001 outbox-gate failures.
+_KEEP_INLINE_NESTED_TYPES: frozenset[str] = frozenset(
+    {
+        # as_TransitiveActivityType values
+        "Accept",
+        "Add",
+        "Announce",
+        "Block",
+        "Create",
+        "Delete",
+        "Dislike",
+        "Flag",
+        "Follow",
+        "Ignore",
+        "Invite",
+        "Join",
+        "Leave",
+        "Like",
+        "Listen",
+        "Move",
+        "Offer",
+        "Read",
+        "Reject",
+        "Remove",
+        "TentativeAccept",
+        "TentativeReject",
+        "Undo",
+        "Update",
+        "View",
+        # as_IntransitiveActivityType values
+        "Arrive",
+        "Question",
+        "Travel",
+        # Vultron-specific type kept inline for the same reason
+        "CaseLedgerEntry",
+    }
+)
+
 # Fields that hold a *list* of object references (ID strings or inline
 # objects).  Used by ``DataLayer.hydrate()`` to expand bare ID strings to
 # full domain objects — the list analogue of ``_AS_OBJECT_REF_FIELDS``.
@@ -73,14 +117,13 @@ def _dehydrate_data(data: dict[str, Any]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in data.items():
         if key in _AS_OBJECT_REF_FIELDS and isinstance(value, dict):
-            # SYNC-13-002/SYNC-02-004: a CaseLedgerEntry is never stored as an
-            # independent DataLayer record by ingress, so collapsing it to a
-            # bare ID here would lose it (the referent is not resolvable on
-            # read/replay).  SYNC-02-004 also requires the full inline entry to
-            # travel inside the Announce envelope.  Keep it inline so a
-            # replayed Announce(CaseLedgerEntry) still routes and applies its
-            # effects.
-            if value.get("type_") == "CaseLedgerEntry":
+            # Keep Activity-type and CaseLedgerEntry nested objects inline.
+            # These may not have independent DataLayer records (e.g. a
+            # reconstituted Offer in validate-report, or a CaseLedgerEntry
+            # inside an Announce envelope), so collapsing them to a bare ID
+            # would make rehydration impossible on outbox read-back, causing
+            # MV-09-001 gate failures.  See _KEEP_INLINE_NESTED_TYPES.
+            if value.get("type_") in _KEEP_INLINE_NESTED_TYPES:
                 result[key] = value
                 continue
             nested_id = value.get("id_")

--- a/vultron/adapters/driven/db_record.py
+++ b/vultron/adapters/driven/db_record.py
@@ -181,8 +181,11 @@ def _retype_inline_object_refs(
     """
     updates: dict[str, Any] = {}
     for field_name in _AS_OBJECT_REF_FIELDS:
-        typed = _retype_inline_ref(obj, field_name, data.get(field_name))
+        raw_sub = data.get(field_name)
+        typed = _retype_inline_ref(obj, field_name, raw_sub)
         if typed is not None:
+            if isinstance(raw_sub, dict):
+                typed = _retype_inline_object_refs(typed, raw_sub)
             updates[field_name] = typed
     if not updates:
         return obj


### PR DESCRIPTION
- Closes #2194

## Summary

Outbound `Accept(Offer)` carried a bare-string `object_` on the invite path
(`_dehydrate_data` collapsed the nested Offer to an ID that didn't exist in the
DataLayer), causing MV-09-001 outbox-gate rejection, sticking participants at
`RM.RECEIVED` and making `engage-case` return 422.

## Changes

- **`vultron/adapters/driven/db_record.py`**: Add `_KEEP_INLINE_NESTED_TYPES`
  frozenset (all AS2 Activity type strings + `CaseLedgerEntry`). `_dehydrate_data`
  now keeps nested objects of these types inline instead of collapsing to bare IDs.

- **`vultron/adapters/driven/datalayer_sqlite/datalayer.py`**: Extend
  `_rehydrate_fields` to recurse into inline `BaseModel` objects in
  `_AS_OBJECT_REF_FIELDS` slots, so a stored Accept with an inline Offer also
  expands the Offer's own `target` field from the DataLayer. Without this,
  `OfferCaseManagerRolePattern` permissively matched the bare-string target,
  mis-routing ownership-transfer Accepts as `accept_case_manager_role`.

- **`test/adapters/driven/test_issue_2194_accept_object_inline.py`**: Remove
  `@pytest.mark.xfail(strict=True)` from `test_stored_validate_report_accept_carries_inline_typed_object`
  (all three ratchet tests now pass).

## Verification

- Three ratchet tests in `test_issue_2194_accept_object_inline.py` pass
- Integration regression `TestOwnershipTransferAnnounceReachesFinderAC5c::test_finder_receives_announce_ledger_entry` passes
- Full unit suite: no new failures (4 pre-existing failures unchanged on `fix/demo-ci`)
- Full integration suite: no new failures (1 pre-existing XPASS unchanged)
- `black` + `flake8` + `mypy` + `pyright` clean (pre-existing issues only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)