### PR TITLE
docs: plan issue #2243 — engage_case harness/spec drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,6 +466,27 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   conflict markers, `git add <file>`, `git cherry-pick --continue --no-edit`,
   then `git branch -f "$TASK_BRANCH" HEAD && git checkout "$TASK_BRANCH"`.
   Use `manage_worktree.sh ensure-synced` in preference to the raw script.
+- **A Red CI Job Is Not Evidence That Its Assertions Ran** — a job that dies in
+  an earlier step (artifact download, dependency setup, container build) never
+  reaches pytest, so its red status says nothing about what the tests assert.
+  Open the log and identify the failing *step* before concluding a test is
+  wrong, unsatisfiable, or "can never pass". A permanently-red
+  `<scenario> Invariant Harness` job was misread this way in CONCERN-2243: it
+  failed at `actions/download-artifact` on every run, so the assertion blamed
+  for the failure had never once executed. Note the inverse trap too — an
+  all-skipped pytest run exits 0 and reports **green** while checking nothing.
+  See [notes/demo-ci-invariants.md](notes/demo-ci-invariants.md) § "Reading a
+  Red Invariant Harness Job".
+- **Trace Shared Helper Layers Before Declaring an Event Unemitted** — in the
+  demo suite, protocol activity is emitted from shared helpers in
+  `vultron/demo/helpers/workflow.py` (e.g. `receiver_engages_case()`,
+  `run_direct_path_rm_triage()`), not from the scenario files. Grepping a
+  scenario file — or even all of `vultron/demo/scenario/` — finds nothing and
+  invites the false conclusion that no code emits the event. Search the helper
+  and semantic-registry layers, and confirm against
+  `graphify explain "<function>"` call edges, before asserting absence.
+  CONCERN-2243 filed a Concern on this basis for an event emitted by all nine
+  scenarios.
   See also ISSUE-1784 (tracking the script fix).
 - **`git rebase` "local changes would be overwritten" With a Clean Working Tree**
   — this error can be a false positive when the rebased branch diverges far from

--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -44,7 +44,7 @@ invariant-harness (matrix: fv) → downloads artifact → runs pytest
 Each scenario gets **one self-contained harness file**,
 `test/ci/invariants/test_<scenario>_invariants.py`. There is no shared
 per-scenario base class and no registry module. A new harness follows the
-existing eight:
+existing nine:
 
 1. Declare `_DEMO_NAME = "<scenario>"` at module scope.
 2. Load replicas with `load_devlogs(demo_name=_DEMO_NAME)`, imported from
@@ -71,7 +71,7 @@ and must be kept in step.
 > in `common.py` — it carries no scenario mapping. Do not bolt scenario routing
 > onto it.
 
-Known duplication: all eight harnesses re-implement the same ~14 universal
+Known duplication: all nine harnesses re-implement the same ~14 universal
 invariant tests as near-identical thin wrappers over `common.py`. Extracting
 them is tracked separately; the per-file `_DEMO_NAME` + `load_devlogs` idiom is
 not the duplication worth fixing.
@@ -90,19 +90,27 @@ missing from a scenario that requires it).
 **Design**: Each scenario defines its own required event-type list that
 extends the four universal types with scenario-specific required phases.
 The spec requirements in `specs/multi-actor-demo.yaml` DEMOMA-16-001 through
-DEMOMA-16-008 are the normative source; the test constants implement them.
+DEMOMA-16-011 are the normative source; the test constants implement them.
 
 ### Scenario required event types
 
