### PR TITLE
fix(pr-ship): gate READY-TO-MERGE on live mergeability

### DIFF
--- a/.agents/skills/pr-execute/REFERENCE.md
+++ b/.agents/skills/pr-execute/REFERENCE.md
@@ -24,7 +24,7 @@ Run **full suite (unit + integration)** if PR modifies any of:
 
 ### All Tests Pass ✅
 
-Proceed to Phase 5.
+Proceed to Phase 6.
 
 ### Unit Tests Fail ❌
 
@@ -144,9 +144,80 @@ Stop and surface to the user if:
 - 2+ consecutive test failures after fix attempts
 - Test output suggests missing context (env vars, setup, infrastructure)
 - Error suggests architectural issue (breaking change to core logic)
+- A merge conflict whose correct resolution is genuinely unclear (see
+  § "Conflict Resolution Rules") — abort the merge, do not guess
+- `merge-state.sh` still reports `CONFLICTING` after a resolution was pushed
+- `git push` is rejected as non-fast-forward after a merge, implying someone
+  rewrote the remote branch
 
 Report the state with linked Bug issue evidence, structured blockers, and
 explicit blocked/unblocked status.
+
+---
+
+## Conflict Resolution Rules
+
+### Why sync runs late
+
+The branch is synced in Phase 4 — after all fixes and CI remediation, before the
+test suite. Three reasons:
+
+1. **Execute's own fixes can create conflicts.** A fix touching the same lines a
+   base-branch commit touched is only conflicting once both exist.
+2. **The base branch moves during the run.** Triage's merge state is stale by the
+   time execute finishes; another PR can land mid-pipeline.
+3. **Tests must run on the merged tree.** A clean merge can still be a *semantic*
+   conflict — both sides apply, the result is broken. Only running the suite
+   post-merge catches that.
+
+### Merge, do not rewrite
+
+Once a branch is pushed and a PR is open, use `sync-with-main.sh` (merge commit),
+not `freshen-branch.sh` (cherry-pick rewrite). Rewriting a pushed branch requires
+a force-push, which orphans reviewers' line comments and breaks any `commit_ref`
+already recorded in the triage/execute artifacts. `freshen-branch.sh` belongs to
+`create-pr`, before the first push.
+
+### Resolving each path
+
+| Situation | Resolution |
+|---|---|
+| Base changed a line the PR does not care about | Take base (`--theirs` in merge terms), then re-verify the PR's intent still holds |
+| PR intentionally changed what base also changed | Combine by hand — keep the PR's semantic and base's refactor |
+| Both added entries to a list/registry/index | Keep **both** entries; this is the most common false conflict |
+| Generated or lock file (`uv.lock`, `board-ids.json`) | Take base, then regenerate from the merged sources |
+| `CHANGELOG`/history/append-only file | Keep both blocks in chronological order — see `archived_notes/append-only-file-handling.md` |
+| Conflict is in a file the PR never meant to touch | Take base wholesale, then confirm with `git diff <base_ref>...HEAD` that the file is absent from the PR diff |
+
+Rules that do not bend:
+
+- **Read both sides before resolving.** `git log --merge -p -- <path>` shows the
+  competing commits. Blind `--ours`/`--theirs` on an unread file silently reverts
+  someone's work.
+- **Never resolve by deleting the base's changes** to make the PR's diff apply.
+  That is a silent revert; it is worse than the conflict.
+- **Verify no markers remain** before pushing:
+  `git grep -nE '^(<<<<<<<|=======|>>>>>>>)'` must be empty.
+- **Re-run the full suite after resolving**, even if it passed pre-merge.
+- **Never resolve a conflict you do not understand.** Abort
+  (`sync-with-main.sh --abort`), record the merge-state finding as `skipped` with
+  the conflicted paths and why, and stop. An honest stop beats a wrong merge.
+
+### Commit message
+
+`git commit --no-edit` keeps git's generated `Merge branch 'main' into <branch>`
+message, which is what tooling expects. If the resolution required judgment,
+amend a body describing it:
+
+```text
+Merge branch 'main' into task/1234-slug
+
+Resolved conflicts in:
+- vultron/core/models/case/case.py — kept both new fields
+- uv.lock — regenerated after taking main's version
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
 
 ---
 
@@ -207,6 +278,15 @@ File: `.claude/pr-{number}-execute.json`
   "timestamp": "2026-01-01T00:00:00Z",
   "integration_tests_run": true,
   "final_ci_status": "passing",
+  "merge_state": {
+    "base_ref": "main",
+    "synced": true,
+    "sync_commit_ref": "def5678",
+    "conflicts_resolved": ["vultron/core/models/case/case.py", "uv.lock"],
+    "mergeable_after_sync": "MERGEABLE",
+    "merge_state_status_after_sync": "CLEAN",
+    "undrafted": false
+  },
   "results": [
     {
       "finding_id": "phase5-missing-nonemptystring-0",
@@ -250,6 +330,22 @@ File: `.claude/pr-{number}-execute.json`
 finding must have an outcome. `pr-verify` checks this count and warns if they
 diverge (indicating execute was interrupted before completion).
 
+### `merge_state` Fields
+
+| Field | Meaning |
+|---|---|
+| `base_ref` | Branch synced against — copied from `pr_metadata.base_ref`, not assumed to be `main` |
+| `synced` | `true` if the branch contains the base tip after Phase 4 |
+| `sync_commit_ref` | Merge commit SHA, or `null` if the branch was already current |
+| `conflicts_resolved` | Paths that had conflict markers; `[]` for a clean merge |
+| `mergeable_after_sync` | `merge-state.sh` result from Phase 4 step 6 |
+| `merge_state_status_after_sync` | `mergeStateStatus` from the same call |
+| `undrafted` | `true` if execute ran `gh pr ready` and dropped `needs-rebase` |
+
+`merge_state` is **required**. `pr-verify` treats a missing or `synced: false`
+block as a hard gate failure — an execute run that never checked mergeability
+cannot produce a READY-TO-MERGE verdict.
+
 ---
 
 ## Execute Comment Format
@@ -262,6 +358,18 @@ diverge (indicating execute was interrupted before completion).
 **Deferred (awaiting your input)**: <K>
 **Tests run**: unit only / unit + integration
 **CI status after push**: ✅ passing / ❌ failing / ⏳ pending
+**Base sync**: ✅ merged `<base_ref>` @ `def5678` — <N> conflicts resolved / ✅ already current / ❌ conflicts unresolved
+
+---
+
+### Conflicts Resolved
+
+| Path | Resolution |
+|---|---|
+| `vultron/core/models/case/case.py` | Kept both new fields |
+| `uv.lock` | Took `main`, regenerated |
+
+_Omit this section entirely when the merge was clean._
 
 ---
 

--- a/.agents/skills/pr-execute/SKILL.md
+++ b/.agents/skills/pr-execute/SKILL.md
@@ -2,8 +2,9 @@
 name: pr-execute
 description: >
   Execution phase of the PR review pipeline. Reads .claude/pr-{number}-triage.json,
-  applies all FAIL/IMPROVE fixes inline, remediates CI failures, files GitHub issues
-  for out-of-scope findings, resolves review thread comments, and writes
+  applies all FAIL/IMPROVE fixes inline, remediates CI failures, syncs the branch
+  with its base and resolves merge conflicts, files GitHub issues for out-of-scope
+  findings, resolves review thread comments, and writes
   .claude/pr-{number}-execute.json. Use after /pr-triage, or as the second step
   of /pr-ship.
 ---
@@ -15,6 +16,12 @@ description: >
 Execute consumes the closed finding list from `pr-triage` and processes it in
 one batch pass. No new discovery happens here. The finding set is fixed at the
 start; execute either resolves each item or records why it was skipped.
+
+**One exception to "no new discovery"**: the base-sync in Phase 4 re-reads merge
+state from git rather than trusting triage's snapshot. Conflicts are a moving
+target — execute's own fixes in Phases 2–3 can create them, and another PR can
+land on the base branch mid-run. Sync runs *after* all code mutation and
+*before* the test suite, so tests validate the actually-mergeable tree.
 
 ## Quick Start
 
@@ -44,14 +51,16 @@ Run /pr-triage first (or /pr-ship to run the full pipeline).
 3. Validate `schema_version == "1.0"`. If mismatch, stop and report.
 4. Extract `pr_metadata.domains` and invoke `deepen-context` with those hints
    to load the same domain context that triage used.
-5. Check `pr_metadata.needs_integration_tests` — determines test scope in Phase 4.
+5. Check `pr_metadata.needs_integration_tests` — determines test scope in Phase 5.
+6. Note `pr_metadata.base_ref` — Phase 4 syncs against this branch, not
+   necessarily `main`.
 
 ### Phase 2 — Apply fix-now Fixes
 
 For each finding where `decision_outcome` is `fix-now` or `fix-now-expand-scope`
 and `severity` is `FAIL` or `IMPROVE`:
 
-> Note: findings with `severity: NEW-ISSUE` are handled exclusively in Phase 5,
+> Note: findings with `severity: NEW-ISSUE` are handled exclusively in Phase 6,
 > regardless of their `decision_outcome`. Do not process them here.
 
 1. Apply the fix (edit files as needed).
@@ -67,11 +76,11 @@ and `severity` is `FAIL` or `IMPROVE`:
    ```
 
 4. Record `commit_ref` (short SHA) for each finding addressed in this commit.
