### PR TITLE
fix: CI demo jobs — stale docs, vendor hang, dead buildx cache

### DIFF
--- a/.github/actions/build-demo-images/action.yml
+++ b/.github/actions/build-demo-images/action.yml
@@ -1,30 +1,13 @@
 name: Build demo images
 description: >
-  Builds the demo-integration Docker images via `docker buildx bake` using
-  the GHA cache backend. Shared by demo-integration.yml (PR builds, which
-  also load the images for `docker compose up`) and
-  demo-image-cache-warm.yml (main-branch cache warming, which only needs to
-  populate the cache) so the bake invocation doesn't drift out of sync
-  between the two workflows.
+  Builds the demo-integration Docker images via `docker buildx bake`.
+  Used by demo-integration.yml for PR and push-to-main builds.
 
 inputs:
-  cache-scope:
-    description: >
-      GHA cache scope to read from and write to. cache-to always writes
-      this scope with mode=max.
-    required: true
-  cache-from-extra-scope:
-    description: >
-      Optional additional GHA cache scope to read from as a fallback (never
-      written to). Used by PR builds to fall back to the cache warmed on
-      main when the PR branch has no cache of its own yet.
-    required: false
-    default: ""
   load:
     description: >
       Whether to pass --load so built images are available to the Docker
-      daemon for a subsequent `docker compose up`. Set to "false" for
-      cache-warming-only builds.
+      daemon for a subsequent `docker compose up`.
     required: false
     default: "true"
 
@@ -38,19 +21,12 @@ runs:
       working-directory: docker
       shell: bash
       env:
-        CACHE_SCOPE: ${{ inputs.cache-scope }}
-        CACHE_FROM_EXTRA_SCOPE: ${{ inputs.cache-from-extra-scope }}
         LOAD: ${{ inputs.load }}
       run: |
         args=(
           --allow=fs.read=..
           -f docker-compose-multi-actor.yml
-          --set "*.cache-from=type=gha,scope=${CACHE_SCOPE}"
-          --set "*.cache-to=type=gha,scope=${CACHE_SCOPE},mode=max"
         )
-        if [[ -n "$CACHE_FROM_EXTRA_SCOPE" ]]; then
-          args+=(--set "*.cache-from=type=gha,scope=${CACHE_FROM_EXTRA_SCOPE}")
-        fi
         if [[ "$LOAD" == "true" ]]; then
           args+=(--load)
         fi

--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -115,7 +115,7 @@ concurrency:
 
 permissions:
   contents: read
-  actions: write  # needed for docker buildx bake cache-to: type=gha
+  actions: write  # needed for cancel-in-progress (concurrency group)
 
 jobs:
   # DEMOCI-06-002, DEMOCI-06-003: resolve the scenario matrix for this event.
@@ -177,23 +177,8 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      # DEMOCI-02-007: Docker layer caching via Buildx GHA cache.
-      # On push-to-main runs, write to the "demo-integration-main" scope so
-      # new PR branches can read it as a warm fallback (DEMOCI-05-003).
-      # On pull_request runs, write to "demo-integration" (visible only to
-      # the same PR branch) and read "demo-integration-main" as a fallback so
-      # a brand-new PR branch still gets a warm start.
       - name: Build Docker images
         uses: ./.github/actions/build-demo-images
-        with:
-          cache-scope: >-
-            ${{ github.ref == 'refs/heads/main'
-              && 'demo-integration-main'
-              || 'demo-integration' }}
-          cache-from-extra-scope: >-
-            ${{ github.ref != 'refs/heads/main'
-              && 'demo-integration-main'
-              || '' }}
 
       # DEMOCI-02-005, DEMOCI-02-006: run demo; detect failure via
       # exit code of the demo-runner container.
@@ -218,9 +203,10 @@ jobs:
           path: devlogs/
           retention-days: 30
 
-      # DEMOCI-02-008: collect combined stream and per-service logs on failure.
+      # DEMOCI-02-008: collect combined stream and per-service logs on failure
+      # or cancellation (a cancelled job ends up undiagnosable without logs).
       - name: Collect container logs
-        if: failure()
+        if: failure() || cancelled()
         run: |
           COMPOSE_FILE=docker/docker-compose-multi-actor.yml
           mkdir -p /tmp/demo-logs
@@ -232,7 +218,7 @@ jobs:
           done
 
       - name: Upload container logs
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ matrix.demo }}-container-logs
@@ -240,10 +226,12 @@ jobs:
           retention-days: 7
 
       # DEMOCI-02-010: always tear down containers and volumes.
+      # --timeout 30 caps the per-container stop grace period so a wedged
+      # container cannot consume the remaining job time budget (#2245).
       - name: Tear down containers and volumes
         if: always()
         run: |
