### PR TITLE
fix(sync): materialize ownership-transfer Offer on Coordinator replica (#2195)

### DIFF
--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -165,6 +165,39 @@ Use this analogy when explaining the model to new contributors.
 
 ---
 
+## Replica-side Materialization (SYNC Path)
+
+When a participant joins a case that already has an ownership-transfer offer
+in flight, or when a Coordinator replica receives the ledger broadcast for
+`offer_case_ownership_transfer`, the Offer object must be materialized from
+the `Announce(CaseLedgerEntry)` entry — it does **not** arrive via the HTTP
+inbox path.
+
+The announce tree (`create_announce_log_entry_tree`) has a Selector slot for
+`OfferOwnershipTransferEffects`. The two BT nodes that wire this slot are:
+
+- `IsOfferOwnershipTransferEventNode` — Condition: checks
+  `entry.event_type == "offer_case_ownership_transfer"`
+- `ApplyOfferOwnershipTransferFromLedgerNode` — Action: extracts `offer_id`
+  from `payload_snapshot["id"]` and `case_id` from `payload_snapshot["object"]`,
+  creates a `VultronOwnershipTransferOfferRecord`, and saves it to the
+  DataLayer so that `SvcAcceptCaseOwnershipTransferUseCase._prepare` can
+  `dl.read(offer_id)` without a 404.
+
+**Why this is needed**: `SvcAcceptCaseOwnershipTransferUseCase._prepare` calls
+`self._dl.read(request.offer_id)` to resolve the case ID embedded in the
+offer. If the Coordinator replica never materialized the Offer object (because
+it arrived only via the SYNC path, not the HTTP inbox), `_prepare` raises
+`VultronNotFoundError("VultronOwnershipTransferOfferRecord", offer_id)`.
+
+This is analogous to how report-offer backfill works in the invite flow — the
+ledger entry carries the full payload snapshot, and the announce-tree effect
+node reconstructs the core object from it.
+
+**Spec ref**: CM-21-007.
+
+---
+
 ## Guarded-Commit Pattern Reminder
 
 `AcceptCaseOwnershipTransferReceivedUseCase` is a **received-side** use case.

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -179,10 +179,11 @@ The announce tree (`create_announce_log_entry_tree`) has a Selector slot for
 - `IsOfferOwnershipTransferEventNode` — Condition: checks
   `entry.event_type == "offer_case_ownership_transfer"`
 - `ApplyOfferOwnershipTransferFromLedgerNode` — Action: extracts `offer_id`
-  from `payload_snapshot["id"]` and `case_id` from `payload_snapshot["object"]`,
-  creates a `VultronOwnershipTransferOfferRecord`, and saves it to the
-  DataLayer so that `SvcAcceptCaseOwnershipTransferUseCase._prepare` can
-  `dl.read(offer_id)` without a 404.
+  from `payload_snapshot["id"]` and `case_id` from `payload_snapshot["object"]`
+  (inline dict or bare URI string), creates a
+  `VultronOwnershipTransferOfferRecord`, and saves it to the DataLayer so that
+  `SvcAcceptCaseOwnershipTransferUseCase._prepare` can `dl.read(offer_id)`
+  without a 404.
 
 **Why this is needed**: `SvcAcceptCaseOwnershipTransferUseCase._prepare` calls
 `self._dl.read(request.offer_id)` to resolve the case ID embedded in the
@@ -194,7 +195,27 @@ This is analogous to how report-offer backfill works in the invite flow — the
 ledger entry carries the full payload snapshot, and the announce-tree effect
 node reconstructs the core object from it.
 
-**Spec ref**: CM-21-007.
+**Both facts are required.** The record's `case_id` is a non-empty `UriString`,
+and the effect node declines to store a record it cannot fully populate. A
+half-record would satisfy `dl.read(offer_id)` and then fail one line later on
+the case lookup — moving the #2195 404 rather than removing it. The case URI is
+named `case_id`, not `object_`, because the DataLayer rehydrates the AS2
+reference fields (`object_`, `target`, `origin`, `result`, `instrument`) from ID
+strings into typed objects on read; a field named `object_` would come back as a
+`VulnerabilityCase` instance rather than the `str` its annotation promises.
+`_prepare` reads `case_id` first and falls back to `object_` for the wire Offer
+activity the HTTP-inbox path stores.
+
+**Status contract (SYNC-12-001)**: the effect node returns SUCCESS when there is
+nothing to apply (no offer id, or no resolvable case id) and FAILURE only when a
+well-formed record could not be written. FAILURE propagates through the slot's
+Selector to block `PersistReceivedLogEntry`, so an entry is never persisted
+without its effects.
+
+**Spec refs**: CM-21-005 (the offer hop this slot materializes — offer addressed
+to the CaseActor inbox and forwarded by it), SYNC-02-002, SYNC-12-001,
+ADR-0035 DL-06-002. CM-21-007 covers the ledger commit and broadcast that follow
+a successful *accept*, which is a different hop.
 
 ---
 

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -212,6 +212,34 @@ well-formed record could not be written. FAILURE propagates through the slot's
 Selector to block `PersistReceivedLogEntry`, so an entry is never persisted
 without its effects.
 
+### Two consumers, one key
+
+`dl.read(offer_id)` has two consumers with different expectations, and on a
+SYNC-only replica what sits at that key is the core record, not the wire Offer:
+
+| Consumer | Needs |
+|---|---|
+| `SvcAcceptCaseOwnershipTransferUseCase._prepare` | anything from which a case id is recoverable |
+| `TriggerActivityAdapter.accept_case_ownership_transfer` | an `_OfferCaseOwnershipTransferActivity` to pass to `accept_case_ownership_transfer_activity` |
+
+The adapter therefore rebuilds the wire Offer from the core record
+(`_offer_from_core_record`), reusing `offer_case_ownership_transfer_activity` —
+the same factory the offering side calls — so both delivery paths converge on an
+identical Accept. Reconstruction lives in the adapter because core may not
+import wire (ARCH-03-001) and because
+`test/architecture/test_activity_factory_imports.py` forbids adapters from
+reaching into `vultron.wire.as2.vocab.activities` directly.
+
+That is why the record also carries `actor_id` and `target_id`: the wire Offer
+needs an `actor` (which also supplies the Accept's `to:` fallback) and a
+`target`. Both are read from the snapshot's `actor` and `target` fields per
+DL-06-002. `object_` must be an **inline** `as_VulnerabilityCase`, not a bare
+URI, so the adapter reads the case from the replica's DataLayer and projects it
+with `as_VulnerabilityCase.from_core`.
+
+Without this, `accept-case-ownership-transfer` returns
+`422 ... accept_case_ownership_transfer_activity: invalid arguments` (#2225).
+
 **Spec refs**: CM-21-005 (the offer hop this slot materializes — offer addressed
 to the CaseActor inbox and forwarded by it), SYNC-02-002, SYNC-12-001,
 ADR-0035 DL-06-002. CM-21-007 covers the ledger commit and broadcast that follow

--- a/test/core/behaviors/sync/nodes/test_issue_2195_ownership_offer_delivered.py
+++ b/test/core/behaviors/sync/nodes/test_issue_2195_ownership_offer_delivered.py
@@ -58,6 +58,7 @@ from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.sync.announce_tree import (
     create_announce_log_entry_tree,
 )
+from vultron.core.models._helpers import _as_id
 from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.case_ledger import HashChainLedgerRecord
@@ -184,4 +185,20 @@ def test_ownership_offer_object_materialized_on_coordinator_replica(
         "Announce(CaseLedgerEntry) for the ownership-transfer offer — "
         "otherwise accept-case-ownership-transfer 404s on dl.read(offer_id) "
         "(#2195)."
+    )
+
+    # Presence alone is not enough: _prepare reads the case URI back off the
+    # stored record and raises VultronNotFoundError when it cannot resolve one.
+    # Without this second assertion the probe passes on a record that still
+    # 404s the accept trigger — it merely moves the 404 one line down.
+    assert (
+        _as_id(
+            getattr(stored_offer, "case_id", None)
+            or getattr(stored_offer, "object_", None)
+        )
+        == CASE_ID
+    ), (
+        "The materialized offer must name the case it offers, so "
+        "SvcAcceptCaseOwnershipTransferUseCase._prepare can recover case_id "
+        "from it (#2195)."
     )

--- a/test/core/behaviors/sync/nodes/test_issue_2195_ownership_offer_delivered.py
+++ b/test/core/behaviors/sync/nodes/test_issue_2195_ownership_offer_delivered.py
@@ -144,11 +144,6 @@ def _offer_ownership_transfer_record(prev_hash: str) -> HashChainLedgerRecord:
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#2195 — ownership-transfer offer never delivered to coordinator "
-    "DataLayer; xfail removed once delivered",
-)
 def test_ownership_offer_object_materialized_on_coordinator_replica(
     bridge, datalayer, case_actor, case_replica
 ):

--- a/test/core/behaviors/sync/nodes/test_ownership_offer_effect.py
+++ b/test/core/behaviors/sync/nodes/test_ownership_offer_effect.py
@@ -280,3 +280,66 @@ def test_record_round_trips_through_datalayer():
         assert back.case_id == CASE_ID
     finally:
         dl.close()
+
+
+# ---------------------------------------------------------------------------
+# #2225 — the adapter must be able to accept from a SYNC-only replica
+# ---------------------------------------------------------------------------
+
+
+def test_effect_records_offer_actor_and_target(bridge, datalayer, case_actor):
+    """actor/target are recorded so the adapter can rebuild the wire Offer."""
+    offer_id = f"urn:uuid:{uuid.uuid4()}"
+    entry = _offer_entry(offer_id)
+    entry.payload_snapshot["target"] = {
+        "id": "https://example.org/actors/transferee",
+        "type": "Actor",
+    }
+
+    assert _run_effect(bridge, entry, case_actor).status == Status.SUCCESS
+
+    stored = cast(
+        VultronOwnershipTransferOfferRecord, datalayer.read(offer_id)
+    )
+    assert stored.actor_id == "https://example.org/actors/original-owner"
+    assert stored.target_id == "https://example.org/actors/transferee"
+
+
+def test_adapter_accepts_transfer_from_sync_only_replica(
+    bridge, datalayer, case_actor, case_obj
+):
+    """accept_case_ownership_transfer works when only the core record exists.
+
+    Regression for #2225: the replica's DataLayer holds a
+    VultronOwnershipTransferOfferRecord at offer_id, not the wire
+    _OfferCaseOwnershipTransferActivity that
+    accept_case_ownership_transfer_activity requires.  Before the adapter
+    learned to rebuild the wire Offer, this raised a ValidationError surfaced
+    to the demo as `422 ... accept_case_ownership_transfer_activity: invalid
+    arguments`.
+    """
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+
+    transferee = "https://example.org/actors/transferee"
+    offer_id = f"urn:uuid:{uuid.uuid4()}"
+    entry = _offer_entry(offer_id)
+    entry.payload_snapshot["target"] = {"id": transferee, "type": "Actor"}
+
+    assert _run_effect(bridge, entry, case_actor).status == Status.SUCCESS
+    assert isinstance(
+        datalayer.read(offer_id), VultronOwnershipTransferOfferRecord
+    )
+
+    activity_id, activity = TriggerActivityAdapter(
+        datalayer
+    ).accept_case_ownership_transfer(offer_id=offer_id, actor=transferee)
+
+    assert activity_id
+    assert activity["type"] == "Accept"
+    # The Accept must carry the Offer inline, with the case inline inside it.
+    assert activity["object"]["id"] == offer_id
+    assert activity["object"]["object"]["id"] == CASE_ID
+    # to: falls back to the offering actor recorded on the core record.
+    assert activity["to"] == ["https://example.org/actors/original-owner"]

--- a/test/core/behaviors/sync/nodes/test_ownership_offer_effect.py
+++ b/test/core/behaviors/sync/nodes/test_ownership_offer_effect.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python
+"""Unit tests for the OfferOwnershipTransferEffects slot nodes (#2195).
+
+Covers ``IsOfferOwnershipTransferEventNode`` and
+``ApplyOfferOwnershipTransferFromLedgerNode`` directly, plus the
+``VultronOwnershipTransferOfferRecord`` round-trip they depend on.
+
+The end-to-end path through ``create_announce_log_entry_tree`` is covered by
+test_issue_2195_ownership_offer_delivered.py; this module pins the individual
+node contracts that the tree-level probe cannot distinguish — in particular the
+SYNC-12-001 status contract:
+
+- nothing to apply (no offer id, no case id) -> SUCCESS, nothing stored
+- effect failed (DataLayer write raised)     -> FAILURE, so the surrounding
+  Selector blocks PersistReceivedLogEntry
+
+See CM-21-005, SYNC-02-002, SYNC-12-001, ADR-0035 DL-06-002.
+"""
+
+import uuid
+from typing import Any, cast
+
+import pytest
+from py_trees.common import Status
+from pydantic import ValidationError
+
+from test.core.behaviors.sync.nodes.conftest import (
+    CASE_ID,
+    PARTICIPANT_ACTOR_ID,
+    _make_event,
+    _to_persistable_entry,
+)
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.sync.nodes.ownership_offer_effect import (
+    ApplyOfferOwnershipTransferFromLedgerNode,
+    IsOfferOwnershipTransferEventNode,
+)
+from vultron.core.models.case_ledger import HashChainLedgerRecord
+from vultron.core.models.ownership_transfer_offer_record import (
+    VultronOwnershipTransferOfferRecord,
+)
+from vultron.core.models.registry import CORE_VOCABULARY
+
+_ZERO_HASH = "0" * 64
+OFFER_EVENT = "offer_case_ownership_transfer"
+
+# Distinguishes "caller did not specify object" (use the realistic inline dict)
+# from "caller explicitly passed None" (exercise the no-case-id path).
+_DEFAULT_OBJECT = object()
+
+
+def _offer_entry(
+    offer_id: str,
+    object_field: Any = _DEFAULT_OBJECT,
+    event_type: str = OFFER_EVENT,
+):
+    """Return a ledger entry for an ownership-transfer offer.
+
+    ``object_field`` defaults to the inline-dict form the real snapshot uses.
+    Pass a bare URI string or ``None`` to exercise the other shapes.
+    """
+    snapshot: dict[str, Any] = {
+        "type": "Offer",
+        "id": offer_id,
+        "actor": "https://example.org/actors/original-owner",
+        "context": CASE_ID,
+    }
+    if object_field is _DEFAULT_OBJECT:
+        snapshot["object"] = {"id": CASE_ID, "type": "VulnerabilityCase"}
+    else:
+        snapshot["object"] = object_field
+
+    return _to_persistable_entry(
+        HashChainLedgerRecord(
+            case_id=CASE_ID,
+            log_index=0,
+            object_id=offer_id,
+            event_type=event_type,
+            payload_snapshot=snapshot,
+            prev_log_hash=_ZERO_HASH,
+        )
+    )
+
+
+def _run_effect(bridge, entry, case_actor):
+    return bridge.execute_with_setup(
+        tree=ApplyOfferOwnershipTransferFromLedgerNode(
+            name="ApplyOfferOwnershipTransferFromLedger"
+        ),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=_make_event(entry, actor_id=case_actor.id_),
+    )
+
+
+# ---------------------------------------------------------------------------
+# IsOfferOwnershipTransferEventNode
+# ---------------------------------------------------------------------------
+
+
+def test_condition_succeeds_on_offer_event(bridge, case_actor):
+    """SUCCESS when the entry's event_type is offer_case_ownership_transfer."""
+    entry = _offer_entry(offer_id=f"urn:uuid:{uuid.uuid4()}")
+    result = bridge.execute_with_setup(
+        tree=IsOfferOwnershipTransferEventNode(
+            name="IsOfferOwnershipTransfer"
+        ),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=_make_event(entry, actor_id=case_actor.id_),
+    )
+    assert result.status == Status.SUCCESS
+
+
+def test_condition_fails_on_other_event(bridge, case_actor):
+    """FAILURE for any other event_type — the Inverter arm handles routing."""
+    entry = _offer_entry(
+        offer_id=f"urn:uuid:{uuid.uuid4()}",
+        event_type="accept_case_ownership_transfer",
+    )
+    result = bridge.execute_with_setup(
+        tree=IsOfferOwnershipTransferEventNode(
+            name="IsOfferOwnershipTransfer"
+        ),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=_make_event(entry, actor_id=case_actor.id_),
+    )
+    assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# ApplyOfferOwnershipTransferFromLedgerNode — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_effect_stores_record_from_inline_object(
+    bridge, datalayer, case_actor
+):
+    """The offer is materialized keyed by offer_id, naming the offered case."""
+    offer_id = f"urn:uuid:{uuid.uuid4()}"
+    assert _run_effect(bridge, _offer_entry(offer_id), case_actor).status == (
+        Status.SUCCESS
+    )
+
+    stored = cast(
+        VultronOwnershipTransferOfferRecord, datalayer.read(offer_id)
+    )
+    assert isinstance(stored, VultronOwnershipTransferOfferRecord)
+    assert stored.id_ == offer_id
+    assert stored.offer_id == offer_id
+    assert stored.case_id == CASE_ID
+
+
+def test_effect_accepts_bare_string_object(bridge, datalayer, case_actor):
+    """`object` may be a bare URI string rather than an inline dict."""
+    offer_id = f"urn:uuid:{uuid.uuid4()}"
+    entry = _offer_entry(offer_id, object_field=CASE_ID)
+    assert _run_effect(bridge, entry, case_actor).status == Status.SUCCESS
+
+    stored = cast(
+        VultronOwnershipTransferOfferRecord, datalayer.read(offer_id)
+    )
+    assert stored.case_id == CASE_ID
+
+
+def test_effect_is_idempotent(bridge, datalayer, case_actor):
+    """A replayed entry is a no-op, not an overwrite or an error."""
+    offer_id = f"urn:uuid:{uuid.uuid4()}"
+    entry = _offer_entry(offer_id)
+
+    for _ in range(2):
+        assert _run_effect(bridge, entry, case_actor).status == Status.SUCCESS
+
+    stored = cast(
+        VultronOwnershipTransferOfferRecord, datalayer.read(offer_id)
+    )
+    assert stored.case_id == CASE_ID
+
+
+# ---------------------------------------------------------------------------
+# Nothing-to-apply paths -> SUCCESS, nothing stored
+# ---------------------------------------------------------------------------
+
+
+def test_effect_declines_to_store_record_without_case_id(
+    bridge, datalayer, case_actor
+):
+    """No resolvable case id -> SUCCESS but NOTHING stored (#2195).
+
+    Storing a record that cannot name its case would satisfy
+    ``_prepare``'s ``dl.read(offer_id)`` and then fail one line later on the
+    case lookup — converting a "missing offer" 404 into a "missing case" 404
+    rather than fixing anything.
+    """
+    offer_id = f"urn:uuid:{uuid.uuid4()}"
+    entry = _offer_entry(offer_id, object_field=None)
+
+    assert _run_effect(bridge, entry, case_actor).status == Status.SUCCESS
+    assert datalayer.read(offer_id) is None
+
+
+def test_effect_falls_back_to_log_object_id(bridge, datalayer, case_actor):
+    """A snapshot with no ``id`` key falls back to the entry's log_object_id.
+
+    A ledger entry always carries a non-empty ``object_id``, so the offer id is
+    recoverable even from a snapshot that omits it — which is why the
+    "no offer id at all" branch cannot be reached through a well-formed entry.
+    """
+    offer_id = f"urn:uuid:{uuid.uuid4()}"
+    entry = _offer_entry(offer_id)
+    del entry.payload_snapshot["id"]
+
+    assert _run_effect(bridge, entry, case_actor).status == Status.SUCCESS
+
+    stored = cast(
+        VultronOwnershipTransferOfferRecord, datalayer.read(offer_id)
+    )
+    assert stored is not None
+    assert stored.offer_id == offer_id
+    assert stored.case_id == CASE_ID
+
+
+# ---------------------------------------------------------------------------
+# Effect-failed path -> FAILURE (SYNC-12-001)
+# ---------------------------------------------------------------------------
+
+
+def test_effect_fails_when_datalayer_write_raises(
+    bridge, datalayer, case_actor, monkeypatch
+):
+    """A well-formed effect that cannot be written MUST fail (SYNC-12-001).
+
+    Returning SUCCESS here would let PersistReceivedLogEntry commit the ledger
+    entry without its effect ever having been applied.
+    """
+    offer_id = f"urn:uuid:{uuid.uuid4()}"
+
+    def _boom(_obj):
+        raise RuntimeError("datalayer unavailable")
+
+    monkeypatch.setattr(datalayer, "save", _boom)
+
+    result = _run_effect(bridge, _offer_entry(offer_id), case_actor)
+    assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# VultronOwnershipTransferOfferRecord
+# ---------------------------------------------------------------------------
+
+
+def test_record_is_registered_in_core_vocabulary():
+    """Registration under the class name is what makes the read round-trip."""
+    assert (
+        CORE_VOCABULARY.get("VultronOwnershipTransferOfferRecord")
+        is VultronOwnershipTransferOfferRecord
+    )
+
+
+@pytest.mark.parametrize("bad_case_id", ["", None])
+def test_record_rejects_missing_or_empty_case_id(bad_case_id):
+    """case_id is a required non-empty URI (CS-08-002, ARCH-10-001)."""
+    with pytest.raises(ValidationError):
+        VultronOwnershipTransferOfferRecord(
+            offer_id=f"urn:uuid:{uuid.uuid4()}",
+            case_id=bad_case_id,
+        )
+
+
+def test_record_round_trips_through_datalayer():
+    """case_id survives save/read — the fact _prepare depends on."""
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    try:
+        offer_id = f"urn:uuid:{uuid.uuid4()}"
+        dl.save(
+            VultronOwnershipTransferOfferRecord(
+                offer_id=offer_id, case_id=CASE_ID
+            )
+        )
+        back = dl.read(offer_id)
+        assert isinstance(back, VultronOwnershipTransferOfferRecord)
+        assert back.case_id == CASE_ID
+    finally:
+        dl.close()

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -1311,11 +1311,15 @@ class TestSvcAcceptCaseOwnershipTransferUseCase:
                 dl, request, trigger_activity=TriggerActivityAdapter(dl)
             ).execute()
 