-5. Push the branch: `git push` — CI must see the new commits before Phase 4.
+5. Push the branch: `git push` — CI must see the new commits before Phase 5.
 
 ### Phase 3 — CI Remediation
 
-For findings from Phase 11 (CI failures) in the triage artifact:
+For findings from triage's Phase 11 (CI failures) in the triage artifact:
 
 1. Fetch current CI failure logs: `gh run list --branch <head_ref> --limit 1`
    then `gh run view <run-id> --log-failed`.
@@ -91,7 +100,73 @@ For findings from Phase 11 (CI failures) in the triage artifact:
 7. Push the branch: `git push`.
 8. Record `commit_ref` for each CI finding addressed.
 
-### Phase 4 — Run Test Suite
+### Phase 4 — Sync With Base and Resolve Conflicts
+
+Runs after every code mutation (Phases 2–3) and before the test suite, so a
+conflict introduced by execute's own fixes is caught and the tests exercise the
+post-merge tree.
+
+1. Re-read merge state — do not trust `pr_metadata` from triage:
+
+   ```bash
+   bash .agents/skills/shared/merge-state.sh <number>
+   ```
+
+2. Sync the branch with its **actual base** (`pr_metadata.base_ref`, which is
+   not always `main`):
+
+   ```bash
+   bash .agents/skills/shared/sync-with-main.sh <base_ref>
+   ```
+
+   | Exit | Meaning | Action |
+   |---|---|---|
+   | `0` | Already current, or merged cleanly | Go to step 5 |
+   | `1` | Conflicts left in the worktree | Resolve them (step 3) |
+   | `2` | Unexpected error (dirty tree, merge in progress) | Stop and report; do not force anything |
+
+3. Resolve each conflicted path per [REFERENCE.md](REFERENCE.md) § "Conflict
+   Resolution Rules". Read both sides before editing. Never resolve by
+   wholesale `--ours`/`--theirs` on a file you have not read.
+
+4. Stage and commit the resolution:
+
+   ```bash
+   uv run black <changed files>
+   git add <resolved files>
+   git commit --no-edit
+   ```
+
+   Then verify no markers survived anywhere in the tree:
+
+   ```bash
+   git grep -nE '^(<<<<<<<|>>>>>>>) ' -- . && echo "MARKERS PRESENT — do not push"
+   ```
+
+   Match only the `<<<<<<<` and `>>>>>>>` markers, each followed by a space — a
+   bare `=======` row is a valid markdown setext heading underline and
+   false-positives constantly in this repo.
+
+5. Push: `git push` (a merge never needs `--force`; if git demands a force-push,
+   stop — something rewrote history and that needs a human).
+
+6. Confirm the result with `merge-state.sh <number>` again. If it still reports
+   `CONFLICTING`, record the merge-state finding as `outcome: skipped` with the
+   reason, and stop the pipeline — do not proceed to a verdict.
+
+7. Record the outcome for the Phase 12 merge-state finding(s) from triage, and
+   populate the `merge_state` block of the execute artifact.
+
+**If the PR is a draft with a `needs-rebase` label** (`create-pr` opens these
+when it cannot freshen a branch): once the sync succeeds and tests pass in
+Phase 5, remove the label and undraft it:
+
+```bash
+gh pr ready <number>
+gh pr edit <number> --remove-label needs-rebase
+```
+
+### Phase 5 — Run Test Suite
 
 Based on `pr_metadata.needs_integration_tests`:
 
@@ -118,10 +193,14 @@ After tests pass, also run the xfail ratchet per
 [REFERENCE.md](REFERENCE.md) § "xfail Ratchet" — scan `XFAIL` output lines
 and verify each references a live open issue.
 
-Do not proceed to Phase 5 until tests pass or all remaining failures are
+Do not proceed to Phase 6 until tests pass or all remaining failures are
 documented as pre-existing with linked Bug issues.
 
-### Phase 5 — Handle NEW-ISSUE Findings
+> If fixing a test failure here required new commits, re-run
+> `merge-state.sh <number>` before Phase 6 — a push can race a base-branch
+> merge. If it now reports `CONFLICTING`, return to Phase 4.
+
+### Phase 6 — Handle NEW-ISSUE Findings
 
 For each finding with `severity: NEW-ISSUE`:
 
@@ -139,7 +218,7 @@ For each finding with `severity: NEW-ISSUE`:
 2. Add to Project #24.
 3. Record as `outcome: filed` with `issue_number`.
 
-### Phase 6 — Resolve Review Thread Comments
+### Phase 7 — Resolve Review Thread Comments
 
 For each unresolved review comment on the PR (fetched via
 `gh api repos/CERTCC/Vultron/pulls/<number>/comments`):
@@ -153,9 +232,9 @@ Match each comment to the finding(s) it corresponds to. Then per
 
 Do not mark a comment resolved unless the code actually addresses it.
 
-### Phase 7 — Emit Artifact and Post Comment
+### Phase 8 — Emit Artifact and Post Comment
 
-1. Build the execute artifact in memory throughout Phases 2–6; write it only now.
+1. Build the execute artifact in memory throughout Phases 2–7; write it only now.
    Write `.claude/pr-{number}-execute.json` per the schema in [REFERENCE.md](REFERENCE.md).
 2. Render the execute summary comment (format in [REFERENCE.md](REFERENCE.md)
    § "Execute Comment Format").