-| Scenario | Universal 4 | Additional required |
-|---|---|---|
-| FV | validate_report, add_participant_status_to_participant, close_case, add_note_to_case | (none) |
-| FVV | same | invite_actor_to_case |
-| FVCV-extension | same | invite_actor_to_case, offer_case_participant |
-| FVCV-handoff | same | invite_actor_to_case, accept_invite_actor_to_case |
-| FCCV-handoff | same | invite_actor_to_case, accept_invite_actor_to_case |
-| FCV | same | invite_actor_to_case |
-| FCVCV | same | invite_actor_to_case (≥3), offer_case_participant (≥1), accept_invite_actor_to_case (≥3) |
+This table MUST match the DEMOMA-16 requirements one-for-one — one row per
+scenario, no scenario omitted. It drifted from the spec on four counts before
+CONCERN-2243 (three rows understated their required types; the FCCV-extension
+and FCV-reject rows were absent entirely), which is exactly the drift
+DEMOMA-16-008 exists to prevent.
+
+| Scenario | Spec | Universal 4 | Additional required |
+|---|---|---|---|
+| FV | DEMOMA-16-002 | validate_report, add_participant_status_to_participant, close_case, add_note_to_case | (none) |
+| FVV | DEMOMA-16-003 | same | invite_actor_to_case, accept_invite_actor_to_case |
+| FVCV-extension | DEMOMA-16-004 | same | invite_actor_to_case, offer_case_participant, accept_invite_actor_to_case, accept_actor_recommendation |
+| FVCV-handoff | DEMOMA-16-005 | same | invite_actor_to_case, accept_invite_actor_to_case |
+| FCCV-handoff | DEMOMA-16-006 | same | invite_actor_to_case, accept_invite_actor_to_case |
+| FCV | DEMOMA-16-007 | same | invite_actor_to_case, accept_invite_actor_to_case |
+| FCVCV | DEMOMA-16-009 | same | invite_actor_to_case (≥3), offer_case_participant (≥1), accept_invite_actor_to_case (≥3), accept_actor_recommendation (≥1) |
+| FCCV-extension | DEMOMA-16-010 | same | invite_actor_to_case, offer_case_participant, accept_invite_actor_to_case, accept_actor_recommendation |
+| FCV-reject | DEMOMA-16-011 | same | invite_actor_to_case, reject_invite_actor_to_case |
 
 ### Relationship to scenario-specific test functions
 
@@ -125,6 +133,52 @@ When a scenario phase is added or removed, update both:
 Both MUST change in the same PR per DEMOMA-16-008. Failure to update the spec
 is a latent silent-failure risk; failure to update the test means the new spec
 requirement is untested.
+
+Corollary for planning work: an amendment to a DEMOMA-16 requirement and the
+corresponding edits to `_XXX_EXPECTED_EVENT_TYPES` cannot be split across a
+docs PR and a later implementation PR. Either both land now, or both are
+deferred to the implementation PR together.
+
+---
+
+## Reading a Red Invariant Harness Job (CONCERN-2243)
+
+**A red `<scenario> Invariant Harness` job is not evidence that any invariant
+was violated — or even evaluated.** The job has three distinct red modes and
+one false-green mode, and they are easy to confuse:
+
+| Job outcome | What actually happened | What it tells you about invariants |
+|---|---|---|
+| Red at `Download case log JSONL files` | The demo job never uploaded an artifact, so `actions/download-artifact` errored (`Artifact not found for name: <scenario>-case-logs`). **pytest never ran.** | Nothing at all |
+| Red at `Run case-ledger invariant harness` | pytest ran and an assertion failed | A real invariant result |
+| Green with every test skipped | `load_devlogs` called `pytest.skip` because `devlogs/<scenario>/` held no `*-case-ledger.jsonl`; a skip-only run exits 0 | Nothing — this is a **false green** |
+
+CONCERN-2243 was filed because a permanently-red `fvcv-handoff Invariant
+Harness` was read as proof that its `engage_case` assertion could never pass.
+The job was in fact dying in the first mode: it failed at artifact download on
+every run, so the assertion had never once executed. The assertion itself is
+correct — `engage_case` is emitted by all nine scenarios (see below) — and the
+absence of the entries it looks for was a real protocol defect elsewhere.
+
+Before drawing any conclusion from this job, open the log and confirm which
+step failed.
+
+### `engage_case` is universal, not scenario-specific
+
+Every scenario drives an engage-case trigger, so `engage_case` is a universal
+required event type on the same footing as `validate_report`:
+
+- `run_direct_path_rm_triage()` (`vultron/demo/helpers/workflow.py`) calls
+  `receiver_engages_case()` for the report's direct receiver — used by all
+  eight multi-actor scenarios.
+- `run_invite_path_rm_triage()` calls it again for the invited participant —
+  used by seven of them (CM-11-002).
+- `fv_demo.py` calls `receiver_engages_case()` directly via
+  `vendor_engages_case()`.
+
+Emission is therefore located in the **shared helper layer**, not at scenario
+call sites; grepping a single scenario file for `engage` finds nothing and
+invites the false conclusion that no code emits it.
 
 ---
 

