### PR TITLE
fix(devcontainer): remove unreachable per-slot clone block

### DIFF
--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -5,26 +5,6 @@ set -euo pipefail
 echo "=== Post-create setup ==="
 echo ""
 
-# --- Independent clone (non-main slots only) ---
-# main already has the host checkout bind-mounted at $PWD; every other slot
-# clones its own copy here, inside this container's own writable layer, so
-# it shares no git state with any other slot or the host. Seeded from the
-# host checkout via a read-only, one-time --reference for speed; --dissociate
-# copies the borrowed objects in immediately, so this has no ongoing
-# dependency on the mount afterward.
-if [ -n "${VULTRON_ORIGIN_URL:-}" ] && [ ! -d "$PWD/.git" ]; then
-    # Don't echo $VULTRON_ORIGIN_URL — never print a repo URL verbatim, since
-    # a differently-configured remote (this machine or another dev's) could
-    # carry embedded credentials.
-    echo "Cloning repository into $PWD ..."
-    if [ -f /mnt/main-repo.git/HEAD ]; then
-        git clone --reference /mnt/main-repo.git --dissociate "$VULTRON_ORIGIN_URL" "$PWD"
-    else
-        git clone "$VULTRON_ORIGIN_URL" "$PWD"
-    fi
-    echo ""
-fi
-
 # Update Claude Code to latest
 echo "Updating Claude Code..."
 claude update || true


### PR DESCRIPTION
## Summary

Removes a 20-line dead-code block from `.devcontainer/postcreate.sh`. No behavior change.

## Why it's dead

The block is guarded on `$VULTRON_ORIGIN_URL`:

```bash
if [ -n "${VULTRON_ORIGIN_URL:-}" ] && [ ! -d "$PWD/.git" ]; then
```

It was added in dc38a439 (*"give each slot its own independent clone"*), but 33f5e7f5 (*"unify on /app, add persistent host mounts"*) replaced that design with a baked `/app` refreshed by `git pull` in `poststart.sh`. The block was never removed.

It is unreachable on **both** halves of the guard:

- **`VULTRON_ORIGIN_URL` is never set.** `start-dev.sh` passes `VULTRON_MAIN_NAME`, `WIP_NOTES`, and `WIP_OUTPUTS` — not this. `grep -rn VULTRON_ORIGIN_URL` matches only the block that reads it.
- **`$PWD/.git` always exists.** `start-dev.sh` runs `postcreate.sh` with `-w /app`, and `/app/.git` is baked into the image at build time.

`/mnt/main-repo.git`, referenced for the `--reference` seed, is likewise never mounted.

## Testing

- `bash -n .devcontainer/postcreate.sh` — syntax OK
- `grep -rn 'VULTRON_ORIGIN_URL|main-repo.git'` — no remaining references
- pre-commit hooks pass (flake8; shell/markdown/ADR hooks report no applicable files)

## Note for reviewers

Found while auditing stale `.devcontainer` docs. Two adjacent issues surfaced but are **not** addressed here, since this PR is deliberately a no-op removal:

1. `.devcontainer/README.md` still documents a `~/.claude` → `/home/vscode/.claude` bind mount, which 95a95867 replaced with the `<repo-name>-data` named volume. The mount table is stale.
2. `~/.gitconfig` is bind-mounted read-only from the macOS host, so its `credential.helper` points at Homebrew's `/usr/local/bin/gh`. That path doesn't exist in the container (`gh` is at `/usr/bin/gh`), which breaks `git push` from inside a slot until overridden per-command.

Happy to file either as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)