--- a/.agents/skills/pr-ship/SKILL.md
+++ b/.agents/skills/pr-ship/SKILL.md
@@ -62,11 +62,19 @@ Before running any phase, check for existing artifacts:
 |---|---|
 | No artifacts exist | Run full pipeline: triage → execute → verify |
 | `pr-{N}-triage.json` exists, `pr-{N}-execute.json` absent | Skip triage; start at execute |
-| Both artifacts exist AND last verify verdict was not GAPS-FOUND | Skip triage and execute; start at verify |
+| Both artifacts exist AND last verify verdict was not GAPS-FOUND / CONFLICTS-FOUND | Skip triage and execute; start at verify |
 | Both artifacts exist AND last verify verdict was GAPS-FOUND | Delete `.claude/pr-{N}-execute.json`; re-run execute then verify |
+| Both artifacts exist AND last verify verdict was CONFLICTS-FOUND | Delete `.claude/pr-{N}-execute.json`; re-run execute then verify — execute Phase 4 owns the resolution |
+| Both artifacts exist AND last verify verdict was PENDING-MERGE-CHECK | Skip triage and execute; re-run verify only (GitHub just needed time) |
 | Verify ran and cleaned up (no artifacts) | Pipeline already completed; report last comment URL if available |
 
 When resuming, print which phase is being skipped and why.
+
+**Resume caveat**: an execute artifact can be stale about merge state even when
+it is complete — the base branch may have moved since. That is fine and needs no
+special handling here: verify re-checks mergeability live in its Phase 2, so a
+resume that skips straight to verify still catches a newly-conflicted branch and
+sends the pipeline back through execute.
 
 ## Execution Model
 
@@ -81,7 +89,7 @@ automatic.
 ### Step 1 — Detect PR
 
 ```bash
-gh pr view --json number,title,headRefName,state
+gh pr view --json number,title,headRefName,baseRefName,state,isDraft,mergeable,mergeStateStatus
 ```
 
 Confirm state is `OPEN`. If no PR exists, stop:
@@ -90,6 +98,15 @@ Confirm state is `OPEN`. If no PR exists, stop:
 ❌ No open PR found for branch <head_ref>.
 Create a PR first, then re-run /pr-ship.
 ```
+
+Print the base branch and merge state alongside the PR title. Do **not** stop on
+a conflicting or draft PR — resolving conflicts is exactly what the pipeline is
+for. `pr-execute` Phase 4 syncs and resolves; `pr-verify` Phase 2 gates the
+verdict. A conflicted PR at this point is a normal input, not an error.
+
+If the PR is a draft carrying the `needs-rebase` label, note that `create-pr`
+opened it that way because it could not freshen the branch, and that execute will
+undraft it once the sync lands.
 
 ### Step 2 — Gitignore Check
 
@@ -140,6 +157,10 @@ If execute stops due to a blocking test failure (pre-existing with linked Bug
 issue): report the blocked status and stop pr-ship. The user must resolve the
 blocker before re-running.
 
+If execute stops because a merge conflict could not be resolved safely (Phase 4):
+report the conflicting paths and stop. Do not skip ahead to verify — an
+unresolved conflict is a hard stop, and running verify would only restate it.
+
 When pr-execute returns successfully, proceed immediately to Step 6.
 
 ### Step 6 — Run pr-verify
@@ -154,10 +175,18 @@ After verify completes, print:
 
 ```text
 PR #N — <title>