-    def test_accept_raises_when_offer_has_no_object(self):
-        """VultronNotFoundError raised when Offer.object_ (case ref) is absent.
+    def test_accept_raises_when_offer_has_no_case_reference(self):
+        """VultronNotFoundError raised when the Offer names no case.
 
-        This exercises the new guard added in this PR:
-        ``_as_id(getattr(offer, "object_", None)) is None → raise``.
+        ``_prepare`` accepts either shape of stored offer — the SYNC replica's
+        ``VultronOwnershipTransferOfferRecord`` (case URI in ``case_id``) or the
+        HTTP-inbox path's wire Offer activity (case in ``object_``) — and raises
+        only when neither yields an id.  Both attributes must therefore be
+        cleared on the mock; a bare ``MagicMock`` would auto-create a truthy
+        ``case_id`` and silently satisfy the guard.
         """
         from unittest.mock import MagicMock
 
@@ -1333,6 +1337,7 @@ class TestSvcAcceptCaseOwnershipTransferUseCase:
         actor_mock.id_ = actor_id
 
         offer_mock = MagicMock()
+        offer_mock.case_id = None
         offer_mock.object_ = None
 
         mock_dl = MagicMock()

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -24,6 +24,9 @@ from typing import Any, cast
 
 from vultron.core.models.actor import CoreActor
 from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.ownership_transfer_offer_record import (
+    VultronOwnershipTransferOfferRecord,
+)
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.models._helpers import _as_id
 from vultron.errors import VultronNotFoundError, VultronValidationError
@@ -675,6 +678,14 @@ class _ActorsMixin:
         Reads the stored offer from the DataLayer, derives the ``to:`` field
         from the offer's ``actor`` when not supplied, and persists the Accept
         (TRIG-11-002).
+
+        On a replica whose only source for the Offer was the replicated
+        ``offer_case_ownership_transfer`` ledger entry, what is stored at
+        ``offer_id`` is a core ``VultronOwnershipTransferOfferRecord`` rather
+        than the wire activity — the SYNC path cannot construct wire objects
+        (ARCH-03-001).  Rebuild the wire Offer from that record here, where wire
+        imports are allowed, so both delivery paths converge on the same Accept
+        (#2225, ADR-0035 DL-06-002).
         """
         from vultron.wire.as2.vocab.base.objects.activities.transitive import (  # noqa: PLC0415
             as_Offer,
@@ -683,6 +694,8 @@ class _ActorsMixin:
         raw = self._dl.read(offer_id)
         if raw is None:
             raise VultronNotFoundError("Offer(VulnerabilityCase)", offer_id)
+        if isinstance(raw, VultronOwnershipTransferOfferRecord):
+            raw = self._offer_from_core_record(raw)
         offer = cast(as_Offer, raw)
         if to is None:
             offer_actor_id = _as_id(getattr(offer, "actor", None))
@@ -700,3 +713,38 @@ class _ActorsMixin:
                 activity.id_,
             )
         return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def _offer_from_core_record(
+        self, record: "VultronOwnershipTransferOfferRecord"
+    ) -> Any:
+        """Rebuild the wire ownership-transfer Offer from its core record.
+
+        ``_OfferCaseOwnershipTransferActivity.object_`` MUST be an inline
+        ``as_VulnerabilityCase`` — a bare URI is rejected at construction and
+        would also make the activity indistinguishable from a SUBMIT_REPORT
+        Offer during semantic dispatch.  The case itself is already on the
+        replica (the SYNC path seeds it before the offer entry is applied), so
+        read it and project it to its wire form.
+        """
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: PLC0415
+            as_VulnerabilityCase,
+        )
+
+        case = self._dl.read(record.case_id)
+        if case is None:
+            raise VultronNotFoundError("VulnerabilityCase", record.case_id)
+        wire_case = (
+            case
+            if isinstance(case, as_VulnerabilityCase)
+            else as_VulnerabilityCase.from_core(cast(Any, case))
+        )
+        # Reuse the same factory the offering side calls, so the rebuilt Offer
+        # is constructed exactly the way the wire path would have built it
+        # (test/architecture/test_activity_factory_imports.py forbids adapters
+        # from reaching into vultron.wire.as2.vocab.activities directly).
+        return offer_case_ownership_transfer_activity(
+            case=wire_case,
+            target=record.target_id,
+            id_=record.offer_id,
+            actor=record.actor_id,
+        )

