### PR TITLE
fix(devcontainer): correct stale mount docs and make host gh credential helper resolve

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -7,8 +7,7 @@ There is no VS Code devcontainer.json — the script handles everything.
 
 - macOS with Docker Desktop installed and running
 - AWS credentials with Bedrock access (for Claude Code)
-- GitHub CLI auth (`gh auth login`) — only needed if you plan to push/PR from
-  inside the container
+- A GitHub token, only if you plan to push/PR from inside the container — see [GitHub authentication](#github-authentication) below
 
 ## First-time setup
 
@@ -18,9 +17,9 @@ From the repo root, run:
 ./start-dev.sh <slot>
 ```
 
-Replace `<slot>` with any name you like — it's personal to you and not stored
-in the repo. On first run the script will prompt you for AWS credentials and
-write them to `.devcontainer/devcontainer.env` (git-ignored).
+Replace `<slot>` with any name you like — it's personal to you and not stored in the repo.
+On first run the script will prompt you for AWS credentials and write them to
+`.devcontainer/devcontainer.env` (git-ignored).
 
 The script will:
 
@@ -33,13 +32,14 @@ The script will:
 
 Every slot container is ephemeral — it is destroyed when you exit the shell.
 The source code lives at `/app` inside the container, baked into the image at
-build time. On every startup, `poststart.sh` runs `git pull` to bring `/app`
-up to date with `origin/main`.
+build time. On every startup, `poststart.sh` runs `git pull --ff-only` to bring
+`/app` up to date with `origin/main`.
 
 Because containers are destroyed on exit, any uncommitted work in `/app` is
 lost. **Push your work before exiting.**
 
-All slots are identical. There is no "main" slot.
+All slots are identical. There is no "main" slot, and no git worktrees are
+involved — each slot is just a separate container over the same baked `/app`.
 
 ## Command reference
 
@@ -51,26 +51,69 @@ All slots are identical. There is no "main" slot.
 ./start-dev.sh <slot> --rebuild
 ```
 
+These are the only two forms. `start-dev.sh` rejects any other `--flag`.
+
 ## What persists across container restarts
 
 Containers are ephemeral — `/app` is rebuilt from the image each time.
-Three host directories are bind-mounted into every container to persist
-data across restarts:
+Two mechanisms carry data across restarts: one named Docker volume, and a
+set of host bind mounts.
+
+### Named volume
+
+| Volume | Mount in container | Purpose |
+|---|---|---|
+| `<repo-name>-data` | `/home/vscode/.data` | Claude Code config and shell history — shared across all slots |
+
+`postcreate.sh` symlinks into this volume, so the real storage lives in Docker,
+**not** in your Mac's home directory:
+
+- `~/.claude` → `~/.data/claude` (config, sessions, settings)
+- `~/.claude.json` → `~/.data/claude/claude.json`
+- `$HISTFILE` → `~/.data/shell-history/` (both zsh and bash)
+
+The volume survives `--rebuild`, which removes only the container and image.
+To discard Claude config and history you must remove the volume explicitly:
+`docker volume rm <repo-name>-data`.
+
+### Bind mounts
 
 | Host path | Mount in container | Access | Purpose |
 |---|---|---|---|
-| `~/.claude` | `/home/vscode/.claude` | read-write | Claude Code config, sessions, memory — shared across all slots |
+| `.devcontainer/` (repo root) | `/app/.devcontainer` | read-write | Withheld from the build context by `.dockerignore`, so it is mounted instead; without it these tracked files show up as phantom deletions in `git status` |
 | `wip_notes/` (repo root) | `/app/wip_notes` (`$WIP_NOTES`) | read-only | Drop context files here on the host; agents can read them |
 | `wip_outputs/<slot>/` (repo root) | `/app/wip_outputs` (`$WIP_OUTPUTS`) | read-write | Agents write outputs here; each slot sees only its own subdirectory |
 | `~/dev/graphify-out/<slot>/` | `/app/graphify-out` | read-write | Per-slot graph data from `/graphify`; expensive to regenerate |
+| `~/.gitconfig` | `/home/vscode/.gitconfig` | read-only | Commits use your real git identity |
+| `~/.agents/skills/` | `/home/vscode/.agents/skills` | read-only | User-level skills; mounted only if the directory exists |
 
 `start-dev.sh` creates `wip_notes/`, `wip_outputs/`, and
 `~/dev/graphify-out/<slot>/` automatically on first use.
+
+## GitHub authentication
+
+Running `gh auth login` on your Mac does **not** carry into the container —
+there is no `~/.config/gh` mount. Container `gh` authenticates from a
+`GH_TOKEN` entry in `.devcontainer/devcontainer.env`:
+
+```sh
+GH_TOKEN=ghp_your_token_here
+```
+
+`setup.sh` does not prompt for this, so add the line yourself if you need it.
+`devcontainer.env` is git-ignored; keep the token out of tracked files.
+
+Your host `~/.gitconfig` is mounted read-only, so if its `credential.helper`
+points at a Homebrew `gh` path the container makes that path resolve to the
+apt-installed binary via symlink. Pushing works without further setup.
+
+SSH remotes do not work inside a slot: `start-dev.sh` forwards the SSH agent
+socket when present, but `openssh-client` is not installed in the image, so
+`ssh` is not on `PATH`. Use HTTPS remotes.
 
 ## Skills
 
 Claude Code loads skills from two places simultaneously:
 
 - **Project skills** — `.claude/skills/` in the repo (auto-discovered)
-- **User skills** — `~/.claude/skills/`, symlinked from `~/.agents/skills` on
-  your Mac if present
+- **User skills** — `~/.claude/skills/`, symlinked to the read-only `~/.agents/skills` mount if that directory exists on your Mac

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,6 +92,16 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
+# start-dev.sh bind-mounts the host ~/.gitconfig read-only, and on macOS its
+# credential.helper points at a Homebrew gh path (/usr/local/bin on Intel,
+# /opt/homebrew/bin on Apple Silicon). apt installs gh to /usr/bin here, so
+# without these links git cannot find the helper and every push inside a slot
+# dies with "could not read Username for 'https://github.com'". The mount is
+# read-only, so the host config cannot be rewritten — make its path resolve.
+RUN ln -sf /usr/bin/gh /usr/local/bin/gh \
+    && mkdir -p /opt/homebrew/bin \
+    && ln -sf /usr/bin/gh /opt/homebrew/bin/gh
+
 # Node.js 22 (required by Claude Code)
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \


### PR DESCRIPTION
Closes #2226.

Two independent devcontainer papercuts, found by diffing `.devcontainer/README.md` against what `start-dev.sh` actually does.

## 1. `git push` failed inside every slot — `docker/Dockerfile`

`start-dev.sh` bind-mounts the host `~/.gitconfig` **read-only**. On macOS that config's `credential.helper` points at a Homebrew `gh` path, but apt installs `gh` to `/usr/bin` in the image, so git could not find the helper:

```
/usr/local/bin/gh auth git-credential get: 1: /usr/local/bin/gh: not found
fatal: could not read Username for 'https://github.com': No such device or address
```

Because the mount is read-only, the host config cannot be rewritten in place. Instead, symlink both Homebrew locations to the apt-installed binary so the host config resolves as written:

```dockerfile
RUN ln -sf /usr/bin/gh /usr/local/bin/gh \
    && mkdir -p /opt/homebrew/bin \
    && ln -sf /usr/bin/gh /opt/homebrew/bin/gh
```

`/usr/local/bin` covers Intel Homebrew, `/opt/homebrew/bin` Apple Silicon. `ln -sf` is idempotent, so this is safe if a future base image ships either path.

## 2. Stale mount documentation — `.devcontainer/README.md`

The table documented a `~/.claude` → `/home/vscode/.claude` bind mount that 95a95867 replaced with the `<repo-name>-data` named volume. Readers expected Claude config in their Mac home directory when it actually lives in a Docker volume — which also changes what `--rebuild` destroys.

Rewritten against the current `start-dev.sh`:

- Split the named volume from the bind mounts; documented the `~/.claude` → `~/.data/claude`, `~/.claude.json`, and `$HISTFILE` symlinks that `postcreate.sh` creates
- Documented the `.devcontainer` bind mount added in cdab0905 and why it exists (`.dockerignore` withholds it; without the mount its tracked files appear as phantom deletions)
- Noted the volume survives `--rebuild`, with the explicit `docker volume rm` needed to discard it
- Fixed the "three host directories" count — the table listed four
- Removed worktree and `--reset` content describing designs superseded by 33f5e7f5; `start-dev.sh` supports only `<slot>` and `--rebuild` and hard-rejects other flags
- Replaced the misleading `gh auth login` prerequisite with a **GitHub authentication** section covering how auth actually reaches the container

## Testing

- **The push that opened this PR is the test for part 1.** A plain `git push`, with no `-c credential.helper` override, succeeded from inside a slot after applying the symlinks — the same command failed before them.
- Ran the two `RUN` commands verbatim in a live dev container: both links resolve and `/usr/local/bin/gh --version` reports `gh version 2.97.0`.
- `markdownlint-cli2` clean; pre-commit passed (markdownlint + flake8).
- Docker is not available inside the dev container, so the image build itself was **not** exercised here — the `RUN` commands were validated by direct execution rather than by `docker build`. Worth a CI build or one host-side `./start-dev.sh <slot> --rebuild` to confirm.

## Deliberately out of scope

Both are noted in #2226 and left for follow-up rather than widening this PR:

- `openssh-client` is absent from the dev stage, so the SSH-agent forwarding `start-dev.sh` sets up cannot work — `ssh` is not on `PATH`. The README now tells users to use HTTPS remotes; it does not fix the cause.
- `setup.sh` never prompts for `GH_TOKEN` even though that is what authenticates `gh` in the container. The README now documents adding it by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)