-Overall verdict: READY-TO-MERGE / GAPS-FOUND / PENDING-CI
+Overall verdict: READY-TO-MERGE / GAPS-FOUND / CONFLICTS-FOUND / PENDING-CI / PENDING-MERGE-CHECK
+Merge state:     MERGEABLE (CLEAN) / CONFLICTING (DIRTY) / BEHIND / DRAFT / UNKNOWN — base <base_ref>
+CI status:       passing / failing / pending
 
 PR URL: https://github.com/CERTCC/Vultron/pull/N
 ```
+
+**Report verify's verdict verbatim — never upgrade it.** In particular, never
+print `READY-TO-MERGE` unless verify itself emitted it. Confirmed findings and
+green CI are not sufficient: if verify reported `CONFLICTS-FOUND`, the PR cannot
+merge and the final report must say so. Always include the merge-state line, even
+on the happy path.
 
 If any findings in the execute artifact have `outcome: skipped` and a
 `skip_reason` referencing a flaky-test issue, append a warning block:
@@ -178,9 +207,17 @@ If `GAPS-FOUND`: print which findings are unresolved. To retry:
 2. Then re-run `/pr-ship` — the resume logic will detect the missing execute
    artifact and re-run execute before verify.
 
+If `CONFLICTS-FOUND`: print the conflicting paths from verify's comment, then
+delete `.claude/pr-{N}-execute.json` and re-run `/pr-ship` — execute Phase 4 will
+sync and resolve. If a re-run lands on the same conflict twice, stop and hand it
+to the user; the resolution needs judgment the pipeline does not have.
+
 If `PENDING-CI`: print the PR URL and note that CI is still running. Re-run
 `/pr-ship` (or `/pr-verify`) after CI completes to get the final verdict and
 clean up artifacts.
+
+If `PENDING-MERGE-CHECK`: GitHub had not finished computing mergeability. Wait a
+moment and re-run `/pr-verify` — no execute re-run is needed.
 
 ## Failure Handling
 
@@ -194,3 +231,19 @@ If any step fails (unexpected error, not a structured stop):
 
 Artifacts are only cleaned up by `pr-verify` on a successful `READY-TO-MERGE`
 or `PENDING-CI` verdict.
+
+## Where Merge Conflicts Are Handled
+
+Conflicts are checked three times, deliberately, because the answer changes as
+the pipeline runs:
+
+| Phase | Check | Role |
+|---|---|---|
+| `pr-triage` Phase 12 | Read merge state, emit a FAIL finding | Early warning; recorded in `pr_metadata` |
+| `pr-execute` Phase 4 | Sync with base, resolve conflicts, re-verify | The only phase that **fixes** conflicts. Runs after all other mutation so execute's own fixes are included, and before the test suite so tests see the merged tree |
+| `pr-verify` Phase 2 | Live re-check as a hard gate | The **authoritative** answer. Blocks `READY-TO-MERGE` |
+
+Execute resolves rather than verify because verify is a read-only reporter by
+design. Verify runs last, so it is the only phase whose reading is still true at
+verdict time — but that also makes it the wrong place to start mutating. When
+verify finds a conflict, the pipeline loops back through execute.

--- a/.agents/skills/pr-triage/REFERENCE.md
+++ b/.agents/skills/pr-triage/REFERENCE.md
@@ -156,6 +156,45 @@ full suite.
 
 ---
 
+## Merge State Findings
+
+`mergeable` and `merge_state_status` come from `merge-state.sh` (which wraps
+`gh pr view --json mergeable,mergeStateStatus`). They are computed independently
+by GitHub, so check both.
+
+| `mergeable` | Meaning | Severity |
+|---|---|---|
+| `MERGEABLE` | No conflicts with base | none |
+| `CONFLICTING` | Merge conflicts present | **FAIL** |
+| `UNKNOWN` | GitHub has not finished computing (or the PR is closed) | **FAIL** — cannot be treated as clean |
+
+| `merge_state_status` | Meaning | Severity |
+|---|---|---|
+| `CLEAN` | Mergeable, checks green | none |
+| `UNSTABLE` | Mergeable, but a non-required check is failing/pending | none — Phase 11 owns CI |
+| `BEHIND` | Base advanced; repo requires up-to-date branches | **IMPROVE** |
+| `DIRTY` | Conflicts — authoritative even if `mergeable` says otherwise | **FAIL** |
+| `BLOCKED` | Missing required review or failing required check | **IMPROVE** (note the cause; not fixable by execute) |
+| `DRAFT` | PR is a draft and cannot merge | **IMPROVE** |
+| `HAS_HOOKS` | Mergeable with pre-receive hooks | none |
+| `UNKNOWN` | Not yet computed | **FAIL** |
+
+### Why merge conflicts are always FAIL
+
+A conflict means the PR cannot be merged at all — it is the most complete form
+of "broken" in the FAIL/IMPROVE/NEW-ISSUE taxonomy. Resolving it is never out of
+scope and never a separate issue: only the conflicted branch can be fixed, and
+only by whoever holds it. Do not tag a conflict `new-issue-ask` or
+`new-issue-no-ask`.
+
+### Stacked PRs
+
+`base_ref` is not always `main`. When a PR targets another task branch, all
+sync operations in execute must use that base — see `sync-with-main.sh`, which
+takes the base branch as its first argument.
+
+---
+
 ## Triage Artifact Schema
 
 File: `.claude/pr-{number}-triage.json`
@@ -173,7 +212,10 @@ File: `.claude/pr-{number}-triage.json`
     "changed_files": ["vultron/core/behaviors/foo.py"],
     "ci_status": "failing",
     "domains": ["core/behaviors"],
-    "needs_integration_tests": true
+    "needs_integration_tests": true,
+    "mergeable": "CONFLICTING",
+    "merge_state_status": "DIRTY",
+    "is_draft": false
   },
   "findings": [
     {
@@ -221,6 +263,8 @@ File: `.claude/pr-{number}-triage.json`
 **Linked issues**: #N (<title>)
 **Changed files**: <count> files — <domains>
 **CI status**: ✅ passing / ❌ failing / ⏳ pending
+**Merge state**: ✅ mergeable (CLEAN) / ❌ CONFLICTING (DIRTY) / ⚠️ BEHIND / 📝 DRAFT / ⏳ UNKNOWN
+**Base branch**: <base_ref>
 **Needs integration tests**: yes / no
 
 ---
@@ -232,8 +276,9 @@ File: `.claude/pr-{number}-triage.json`
 | phase5-missing-nonemptystring-0 | spec-conformance | ❌ FAIL | Field `summary` must use OptionalNonEmptyString | fix-now |
 | phase9-bt-integration-note-stale-0 | notes-currency | ⚠️ IMPROVE | `notes/bt-integration.md` not updated | fix-now |
 | phase8-unused-import-0 | code-review | ⚠️ IMPROVE | Unused import in `behaviors/foo.py:12` | fix-now |
+| phase12-merge-conflict-0 | merge-state | ❌ FAIL | Conflicts with `main` in 3 files | fix-now |
 
-**Total**: 2 FAIL · 1 IMPROVE · 0 NEW-ISSUE
+**Total**: 2 FAIL · 2 IMPROVE · 0 NEW-ISSUE
 
 ---
 

--- a/.agents/skills/pr-triage/SKILL.md
+++ b/.agents/skills/pr-triage/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pr-triage
 description: >
-  Pure-discovery phase of the PR review pipeline. Runs all 11 inspection
-  phases (orient through CI status), produces a machine-readable finding list
+  Pure-discovery phase of the PR review pipeline. Runs all 12 inspection
+  phases (orient through merge state), produces a machine-readable finding list
   at .claude/pr-{number}-triage.json, and posts a human-readable PR comment.
   Makes NO code changes. Use as the first step of /pr-ship, or standalone
   when you want a full finding inventory before deciding whether to execute
@@ -13,9 +13,14 @@ description: >
 
 ## Purpose
 
-Triage closes the finding list before any mutation occurs. All 11 inspection
+Triage closes the finding list before any mutation occurs. All 12 inspection
 phases run to completion; then and only then is the artifact written and the
 comment posted. `pr-execute` reads the artifact — it never re-runs discovery.
+
+Merge conflicts are discovered here (Phase 12) but re-checked authoritatively in
+`pr-verify`, because conflicts can appear *after* triage runs — either from
+execute's own fixes or from another PR landing on the base branch mid-pipeline.
+Triage's merge-state finding is a heads-up, not the gate.
 
 ## Finding Severity
 
@@ -154,7 +159,43 @@ finding list before the artifact is written.
 2. Summarize which checks fail if CI is failing.
 3. Note if CI has not yet run.
 
-### Phase 12 — Emit Artifact and Post Comment
+### Phase 12 — Merge State
+
+A PR that cannot merge is not shippable, no matter how clean its diff is.
+
+```bash
+bash .agents/skills/shared/merge-state.sh <number>
+```
+
+The script polls past GitHub's transient `UNKNOWN` mergeability. Record
+`mergeable`, `merge_state_status`, `is_draft`, and `base_ref` into
+`pr_metadata` — execute and verify both read them.
+
+Emit a finding per [REFERENCE.md](REFERENCE.md) § "Merge State Findings":
+
+| Script exit | `mergeable` | Finding |
+|---|---|---|
+| `1` | `CONFLICTING` | **FAIL**, `decision_outcome: fix-now` — id `phase12-merge-conflict-0` |
+| `2` | `UNKNOWN` | **FAIL**, `decision_outcome: fix-now` — id `phase12-merge-state-unknown-0` |
+| `0` | `MERGEABLE` | No finding; record the state in `pr_metadata` only |
+
+Also emit findings for these `merge_state_status` values even when
+`mergeable` is `MERGEABLE`:
+
+- `BEHIND` — base has advanced and the repo requires branches be up to date:
+  **IMPROVE**, `fix-now` (execute's sync resolves it)
+- `DIRTY` — treat exactly like `CONFLICTING` above, even if `mergeable`
+  disagrees; the two fields are computed separately and `DIRTY` is the stronger
+  signal
+- `DRAFT` — **IMPROVE**, `fix-now`. Note whether the PR carries the
+  `needs-rebase` label, which means `create-pr` opened it as a draft *because*
+  it could not freshen the branch. That draft is only undraftable once the
+  conflict is resolved.
+
+Never downgrade a conflict to IMPROVE or NEW-ISSUE. Resolving it is always
+in scope for the PR that has it.
+
+### Phase 13 — Emit Artifact and Post Comment
 
 This is the only phase that produces output. No mutations before this point.
 

--- a/.agents/skills/pr-verify/REFERENCE.md
+++ b/.agents/skills/pr-verify/REFERENCE.md
@@ -7,9 +7,26 @@
 ```markdown
 ## PR Verify: #<number> — <title>
 
-**Overall verdict**: ✅ READY-TO-MERGE / ❌ GAPS-FOUND / ⏳ PENDING-CI
+**Overall verdict**: ✅ READY-TO-MERGE / ❌ GAPS-FOUND / 🔀 CONFLICTS-FOUND / ⏳ PENDING-CI / ⏳ PENDING-MERGE-CHECK
 **CI status**: ✅ passing / ❌ failing / ⏳ pending
+**Merge state**: ✅ MERGEABLE (CLEAN) / 🔀 CONFLICTING (DIRTY) / ⚠️ BEHIND / 📝 DRAFT / ⏳ UNKNOWN — base `<base_ref>`
+**Base sync in execute**: ✅ merged @ `def5678` (<N> conflicts resolved) / ✅ already current / ❌ not performed
 **Integrity check**: ✅ all <N> findings accounted for / ❌ INCOMPLETE-EXECUTE (<M> of <N> results found)