-          docker compose -f docker/docker-compose-multi-actor.yml down -v
+          docker compose -f docker/docker-compose-multi-actor.yml down -v --timeout 30
 
   # DEMOCI-04-001, DEMOCI-04-002, DEMOCI-04-003: separate invariant-harness job
   # so invariant failures produce an independent pass/fail status on the PR even
@@ -278,9 +266,8 @@ jobs:
           path: devlogs/
 
       # AC-925-1: run canonical-log invariant harness against JSONL artifacts.
-      # Invariants not yet passing are marked xfail so the build stays green;
-      # unexpected passes appear as XPASS (visible but not failing).
-      # See test/ci/README-case-log-ratchet.md for the ratchet workflow.
+      # All invariants are currently passing; no xfail markers are in use.
+      # See test/ci/README-case-log-ratchet.md for the invariant inventory.
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-uv
 

--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -227,15 +227,20 @@ Note: DEMOCI-02-011 was authored as a SHOULD but never implemented — neither
 workflow carried a `concurrency` block before CONCERN-1859. It is now a MUST
 and is wired on both triggers.
 
-### Cache-warm workflow removal (DEMOCI-05-003)
+### Cache configuration (DEMOCI-02-007)
 
-`demo-image-cache-warm.yml` existed *only* because `demo-integration.yml` did
-not run on `main`: it built the demo images on push-to-main and exported them
-to the `demo-integration-main` GHA cache scope so new PR branches got a warm
-fallback cache (PR-branch caches are not visible across branches). Once the
-on-main run of `demo-integration.yml` exports that same scope, the dedicated
-cache-warm workflow is a redundant second image build and is **removed**. One
-on-main build now both validates the demo and warms the cache.
+`demo-image-cache-warm.yml` was removed when `demo-integration.yml` gained an
+on-main trigger (DEMOCI-05-001): a single build could then both validate the
+demo and export the GHA cache, making a separate cache-warming run redundant.
+
+Subsequently, the GHA cache export was found to be completely inoperable: the
+required tokens (`ACTIONS_RUNTIME_TOKEN`, `ACTIONS_CACHE_URL`) are only
+injected into `uses:` action steps, not into `run:` shell steps — so the
+`docker buildx bake --set "*.cache-to=type=gha"` args in the composite
+action's `run:` step could never reach the cache backend (#2248). The cache
+configuration has been removed; every job builds from scratch.
+DEMOCI-02-007 is retained as a SHOULD, documenting the intent when a
+working caching mechanism becomes available.
 
 ### Out of scope: merge queue
 