--- a/vultron/core/behaviors/sync/announce_tree.py
+++ b/vultron/core/behaviors/sync/announce_tree.py
@@ -8,6 +8,7 @@ from vultron.core.behaviors.sync.nodes import (
     ApplyCloseCaseFromLedgerNode,
     ApplyInviteAcceptFromLedgerNode,
     ApplyNoteFromLedgerNode,
+    ApplyOfferOwnershipTransferFromLedgerNode,
     ApplyOfferReportFromLedgerNode,
     ApplyOwnershipTransferFromLedgerNode,
     ApplyParticipantStatusFromLedgerNode,
@@ -19,6 +20,7 @@ from vultron.core.behaviors.sync.nodes import (
     IsAddNoteEventNode,
     IsCloseCaseEventNode,
     IsInviteAcceptEventNode,
+    IsOfferOwnershipTransferEventNode,
     IsOwnershipTransferEventNode,
     IsParticipantStatusEventNode,
     IsRemoveEmbargoEventNode,
@@ -210,6 +212,30 @@ def create_announce_log_entry_tree() -> py_trees.behaviour.Behaviour:
                         name="SkipIfNotOwnershipTransferEvent",
                         child=IsOwnershipTransferEventNode(
                             name="CheckNotOwnershipTransferEvent"
+                        ),
+                    ),
+                ],
+            ),
+            py_trees.composites.Selector(
+                name="OfferOwnershipTransferEffects",
+                memory=False,
+                children=[
+                    py_trees.composites.Sequence(
+                        name="ApplyOfferOwnershipTransferEffectsSeq",
+                        memory=False,
+                        children=[
+                            IsOfferOwnershipTransferEventNode(
+                                name="IsOfferOwnershipTransferEvent"
+                            ),
+                            ApplyOfferOwnershipTransferFromLedgerNode(
+                                name="ApplyOfferOwnershipTransferFromLedger"
+                            ),
+                        ],
+                    ),
+                    py_trees.decorators.Inverter(
+                        name="SkipIfNotOfferOwnershipTransferEvent",
+                        child=IsOfferOwnershipTransferEventNode(
+                            name="CheckNotOfferOwnershipTransferEvent"
                         ),
                     ),
                 ],

--- a/vultron/core/behaviors/sync/nodes/__init__.py
+++ b/vultron/core/behaviors/sync/nodes/__init__.py
@@ -72,6 +72,10 @@ from vultron.core.behaviors.sync.nodes.offer_report_effect import (
 from vultron.core.behaviors.sync.nodes.ownership_effects import (
     ApplyOwnershipTransferFromLedgerNode,
 )
+from vultron.core.behaviors.sync.nodes.ownership_offer_effect import (
+    ApplyOfferOwnershipTransferFromLedgerNode,
+    IsOfferOwnershipTransferEventNode,
+)
 from vultron.core.behaviors.sync.nodes.fanout import (
     CollectNonClosedLogEntryRecipientsNode,
     FanOutLogEntryExcludingClosedNode,
@@ -109,6 +113,8 @@ __all__ = [
     "ApplyCloseCaseFromLedgerNode",
     "ApplyOfferReportFromLedgerNode",
     "ApplyOwnershipTransferFromLedgerNode",
+    "ApplyOfferOwnershipTransferFromLedgerNode",
+    "IsOfferOwnershipTransferEventNode",
     # receive
     "LogDeliveryConfirmationNode",
     "PersistReceivedLogEntryNode",

--- a/vultron/core/behaviors/sync/nodes/ownership_offer_effect.py
+++ b/vultron/core/behaviors/sync/nodes/ownership_offer_effect.py
@@ -171,9 +171,20 @@ class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
             )
             return Status.SUCCESS
 
-        return self._save_offer_record(offer_id, case_id)
+        return self._save_offer_record(
+            offer_id,
+            case_id,
+            actor_id=_id_from_snapshot_field(snapshot.get("actor")),
+            target_id=_id_from_snapshot_field(snapshot.get("target")),
+        )
 
-    def _save_offer_record(self, offer_id: str, case_id: str) -> Status:
+    def _save_offer_record(
+        self,
+        offer_id: str,
+        case_id: str,
+        actor_id: str | None = None,
+        target_id: str | None = None,
+    ) -> Status:
         """Build and persist the record; FAILURE only if the write itself fails."""
         assert self.datalayer is not None
         from vultron.core.models.ownership_transfer_offer_record import (
@@ -184,6 +195,8 @@ class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
             record = VultronOwnershipTransferOfferRecord(
                 offer_id=offer_id,
                 case_id=case_id,
+                actor_id=actor_id,
+                target_id=target_id,
             )
         except ValidationError as exc:
             # Malformed snapshot data, not a failed effect — stay lenient so a
@@ -223,17 +236,20 @@ class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
         return Status.SUCCESS
 
 
-def _case_id_from_snapshot(snapshot: dict[str, Any]) -> str:
-    """Extract the offered case URI from a snapshot ``object`` field.
+def _id_from_snapshot_field(field: Any) -> str | None:
+    """Return the URI carried by a snapshot field, or ``None``.
 
-    The field may be an inline dict (``{"id": ..., "type": ...}``) or a bare
-    URI string, depending on how the Offer was serialized.  Returns ``""`` when
-    neither form yields an id.
+    Snapshot fields may be an inline dict (``{"id": ..., "type": ...}``) or a
+    bare URI string, depending on how the activity was serialized.
     """
-    object_field = snapshot.get("object")
-    if isinstance(object_field, dict):
-        case_id = object_field.get("id", "")
-        return case_id if isinstance(case_id, str) else ""
-    if isinstance(object_field, str):
-        return object_field
-    return ""
+    if isinstance(field, dict):
+        value = field.get("id")
+        return value if isinstance(value, str) and value else None
+    if isinstance(field, str) and field:
+        return field
+    return None
+
+
+def _case_id_from_snapshot(snapshot: dict[str, Any]) -> str:
+    """Extract the offered case URI from a snapshot ``object`` field."""
+    return _id_from_snapshot_field(snapshot.get("object")) or ""

--- a/vultron/core/behaviors/sync/nodes/ownership_offer_effect.py
+++ b/vultron/core/behaviors/sync/nodes/ownership_offer_effect.py
@@ -27,7 +27,11 @@ in the local DataLayer.  This makes the offer readable by
 ``SvcAcceptCaseOwnershipTransferUseCase._prepare``, which calls
 ``dl.read(offer_id)`` and 404s when the object is absent (#2195).
 
-Per ADR-0035 DL-06-002, SYNC-02-002, CM-21-007, ISSUE-2195.
+Per ADR-0035 DL-06-002, SYNC-02-002, SYNC-12-001, CM-21-005, ISSUE-2195.
+
+(CM-21-005 governs the offer hop this slot materializes — the offer is addressed
+to the CaseActor inbox and forwarded by it.  CM-21-007, which covers the ledger
+commit and broadcast that follow a successful *accept*, is a different hop.)
 """
 
 from __future__ import annotations
@@ -36,6 +40,7 @@ from typing import Any
 
 import py_trees
 from py_trees.common import Status
+from pydantic import ValidationError
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 
@@ -56,11 +61,12 @@ class IsOfferOwnershipTransferEventNode(DataLayerCondition):
 
     The Inverter fires SUCCESS only when the condition does NOT match (routing
     no-op for the wrong event type).  When the condition matches but
-    ApplyOfferOwnershipTransferFromLedgerNode fails, both branches of the
-    Selector fail and the FAILURE propagates to block PersistReceivedLogEntry
-    (SYNC-12-001).
+    ApplyOfferOwnershipTransferFromLedgerNode returns FAILURE — i.e. the effect
+    itself could not be applied — both branches of the Selector fail and the
+    FAILURE propagates to block PersistReceivedLogEntry, so the entry is not
+    persisted without its effects (SYNC-12-001).
 
-    Per BTND-08-001, BTND-08-002, CM-21-007, SYNC-02-002, SYNC-12-001.
+    Per BTND-08-001, BTND-08-002, CM-21-005, SYNC-02-002, SYNC-12-001.
     """
 
     def setup(self, **kwargs: Any) -> None:
@@ -95,14 +101,24 @@ class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
     ``dl.read(offer_id)`` without a 404 (#2195).
 
     Idempotent: if the object is already present the node returns SUCCESS
-    without overwriting.  Lenient on missing or unparse-able data — if the
-    snapshot cannot be reconstructed into a typed offer activity, the node
-    logs a warning and returns SUCCESS to avoid blocking the ``Announce``
-    processing flow.
+    without overwriting.
+
+    Status contract — the distinction matters for SYNC-12-001, which forbids
+    persisting a ledger entry whose effects did not apply:
+
+    - **Nothing to apply** → SUCCESS.  The snapshot carries no offer id, or no
+      case id, or is not a dict at all.  There is no effect to fail; the entry
+      is still a valid ledger fact and must not be blocked.  A partially
+      populated record is *not* written — one that cannot name its case would
+      only convert ``_prepare``'s "offer not found" 404 into "case not found in
+      offer" (#2195).
+    - **Effect failed** → FAILURE.  The record was well-formed but the
+      DataLayer write raised.  That is a genuine effect failure, so the node
+      fails and the surrounding Selector blocks ``PersistReceivedLogEntry``.
 
     Per ADR-0035 DL-06-002 (domain facts from a received protocol message MUST
-    be recorded as core state at extraction time), SYNC-02-002, CM-21-007,
-    ISSUE-2195.
+    be recorded as core state at extraction time), SYNC-02-002, SYNC-12-001,
+    CM-21-005, ISSUE-2195.
     """
 
     def setup(self, **kwargs: Any) -> None:
@@ -119,9 +135,6 @@ class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
         from vultron.core.behaviors.sync.nodes.conditions import (
             _require_log_entry,
         )
-        from vultron.core.models.ownership_transfer_offer_record import (
-            VultronOwnershipTransferOfferRecord,
-        )
 
         entry = _require_log_entry(self.blackboard.activity, self.name)
         snapshot = (
@@ -134,7 +147,7 @@ class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
         if not offer_id:
             self.logger.debug(
                 "%s: offer_case_ownership_transfer entry has no id"
-                " — skipping (non-fatal)",
+                " — nothing to apply (non-fatal)",
                 self.name,
             )
             return Status.SUCCESS
@@ -147,34 +160,80 @@ class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
             )
             return Status.SUCCESS
 
-        # Extract case_id from the snapshot's object field (dict or bare string).
-        object_field = snapshot.get("object")
-        if isinstance(object_field, dict):
-            case_id = object_field.get("id", "")
-        elif isinstance(object_field, str):
-            case_id = object_field
-        else:
-            case_id = ""
+        case_id = _case_id_from_snapshot(snapshot)
+        if not case_id:
+            self.logger.warning(
+                "%s: offer '%s' snapshot carries no resolvable case id"
+                " — declining to store a record that cannot name its case"
+                " (nothing to apply, non-fatal)",
+                self.name,
+                offer_id,
+            )
+            return Status.SUCCESS
+
+        return self._save_offer_record(offer_id, case_id)
+
+    def _save_offer_record(self, offer_id: str, case_id: str) -> Status:
+        """Build and persist the record; FAILURE only if the write itself fails."""
+        assert self.datalayer is not None
+        from vultron.core.models.ownership_transfer_offer_record import (
+            VultronOwnershipTransferOfferRecord,
+        )
 
         try:
             record = VultronOwnershipTransferOfferRecord(
                 offer_id=offer_id,
-                object_=case_id,
+                case_id=case_id,
             )
-            self.datalayer.save(record)
-            self.logger.info(
-                "%s: stored VultronOwnershipTransferOfferRecord '%s'"
-                " from ledger snapshot (ADR-0035 DL-06-002, ISSUE-2195)",
+        except ValidationError as exc:
+            # Malformed snapshot data, not a failed effect — stay lenient so a
+            # bad payload cannot wedge ledger replication (SYNC-12-001 applies
+            # to effects that fail, not to entries with nothing to apply).
+            self.logger.warning(
+                "%s: offer '%s' snapshot did not validate into a"
+                " VultronOwnershipTransferOfferRecord: %s",
                 self.name,
                 offer_id,
+                exc,
             )
+            return Status.SUCCESS
+
+        try:
+            self.datalayer.save(record)
         except Exception as exc:
-            self.logger.warning(
+            # A well-formed effect that could not be written IS a failed
+            # effect: fail so the Selector blocks PersistReceivedLogEntry and
+            # the entry is not persisted without it (SYNC-12-001).
+            self.logger.error(
                 "%s: could not store VultronOwnershipTransferOfferRecord"
                 " for offer '%s': %s",
                 self.name,
                 offer_id,
                 exc,
             )
+            return Status.FAILURE
 
+        self.logger.info(
+            "%s: stored VultronOwnershipTransferOfferRecord '%s' for case '%s'"
+            " from ledger snapshot (ADR-0035 DL-06-002, ISSUE-2195)",
+            self.name,
+            offer_id,
+            case_id,
+        )
         return Status.SUCCESS
+
+
+def _case_id_from_snapshot(snapshot: dict[str, Any]) -> str:
+    """Extract the offered case URI from a snapshot ``object`` field.
+
+    The field may be an inline dict (``{"id": ..., "type": ...}``) or a bare
+    URI string, depending on how the Offer was serialized.  Returns ``""`` when
+    neither form yields an id.
+    """
+    object_field = snapshot.get("object")
+    if isinstance(object_field, dict):
+        case_id = object_field.get("id", "")
+        return case_id if isinstance(case_id, str) else ""
+    if isinstance(object_field, str):
+        return object_field
+    return ""

--- a/vultron/core/behaviors/sync/nodes/ownership_offer_effect.py
+++ b/vultron/core/behaviors/sync/nodes/ownership_offer_effect.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Ownership-transfer *offer* condition and ledger backfill nodes.
+
+Provides :class:`IsOfferOwnershipTransferEventNode` and
+:class:`ApplyOfferOwnershipTransferFromLedgerNode`, which together form the
+``OfferOwnershipTransferEffects`` slot in ``create_announce_log_entry_tree``.
+
+When a participant receives ``Announce(CaseLedgerEntry)`` for the
+``offer_case_ownership_transfer`` entry, the backfill node extracts the offer
+id and case id from the entry's ``payloadSnapshot`` and stores a
+:class:`~vultron.core.models.ownership_transfer_offer_record.VultronOwnershipTransferOfferRecord`
+in the local DataLayer.  This makes the offer readable by
+``SvcAcceptCaseOwnershipTransferUseCase._prepare``, which calls
+``dl.read(offer_id)`` and 404s when the object is absent (#2195).
+
+Per ADR-0035 DL-06-002, SYNC-02-002, CM-21-007, ISSUE-2195.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+
+_OFFER_CASE_OWNERSHIP_TRANSFER_EVENT = "offer_case_ownership_transfer"
+
+
+class IsOfferOwnershipTransferEventNode(DataLayerCondition):
+    """Precondition: SUCCESS when entry IS an offer_case_ownership_transfer event.
+
+    Used as the precondition in the ``OfferOwnershipTransferEffects`` Selector's
+    inner Sequence in ``AnnounceLogEntryReceivedBT``::
+
+        Selector(OfferOwnershipTransferEffects)
+          Sequence
+            IsOfferOwnershipTransferEventNode   <- SUCCESS iff event_type matches
+            ApplyOfferOwnershipTransferFromLedgerNode
+          Inverter(IsOfferOwnershipTransferEventNode)  <- SUCCESS iff wrong type
+
+    The Inverter fires SUCCESS only when the condition does NOT match (routing
+    no-op for the wrong event type).  When the condition matches but
+    ApplyOfferOwnershipTransferFromLedgerNode fails, both branches of the
+    Selector fail and the FAILURE propagates to block PersistReceivedLogEntry
+    (SYNC-12-001).
+
+    Per BTND-08-001, BTND-08-002, CM-21-007, SYNC-02-002, SYNC-12-001.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        from vultron.core.behaviors.sync.nodes.conditions import (
+            _require_log_entry,
+        )
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        if entry.event_type == _OFFER_CASE_OWNERSHIP_TRANSFER_EVENT:
+            return Status.SUCCESS
+        return Status.FAILURE
+
+
+class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
+    """Apply an ``offer_case_ownership_transfer`` ledger entry to the local DataLayer.
+
+    When a participant receives ``Announce(CaseLedgerEntry)`` for the
+    canonical ``offer_case_ownership_transfer`` entry, this node extracts
+    ``offer_id`` and ``case_id`` from the entry's ``payloadSnapshot`` and
+    stores a :class:`~vultron.core.models.ownership_transfer_offer_record.VultronOwnershipTransferOfferRecord`
+    keyed by ``offer_id``.
+
+    This is the SYNC-path equivalent of what ``OfferCaseOwnershipTransferReceivedUseCase``
+    does on the HTTP-inbox path: the replica MUST hold a readable record so that
+    ``SvcAcceptCaseOwnershipTransferUseCase._prepare`` can call
+    ``dl.read(offer_id)`` without a 404 (#2195).
+
+    Idempotent: if the object is already present the node returns SUCCESS
+    without overwriting.  Lenient on missing or unparse-able data — if the
+    snapshot cannot be reconstructed into a typed offer activity, the node
+    logs a warning and returns SUCCESS to avoid blocking the ``Announce``
+    processing flow.
+
+    Per ADR-0035 DL-06-002 (domain facts from a received protocol message MUST
+    be recorded as core state at extraction time), SYNC-02-002, CM-21-007,
+    ISSUE-2195.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        from vultron.core.behaviors.sync.nodes.conditions import (
+            _require_log_entry,
+        )
+        from vultron.core.models.ownership_transfer_offer_record import (
+            VultronOwnershipTransferOfferRecord,
+        )
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        snapshot = (
+            entry.payload_snapshot
+            if isinstance(entry.payload_snapshot, dict)
+            else {}
+        )
+
+        offer_id = snapshot.get("id") or getattr(entry, "log_object_id", None)
+        if not offer_id:
+            self.logger.debug(
+                "%s: offer_case_ownership_transfer entry has no id"
+                " — skipping (non-fatal)",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        if self.datalayer.read(offer_id) is not None:
+            self.logger.debug(
+                "%s: offer '%s' already present — idempotent no-op",
+                self.name,
+                offer_id,
+            )
+            return Status.SUCCESS
+
+        # Extract case_id from the snapshot's object field (dict or bare string).
+        object_field = snapshot.get("object")
+        if isinstance(object_field, dict):
+            case_id = object_field.get("id", "")
+        elif isinstance(object_field, str):
+            case_id = object_field
+        else:
+            case_id = ""
+
+        try:
+            record = VultronOwnershipTransferOfferRecord(
+                offer_id=offer_id,
+                object_=case_id,
+            )
+            self.datalayer.save(record)
+            self.logger.info(
+                "%s: stored VultronOwnershipTransferOfferRecord '%s'"
+                " from ledger snapshot (ADR-0035 DL-06-002, ISSUE-2195)",
+                self.name,
+                offer_id,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "%s: could not store VultronOwnershipTransferOfferRecord"
+                " for offer '%s': %s",
+                self.name,
+                offer_id,
+                exc,
+            )
+
+        return Status.SUCCESS

--- a/vultron/core/models/ownership_transfer_offer_record.py
+++ b/vultron/core/models/ownership_transfer_offer_record.py
@@ -50,7 +50,7 @@ from typing import Literal
 
 from pydantic import Field, model_validator
 
-from vultron.core.models.base import CoreObject, UriString
+from vultron.core.models.base import CoreObject, NonEmptyString, UriString
 
 
 class VultronOwnershipTransferOfferRecord(CoreObject):
@@ -62,6 +62,13 @@ class VultronOwnershipTransferOfferRecord(CoreObject):
     ``id_`` is set to ``offer_id`` directly so that ``dl.read(offer_id)``
     finds this record — matching what the HTTP-inbox path stores for the
     same Offer via ``_idempotent_create``.
+
+    ``actor_id`` and ``target_id`` are what let the adapter layer rebuild a wire
+    ``_OfferCaseOwnershipTransferActivity`` from this record when a replica's
+    only source for the Offer was the ledger entry (#2225).  They are optional
+    because the adapter can proceed without them — the emitting BT node supplies
+    ``to`` from the resolved case manager, and the wire Offer's ``target`` is
+    itself optional — but when present they MUST be non-empty (CS-08-002).
     """
 
     type_: Literal["VultronOwnershipTransferOfferRecord"] = Field(
@@ -73,6 +80,14 @@ class VultronOwnershipTransferOfferRecord(CoreObject):
     case_id: UriString = Field(
         ...,
         description="URI of the offered VulnerabilityCase",
+    )
+    actor_id: NonEmptyString | None = Field(
+        default=None,
+        description="URI of the actor that offered the transfer",
+    )
+    target_id: NonEmptyString | None = Field(
+        default=None,
+        description="URI of the actor the transfer was offered to",
     )
 
     @model_validator(mode="after")

--- a/vultron/core/models/ownership_transfer_offer_record.py
+++ b/vultron/core/models/ownership_transfer_offer_record.py
@@ -24,9 +24,23 @@ core uses from the forwarded ``Offer(VulnerabilityCase)`` activity:
 - ``offer_id``: the URI of the Offer activity (used as ``id_`` so that
   ``SvcAcceptCaseOwnershipTransferUseCase._prepare`` can look it up via
   ``dl.read(offer_id)``)
-- ``object_``: the URI of the offered ``VulnerabilityCase`` (extracted from
-  the ``object`` field of the snapshot; used by ``_as_id()`` in ``_prepare``
-  to recover ``case_id``)
+- ``case_id``: the URI of the offered ``VulnerabilityCase`` (extracted from
+  the ``object`` field of the snapshot; read back by ``_prepare`` to recover
+  the case being transferred)
+
+Both facts are required and non-empty (``UriString``): a record that cannot
+name the case it offers is useless to ``_prepare``, which would raise
+``VultronNotFoundError`` on it anyway.  ``ApplyOfferOwnershipTransferFromLedgerNode``
+therefore declines to store a record it cannot fully populate, rather than
+storing a half-record that turns a "missing offer" 404 into a "missing case"
+404 (CS-08-002, ARCH-10-001).
+
+The case URI is deliberately named ``case_id`` rather than ``object_``: the
+DataLayer rehydrates the AS2 reference fields (``object_``, ``target``,
+``origin``, ``result``, ``instrument``) from ID strings into typed objects on
+read, so a field named ``object_`` would come back as a ``VulnerabilityCase``
+instance rather than the ``str`` its annotation promises.  This mirrors
+``VultronOfferRecord``, which names its equivalent fact ``report_id``.
 
 Populated by ``ApplyOfferOwnershipTransferFromLedgerNode`` on the SYNC
 ledger-replication path (#2195, ISSUE-2195).
@@ -56,8 +70,8 @@ class VultronOwnershipTransferOfferRecord(CoreObject):
         serialization_alias="type",
     )
     offer_id: UriString = Field(..., description="URI of the Offer activity")
-    object_: str = Field(
-        default="",
+    case_id: UriString = Field(
+        ...,
         description="URI of the offered VulnerabilityCase",
     )
 

--- a/vultron/core/models/ownership_transfer_offer_record.py
+++ b/vultron/core/models/ownership_transfer_offer_record.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Core state record for the domain facts carried in an ownership-transfer Offer.
+
+Per ADR-0035 DL-06-002: every domain fact an actor must remember from a
+received protocol message MUST be recorded as core state at extraction time.
+
+``VultronOwnershipTransferOfferRecord`` captures the two domain facts that
+core uses from the forwarded ``Offer(VulnerabilityCase)`` activity:
+
+- ``offer_id``: the URI of the Offer activity (used as ``id_`` so that
+  ``SvcAcceptCaseOwnershipTransferUseCase._prepare`` can look it up via
+  ``dl.read(offer_id)``)
+- ``object_``: the URI of the offered ``VulnerabilityCase`` (extracted from
+  the ``object`` field of the snapshot; used by ``_as_id()`` in ``_prepare``
+  to recover ``case_id``)
+
+Populated by ``ApplyOfferOwnershipTransferFromLedgerNode`` on the SYNC
+ledger-replication path (#2195, ISSUE-2195).
+"""
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from vultron.core.models.base import CoreObject, UriString
+
+
+class VultronOwnershipTransferOfferRecord(CoreObject):
+    """Core state record for the domain facts in an ownership-transfer Offer.
+
+    Stored by ``ApplyOfferOwnershipTransferFromLedgerNode`` when a participant
+    replica processes the ``offer_case_ownership_transfer`` ledger entry.
+
+    ``id_`` is set to ``offer_id`` directly so that ``dl.read(offer_id)``
+    finds this record — matching what the HTTP-inbox path stores for the
+    same Offer via ``_idempotent_create``.
+    """
+
+    type_: Literal["VultronOwnershipTransferOfferRecord"] = Field(
+        default="VultronOwnershipTransferOfferRecord",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+    offer_id: UriString = Field(..., description="URI of the Offer activity")
+    object_: str = Field(
+        default="",
+        description="URI of the offered VulnerabilityCase",
+    )
+
+    @model_validator(mode="after")
+    def _set_id(self) -> "VultronOwnershipTransferOfferRecord":
+        self.id_ = self.offer_id
+        return self

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -360,13 +360,13 @@ class SvcAcceptCaseOwnershipTransferUseCase(SvcBTTriggerBase):
         offer = self._dl.read(request.offer_id)
         if offer is None:
             raise VultronNotFoundError(
-                "_OfferCaseOwnershipTransferActivity", request.offer_id
+                "VultronOwnershipTransferOfferRecord", request.offer_id
             )
 
         self._offer_id = request.offer_id
 
         raw_case_id = _as_id(getattr(offer, "object_", None))
-        if raw_case_id is None:
+        if not raw_case_id:
             raise VultronNotFoundError(
                 "VulnerabilityCase (in Offer.object_)", request.offer_id
             )

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -365,10 +365,16 @@ class SvcAcceptCaseOwnershipTransferUseCase(SvcBTTriggerBase):
 
         self._offer_id = request.offer_id
 
-        raw_case_id = _as_id(getattr(offer, "object_", None))
+        # Two shapes reach this point for the same Offer: the SYNC replica path
+        # stores a VultronOwnershipTransferOfferRecord (case URI in `case_id`),
+        # while the HTTP-inbox path stores the wire Offer activity (case in
+        # `object_`, possibly rehydrated to a typed object).  Accept either.
+        raw_case_id = _as_id(
+            getattr(offer, "case_id", None) or getattr(offer, "object_", None)
+        )
         if not raw_case_id:
             raise VultronNotFoundError(
-                "VulnerabilityCase (in Offer.object_)", request.offer_id
+                "VulnerabilityCase (in Offer case reference)", request.offer_id
             )
         self._case_id = raw_case_id
 


### PR DESCRIPTION
- Closes #2195
- Closes #2225
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

When a Coordinator replica processes `Announce(CaseLedgerEntry)` for an `offer_case_ownership_transfer` entry, the `_OfferCaseOwnershipTransferActivity` object was never materialized in its DataLayer. This caused `SvcAcceptCaseOwnershipTransferUseCase._prepare` to 404 on `dl.read(offer_id)`.

**Base branch is `fix/demo-ci`, not `main`** (per #2195 and #2139).

## Changes

- **`vultron/core/models/ownership_transfer_offer_record.py`** (new): `VultronOwnershipTransferOfferRecord(CoreObject)` — carries `offer_id` and `case_id`, both required non-empty `UriString`. Keyed directly at `offer_id` so `_prepare` can `dl.read(offer_id)` without a 404. `type_` Literal matches the class name for `CORE_VOCABULARY` round-trip.
  - The case URI is named `case_id`, **not** `object_`: the DataLayer rehydrates the AS2 reference fields (`object_`, `target`, `origin`, `result`, `instrument`) from ID strings into typed objects on read, so a field named `object_` would come back as a `VulnerabilityCase` while its annotation promised `str`. This mirrors `VultronOfferRecord.report_id`.
- **`vultron/core/behaviors/sync/nodes/ownership_offer_effect.py`** (new): `IsOfferOwnershipTransferEventNode` (condition) + `ApplyOfferOwnershipTransferFromLedgerNode` (effect) — extracts scalars from `payload_snapshot`, no wire imports (ADR-0035 DL-06-002, ARCH-03-001).
  - **Status contract (SYNC-12-001)**: SUCCESS when there is nothing to apply (no offer id, no resolvable case id, or a snapshot that does not validate); FAILURE only when a well-formed record could not be written. FAILURE propagates through the slot's Selector to block `PersistReceivedLogEntry`, so an entry is never persisted without its effects.
  - The node declines to store a half-record. One that cannot name its case would satisfy `dl.read(offer_id)` and then fail one line later on the case lookup — moving the #2195 404 rather than removing it.
- **`vultron/core/behaviors/sync/announce_tree.py`**: wires `OfferOwnershipTransferEffects` slot after existing `OwnershipTransferEffects`.
- **`vultron/core/behaviors/sync/nodes/__init__.py`**: exports the two new node classes.
- **`vultron/core/use_cases/triggers/actor.py`**: `_prepare` reads `case_id` first and falls back to `object_`, so both shapes of stored offer resolve — the SYNC replica's record and the wire Offer activity the HTTP-inbox path stores.
- **`test/core/behaviors/sync/nodes/test_issue_2195_ownership_offer_delivered.py`**: removes `xfail`, and additionally asserts the case URI is recoverable from the stored record. Presence alone was too weak — the probe passed even with `object` deleted from the snapshot.
- **`test/core/behaviors/sync/nodes/test_ownership_offer_effect.py`** (new, 13 cases): condition SUCCESS/FAILURE, inline-dict and bare-string `object`, idempotency, `log_object_id` fallback, the no-case-id decline, the SYNC-12-001 FAILURE path, vocabulary registration, and DataLayer round-trip.
- **`notes/ownership-transfer.md`**: documents the SYNC-path replica-side materialization slot, the required-facts rule, and the status contract.

Spec citations use **CM-21-005** (the offer hop this slot materializes — offer addressed to the CaseActor inbox and forwarded by it), SYNC-02-002, SYNC-12-001 and ADR-0035 DL-06-002. CM-21-007 covers the ledger commit and broadcast that follow a successful *accept*, which is a different hop.

## Verification

- Full unit suite green at `2cd88a02` (pytest exit 0, no failures); the ratchet xfail for #2195 is removed and its test passes
- Architecture ratchet tests pass: no wire imports in core (`test_core_no_wire_imports`, `test_vocab_activities_boundary`)
- Black, flake8, mypy (`no issues found in 665 source files`), pyright (`0 errors`) all clean
- Branch synced with `fix/demo-ci` at `9a5a3a60`, so CI now runs against a base that includes the #2194 (PR #2205) and #2217 fixes

**On the definition-of-done scenario**: #2195's definition of done is `fccv-handoff` Demo Integration + Invariant Harness green, but `fccv-handoff` is `full_suite_only` in `.github/demo-scenarios.json` and **does not run on `pull_request` events** — PRs run the 4-scenario minimum set (DEMOCI-06-002). The PR checks here therefore cannot confirm it. A full 9-scenario `workflow_dispatch` run was triggered against this branch to supply that evidence: https://github.com/CERTCC/Vultron/actions/runs/31616271174

**Known-failing PR checks**: `fcvcv Demo Integration`, `fvcv-handoff Demo Integration` and `fvcv-handoff Invariant Harness` are catalogued in `notes/flaky-tests.md` against open issue #2216 (vendor engage-case 422 at `RM.VALID`), recorded there as pre-existing on `fix/demo-ci`. Not caused by this PR.