+
+---
+
+### 🔀 Merge Conflicts — Blocking
+
+This PR conflicts with `<base_ref>` and cannot be merged. Conflicting paths:
+
+- `vultron/core/models/case/case.py`
+- `uv.lock`
+
+Re-run `/pr-execute` (Phase 4 syncs and resolves), or resolve manually with
+`bash .agents/skills/shared/sync-with-main.sh <base_ref>`, then
+`git add <paths> && git commit --no-edit && git push`.
+
+*Omit this section when merge state is clear.*
 
 ---
 
@@ -48,11 +65,36 @@ this PR. Please decide whether to fold them in before merge:
 | 📋 NOTED | filed/skipped/deferred-ask — no code check; issue confirmed open |
 | ⚠️ INCOMPLETE-EXECUTE | Finding count mismatch; execute likely interrupted |
 | ⚠️ UNVERIFIED-CI-FAILING | CI still failing after execute's push; fix may be correct but cannot be confirmed |
+| 🔀 MERGE-CONFLICT | `mergeable: CONFLICTING`, `mergeStateStatus: DIRTY`, or conflict markers found at HEAD |
+| ⏳ MERGE-STATE-UNKNOWN | GitHub had not computed mergeability after polling |
+| ⚠️ BRANCH-BEHIND | `mergeStateStatus: BEHIND` — base advanced and the repo requires up-to-date branches |
+| ⚠️ UNSYNCED-EXECUTE | `execute.merge_state` missing or `synced: false` — execute never confirmed mergeability |
+| 📝 PR-IS-DRAFT | PR is still a draft (check for a lingering `needs-rebase` label) |
+| 🔒 BLOCKED-BY-POLICY | `mergeStateStatus: BLOCKED` — missing required review/check; reported, not verdict-blocking |
 
 ### Overall Verdict Rules
 
-| Verdict | Condition |
-|---|---|
-| `READY-TO-MERGE` | All FAIL findings CONFIRMED; CI green; no INCOMPLETE-EXECUTE; no UNVERIFIED-CI-FAILING |
-| `GAPS-FOUND` | Any FAIL finding UNRESOLVED or MISSING-COMMIT; or INCOMPLETE-EXECUTE; or any UNVERIFIED-CI-FAILING |
-| `PENDING-CI` | All findings CONFIRMED but CI not yet complete (still running/pending) |
+Evaluated top to bottom; first match wins.
+
+| # | Verdict | Condition |
+|---|---|---|
+| 1 | `CONFLICTS-FOUND` | MERGE-CONFLICT flagged |
+| 2 | `GAPS-FOUND` | Any FAIL finding UNRESOLVED or MISSING-COMMIT; or INCOMPLETE-EXECUTE; or any UNVERIFIED-CI-FAILING |
+| 3 | `PENDING-MERGE-CHECK` | MERGE-STATE-UNKNOWN flagged |
+| 4 | `PENDING-CI` | All findings CONFIRMED but CI not yet complete (still running/pending) |
+| 5 | `READY-TO-MERGE` | All FAIL findings CONFIRMED; CI green; live `mergeable == MERGEABLE`; no INCOMPLETE-EXECUTE, UNVERIFIED-CI-FAILING, UNSYNCED-EXECUTE, BRANCH-BEHIND, or PR-IS-DRAFT |
+| 6 | `GAPS-FOUND` | Anything else — name the blocking flag in the comment |
+
+Conflicts outrank finding gaps (row 1 above row 2) because they are the coarser
+failure: nothing about the PR can land until the branch merges, so that is the
+headline the user needs.
+
+### Retry Guidance by Verdict
+
+| Verdict | Next step | Artifacts |
+|---|---|---|
+| `READY-TO-MERGE` | Merge | Cleaned up |
+| `PENDING-CI` | Re-run `/pr-verify` after CI finishes | Cleaned up |
+| `PENDING-MERGE-CHECK` | Re-run `/pr-verify` in a minute — GitHub is still computing | Preserved |
+| `CONFLICTS-FOUND` | Delete the execute artifact, re-run `/pr-execute` (Phase 4 resolves) | Preserved |
+| `GAPS-FOUND` | Fix manually, or delete the execute artifact and re-run `/pr-execute` | Preserved |

--- a/.agents/skills/pr-verify/SKILL.md
+++ b/.agents/skills/pr-verify/SKILL.md
@@ -2,10 +2,10 @@
 name: pr-verify
 description: >
   Verification phase of the PR review pipeline. Reads .claude/pr-{number}-execute.json,
-  spot-checks each claimed fix against HEAD (not just the commit diff), validates CI
-  and test suite, and posts a per-finding verdict comment on the PR. Cleans up both
-  artifact files as its final step. Makes NO code changes. Use after /pr-execute,
-  or as the third step of /pr-ship.
+  re-checks mergeability as a hard gate, spot-checks each claimed fix against HEAD
+  (not just the commit diff), validates CI and test suite, and posts a per-finding
+  verdict comment on the PR. Cleans up both artifact files as its final step. Makes
+  NO code changes. Use after /pr-execute, or as the third step of /pr-ship.
 ---
 
 # Skill: PR Verify
@@ -16,6 +16,12 @@ Verify closes the loop. It checks what execute *claimed* to do against what
 actually exists at HEAD, posts a verdict, and cleans up the session artifacts.
 It does not fix anything — if gaps are found, they are flagged for the user to
 re-run `/pr-execute` or fix manually.
+
+Verify is also the **last and authoritative mergeability check**. Because it runs
+after every mutation in the pipeline, its merge-state reading is the only one
+that can be trusted at verdict time. `READY-TO-MERGE` is impossible without a
+live `MERGEABLE` result — a PR that cannot merge is never ready to merge,
+regardless of how many findings were confirmed.
 
 ## Quick Start
 
@@ -50,10 +56,66 @@ comment.
 3. Read `.claude/pr-{number}-triage.json` if present.
 4. **Integrity check**: verify `len(execute.results) == len(triage.findings)`.
    If counts diverge, flag `INCOMPLETE-EXECUTE` and **continue to Phase 2**
-   (CI status must still be checked). After Phase 2, skip Phases 3–4 and go
-   directly to Phase 5 with an overall verdict of `GAPS-FOUND`.
+   (merge state and CI must still be checked). After Phase 3, skip Phases 4–5
+   and go directly to Phase 6 with an overall verdict of `GAPS-FOUND`.
+5. **Merge-state block check**: if `execute.merge_state` is absent, or
+   `merge_state.synced` is not `true`, flag `UNSYNCED-EXECUTE`. Continue to
+   Phase 2 — the live check there is what decides the verdict — but this flag
+   alone blocks `READY-TO-MERGE`, because it means execute never confirmed the
+   branch could merge.
 