--- a/plan/incoming/learnings/20260812-teardown-timeout-not-specced.md
+++ b/plan/incoming/learnings/20260812-teardown-timeout-not-specced.md
@@ -1,0 +1,16 @@
+---
+title: DEMOCI-02-010 does not bound the docker compose down stop timeout
+type: learning
+timestamp: 2026-08-12
+source: ISSUE-2245
+signal: spec-gap
+---
+
+DEMOCI-02-010 requires `docker compose down -v` in the teardown step but does
+not specify a per-container stop grace period. When the vendor container wedged
+(#2245), `compose down` inherited Docker's default 10-second SIGTERM window
+followed by unbounded SIGKILL retries, consuming the remaining job budget.
+
+Fix added `--timeout 30` (30-second cap per container), which is not backed by
+a spec entry. Consider adding a sub-requirement to DEMOCI-02-010 specifying the
+maximum stop timeout to bound wedge impact.

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -6,7 +6,7 @@ description: >-
   when the demo fails — closing the gap where tests pass while the demo produces
   silent failures. Includes requirements for the invariant harness to run as an
   independent CI gate so failures are visible even when the demo itself also fails.
-version: 1.7.0
+version: 1.8.0
 scope:
   - prototype
   - production
@@ -213,22 +213,31 @@ groups:
           `--abort-on-container-exit --exit-code-from demo-runner`.
 
       - id: DEMOCI-02-007
-        priority: MUST
+        priority: SHOULD
         kind: project
         statement: >-
-          The workflow MUST use GitHub Actions Docker layer caching to avoid
-          rebuilding unchanged dependency layers on every run.
+          The workflow SHOULD use Docker layer caching to avoid rebuilding
+          unchanged dependency layers on every run. GHA cache export via
+          composite `run:` steps is inoperable because GitHub only injects
+          the required cache tokens (ACTIONS_RUNTIME_TOKEN,
+          ACTIONS_CACHE_URL) into `uses:` steps; accordingly the GHA cache
+          configuration has been removed. This entry documents the intent for
+          when a working caching mechanism becomes available (#2248).
 
       - id: DEMOCI-02-008
         priority: MUST
         kind: project
         statement: >-
           The workflow MUST upload all container logs as a CI artifact when
-          the demo job fails, and MUST NOT upload logs on success.
+          the demo job fails or is cancelled, and MUST NOT upload logs on
+          success.
         rationale: >-
-          Logs are diagnostic information; uploading them only on failure
-          keeps successful run artifacts clean while providing full context
-          for debugging broken runs.
+          Logs are diagnostic information; uploading them only on failure or
+          cancellation keeps successful run artifacts clean while providing
+          full context for debugging broken or timed-out runs. A cancelled
+          job (e.g. caused by a wedged container hitting the job timeout)
+          converts a diagnosable failure into an undiagnosable one unless
+          logs are collected on the cancelled path (#2245).
 
       - id: DEMOCI-02-009
         priority: MUST
@@ -271,11 +280,10 @@ groups:
           pile up and waste CI minutes while delaying feedback; a newer commit
           renders earlier PR-branch runs pointless. Cancelling superseded PR
           runs reclaims those minutes. On-main runs are never cancelled because
-          each run both validates the merged main HEAD (DEMOCI-05-001) and
-          protects the fallback cache scope that new PR branches read from (see
-          DEMOCI-02-007 and DEMOCI-05-003). Keyed on the ref, a burst of merges
-          to main still runs each qualifying commit to completion rather than
-          collapsing to the newest, preserving per-commit failure attribution.
+          each run validates the merged main HEAD (DEMOCI-05-001); keyed on
+          the ref, a burst of merges to main still runs each qualifying commit
+          to completion rather than collapsing to the newest, preserving
+          per-commit failure attribution.
 
   - id: DEMOCI-03
     title: Extensibility for Additional Demo Scenarios
@@ -491,31 +499,6 @@ groups:
             spec_id: DEMOCI-05-001
           - rel_type: refines
             spec_id: DEMOCI-02-011
-
-      - id: DEMOCI-05-003
-        priority: MUST
-        kind: project
-        statement: >-
-          The on-main run of demo-integration.yml MUST export its Docker image
-          layers to the `demo-integration-main` GitHub Actions cache scope so
-          that new PR branches read a warm fallback cache (per DEMOCI-02-007).
-          The dedicated demo-image-cache-warm.yml workflow, whose sole purpose
-          was to warm this cache on main, MUST be removed once the on-main demo
-          run performs the same cache export, to avoid a redundant second image
-          build on every qualifying push to main.
-        rationale: >-
-          Before this change, demo-integration.yml ran only on pull_request, so
-          a separate demo-image-cache-warm.yml existed purely to build the demo
-          images on main and populate the demo-integration-main cache scope for
-          new PR branches. Once demo-integration.yml itself runs on push to main
-          and writes that scope, a second cache-only build is pure waste. Folding
-          the cache export into the on-main run gives one build that both
-          validates the demo and warms the cache.
-        relationships:
-          - rel_type: refines
-            spec_id: DEMOCI-05-001
-          - rel_type: refines
-            spec_id: DEMOCI-02-007
 
       - id: DEMOCI-05-004
         priority: MUST

--- a/test/ci/README-case-log-ratchet.md
+++ b/test/ci/README-case-log-ratchet.md
@@ -1,8 +1,7 @@
-# Case-Log Invariant Ratchet Workflow
+# Case-Log Invariant Harness
 
-This document describes the ratchet workflow for the CI case-ledger invariant
-harness, satisfying AC-6 of issue
-[#925](https://github.com/CERTCC/Vultron/issues/925).
+This document describes the CI case-ledger invariant harness, satisfying AC-6
+of issue [#925](https://github.com/CERTCC/Vultron/issues/925).
 
 The harness is modular (issue [#1592](https://github.com/CERTCC/Vultron/issues/1592)):
 universal invariant check functions live in
@@ -22,12 +21,8 @@ universal invariant check functions live in
 
 Each scenario test file parses JSONL case-ledger replica files produced by
 the corresponding demo and asserts universal invariants (via `common.py`)
-plus scenario-specific checks. All invariants that are not yet passing are
-decorated with `pytest.mark.xfail` so the CI build stays green while fix
-PRs land one at a time.
-
-Each fix PR ratchets exactly one invariant from "expected failure" to
-"permanent regression guard" by removing its `xfail` decorator.
+plus scenario-specific checks. All invariants are currently passing — there
+are no active `xfail` markers.
 
 ---
 
@@ -55,10 +50,9 @@ to include in the regular unit-test run.
 
 ---
 
-## Invariant List and Status
+## Invariant Status
 
 Per-actor parametrized tests (1, 12–14) show status per actor role.
-`✅` = passing today, `⏳` = xfail (fix tracked in linked issue).
 
 | # | Description | case-actor | vendor | finder | Resolved by |
 |---|-------------|-----------|--------|--------|-------------|
@@ -80,28 +74,13 @@ Per-actor parametrized tests (1, 12–14) show status per actor role.
 
 ---
 
-## Ratchet: Flipping an xfail to Passing
+## CI Behavior (AC-5)
 
-When a fix PR lands that resolves one of the `xfail` invariants:
-
-1. **Identify the test function** — each test's docstring contains its
-   AC number (e.g., `AC-4.2`) and a note: "remove the `xfail` decorator
-   to make it a permanent regression guard."
-
-2. **Remove the `xfail` decorator** from that test function.
-
-3. **Run the harness** (with demo artifacts in place) to confirm the test
-   now passes:
-
-   ```bash
-   uv run pytest test/ci/invariants/ -v
-   ```
-
-4. **Commit the decorator removal** in the same PR as (or immediately
-   after) the fix, citing the issue number.
-
-5. **Update the table above** — change ⏳ xfail to ✅ passing and clear
-   the "Resolving issue" column.
+| Scenario | Outcome |
+|----------|---------|
+| Invariant passes | ✅ green |
+| Invariant **fails** | ❌ build fails |
+| No `devlogs/` present | ✅ green (all tests skipped) |
 
 ---
 
@@ -144,10 +123,7 @@ When a fix PR lands that resolves one of the `xfail` invariants:
        ...
    ```
 
-5. Add a row to the invariant table above.
-
-6. Run `uv run pytest test/ci/invariants/ -v` (with demo artifacts) to
-   confirm the new test appears with the expected `XFAIL` status.
+   Then add a row to the invariant status table above.
 
 ### Adding a new scenario
 
@@ -161,22 +137,6 @@ When a fix PR lands that resolves one of the `xfail` invariants:
 4. Add scenario-specific invariants below the universal section.
 
 5. Update the scenario table at the top of this document.
-
----
-
-## CI Behavior (AC-5)
-
-| Scenario | Outcome |
-|----------|---------|
-| Non-xfailed invariant passes | ✅ green |
-| Non-xfailed invariant **fails** | ❌ build fails |
-| xfailed invariant fails (expected) | ✅ green (reported as `XFAIL`) |
-| xfailed invariant passes unexpectedly | ✅ green but reported as `XPASS` |
-| No `devlogs/` present | ✅ green (all tests skipped) |
-
-The `strict=False` on every `xfail` decorator implements this: unexpected
-passes (`XPASS`) are visible in the CI report but do not cause a non-zero
-exit code.
 
 ---
 


### PR DESCRIPTION
- Closes #2244
- Closes #2245
- Closes #2248

## Summary

Three CI housekeeping fixes identified during the run-31619546349 investigation:
stale xfail documentation, a vendor container that could hang teardown indefinitely,
and dead buildx GHA cache configuration that has never worked.

## Changes

- **`.github/workflows/demo-integration.yml`**: Remove dead
  `cache-scope`/`cache-from-extra-scope` inputs from the Build Docker Images
  step (#2248). Fix `actions: write` comment (reason is `cancel-in-progress`,
  not cache). Change `Collect/Upload container-logs` from `if: failure()` to
  `if: failure() || cancelled()` so diagnostics survive a cancelled job
  (#2245). Add `--timeout 30` to `docker compose down` so a wedged container
  cannot consume the remaining job budget (#2245). Fix stale xfail comment in
  the invariant-harness step (#2244).

- **`.github/actions/build-demo-images/action.yml`**: Remove dead
  `cache-scope` and `cache-from-extra-scope` inputs and the corresponding
  `--set "*.cache-from/cache-to=type=gha"` bake args. Update description to
  remove reference to the deleted `demo-image-cache-warm.yml` workflow (#2244,
  #2248).

- **`test/ci/README-case-log-ratchet.md`**: Rewrite to reflect current state:
  all 15 invariants pass, no active xfail markers. Retain invariant status
  table and "Adding a New Invariant" how-to section (#2244).

- **`specs/demo-ci.yaml`**: Update DEMOCI-02-007 from MUST to SHOULD with
  rationale (GHA cache tokens unavailable in composite `run:` steps). Update
  DEMOCI-02-008 to require log upload on failure **or cancellation**. Remove
  DEMOCI-05-003 (cache-warming requirement, superseded). Clean stale cache
  references from DEMOCI-02-011 rationale. Bump version to 1.8.0.

- **`notes/demo-ci-invariants.md`**: Update cache section to document why the
  GHA cache was removed and what DEMOCI-02-007 now means.

## Verification

- Black, flake8, mypy, pyright clean
- markdownlint, spec-lint, actionlint all pass
- 6577 unit tests passed, 2 xfailed (pre-existing), 0 failures
- No Python changed; integration suite not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)