### PR TITLE
fix(docker): stop the build context from stripping tracked files in the dev stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,16 @@
-# Version control
-.gitignore
-.gitattributes
+# This file applies to the whole build context and therefore to EVERY stage in
+# docker/Dockerfile, including the `dev` stage that backs the devcontainer.
+#
+# Two rules keep it honest:
+#   1. Only list paths that NO stage needs at build time. Paths that runtime
+#      images should skip but the dev stage requires (.github, archived_notes,
+#      .gitignore, docker/Dockerfile, ...) belong in a per-stage
+#      `COPY --exclude=` on the runtime/test stages instead. Excluding them here
+#      silently strips them from the devcontainer and makes `git status` report
+#      them as deleted.
+#   2. Anything start-dev.sh clobber-mounts over /app at runtime should be
+#      excluded here — copying it in is waste. Safe only because every such path
+#      is gitignored, so its absence cannot surface as a phantom deletion.
 
 # Python artifacts
 __pycache__
@@ -45,22 +55,38 @@ package-lock.json
 devlogs
 diosts.log
 
-# Notes and docs not needed in runtime images
-archived_notes
-wip_notes
-
 # macOS metadata
 .DS_Store
 **/.DS_Store
 
-# Dev-environment files
-.env
-.github
+# Local agent/assistant state — unknown contents, may hold tokens
 .copilot
+
+# Runtime-mounted paths (rule 2 above). start-dev.sh mounts each of these over
+# /app when it creates the container, so the copied-in version is never read.
+wip_notes
+wip_outputs
+graphify-out
+
+# .devcontainer is clobber-mounted at /app/.devcontainer at runtime, so only
+# what the BUILD needs is admitted: certs/, which docker/Dockerfile copies to
+# /usr/local/share/ca-certificates/ and feeds to update-ca-certificates before
+# the gh / Node / AWS CLI / Claude Code installs curl over HTTPS. Those .crt
+# files are host-local (see .git/info/exclude), so they can never arrive via the
+# in-container `git pull` — the build context is their only route in.
 .devcontainer
 !.devcontainer/certs
-!.devcontainer/postcreate.sh
-!.devcontainer/poststart.sh
 