-### Phase 2 — CI and Test Suite Check
+### Phase 2 — Merge State Gate
+
+This is a hard gate and runs before the per-finding spot checks: a conflicted PR
+cannot be ready to merge no matter what those checks find.
+
+1. Re-check merge state live — never reuse the value from either artifact:
+
+   ```bash
+   bash .agents/skills/shared/merge-state.sh <number>
+   ```
+
+2. Map the result:
+
+   | Exit | `mergeable` | Flag | Effect on overall verdict |
+   |---|---|---|---|
+   | `0` | `MERGEABLE` | none | No block from this phase |
+   | `1` | `CONFLICTING` | `MERGE-CONFLICT` | Forces `CONFLICTS-FOUND` |
+   | `2` | `UNKNOWN` | `MERGE-STATE-UNKNOWN` | Forces `PENDING-MERGE-CHECK` |
+
+3. Check `merge_state_status` independently of `mergeable`:
+   - `DIRTY` → flag `MERGE-CONFLICT` even if `mergeable` says `MERGEABLE`
+   - `BEHIND` → flag `BRANCH-BEHIND`; blocks `READY-TO-MERGE`
+   - `DRAFT` → flag `PR-IS-DRAFT`; blocks `READY-TO-MERGE`. Report whether the
+     `needs-rebase` label is still attached.
+   - `BLOCKED` → note it in the comment (missing required review, etc.). This
+     does *not* block the verdict — it is a repo policy state a human resolves,
+     not a defect in the PR.
+
+4. If `MERGE-CONFLICT` is flagged, list the conflicting paths as evidence:
+
+   ```bash
+   git fetch origin <base_ref>
+   git merge-tree --write-tree HEAD origin/<base_ref> 2>&1 | grep -i "^CONFLICT" || true
+   ```
+
+   Verify does not resolve them. Report and stop after posting the comment.
+
+5. If `execute.merge_state.conflicts_resolved` is non-empty, confirm no markers
+   survived the resolution — a resolved-then-recommitted marker passes CI lint on
+   some file types and would otherwise ship:
+
+   ```bash
+   git grep -nE '^(<<<<<<<|>>>>>>>) ' -- . || echo "clean"
+   ```
+
+   Any hit is a `MERGE-CONFLICT` flag regardless of what GitHub reports.
+
+   > Match only the `<<<<<<<` and `>>>>>>>` markers, each followed by a space.
+   > Do **not** grep for `=======` — a bare row of equals signs is a valid
+   > markdown setext heading underline, and this repo is docs-heavy.
+
+### Phase 3 — CI and Test Suite Check
 
 1. `gh pr checks <number>` — fetch current CI status.
 2. If `execute.integration_tests_run == true`: confirm the integration test CI
@@ -65,7 +127,7 @@ comment.
 4. If CI is pending: note it; proceed with spot-checks but mark overall verdict
    as `PENDING-CI`.
 
-### Phase 3 — Spot-Verify FAIL Findings
+### Phase 4 — Spot-Verify FAIL Findings
 
 For each finding with `severity: FAIL` and `outcome: fixed`:
 
@@ -83,36 +145,52 @@ For each finding with `severity: FAIL` and `outcome: fixed`:
    - `UNRESOLVED` — commit ref exists but HEAD does not show the fix
    - `MISSING-COMMIT` — commit ref not found on branch
 
-### Phase 4 — Spot-Verify IMPROVE Findings
+### Phase 5 — Spot-Verify IMPROVE Findings
 
 Lighter check:
 
 1. Confirm `commit_ref` exists on the branch.
-2. Check the file at HEAD for the improvement (same HEAD-check as Phase 3).
+2. Check the file at HEAD for the improvement (same HEAD-check as Phase 4).
 3. Assign `CONFIRMED` or `UNRESOLVED`.
 
 For findings with `outcome: filed`, `skipped`, or `deferred-ask`: assign
 `NOTED` — no code check needed, just confirm the issue number is real:
 `gh issue view <issue_number> --json number,state` must return an open issue.
 
-### Phase 5 — Render Verdict and Post Comment
+### Phase 6 — Render Verdict and Post Comment
 
 1. Build the per-finding verdict table.
-2. Determine overall verdict:
-   - `READY-TO-MERGE` — all FAIL findings `CONFIRMED`, CI green,
-     no `INCOMPLETE-EXECUTE`, no `UNVERIFIED-CI-FAILING`
-   - `GAPS-FOUND` — any FAIL finding is `UNRESOLVED` or `MISSING-COMMIT`, or
-     `INCOMPLETE-EXECUTE` was flagged, or any finding is `UNVERIFIED-CI-FAILING`
-   - `PENDING-CI` — all findings confirmed but CI not yet complete (pending)
-3. If `deferred-ask` items exist: list them explicitly for user decision.
-4. Post comment: `gh pr review <number> --comment --body "<verdict>"`
+2. Determine the overall verdict. Evaluate the blocking conditions **in this
+   order** and take the first that matches:
+
+   | # | Condition | Verdict |
+   |---|---|---|
+   | 1 | `MERGE-CONFLICT` flagged | `CONFLICTS-FOUND` |
+   | 2 | Any FAIL `UNRESOLVED`/`MISSING-COMMIT`, or `INCOMPLETE-EXECUTE`, or `UNVERIFIED-CI-FAILING` | `GAPS-FOUND` |
+   | 3 | `MERGE-STATE-UNKNOWN` flagged | `PENDING-MERGE-CHECK` |
+   | 4 | CI still pending | `PENDING-CI` |
+   | 5 | All FAIL findings `CONFIRMED`, CI green, `mergeable == MERGEABLE`, and no `UNSYNCED-EXECUTE` / `BRANCH-BEHIND` / `PR-IS-DRAFT` flag | `READY-TO-MERGE` |
+   | 6 | Otherwise | `GAPS-FOUND` (name the flag that blocked it) |
+
+   `READY-TO-MERGE` requires a live `MERGEABLE`. There is no path to it via
+   confirmed findings alone — row 5 is the only rule that emits it, and it is
+   reachable only when every merge-state flag is clear.
+
+3. Always print the merge-state line in the comment, including on the happy path.
+   A verdict that does not state its merge state is the bug this gate exists to
+   prevent.
+4. If `deferred-ask` items exist: list them explicitly for user decision.
+5. Post comment: `gh pr review <number> --comment --body "<verdict>"`
 
 See [REFERENCE.md](REFERENCE.md) § "Verify Comment Format" for the template.
 
-### Phase 6 — Cleanup
+### Phase 7 — Cleanup
 
 Only runs if overall verdict is `READY-TO-MERGE` or `PENDING-CI` (i.e., no
 gaps that require re-running execute).
+
+Do **not** clean up on `CONFLICTS-FOUND` or `PENDING-MERGE-CHECK` — both need
+another execute pass, which needs the triage artifact.
 
 1. Delete `.claude/pr-{number}-triage.json`
 2. Delete `.claude/pr-{number}-execute.json`