--- a/plan/history/2608/learning/CONCERN-2243.md
+++ b/plan/history/2608/learning/CONCERN-2243.md
@@ -1,0 +1,89 @@
+---
+source: CONCERN-2243
+timestamp: '2026-08-12T20:01:39.448481+00:00'
+title: A red CI job is not evidence its assertions ran
+type: learning
+---
+
+CONCERN-2243 reported that the `fvcv-handoff` invariant harness asserts an
+`engage_case` ledger event that no code emits, and asked whether to implement
+the emission or correct the assertion. Both halves of the premise were wrong,
+and the way they were wrong is the reusable lesson.
+
+## What was actually true
+
+`engage_case` is emitted by **all nine** demo scenarios. Emission lives in the
+shared helper layer, not in scenario files: `run_direct_path_rm_triage()` in
+`vultron/demo/helpers/workflow.py` calls `receiver_engages_case()` for the
+report's direct receiver (all eight multi-actor scenarios), and
+`run_invite_path_rm_triage()` calls it again for the invited participant (seven
+of them, per CM-11-002); `fv_demo.py:483` calls it directly. The commit chain is
+complete end to end — `create_engage_case_tree` contains
+`GuardedCommitCaseLedgerEntryBT`, and `("Join", "VulnerabilityCase")` is an
+allowed canonical payload signature, correctly excluded from
+`_CASE_AUTHORED_SIGNATURES` as a participant assertion.
+
+The assertion was never unsatisfiable. `min_count=2` is arithmetically right:
+Vendor1 engages via the direct path, Vendor2 via the invite path.
+
+## The two misreadings
+
+**1. A red CI job was read as evidence about the assertion.** The
+`fvcv-handoff Invariant Harness` job had been permanently red, which was taken
+as proof the assertion could never pass. The job was in fact dying at
+`actions/download-artifact` — `Artifact not found for name:
+fvcv-handoff-case-logs` — because the demo job failed before uploading devlogs.
+**pytest never ran.** There were 0 successful demo-integration runs in the last
+100, including all four on the branch of `915908c2` (PR #2018), the commit that
+added the assertion. It merged never having executed once.
+
+The inverse trap sits right next to it: `load_devlogs` calls `pytest.skip` when
+`devlogs/<scenario>/` holds no ledger files, and the harness step is a bare
+`uv run pytest`, so an all-skipped run exits 0 and reports **green** while
+checking nothing.
+
+**2. Absence was inferred from grepping the wrong layer.** Searching scenario
+files — or even all of `vultron/demo/scenario/` — for `engage` finds nothing,
+because every scenario reaches emission through a shared helper. Absence of a
+call site is not absence of emission when a helper layer sits in between.
+
+## Real defect found underneath
+
+Every harness matches its DEMOMA-16 requirement exactly **except**
+`fvcv-handoff`, which carries one extra entry — `engage_case` — that
+`915908c2` added to the test without amending the spec. That is a
+DEMOMA-16-008 violation, and its cost is that an engage-case regression is
+silent in eight of nine scenarios. Since all nine scenarios drive engage-case,
+the fix is to promote `engage_case` to the universal set in DEMOMA-16-001
+alongside `validate_report` — the same instinct PR #2018 had, applied at the
+right scope. The entries are currently absent for an unrelated reason: the
+engage-case 422 tracked in #2233.
+
+Investigation also surfaced four documentation drift defects in the
+`notes/demo-ci-invariants.md` scenario table (three rows understating their
+required types; the FCCV-extension and FCV-reject rows missing entirely).
+
+## Planning consequence
+
+DEMOMA-16-008 requires a spec requirement and its test constants to change in
+the same PR. That makes the usual plan-issue split — docs now, code later —
+illegal for this change. The DEMOMA-16-001 amendment was therefore deferred to
+the implementation issue so it lands together with the nine test-constant
+edits, and the docs PR carries only what does not depend on it.
+
+## Outcome
+
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/2265>
+  - `notes/demo-ci-invariants.md`: four scenario-table drift fixes, a `Spec`
+    column, corrected `DEMOMA-16-001..011` range and harness counts, plus a new
+    "Reading a Red Invariant Harness Job" section tabulating the job's three red
+    modes and one false-green mode.
+  - `AGENTS.md`: two Common Pitfalls entries — *A Red CI Job Is Not Evidence
+    That Its Assertions Ran* and *Trace Shared Helper Layers Before Declaring an
+    Event Unemitted*.
+- Implementation issue: #2266 (blocked-by #2243, sub-issue of Epic #2230).
+- No ADR: MS-11-001..006 step 2 is NO — once all nine scenarios are known to
+  drive engage-case, universal promotion is uncontested, not a weighed fork.
+- Left to siblings under Epic #2230: engage-case 422 root cause (#2233),
+  ledger artifacts destroyed by an escaping assertion (#2239), skip-only run
+  exits 0 and canonical-replica-only invariants (#2242).


### PR DESCRIPTION
- Closes #2243

## Summary

Concern #2243 reported that the `fvcv-handoff` invariant harness asserts an
`engage_case` ledger event that no code emits. Investigation found the premise
inverted: `engage_case` is emitted by **all nine** demo scenarios, and the
assertion had simply never executed — the harness job was dying at
`actions/download-artifact` on every run. This PR records the corrected
findings and fixes the DEMOMA-16 documentation drift that the investigation
surfaced along the way.

### What the evidence showed

- `receiver_engages_case()` (`vultron/demo/helpers/workflow.py:202`) posts the
  `engage-case` trigger. It is reached from `run_direct_path_rm_triage()` (all
  eight multi-actor scenarios) and again from `run_invite_path_rm_triage()`
  (seven of them, per CM-11-002); `fv_demo.py:483` calls it directly. Emission
  lives in the shared helper layer, not in scenario files — which is why
  grepping a scenario file finds nothing.
- The commit chain is complete: `create_engage_case_tree` contains
  `GuardedCommitCaseLedgerEntryBT`, and `("Join", "VulnerabilityCase")` is an
  allowed canonical payload signature (`canonical_entry.py:61`), correctly
  excluded from `_CASE_AUTHORED_SIGNATURES` as a participant assertion.
- The `fvcv-handoff Invariant Harness` job failed at artifact download
  (`Artifact not found for name: fvcv-handoff-case-logs`) on every run — pytest
  never ran, so the assertion was never evaluated. There were **0 successful
  demo-integration runs in the last 100**, including all four on the PR branch
  that added the assertion (`915908c2`, PR #2018).
- Neither assertion carries `xfail`, and `xfail_strict` is unset repo-wide.

Conclusion: the assertion is correct and `min_count=2` is arithmetically right
(Vendor1 via the direct path plus Vendor2 via the invite path). It should not be
reverted. The reason the entries are absent is the separately-tracked
engage-case 422 in #2233.

### Real defect found

Every harness matches its DEMOMA-16 requirement exactly **except**
`fvcv-handoff`, which carries one extra entry — `engage_case` — that
`915908c2` never added to the spec. That is a DEMOMA-16-008 violation. Since
all nine scenarios drive engage-case, `engage_case` belongs in the universal
set (DEMOMA-16-001) alongside `validate_report`, not as an `fvcv-handoff`
special case.

Per DEMOMA-16-008 the spec amendment and the nine test-constant edits must land
in the **same** PR, so they are deferred together to the implementation issue
rather than split across this docs PR. This PR carries only the documentation
that does not depend on that amendment.

## Changes

- **`notes/demo-ci-invariants.md`**: correct four drift defects in the
  scenario required-event-types table — FVV, FVCV-extension and FCVCV
  understated their required types, and the FCCV-extension and FCV-reject rows
  were missing entirely. Add a `Spec` column mapping each row to its
  requirement ID, and fix the stale `DEMOMA-16-001 through DEMOMA-16-008` range
  (there are now 011) and two "eight harnesses" counts (there are nine).
- **`notes/demo-ci-invariants.md`**: add "Reading a Red Invariant Harness Job
  (CONCERN-2243)" — a table of the job's three distinct red modes and one
  false-green mode (a skip-only pytest run exits 0), plus a subsection
  recording that `engage_case` is universal and emitted from the shared helper
  layer. Add a DEMOMA-16-008 corollary stating that a spec amendment and its
  test-constant edits cannot be split across a docs PR and a later
  implementation PR.
- **`AGENTS.md`**: add two Common Pitfalls entries — *A Red CI Job Is Not
  Evidence That Its Assertions Ran* (identify the failing step before
  concluding a test is unsatisfiable; note the inverse all-skipped-exits-0
  trap) and *Trace Shared Helper Layers Before Declaring an Event Unemitted*.

## Scope

Deliberately out of scope, each owned by a sibling under Epic #2230:

| Concern | Owner |
|---|---|
| engage-case 422 root cause (why entries never land) | #2233 |
| Ledger artifacts destroyed by an escaping assertion | #2239 |
| Skip-only run exits 0; canonical-replica-only invariants | #2242 |

## ADR determination

No ADR. Applying the `notes/specs-vs-adrs.md` decision tree (MS-11-001–006):
step 1 is YES (capturing what the system must do → spec entry), step 2 is NO —
once all nine scenarios are known to drive engage-case, promoting it to the
universal set is uncontested rather than a weighed architectural fork. Step 4
applies: spec entry only.


## Implementation Issues

- #2266 — Promote `engage_case` to a universal invariant-harness event type
  across all nine scenarios (carries the DEMOMA-16-001 amendment together with
  the nine test-constant edits, per DEMOMA-16-008)