-# Dockerfile itself is not needed inside app images; demo-entrypoint.sh is still required
-docker/Dockerfile
+# Secrets — must not be baked into any image layer, the dev stage included.
+# NOTE: .dockerignore is independent of .gitignore. A git-ignored secret is
+# still part of the build context and still lands in the image unless it is
+# listed HERE. Never rely on .gitignore to keep credentials out of a layer.
+#
+# devcontainer.env (AWS credentials, written by .devcontainer/setup.sh) is
+# already covered by the .devcontainer rule above; it is repeated explicitly so
+# that re-including more of .devcontainer later cannot quietly admit it.
+# start-dev.sh supplies it at runtime via `docker run --env-file`.
+# .env.example files are intentionally NOT matched by these patterns.
+.env
+**/.env
+.devcontainer/*.env

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,14 +23,29 @@ FROM dep-layer AS dependencies
 # Copy the full application source and install the project package
 # (including console-script entry points such as vultron-demo).
 # Code-only changes only bust this layer, not the dependency layer above.
-# .git/.agents are dev-only (see the dev stage) and stay out of runtime images.
-COPY --exclude=.git --exclude=.agents . /app/
+#
+# Dev-only paths are excluded HERE rather than in .dockerignore, because
+# .dockerignore applies to the whole build context and would also strip them
+# from the `dev` stage that backs the devcontainer. Keep this list in sync with
+# the `test` stage below; the `dev` stage deliberately copies everything.
+COPY --exclude=.git --exclude=.agents \
+     --exclude=.github --exclude=.devcontainer \
+     --exclude=.gitignore --exclude=.gitattributes \
+     --exclude=archived_notes \
+     --exclude=docker/Dockerfile \
+     . /app/
 ENV PYTHONPATH=/app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen
 
 FROM dep-layer AS test
-COPY --exclude=.git --exclude=.agents . /app/
+# Same exclusion set as the `dependencies` stage above.
+COPY --exclude=.git --exclude=.agents \
+     --exclude=.github --exclude=.devcontainer \
+     --exclude=.gitignore --exclude=.gitattributes \
+     --exclude=archived_notes \
+     --exclude=docker/Dockerfile \
+     . /app/
 ENV PYTHONPATH=/app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --dev
@@ -96,7 +111,16 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
     CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
-# Install project source (after all heavy system tooling is cached)
+# Install project source (after all heavy system tooling is cached).
+# The devcontainer needs every TRACKED path — .git, .github, archived_notes,
+# .gitignore and docker/Dockerfile included. Anything omitted here shows up as a
+# phantom deletion in `git status` inside the container, so this COPY takes no
+# --exclude flags by design; add nothing to .dockerignore that this stage needs.
+#
+# Only two categories are withheld, both via .dockerignore: secrets (.env,
+# .devcontainer/*.env), and gitignored paths that start-dev.sh clobber-mounts
+# over /app at runtime (.devcontainer, wip_notes, wip_outputs, graphify-out).
+# Being gitignored, those cannot surface as phantom deletions.
 COPY . /app/
 ENV PYTHONPATH=/app
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -105,6 +105,11 @@ DOCKER_ARGS=(
     -e WIP_NOTES=/app/wip_notes
     -e WIP_OUTPUTS=/app/wip_outputs
     -v "$HOME/.claude:/home/vscode/.claude"
+    # .devcontainer is excluded from the build context except certs/ (see
+    # .dockerignore), so mount it here. Without this the tracked files under it
+    # are missing from /app and `git status` reports them as deleted. Writable so
+    # that the `git pull` in poststart.sh can fast-forward them.
+    -v "$SCRIPT_DIR/.devcontainer:/app/.devcontainer"
     -v "$MAIN_DIR/wip_notes:/app/wip_notes:ro"
     -v "$WIP_OUTPUTS_SLOT:/app/wip_outputs"
     -v "$GRAPHIFY_HOST:/app/graphify-out"


### PR DESCRIPTION
## Summary

The `dev` stage that backs the devcontainer was missing 51 tracked files, so `git status` inside a container reported them as deleted. Every missing path mapped to a `.dockerignore` entry, because `.dockerignore` applies to the whole build context and cannot distinguish stages — exclusions written for runtime images were also stripping the dev stage.

| `.dockerignore` entry | Files lost from the devcontainer |
|---|---|
| `.github` | 26 |
| `archived_notes` | 20 |
| `.devcontainer` (minus 3 negations) | 3 |
| `docker/Dockerfile` | 1 |
| `.gitignore` | 1 |

Losing `.gitignore` compounded it: 17 normally-ignored paths (`graphify-out/`, `vultron.egg-info/`, `vultron/_version.py`, …) also surfaced as untracked noise. There was no stage-local escape, since every build uses context `..` with `docker/Dockerfile` — `start-dev.sh:93` and all compose services.

Two rules now govern what is withheld, both documented in the files:

1. **Paths runtime images skip but the dev stage needs** move out of `.dockerignore` into per-stage `COPY --exclude=` on `dependencies` and `test`, extending the idiom already used there for `.git`/`.agents`.
2. **Paths `start-dev.sh` clobber-mounts over `/app`** stay excluded, since copying them in is waste. Safe only because all are gitignored, so their absence cannot surface as a phantom deletion.

## Changes

- **`.dockerignore`**: dropped `.github`, `archived_notes`, `.gitignore`, `.gitattributes`, and `docker/Dockerfile` (now per-stage). Added the runtime-mounted paths `wip_notes`, `wip_outputs`, and `graphify-out`. Restored `.devcontainer` with a single `!.devcontainer/certs` negation. Header comment records both rules so the regression can't be reintroduced silently.
- **`docker/Dockerfile`**: `dependencies` and `test` gained `--exclude=` flags covering the paths moved out of `.dockerignore`, keeping runtime image contents unchanged apart from `docker/.env` below. `docs`, `api-dev`, `vultrabot_demo`, and `demo` inherit from `dependencies`. The `dev` stage keeps a flag-free `COPY . /app/` by design.
- **`start-dev.sh`**: bind-mounts `.devcontainer` at `/app/.devcontainer`, writable so the `git pull` in `poststart.sh` can fast-forward it.

### Why `certs` stays in the build context

`.devcontainer/certs` is a **build-time** input: `docker/Dockerfile` copies it to `/usr/local/share/ca-certificates/` and runs `update-ca-certificates` *before* the `gh`, Node 22, AWS CLI, and Claude Code installs curl over HTTPS through Zscaler. A runtime mount cannot satisfy a build-time `COPY`. The `.crt` files are also host-local via `.git/info/exclude`, so the in-container `git pull` can never supply them — the build context is their only route in.

### Two credential leaks closed

- `.devcontainer/devcontainer.env` holds AWS credentials (written by `.devcontainer/setup.sh`). It is excluded by name in addition to the `.devcontainer` rule, so re-including more of that directory later cannot quietly admit it. `start-dev.sh:100` still injects it at runtime via `--env-file`.
- A bare `.env` pattern only matches the context root, so **`docker/.env` had been getting baked into every runtime image**. `**/.env` closes that. This is the one runtime image content change in this PR.

`**/*.env` was deliberately *not* used: it would catch `docker/service-colors.env`, a real input read by `integration_tests/demo/colorize_compose_logs.py:38`.

The load-bearing lesson is now a comment in `.dockerignore`: **`.dockerignore` is independent of `.gitignore`**, so a gitignored secret still lands in an image layer unless listed there. `.gitignore:163` already ignored `devcontainer.env`, which is exactly why this was easy to miss.

## Verification

- 26 path assertions against a Python implementation of moby's `patternmatcher` (`**` spanning segments, `*` not crossing `/`, parent-match excluding children): `certs/*.crt`, `.github/**`, `archived_notes/**`, `.gitignore`, `docker/Dockerfile`, `docker/service-colors.env`, and both `.env.example` files included; the rest of `.devcontainer`, all four mounted dirs, `.env`, `docker/.env`, and `devcontainer.env` excluded. All pass.
- The `!.devcontainer/certs` negation mechanism is already proven in this repo — it is what the pre-change file used, and why `certs/` and the `postcreate`/`poststart` scripts were present while the rest of `.devcontainer` was stripped.
- `bash -n start-dev.sh` clean.
- Black (1189 files), flake8 `vultron/ test/` (0 findings), mypy (661 files, success), pyright (0 errors). No Python changed.

> [!IMPORTANT]
> **Not built yet.** The devcontainer has no Docker daemon, so this could not be exercised in-container. The real test is `./start-dev.sh <slot> --rebuild` on the host, then confirming `git status --porcelain` comes back empty and `/app/.devcontainer/` shows the mounted tree.

### Known wart

The rw mount lets the container's `git pull` fast-forward `.devcontainer` straight into the host checkout. Usually self-correcting and invisible, but if the host has uncommitted `.devcontainer` edits or sits on a different branch, git sees local modifications, `--ff-only` refuses, and because `poststart.sh:9` swallows the error with `|| echo "[warn] …"` the *entire* refresh is skipped rather than just that directory. Rare, since `.devcontainer` changes seldom — that warning line is the signal.