@@ -123,11 +201,16 @@ gaps that require re-running execute).
    PR #N is READY-TO-MERGE / PENDING-CI.
    ```
 
-If verdict is `GAPS-FOUND`: do NOT delete artifacts. The user or a retry of
-`/pr-execute` will need them.
+If verdict is `GAPS-FOUND`, `CONFLICTS-FOUND`, or `PENDING-MERGE-CHECK`: do NOT
+delete artifacts. The user or a retry of `/pr-execute` will need them.
 
 ## This Skill Does Not Fix
 
 If `UNRESOLVED` or `MISSING-COMMIT` findings appear, verify posts the gap and
 stops. The user re-runs `/pr-execute` or fixes manually. Verify never mutates
 files, never commits, never creates issues.
+
+This includes merge conflicts. Verify **detects** conflicts; `pr-execute` Phase 4
+**resolves** them. Verify must not run `sync-with-main.sh`, `git merge`, or any
+other mutation — its job is to be the honest reporter that the pipeline's earlier
+phases cannot be, because they run before the last thing that can change.

--- a/.agents/skills/shared/README.md
+++ b/.agents/skills/shared/README.md
@@ -19,6 +19,25 @@ Shared scripts and reference documents referenced by multiple skills.
 | `add-to-project.sh` | Add issue to Project #24 with Schedule | `bash .agents/skills/shared/add-to-project.sh <N> [Focus\|Now\|Next\|Later\|Someday]` |
 | `query-now-epics.sh` | List open Epics with Schedule=Now | `bash .agents/skills/shared/query-now-epics.sh` |
 | `board-id.sh` | Resolve any board node/field/option/issue-type ID **by name** (TTL-cached) | `bash .agents/skills/shared/board-id.sh <category> [<Name>]` |
+| `freshen-branch.sh` | Rebase-free freshening onto `origin/main` **before the first push** | `bash .agents/skills/shared/freshen-branch.sh` |
+| `sync-with-main.sh` | Merge the base branch into an **already-pushed** PR branch; leaves conflicts for the caller | `bash .agents/skills/shared/sync-with-main.sh [<base-branch>]` |
+| `merge-state.sh` | Report a PR's mergeability, polling past GitHub's transient `UNKNOWN` | `bash .agents/skills/shared/merge-state.sh [<pr-number>]` |
+
+## freshen vs sync — pick by whether the branch is pushed
+
+Both bring a task branch current with its base, but they are not
+interchangeable:
+
+| | `freshen-branch.sh` | `sync-with-main.sh` |
+|---|---|---|
+| When | Before the first push (`create-pr` Phase 2) | After a PR exists (`pr-execute` Phase 4) |
+| How | Cherry-picks onto a fresh base — rewrites history | Merge commit — preserves pushed SHAs |
+| Push | Normal push (branch not yet public) | Normal push (no `--force` ever needed) |
+| On conflict | Aborts cleanly, exit `1` — caller opens a draft PR with `needs-rebase` | Leaves the merge in progress, exit `1` — caller resolves and commits |
+
+Using `freshen-branch.sh` on a pushed branch would require a force-push, which
+orphans reviewers' line comments and invalidates any `commit_ref` already
+recorded in the PR pipeline artifacts.
 
 ## Board IDs — never hardcode them
 

--- a/.agents/skills/shared/merge-state.sh
+++ b/.agents/skills/shared/merge-state.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# merge-state.sh — report an open PR's mergeability against its base branch,
+# polling past GitHub's transient UNKNOWN state.
+#
+# GitHub computes `mergeable` lazily: the first query after a push almost always
+# returns UNKNOWN. Callers that treat UNKNOWN as "fine" silently ship conflicted
+# PRs, so this script polls until GitHub answers (or gives up loudly).
+#
+# Usage: bash .agents/skills/shared/merge-state.sh [<pr-number>]
+#
+# Emits one line of JSON on stdout:
+#   {"pr":N,"mergeable":"MERGEABLE","merge_state_status":"CLEAN",
+#    "is_draft":false,"base_ref":"main","head_ref":"task/123-slug"}
+#
+# Exit codes:
+#   0 — MERGEABLE (no conflicts with base)
+#   1 — CONFLICTING (merge conflicts; must be resolved before merge)
+#   2 — UNKNOWN after polling, or an error (no PR, gh failure, bad args)
+set -uo pipefail
+
+ATTEMPTS=${MERGE_STATE_ATTEMPTS:-6}
+SLEEP=${MERGE_STATE_SLEEP:-5}
+
+PR_ARG=()
+if [ "$#" -gt 0 ] && [ -n "${1:-}" ]; then
+  PR_ARG=("$1")
+fi
+
+FIELDS="number,mergeable,mergeStateStatus,isDraft,baseRefName,headRefName,state"
+
+for i in $(seq 1 "$ATTEMPTS"); do
+  if ! JSON=$(gh pr view "${PR_ARG[@]+"${PR_ARG[@]}"}" --json "$FIELDS" 2>&1); then
+    echo "❌ merge-state: gh pr view failed: $JSON" >&2
+    exit 2
+  fi
+
+  MERGEABLE=$(printf '%s' "$JSON" | jq -r '.mergeable // "UNKNOWN"')
+
+  if [ "$MERGEABLE" != "UNKNOWN" ] || [ "$i" -eq "$ATTEMPTS" ]; then
+    printf '%s' "$JSON" | jq -c '{
+      pr: .number,
+      mergeable: (.mergeable // "UNKNOWN"),
+      merge_state_status: (.mergeStateStatus // "UNKNOWN"),
+      is_draft: .isDraft,
+      base_ref: .baseRefName,
+      head_ref: .headRefName,
+      state: .state
+    }'
+    break
+  fi
+
+  echo "… merge-state: GitHub still computing mergeability (attempt $i/$ATTEMPTS)" >&2
+  sleep "$SLEEP"
+done
+
+case "$MERGEABLE" in
+  MERGEABLE)
+    exit 0
+    ;;
+  CONFLICTING)
+    echo "⚠ merge-state: PR has merge conflicts with its base branch." >&2
+    exit 1
+    ;;
+  *)
+    echo "⚠ merge-state: mergeability still UNKNOWN after $ATTEMPTS attempts." >&2
+    exit 2
+    ;;
+esac

--- a/.agents/skills/shared/sync-with-main.sh
+++ b/.agents/skills/shared/sync-with-main.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# sync-with-main.sh — merge origin/main into the current task branch so an
+# already-pushed PR is conflict-free against its base.
+#
+# Use this (not freshen-branch.sh) once a branch has been pushed and a PR is
+# open: it records a merge commit instead of rewriting history, so no
+# force-push is needed and reviewers' line comments survive.
+#   - freshen-branch.sh → BEFORE the first push (rewrites, keeps history linear)
+#   - sync-with-main.sh → AFTER a PR exists (merges, preserves pushed SHAs)
+#
+# On conflict this script deliberately leaves the merge IN PROGRESS with the
+# conflict markers in the worktree — resolving them needs judgment the script
+# does not have. The caller resolves, stages, and commits (or aborts).
+#
+# Usage:
+#   bash .agents/skills/shared/sync-with-main.sh                 # merge origin/main
+#   bash .agents/skills/shared/sync-with-main.sh fix/demo-ci     # stacked PR base
+#   bash .agents/skills/shared/sync-with-main.sh --abort          # abandon a merge
+#
+# Pass the PR's actual base branch when it is not `main` — stacked PRs target
+# another task branch, and syncing those against main is wrong. The branch name
+# may be given bare (`fix/demo-ci`) or remote-qualified (`origin/fix/demo-ci`).
+#
+# Exit codes:
+#   0 — already up to date, or merged cleanly (merge commit may be created)
+#   1 — conflicts left in the worktree; conflicted paths printed to stdout
+#   2 — unexpected error (detached HEAD, dirty tree, merge already in progress)
+set -uo pipefail
+
+BASE_BRANCH=${1:-main}
+BASE_BRANCH=${BASE_BRANCH#origin/}
+BASE_REF="origin/${BASE_BRANCH}"
+
+if [ "${1:-}" = "--abort" ]; then
+  if git merge --abort 2>/dev/null; then
+    echo "✓ Merge aborted; worktree restored."
+    exit 0
+  fi
+  echo "❌ sync-with-main: no merge in progress to abort." >&2
+  exit 2
+fi
+
+TASK_BRANCH=$(git branch --show-current)
+if [ -z "$TASK_BRANCH" ]; then
+  echo "❌ sync-with-main: not on a named branch (detached HEAD?)" >&2
+  exit 2
+fi
+
+if [ -e "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+  echo "❌ sync-with-main: a merge is already in progress. Resolve it or run --abort." >&2
+  exit 2
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "❌ sync-with-main: worktree is dirty. Commit or stash before syncing." >&2
+  git status --porcelain >&2
+  exit 2
+fi
+
+if ! git fetch origin "$BASE_BRANCH"; then
+  echo "❌ sync-with-main: git fetch of origin/$BASE_BRANCH failed." >&2
+  exit 2
+fi
+
+BASE_TIP=$(git rev-parse "$BASE_REF")
+if git merge-base --is-ancestor "$BASE_TIP" HEAD; then
+  echo "✓ Branch already contains $BASE_REF ($(git rev-parse --short "$BASE_TIP")) — nothing to sync."
+  exit 0
+fi
+
+echo "→ Merging $BASE_REF ($(git rev-parse --short "$BASE_TIP")) into $TASK_BRANCH"
+
+if git merge --no-edit "$BASE_REF"; then
+  echo "✓ Merged $BASE_REF cleanly into $TASK_BRANCH."
+  exit 0
+fi
+
+CONFLICTED=$(git diff --name-only --diff-filter=U)
+if [ -z "$CONFLICTED" ]; then
+  echo "❌ sync-with-main: merge failed but no conflicted paths found — investigate." >&2
+  exit 2
+fi
+
+echo "⚠ Merge conflicts — resolve these paths, then stage and commit:" >&2
+printf '%s\n' "$CONFLICTED"
+exit 1


### PR DESCRIPTION
- Closes #2209

## Summary

Adds merge-conflict handling to the PR review pipeline. `pr-ship` and its
subsidiary skills never queried mergeability, so a branch conflicting with its
base could pass every finding check, get a green CI read, and be reported
`READY-TO-MERGE`.

## Motivation

Nothing in `pr-triage`, `pr-execute`, `pr-verify`, or `pr-ship` mentioned merge
conflicts — `mergeable` was never fetched anywhere. `pr-verify` computed
`READY-TO-MERGE` purely from confirmed findings plus green CI, which is exactly
the set of signals that stays green on a conflicted PR.

Conflict resolution has to land **late** in the pipeline: execute's own fixes can
create conflicts, and another PR can land on the base branch mid-run. Any check
that runs before the last mutation is stale by verdict time.

## Changes

- **`.agents/skills/pr-triage/SKILL.md`**: new Phase 12 (merge state) reads
  mergeability, emits a FAIL finding, and records
  `mergeable` / `merge_state_status` / `is_draft` into `pr_metadata`. Early
  warning only — explicitly not the gate. Emit phase renumbered 12 → 13.
- **`.agents/skills/pr-triage/REFERENCE.md`**: per-value severity tables for
  `mergeable` and `mergeStateStatus`; why conflicts are always FAIL and never
  `new-issue-*`; stacked-PR note; `pr_metadata` schema and comment-format
  additions.
- **`.agents/skills/pr-execute/SKILL.md`**: new Phase 4 (sync with base and
  resolve conflicts) — the only phase that resolves. Placed after all fixes and
  CI remediation so execute's own changes are included, and before the test suite
  so tests exercise the merged tree. Old Phases 4–7 shift to 5–8. Also undrafts
  `needs-rebase` draft PRs once the sync lands.
- **`.agents/skills/pr-execute/REFERENCE.md`**: \"Conflict Resolution Rules\" —
  why sync runs late, merge-vs-rewrite rationale, a per-situation resolution
  table, non-negotiable rules (read both sides; never silently revert base), the
  `merge_state` artifact block, and new stop conditions.
- **`.agents/skills/pr-verify/SKILL.md`**: new Phase 2 (merge state gate), a live
  re-check that never reuses artifact values. Verdict rules become an ordered
  table with exactly one row that emits `READY-TO-MERGE`, requiring a live
  `MERGEABLE`. Old Phases 2–6 shift to 3–7. Verify still fixes nothing.
- **`.agents/skills/pr-verify/REFERENCE.md`**: new verdicts `CONFLICTS-FOUND`
  (outranks `GAPS-FOUND` — nothing can land until the branch merges) and
  `PENDING-MERGE-CHECK`; new flags; per-verdict retry guidance.
- **`.agents/skills/pr-ship/SKILL.md`**: fetches merge state at detection and
  treats a conflicted PR as normal input, not an error; resume cases for the new
  verdicts; \"Where Merge Conflicts Are Handled\" table; and an explicit rule to
  report verify's verdict verbatim and never upgrade it.
- **`.agents/skills/shared/merge-state.sh`** (new): wraps
  `gh pr view --json mergeable,mergeStateStatus,...`, emitting one JSON line with
  exit `0`/`1`/`2` for mergeable/conflicting/unknown. Polls past GitHub's
  transient `UNKNOWN` — the first query after a push almost always returns
  `UNKNOWN`, so a naive check reads as \"not conflicting\", which is the exact
  shape of the original bug.
- **`.agents/skills/shared/sync-with-main.sh`** (new): merges the base branch into
  an already-pushed branch, deliberately leaving conflicts in the worktree for the
  caller to resolve. Takes the base branch as an argument (not all PRs target
  `main`) and supports `--abort`. Refuses to run on a dirty tree or mid-merge.
- **`.agents/skills/shared/README.md`**: documents both new scripts plus the
  previously-undocumented `freshen-branch.sh`, with a freshen-vs-sync comparison
  table.

## Notes

- **`freshen-branch.sh` vs `sync-with-main.sh`** — these are not
  interchangeable. `freshen-branch.sh` cherry-picks onto a fresh base and belongs
  before the first push (`create-pr` Phase 2). Using it on a pushed branch would
  require a force-push, which orphans reviewers' line comments and invalidates
  `commit_ref` values already recorded in the pipeline artifacts. Hence a merge
  commit for the post-PR case.
- **`mergeable` and `mergeStateStatus` are computed separately** by GitHub, so
  `DIRTY` is treated as conflicting even when `mergeable` disagrees.
- **`base_ref` is not always `main`** (e.g. #2206 targets `fix/demo-ci`), so all
  sync operations thread the PR's real base through.
- **The conflict-marker grep excludes `=======`** — a bare row of equals signs is
  a valid markdown setext heading underline, and this repo is docs-heavy.
- **`create-pr` already opens draft PRs labeled `needs-rebase`** on freshen
  failure, but nothing downstream ever cleared them; execute now undrafts them
  after a successful sync, and `DRAFT` blocks `READY-TO-MERGE`.

## Verification

No Python changed — docs and shell only, so no test suite applies.

- `markdownlint-cli2` clean on all 8 changed markdown files (also passed via
  pre-commit)
- `bash -n` clean on both new scripts
- `merge-state.sh` exercised against live PRs: #2206 → exit `0`
  (`MERGEABLE`/`UNSTABLE`), #2205 → exit `0`, merged PR #2190 → exit `2` with the
  `UNKNOWN` polling path
- `sync-with-main.sh` guard paths exercised: dirty-tree refusal and
  `--abort`-with-no-merge-in-progress
- Phase numbering verified sequential in all three renumbered skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
