### PR TITLE
Re-express the legacy CS hypercube invariants against current models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,10 @@ six-step checklist (enum → pattern → use-case → map → tests).
 - **Inbox**: `vultron/adapters/driving/fastapi/routers/actors/` (package; `_routes.py` defines endpoints)
 - **Errors**: `vultron/errors.py`
 - **Demo**: `vultron/demo/cli.py` (entry point)
-- **Case States**: `vultron/case_states/` — enums are authoritative
+- **Case States**: `vultron/core/states/cs.py` — CS/VFD/PXA enums are
+  authoritative; `vultron/core/states/cs_invariants.py` holds the CS validity,
+  transition and history invariants (CSB-17). `vultron/core/case_states/` is the
+  legacy string-pattern reference model — do not import it in new code (ADR-0060)
 
 Full core-layer map → [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md).
 Full wire-layer map → [`vultron/wire/as2/AGENTS.md`](vultron/wire/as2/AGENTS.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,11 @@ six-step checklist (enum → pattern → use-case → map → tests).
 - **Case States**: `vultron/core/states/cs.py` — CS/VFD/PXA enums are
   authoritative; `vultron/core/states/cs_invariants.py` holds the CS validity,
   transition and history invariants (CSB-17). `vultron/core/case_states/` is the
-  legacy string-pattern reference model — do not import it in new code (ADR-0060)
+  legacy string-pattern reference model, retained as an independent oracle and
+  still imported by `states/cs.py` and `use_cases/query/action_rules.py`. Reach
+  for `cs_invariants.py` for new protocol-path work; the legacy module's only
+  remaining new-code use is as the oracle in the CSB-17 equivalence tests
+  (ADR-0060)
 
 Full core-layer map → [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md).
 Full wire-layer map → [`vultron/wire/as2/AGENTS.md`](vultron/wire/as2/AGENTS.md).
@@ -489,8 +493,7 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   and semantic-registry layers, and confirm against
   `graphify explain "<function>"` call edges, before asserting absence.
   CONCERN-2243 filed a Concern on this basis for an event emitted by all nine
-  scenarios.
-  See also ISSUE-1784 (tracking the script fix).
+  scenarios. *Source: CONCERN-2243*
 - **`git rebase` "local changes would be overwritten" With a Clean Working Tree**
   — this error can be a false positive when the rebased branch diverges far from
   main and both sides touched the same files. Fix: cherry-pick onto a fresh branch
@@ -498,7 +501,9 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   instead of rebasing. The error message is misleading — it is NOT evidence of
   uncommitted work. See also: single large-commit branches with 70+ files trigger a
   sequencer duplicate-pick bug; the cherry-pick workaround resolves both variants.
-  *Sources: ISSUE-1518, ISSUE-1504*
+  If `freshen-branch.sh` took this path and then hit a conflict, it can leave the
+  temp branch behind — delete it by hand (ISSUE-1784).
+  *Sources: ISSUE-1518, ISSUE-1504, ISSUE-1784*
 - **Verify Issue ACs Against Current Code Before Starting** — an issue may already
   be fully implemented by a prior PR that did not include a `Closes #N` footer.
   Check current `main` against all ACs before writing any code; if satisfied, close

--- a/docs/adr/0060-re-express-legacy-cs-invariants.md
+++ b/docs/adr/0060-re-express-legacy-cs-invariants.md
@@ -59,9 +59,9 @@ migration.
 - Cross-machine rules (RM/EM × CS emit guards) belong to #2236, not here.
 - `hypercube.py` pulls in networkx, numpy and pandas. Nothing on the protocol
   path should acquire that dependency weight.
-- The 500-line module guideline (CS-18-001): `cs.py` is already 673 lines, so
-  new code goes in a sibling module. `cs_invariants.py` itself lands over the
-  guideline too; it is kept whole deliberately, because the rule family is a
+- The 500-line module guideline (CS-18-001): `cs.py` is already over the
+  guideline, so new code goes in a sibling module. `cs_invariants.py` itself
+  lands over it too; it is kept whole deliberately, because the rule family is a
   single closed set of invariants whose only natural split — predicates apart
   from the tables they read — would put a rule and its enforcement in different
   files. Splitting is revisited if a second rule family lands here.
@@ -185,7 +185,7 @@ analytical model, which is genuinely useful and genuinely non-normative.
 
 ## Validation
 
-- `test/core/states/test_cs_invariants.py` (109 tests) — exhaustive equivalence
+- `test/core/states/test_cs_invariants.py` — exhaustive equivalence
   against the legacy implementation: the `CS` enum equals the legacy 32-state
   set; the new transition rule admits exactly the legacy 58 edges; the causal
   replay admits exactly the legacy 70 histories; and `is_valid_cs_history`

--- a/docs/adr/0060-re-express-legacy-cs-invariants.md
+++ b/docs/adr/0060-re-express-legacy-cs-invariants.md
@@ -1,0 +1,243 @@
+---
+status: accepted
+date: 2026-08-12
+deciders: Allen D. Householder
+consulted: []
+informed: []
+---
+
+# Re-express the Legacy Case-State Invariants and Keep the Hypercube as Reference
+
+## Context and Problem Statement
+
+`vultron/core/case_states/` is the original implementation of the MPCVD
+state-based model (CMU/SEI-2021-SR-021). It encodes the case-state (CS) rules as
+**six-character strings and regular expressions** — `"vfdpxa"`, `"v..P.."` —
+validated by `validations.py` and analysed by `hypercube.py` (a networkx /
+numpy / pandas model that enumerates states, transitions, histories, and scores
+them). The protocol implementation has since moved to typed enums (`CS`,
+`CS_vfd`, `CS_pxa`), `pytransitions` machines, and per-machine dimension objects
+(ADR-0036). The two worlds do not talk to each other.
+
+The legacy module holds rules the current models do not enforce anywhere. The
+most consequential is `is_valid_history`, which makes validity a **causal**
+property of an entire event sequence rather than a point-in-time state check or
+a wall-clock timestamp comparison — exactly what CONCERN #2181 asked for.
+`VFDPXA` and `VFDXAP` visit only valid states, yet only the first is a case
+history any real case could have produced; nothing in the current code can tell
+them apart.
+
+Two questions had to be settled together (issue #2237, which blocks #2236):
+
+1. Which legacy rules are still valid, which have been superseded, and which are
+   wrong — and how should the survivors be expressed against the current models?
+2. What is the legacy module's status: keep, retire, or archive?
+
+Answering (2) required first checking the issue's stated premise that the module
+is "completely orphaned". **It is not.** There are exactly two live importers
+outside its own tree:
+
+- `vultron/core/use_cases/query/action_rules.py` imports
+  `vultron.core.case_states.patterns.potential_actions.action`, reached from the
+  live `actors_get_action_rules` FastAPI endpoint.
+- `vultron/core/states/cs.py` imports `ensure_valid_state` from
+  `validations.py` and decorates four string helpers with it.
+
+The second is the load-bearing one: the *current* CS enum module depends on the
+*legacy* validator, so "retire the legacy module" is not a delete — it is a
+migration.
+
+## Decision Drivers
+
+- The rules, not the code, are the asset. The issue's own framing: treat
+  `case_states/` as the **specification of record**, and prefer a deliberate
+  line-by-line rewrite over `import and use`.
+- Re-expression must be provably faithful. A rewrite that silently admits a
+  different rule set is worse than no rewrite, because it looks authoritative.
+- Real case histories are usually **incomplete**; a rule family that only
+  validates all six events is not usable on live cases.
+- Cross-machine rules (RM/EM × CS emit guards) belong to #2236, not here.
+- `hypercube.py` pulls in networkx, numpy and pandas. Nothing on the protocol
+  path should acquire that dependency weight.
+- The 500-line module guideline (CS-18-001): `cs.py` is already 674 lines, so
+  new code goes in a sibling module.
+
+## Considered Options
+
+- **A. Import and delegate** — have the current models call
+  `validations.is_valid_transition` / `is_valid_history`, converting enums to
+  strings at the boundary.
+- **B. Re-express the surviving rules against the current enums; keep the legacy
+  module as the analytical model and as the test oracle.**
+- **C. Re-express and retire** — rewrite, then delete `validations.py` and
+  `hypercube.py` in this change.
+- **D. Archive the whole tree** — move `case_states/` out of `vultron/` to
+  `docs/` or a research repo, and rebuild any needed rule from the SEI report.
+
+## Decision Outcome
+
+Chosen option: **B — re-express the surviving rules in current idiom; keep the
+legacy module, demoted to reference model and test oracle.**
+
+### The rule inventory
+
+Every rule in `validations.py` and the graph construction in `hypercube.py` was
+assessed. No rule was found to be **wrong**; the verdicts split between *still
+valid* and *superseded by structure*.
+
+| Legacy rule | Verdict | Where it now lives |
+|---|---|---|
+| `is_valid_state`: `vF` and `fD` are impossible → 32 valid states | Still valid, but **structural** | `CS_vfd` has only 4 members, so the impossible combinations are unrepresentable. Expressed as a ratchet test, not a runtime predicate. CSB-17-001 |
+| `is_valid_transition`: Hamming distance 1 | Still valid, unenforced | `cs_transition_event()`, CSB-17-002 |
+| `is_valid_transition`: monotone (no UC→lc), same dimension | Still valid, partly enforced per-dimension | Delegated to `is_valid_vfd_transition` / `is_valid_pxa_transition`; compound-level check in `is_valid_cs_transition()`, CSB-17-002 |
+| `TRANSITION_RULES[1]`: `...pX. → ...PX.` | Still valid | `required_next_cs_events()`. Partly covered by CSB-13-001 (entry cascade); CSB-17-003 generalises it to every successor of a `pX` state |
+| `TRANSITION_RULES[0]`: `v..P.. → V..P..` | Still valid, covered **nowhere** before this change | `required_next_cs_events()`, CSB-17-003 |
+| `is_valid_history`: causal event ordering (`V≺F≺D`, `P≺X`/`XP`, `V≺P`/`PV`) | Still valid — **the most valuable rule in the module** | `is_valid_cs_history()` / `is_valid_cs_history_prefix()` / `replay_cs_history()`, CSB-17-004 |
+| `is_valid_pattern` and the whole `.`-wildcard regex pattern language | **Superseded** | Enum membership tuples (`VFD_VENDOR_AWARE`, `PXA_EXPLOIT_PUBLIC`, …) and the `is_*` predicates already do this, type-safely |
+| `hypercube.py` scoring, tf-idf, pagerank, `DESIDERATA`, adjacency matrices | Out of scope — analytical, not normative | Stays in `hypercube.py`; no protocol path needs it |
+
+The survivors are implemented in `vultron/core/states/cs_invariants.py` as
+CSB-17, raising the current-idiom errors (`VultronInvalidStateTransitionError`,
+`VultronValidationError`) rather than the legacy `CvdStateModelError` tree.
+
+### Two re-expression choices worth recording
+
+**Transitions delegate to the dimension machines instead of re-deriving
+monotonicity.** `is_valid_cs_transition` identifies the single changed dimension
+and hands the check to `is_valid_vfd_transition` / `is_valid_pxa_transition` —
+the same tables `VfdDimension` / `PxaDimension` use. Monotonicity and the VFD
+prerequisite chain then come for free and, more importantly, **cannot drift**
+from what the dimension objects enforce. Only the two ephemeral rules are
+genuinely new logic at the compound level.
+
+**History validity is expressed as causal replay, not as ordering predicates.**
+The legacy formulation compares permutation indices; the re-expression replays
+the sequence through the transition rule from `CS.vfdpxa`. The two are provably
+equivalent — for a permutation of `VFDPXA`, replay succeeds iff `V≺F`, `F≺D`,
+`index(P)−index(X) ≤ 1`, and `index(V)−index(P) ≤ 1`, and the two ephemeral
+rules can never be active simultaneously (one needs `P` set, the other needs it
+unset). Replay was chosen because it **generalises to prefixes**: real cases are
+in progress, and `is_valid_cs_history_prefix` validates what has happened so far
+without demanding all six events. The index-comparison formulation cannot do
+that. The equivalence is asserted directly in the tests, so the two formulations
+cannot silently diverge.
+
+### The legacy module's status: keep, demoted
+
+`validations.py` and `hypercube.py` are **retained**, with a changed role:
+
+- **Not** on the protocol path. `cs_invariants.py` is the runtime source of
+  truth for CS validity. New code MUST NOT import `case_states.validations`.
+- **Reference model.** `hypercube.py` remains the derivation of the 32/58/70
+  figures and the home of the analytical tooling (scoring, desiderata, pagerank)
+  that has no protocol counterpart and no reason to acquire one.
+- **Test oracle.** `test/core/states/test_cs_invariants.py` compares the new
+  implementation against the legacy string implementation over the whole space —
+  64 candidate states, 32×32 candidate transitions, all 720 permutations. This
+  is the strongest available evidence that the rewrite is faithful, and it only
+  works while both implementations exist.
+
+Retirement is therefore **deliberately deferred, not forgotten**, and is gated on
+two migrations that are out of scope here:
+
+1. `vultron/core/states/cs.py` must stop importing `ensure_valid_state`. Its four
+   decorated string helpers (`vfd`, `pxa`, `state_string_to_enums`,
+   `state_string_to_enum2`) need an enum-native validator.
+2. `vultron/core/use_cases/query/action_rules.py` must stop importing
+   `case_states.patterns.potential_actions` — which raises the separate question
+   of whether the `actors_get_action_rules` endpoint should be served from the
+   pattern language at all.
+
+Option A was rejected because it would make the enum models depend on
+string-and-regex validation permanently, and would let the legacy error tree leak
+into protocol paths — the opposite of the issue's explicit instruction to prefer
+rewriting. Option C was rejected because deleting the legacy module in the same
+change that rewrites it destroys the only independent oracle proving the rewrite
+correct, and because two live importers make it a migration rather than a
+deletion. Option D was rejected for the same reason plus the loss of the
+analytical model, which is genuinely useful and genuinely non-normative.
+
+### Consequences
+
+- Good: the `vP → VP` rule is now enforceable for the first time; it existed
+  only in the legacy module and was covered by no spec.
+- Good: history validity is available as a causal check on complete *and*
+  partial histories, which is what CONCERN #2181 needs.
+- Good: compound-transition validity cannot drift from the dimension objects,
+  because it delegates to their tables rather than re-deriving them.
+- Good: the equivalence tests fail loudly if either implementation changes,
+  making the legacy module useful precisely as long as it is still present.
+- Neutral: two implementations of the same rules coexist. Acceptable because one
+  is explicitly non-normative and the tests pin them together.
+- Neutral: `cs_invariants.py` is a library, not an enforcement point. Wiring it
+  into emit/BT paths is #2236's job; nothing calls it on the protocol path yet.
+- Bad: the retirement of `case_states/` is now a recorded intention with two
+  named prerequisites rather than a completed act, so it can still rot if those
+  prerequisites are not tracked.
+
+## Validation
+
+- `test/core/states/test_cs_invariants.py` (92 tests) — exhaustive equivalence
+  against the legacy implementation: the `CS` enum equals the legacy 32-state
+  set; the new transition rule admits exactly the legacy 58 edges; the causal
+  replay admits exactly the legacy 70 histories; and `is_valid_cs_history`
+  agrees with the legacy result on all 720 permutations.
+- Ephemeral-state coverage: the 12 `vP`/`pX` states are identified
+  independently of the predicate under test, and each is asserted to have
+  exactly one valid successor.
+- Prefix coverage: every prefix of every valid history validates, and the
+  causally impossible prefixes (`F` first, `XA`, `PA`) are rejected.
+
+## Pros and Cons of the Options
+
+### A. Import and delegate to the legacy validators
+
+- Good, because it is the smallest change and cannot diverge from the legacy
+  rules by construction.
+- Bad, because it makes the enum models permanently depend on string/regex
+  validation and on the legacy `CvdStateModelError` tree.
+- Bad, because it cannot express prefix validity — `is_valid_history` requires
+  all six events, so live in-progress cases remain unvalidatable.
+- Bad, because it contradicts the issue's explicit preference for a deliberate
+  rewrite over `import and use`.
+
+### B. Re-express; keep the legacy module as reference and oracle
+
+- Good, because the current models gain the rules in their own idiom, with their
+  own errors and their own types.
+- Good, because the legacy implementation becomes an independent oracle that
+  proves the rewrite faithful over the entire state space.
+- Good, because replay-based history validity generalises to prefixes.
+- Neutral, because two implementations coexist until the migration completes.
+- Bad, because retirement becomes a tracked intention rather than a done deed.
+
+### C. Re-express and retire the legacy module now
+
+- Good, because it leaves exactly one implementation of the rules.
+- Bad, because it destroys the only independent evidence that the rewrite is
+  correct, at the moment that evidence is most needed.
+- Bad, because two live importers make this a migration; `cs.py` itself depends
+  on `validations.ensure_valid_state`.
+- Bad, because it would discard the analytical model (scoring, desiderata,
+  pagerank) that has no current-idiom replacement and needs none.
+
+### D. Archive the whole `case_states/` tree out of `vultron/`
+
+- Good, because it makes the non-normative status unmistakable.
+- Bad, because it has all of C's problems plus the loss of the existing
+  `test/core/case_states/` suite.
+- Bad, because the `actors_get_action_rules` endpoint would break immediately.
+
+## More Information
+
+The "completely orphaned" premise in issue #2237 is incorrect and the correction
+matters for the decision — see `plan/incoming/learnings/`. Cross-machine
+(RM/EM × CS) emit-guard enforcement is #2236, which this issue blocks.
+
+Source model: Householder, A. D., and Spring, J. *A State-Based Model for
+Multi-Party Coordinated Vulnerability Disclosure (MPCVD)*, CMU/SEI-2021-SR-021,
+<https://doi.org/10.1184/R1/16416771>.
+
+Generated spec requirements: `cs-behavior.yaml` CSB-17-001 through CSB-17-004.
+Related: ADR-0036 (dimension objects), CSB-13-001 (pX→PX entry cascade),
+CSB-16-001/002 (write-boundary transition validation).

--- a/docs/adr/0060-re-express-legacy-cs-invariants.md
+++ b/docs/adr/0060-re-express-legacy-cs-invariants.md
@@ -59,8 +59,12 @@ migration.
 - Cross-machine rules (RM/EM × CS emit guards) belong to #2236, not here.
 - `hypercube.py` pulls in networkx, numpy and pandas. Nothing on the protocol
   path should acquire that dependency weight.
-- The 500-line module guideline (CS-18-001): `cs.py` is already 674 lines, so
-  new code goes in a sibling module.
+- The 500-line module guideline (CS-18-001): `cs.py` is already 673 lines, so
+  new code goes in a sibling module. `cs_invariants.py` itself lands over the
+  guideline too; it is kept whole deliberately, because the rule family is a
+  single closed set of invariants whose only natural split — predicates apart
+  from the tables they read — would put a rule and its enforcement in different
+  files. Splitting is revisited if a second rule family lands here.
 
 ## Considered Options
 
@@ -91,7 +95,7 @@ valid* and *superseded by structure*.
 | `is_valid_transition`: Hamming distance 1 | Still valid, unenforced | `cs_transition_event()`, CSB-17-002 |
 | `is_valid_transition`: monotone (no UC→lc), same dimension | Still valid, partly enforced per-dimension | Delegated to `is_valid_vfd_transition` / `is_valid_pxa_transition`; compound-level check in `is_valid_cs_transition()`, CSB-17-002 |
 | `TRANSITION_RULES[1]`: `...pX. → ...PX.` | Still valid | `required_next_cs_events()`. Partly covered by CSB-13-001 (entry cascade); CSB-17-003 generalises it to every successor of a `pX` state |
-| `TRANSITION_RULES[0]`: `v..P.. → V..P..` | Still valid, covered **nowhere** before this change | `required_next_cs_events()`, CSB-17-003 |
+| `TRANSITION_RULES[0]`: `v..P.. → V..P..` | Still valid, asserted by SM-09-001 as a persistence-time normalization but with no CS-behavior rule of its own | `required_next_cs_events()`, CSB-17-003, which `refines` SM-09-001 by restating it as a trajectory rule |
 | `is_valid_history`: causal event ordering (`V≺F≺D`, `P≺X`/`XP`, `V≺P`/`PV`) | Still valid — **the most valuable rule in the module** | `is_valid_cs_history()` / `is_valid_cs_history_prefix()` / `replay_cs_history()`, CSB-17-004 |
 | `is_valid_pattern` and the whole `.`-wildcard regex pattern language | **Superseded** | Enum membership tuples (`VFD_VENDOR_AWARE`, `PXA_EXPLOIT_PUBLIC`, …) and the `is_*` predicates already do this, type-safely |
 | `hypercube.py` scoring, tf-idf, pagerank, `DESIDERATA`, adjacency matrices | Out of scope — analytical, not normative | Stays in `hypercube.py`; no protocol path needs it |
@@ -159,8 +163,12 @@ analytical model, which is genuinely useful and genuinely non-normative.
 
 ### Consequences
 
-- Good: the `vP → VP` rule is now enforceable for the first time; it existed
-  only in the legacy module and was covered by no spec.
+- Good: the `vP → VP` rule is now enforceable against the current enums for the
+  first time. SM-09-001 already required it, but only at the persistence
+  boundary and only with the legacy string-pattern module as its implementation;
+  CSB-17-003 gives it a CS-behavior expression, and CSB-17-005 settles what it
+  means for an in-progress history (a prefix may end in `vP`; a persisted state
+  may not be `vP`).
 - Good: history validity is available as a causal check on complete *and*
   partial histories, which is what CONCERN #2181 needs.
 - Good: compound-transition validity cannot drift from the dimension objects,
@@ -177,7 +185,7 @@ analytical model, which is genuinely useful and genuinely non-normative.
 
 ## Validation
 
-- `test/core/states/test_cs_invariants.py` (92 tests) — exhaustive equivalence
+- `test/core/states/test_cs_invariants.py` (109 tests) — exhaustive equivalence
   against the legacy implementation: the `CS` enum equals the legacy 32-state
   set; the new transition rule admits exactly the legacy 58 edges; the causal
   replay admits exactly the legacy 70 histories; and `is_valid_cs_history`
@@ -186,7 +194,13 @@ analytical model, which is genuinely useful and genuinely non-normative.
   independently of the predicate under test, and each is asserted to have
   exactly one valid successor.
 - Prefix coverage: every prefix of every valid history validates, and the
-  causally impossible prefixes (`F` first, `XA`, `PA`) are rejected.
+  causally impossible prefixes (`F` first, `XA`, `PA`) are rejected. The
+  converse is pinned too — the accepted set is exactly the prefix-closure of
+  the 70 valid histories, so no accepted prefix is a dead end (CSB-17-005).
+- Input coercion: because `CSEvent` is a `StrEnum`, the single-letter strings of
+  the legacy API are accepted on every entry point and produce identical
+  verdicts; the bool-returning predicates answer `False` for non-events rather
+  than raising.
 
 ## Pros and Cons of the Options
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -129,6 +129,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0057 Rename `CVDRole.OTHER` to `CVDRole.OBSERVER` and Define Observer Participant Semantics](0057-observer-participant-role.md)
 - [ADR-0058 Gate Demo Scenario Steps on Causal Preconditions, Not Temporal Order](0058-causal-gating-in-demo-scenarios.md) *(provisional)*
 - [ADR-0059 Buffer Pre-Genesis `Announce(CaseLedgerEntry)` and Drain on Case Seed](0059-buffer-pre-genesis-ledger-entries.md)
+- [ADR-0060 Re-express the Legacy Case-State Invariants and Keep the Hypercube as Reference](0060-re-express-legacy-cs-invariants.md)
 
 ## Proposed ADRs
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -49,7 +49,9 @@ The **Case State (CS)** tracks awareness and readiness across six binary dimensi
 | **A/a** | **A** | **a** | Active attacks have been observed / not observed |
 
 Each transition from lowercase to uppercase represents an event; once uppercase,
-it cannot revert. This forms a 64-state lattice (2^6 combinations).
+it cannot revert. The 2^6 combinations give a 64-state lattice, of which only
+**32 are reachable**: `vF*` (fix ready, vendor unaware) and `*fD*` (fix deployed,
+fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 
 ---
 
@@ -210,7 +212,7 @@ it cannot revert. This forms a 64-state lattice (2^6 combinations).
    - The **Case State (CS)** — the six-dimensional VfDpxa lattice model
    - A **Case Status** — a snapshot of CS, RM, and EM at one moment
    - An RM or EM state — a specific state machine location
-   - **Recommendation**: Prefer precise terms. Use "Case State" for the 64-node lattice; "Case Status" for a snapshot; "RM state" or "EM state" for a specific state machine location.
+   - **Recommendation**: Prefer precise terms. Use "Case State" for the lattice (64 combinations, 32 reachable); "Case Status" for a snapshot; "RM state" or "EM state" for a specific state machine location.
 
 2. **"Participant" vs. "Actor"**:
    - An **Actor** is any URI-identified federated peer (a role in the protocol).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -277,6 +277,7 @@ nav:
       - Rename CVDRole.OTHER to CVDRole.OBSERVER and Define Observer Participant Semantics: 'adr/0057-observer-participant-role.md'
       - Gate Demo Scenario Steps on Causal Preconditions, Not Temporal Order: 'adr/0058-causal-gating-in-demo-scenarios.md'
       - Buffer Pre-Genesis Announce(CaseLedgerEntry) and Drain on Case Seed: 'adr/0059-buffer-pre-genesis-ledger-entries.md'
+      - Re-express the Legacy Case-State Invariants and Keep the Hypercube as Reference: 'adr/0060-re-express-legacy-cs-invariants.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -122,8 +122,8 @@ verdicts split between *still valid* and *superseded by structure*.
 | `is_valid_transition`: Hamming distance 1 | Still valid | `cs_transition_event()`, CSB-17-002 |
 | `is_valid_transition`: monotone, same dimension | Still valid | Delegated to `is_valid_vfd_transition` / `is_valid_pxa_transition`; compound check in `is_valid_cs_transition()`, CSB-17-002 |
 | `TRANSITION_RULES`: `...pX. → ...PX.` | Still valid | `required_next_cs_events()`; generalises CSB-13-001 from the entry cascade to every `pX` successor. CSB-17-003 |
-| `TRANSITION_RULES`: `v..P.. → V..P..` | Still valid, previously enforced **nowhere** | `required_next_cs_events()`, CSB-17-003 |
-| `is_valid_history`: `V≺F≺D`, `P≺X`/`XP`, `V≺P`/`PV` | Still valid — the most valuable rule in the module | `is_valid_cs_history()`, `is_valid_cs_history_prefix()`, `replay_cs_history()`, CSB-17-004 |
+| `TRANSITION_RULES`: `v..P.. → V..P..` | Still valid; SM-09-001 already required it at the persistence boundary, with only the legacy module implementing it | `required_next_cs_events()`, CSB-17-003 (which `refines` SM-09-001) |
+| `is_valid_history`: `V≺F≺D`, `P≺X`/`XP`, `V≺P`/`PV` | Still valid — the most valuable rule in the module | `is_valid_cs_history()`, `is_valid_cs_history_prefix()`, `replay_cs_history()`, CSB-17-004 (complete) and CSB-17-005 (prefixes) |
 | `is_valid_pattern` and the `.`-wildcard pattern language | **Superseded** | Enum membership tuples (`VFD_VENDOR_AWARE`, `PXA_EXPLOIT_PUBLIC`, …) plus the `is_*` predicates |
 | `hypercube.py` scoring, tf-idf, pagerank, `DESIDERATA` | Analytical, not normative | Stays in `hypercube.py`; no protocol path needs it |
 

--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -30,14 +30,25 @@ whether a key event has occurred:
 | `X/x`  | Exploit is public (`X`) or not public (`x`) |
 | `A/a`  | Attacks have been observed (`A`) or not (`a`) |
 
-The state space forms a 2^6 = 64-node hypercube. Valid transitions move from
-lowercase to uppercase (events cannot be undone). This model is the
-authoritative definition of the "Case State" (CS) dimension in the
+Six binary dimensions give 2^6 = 64 combinations, but **only 32 are valid
+states**: the VFD dimension is a linear chain, not three free bits, so a fix
+cannot be ready while the vendor is unaware (`vF`) and cannot be deployed if it
+was never ready (`fD`). Valid transitions move from lowercase to uppercase
+(events cannot be undone), one dimension at a time; there are exactly **58 valid
+transitions** and **70 valid complete histories** (of 720 orderings). This model
+is the authoritative definition of the "Case State" (CS) dimension in the
 RM/EM/CS state machine triad.
 
-**Implementation**: `vultron/case_states/states.py` — enums `VendorAwareness`,
+**Implementation**: `vultron/core/states/cs.py` — enums `VendorAwareness`,
 `FixReadiness`, `FixDeployment`, `PublicAwareness`, `ExploitPublication`,
-`AttackObservation`, plus `VFDstate` and `PXAstate` named tuples.
+`AttackObservation`, plus the `VfdState` / `PxaState` named tuples and the
+`CS_vfd` (4 members), `CS_pxa` (8) and `CS` (32) enums. The 32-member `CS` enum
+is where the two impossible-combination rules live: they are unrepresentable
+rather than rejected at runtime.
+
+**Invariants**: `vultron/core/states/cs_invariants.py` — compound transition
+validity, the two ephemeral-state rules, and causal history validity. See the
+rule inventory below and CSB-17 / ADR-0060.
 
 **Reference paper**: [A State-Based Model for Multi-Party Coordinated
 Vulnerability Disclosure](https://doi.org/10.1184/R1/16416771), CMU/SEI-2021-SR-021.
@@ -46,9 +57,9 @@ Vulnerability Disclosure](https://doi.org/10.1184/R1/16416771), CMU/SEI-2021-SR-
 
 ## Hypercube Graph Implementation
 
-`vultron/case_states/hypercube.py` implements the `CVDmodel` class, which:
+`vultron/core/case_states/hypercube.py` implements the `CVDmodel` class, which:
 
-- Builds the 64-state DAG (directed acyclic graph) of all possible
+- Builds the 32-state DAG (directed acyclic graph) of all 58 valid
   transitions using NetworkX.
 - Implements random walks through the state space for simulation.
 - Provides scoring functions to measure the "quality" of a CVD case history.
@@ -63,11 +74,17 @@ The `CVDmodel` can be used to:
 
 **Dependencies**: `networkx`, `numpy`, `pandas`.
 
+**Status (ADR-0060)**: `vultron/core/case_states/` is a **reference model, not a
+protocol path**. It is the specification of record for the CS rules and the
+oracle the `cs_invariants.py` tests compare against, but new code MUST NOT
+import `case_states.validations` — use `vultron/core/states/cs_invariants.py`.
+See "Rule Inventory and Legacy Module Status" below.
+
 ---
 
 ## Potential Actions per Case State
 
-`vultron/case_states/patterns/potential_actions.py` maps 6-character state
+`vultron/core/case_states/patterns/potential_actions.py` maps 6-character state
 patterns (e.g., `"...P.."`, `"VfdpX."`) to `Actions` enum values — things a
 participant COULD do when the case is in a given state.
 
@@ -88,6 +105,61 @@ useful for:
 
 The corresponding documentation is in `docs/reference/case_states/*.md` — one
 file per case state, each listing available actions and context.
+
+---
+
+## Rule Inventory and Legacy Module Status
+
+The legacy `vultron/core/case_states/` tree encodes the CS rules as
+six-character strings and regexes. Issue #2237 assessed each rule and
+re-expressed the survivors against the current enums in
+`vultron/core/states/cs_invariants.py`. No rule was found to be *wrong*; the
+verdicts split between *still valid* and *superseded by structure*.
+
+| Legacy rule (`validations.py`) | Verdict | Current expression |
+|---|---|---|
+| `is_valid_state`: `vF` / `fD` impossible → 32 states | Still valid, **structural** | `CS_vfd` has 4 members, so the combinations are unrepresentable. Ratchet test, not a runtime predicate. CSB-17-001 |
+| `is_valid_transition`: Hamming distance 1 | Still valid | `cs_transition_event()`, CSB-17-002 |
+| `is_valid_transition`: monotone, same dimension | Still valid | Delegated to `is_valid_vfd_transition` / `is_valid_pxa_transition`; compound check in `is_valid_cs_transition()`, CSB-17-002 |
+| `TRANSITION_RULES`: `...pX. → ...PX.` | Still valid | `required_next_cs_events()`; generalises CSB-13-001 from the entry cascade to every `pX` successor. CSB-17-003 |
+| `TRANSITION_RULES`: `v..P.. → V..P..` | Still valid, previously enforced **nowhere** | `required_next_cs_events()`, CSB-17-003 |
+| `is_valid_history`: `V≺F≺D`, `P≺X`/`XP`, `V≺P`/`PV` | Still valid — the most valuable rule in the module | `is_valid_cs_history()`, `is_valid_cs_history_prefix()`, `replay_cs_history()`, CSB-17-004 |
+| `is_valid_pattern` and the `.`-wildcard pattern language | **Superseded** | Enum membership tuples (`VFD_VENDOR_AWARE`, `PXA_EXPLOIT_PUBLIC`, …) plus the `is_*` predicates |
+| `hypercube.py` scoring, tf-idf, pagerank, `DESIDERATA` | Analytical, not normative | Stays in `hypercube.py`; no protocol path needs it |
+
+Two re-expression choices worth knowing:
+
+- **Transitions delegate to the dimension machines** rather than re-deriving
+  monotonicity, so compound-level validity cannot drift from what
+  `VfdDimension` / `PxaDimension` enforce. Only the two ephemeral rules are new
+  logic at the compound level.
+- **History validity is causal replay, not index comparison.** Replaying the
+  event sequence from `CS.vfdpxa` is provably equivalent to the legacy ordering
+  predicates (the tests assert this over all 720 permutations) but also
+  generalises to **prefixes** — which matters because real cases are usually
+  still in progress. Use `is_valid_cs_history_prefix()` for live cases;
+  `is_valid_cs_history()` requires all six events.
+
+**Ephemeral states.** Twelve of the 32 compound states are ephemeral: the six
+`vP` states (public aware, vendor unaware → next event MUST be `V`) and the six
+`pX` states (exploit public, public unaware → next event MUST be `P`). The two
+conditions are mutually exclusive, so each ephemeral state has exactly one valid
+successor.
+
+**Legacy module status: keep, demoted (ADR-0060).** `validations.py` and
+`hypercube.py` are retained as the reference model and as the test oracle that
+proves the re-expression faithful over the whole state space. Retirement is
+deliberately deferred and gated on two migrations:
+
+1. `vultron/core/states/cs.py` must stop importing
+   `case_states.validations.ensure_valid_state` (four decorated string helpers
+   need an enum-native validator).
+2. `vultron/core/use_cases/query/action_rules.py` must stop importing
+   `case_states.patterns.potential_actions` — which is also the live
+   `actors_get_action_rules` endpoint's only source.
+
+Note that `cs_invariants.py` is a **library, not an enforcement point**. Wiring
+it into the emit / BT paths is issue #2236's scope.
 
 ---
 
@@ -216,7 +288,7 @@ Not all participants have a VFD state:
 - **Non-Vendor Deployers**: Have `vfd_state` only for the `d → D` transition.
 - **Finders, Reporters, Coordinators**: Do NOT have VFD state. Use the null
   element `∅` (represented as `CS_vfd.vfd` but semantically "not applicable"
-  for non-vendors — see `vultron/case_states/states.py`).
+  for non-vendors — see `vultron/core/states/cs.py`).
 
 ### Consequence for Handler Implementation
 

--- a/notes/codebase-structure.md
+++ b/notes/codebase-structure.md
@@ -50,14 +50,19 @@ Enums are currently organized across multiple locations in the codebase:
 - `vultron/enums/` — bottom-of-stack neutral enumeration layer (`CVDRole`,
   `serialize_roles`, `validate_roles`; MUST NOT import from `vultron/core/`
   or `vultron/config/`); see `docs/adr/0031-vultron-enums-neutral-layer.md`
-- `vultron/case_states/enums/` — case state enums, split into submodules:
-  - `cvss_31.py`
+- `vultron/core/states/` — the authoritative CS/RM/EM/PEC state enums
+  (`cs.py`, `rm.py`, `em.py`, `participant_embargo_consent.py`) plus
+  `cs_invariants.py` (CS validity/history rules)
+- `vultron/core/case_states/patterns/` — legacy case-state *pattern* tables,
+  keyed by 6-character state patterns rather than enums; reference model only,
+  see ADR-0060:
+  - `base.py`
+  - `cvss31.py`
   - `embargo.py`
   - `explanations.py`
   - `info.py`
   - `potential_actions.py`
-  - `ssvc_2.py`
-  - `utils.py`
+  - `ssvc.py`
   - `vep.py`
   - `zerodays.py`
 - `vultron/wire/as2/vocab/` — vocabulary-level type enums (moved from
@@ -71,14 +76,14 @@ so that enums are easy to find and manage. For example:
   `events.py` base)
 - `vultron/core/models/enums/` — enums shared across core models (e.g.,
   `CVDRole`, state machine enums migrated from `vultron/bt` and
-  `vultron/case_states`)
+  `vultron/core/case_states`)
 - `vultron/wire/as2/enums.py` — AS2 structural enums (already in place)
 
 Enums imported from outside `core` that are used in `core` are candidates
 for relocation into `core` (refactoring from their original location as
 needed). In particular:
 
-- Enums in `vultron/bt/` and `vultron/case_states/` that represent domain
+- Enums in `vultron/bt/` and `vultron/core/case_states/` that represent domain
   concepts (not BT-engine internals) SHOULD migrate to `core/models/enums/`.
 - If a given area has many enums, split them into an `enums/` subpackage
   with multiple files rather than one large `enums.py`.

--- a/notes/documentation-strategy.md
+++ b/notes/documentation-strategy.md
@@ -38,14 +38,15 @@ with the ActivityStreams adoption.
 
 ### Generation 2: State-based model and simulation
 
-**Files**: `vultron/case_states/**/*.py`, `vultron/bt/**/*.py`
+**Files**: `vultron/core/case_states/**/*.py`, `vultron/core/states/**/*.py`,
+`vultron/bt/**/*.py`
 (including `vultron/bt/base/demo/cvd.py`)
 
 These were some of the earliest Python implementations, based on:
 
 - [*A State-Based Model for Coordinated Vulnerability Disclosure*](
   https://www.sei.cmu.edu/documents/1952/2021_003_001_737890.pdf)
-  (CMU/SEI-2021-SR-021) — basis for `vultron/case_states/hypercube.py` and
+  (CMU/SEI-2021-SR-021) — basis for `vultron/core/case_states/hypercube.py` and
   the VFD/PXA state machines.
 - [*Designing Vultron*](
   https://www.sei.cmu.edu/documents/1954/2022_003_001_887202.pdf)
@@ -98,7 +99,7 @@ Update the documentation to match the enum, never the reverse (unless the
 enum itself is explicitly identified as a bug by a maintainer). Canonical
 enum files: `vultron/bt/report_management/states.py` (RM),
 `vultron/bt/embargo_management/states.py` (EM),
-`vultron/case_states/states.py` (CS/VFD/PXA).
+`vultron/core/states/cs.py` (CS/VFD/PXA).
 
 ---
 

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -115,7 +115,22 @@ No open entries.
 | `fcvcv Invariant Harness` | #2233 | 2026-08-13 |
 | `fcv-reject Invariant Harness` | #2233 | 2026-08-13 |
 | `fv Invariant Harness` | #2233 | 2026-08-13 |
+| `fv Demo Integration` | — | 2026-08-13 |
 
+> `fv Demo Integration` is a different animal from the #2233 rows below it, and
+> from the async-race rows above. It passed at `dc31b6c6` and failed at
+> `0b607c11` — a docs-only diff — while base `fe951d00` does not fail it at all,
+> so the trigger is genuinely intermittent. But the *failure* is deterministic
+> once triggered: `add-note-to-case` returns an intermittent 422, and
+> `vultron/demo/helpers/notes.py:92` then reads `result` outside the
+> `with demo_step(...)` block that assigned it. `demo_step` suppresses the
+> exception, so control falls through and raises
+> `UnboundLocalError: cannot access local variable 'result'`, which buries the
+> real 422 under a traceback pointing at the wrong line. Pre-existing base code
+> (last touched by #1387, #543), unrelated to #2279's ledger-dump change —
+> though that path throws its own secondary error at `ledger_dump.py:434` in the
+> same run.
+>
 > The rows with no issue number fail intermittently due to inter-container HTTP
 > delivery timeouts (async race windows). Root cause documented in
 > `plan/incoming/learnings/` entry `20260731-async-race-windows-in-fv-demo.md`.

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -90,7 +90,9 @@ No open entries.
 > followed the `pytest-randomly` seed.
 >
 > **Fixed by #2270** — `test/conftest.py` now gives `integration`-marked tests a
-> 60s tier while the unit suite keeps 5s. Verified 2/2 random-order runs at
+> 60s tier while the unit suite runs at 30s (raised from 5s in the same issue,
+> because AST-walking ratchets at ~3.4s were tripping the old ceiling under
+> full-suite load). Verified 2/2 random-order runs at
 > exit 0, 0 timeout aborts, 1101 passed. Never catalogued as flaky; rows added
 > and removed in the same change (2026-08-12).
 >
@@ -107,17 +109,25 @@ No open entries.
 |---|---|---|
 | `fvcv-extension` | — | 2026-07-31 |
 | `fccv-extension` | — | 2026-07-31 |
-| `fcvcv Demo Integration` | #2216 | 2026-08-12 |
-| `fvcv-handoff Demo Integration` | #2216 | 2026-08-12 |
-| `fvcv-handoff Invariant Harness` | #2216 | 2026-08-12 |
+| `fcvcv Demo Integration` | #2233 | 2026-08-13 |
+| `fvcv-handoff Demo Integration` | #2233 | 2026-08-13 |
+| `fvcv-handoff Invariant Harness` | #2266 | 2026-08-13 |
 | `fcvcv Invariant Harness` | — | 2026-08-10 |
-| `fcv-reject Invariant Harness` | #2121 | 2026-08-10 |
+| `fcv-reject Invariant Harness` | #2121 (closed) | 2026-08-10 |
 
-> These jobs fail intermittently due to inter-container HTTP delivery timeouts
-> (async race windows). Root cause documented in `plan/incoming/learnings/`
-> entry `20260731-async-race-windows-in-fv-demo.md`. When a new occurrence is
-> confirmed, `pr-execute` will open or comment on a `flaky-test` + `bug` issue
-> and record it here.
+> The rows with no issue number fail intermittently due to inter-container HTTP
+> delivery timeouts (async race windows). Root cause documented in
+> `plan/incoming/learnings/` entry `20260731-async-race-windows-in-fv-demo.md`.
+> When a new occurrence is confirmed, `pr-execute` will open or comment on a
+> `flaky-test` + `bug` issue and record it here.
+>
+> The three rows citing #2233 / #2266 are **not** flaky — they are deterministic
+> and branch-independent. `engage-case` returns HTTP 422 on the invite path
+> (`SvcEngageCaseUseCase failed: TransitionParticipantRMtoAccepted`), tracked as
+> #2233; the harness row is the assertion-scope gap tracked as #2266. They are
+> listed here because `pr-execute` records blocked jobs here regardless of
+> cause, and because #2216 — the issue they used to cite — is closed and no
+> longer the right pointer. Do not re-diagnose them as nondeterminism.
 
 ---
 

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -75,6 +75,32 @@ and fall through to Level 2 (GitHub label search).
 
 ---
 
+## Integration-Marker Tests (pytest node IDs)
+
+No open entries.
+
+> Note: `test/demo/test_pcr_late_joiner.py::test_late_joiner_receives_case_replica`
+> and `test/metadata/test_decision_audit_inventory.py` were **not flaky tests** —
+> they were honest 3.5-4.3s tests colliding with a 5s ceiling sized for the unit
+> suite. Because `timeout_method = "thread"` kills the whole pytest process,
+> `uv run pytest -m integration` aborted with **no summary line**, so a red
+> integration run carried no information about the branch. Reliably red in random
+> order (2/2 on clean `origin/main` 65fe33f1b); passed under `-p no:randomly`,
+> which is what made it look like nondeterminism. Only *which* test tripped
+> followed the `pytest-randomly` seed.
+>
+> **Fixed by #2270** — `test/conftest.py` now gives `integration`-marked tests a
+> 60s tier while the unit suite keeps 5s. Verified 2/2 random-order runs at
+> exit 0, 0 timeout aborts, 1101 passed. Never catalogued as flaky; rows added
+> and removed in the same change (2026-08-12).
+>
+> **Lesson**: before adding a row here, ask whether the test is nondeterministic
+> or whether the *ceiling* is wrong. A timeout tuned for one tier of tests will
+> masquerade as flakiness in another. See also #2249 for the opposite error —
+> cataloguing a deterministic protocol bug as noise.
+
+---
+
 ## CI / Demo Integration Jobs (job name granularity)
 
 | Job name | Issue | Last blocked |

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -111,9 +111,10 @@ No open entries.
 | `fccv-extension` | — | 2026-07-31 |
 | `fcvcv Demo Integration` | #2233 | 2026-08-13 |
 | `fvcv-handoff Demo Integration` | #2233 | 2026-08-13 |
-| `fvcv-handoff Invariant Harness` | #2266 | 2026-08-13 |
-| `fcvcv Invariant Harness` | — | 2026-08-10 |
-| `fcv-reject Invariant Harness` | #2121 (closed) | 2026-08-10 |
+| `fvcv-handoff Invariant Harness` | #2233 | 2026-08-13 |
+| `fcvcv Invariant Harness` | #2233 | 2026-08-13 |
+| `fcv-reject Invariant Harness` | #2233 | 2026-08-13 |
+| `fv Invariant Harness` | #2233 | 2026-08-13 |
 
 > The rows with no issue number fail intermittently due to inter-container HTTP
 > delivery timeouts (async race windows). Root cause documented in
@@ -121,13 +122,19 @@ No open entries.
 > When a new occurrence is confirmed, `pr-execute` will open or comment on a
 > `flaky-test` + `bug` issue and record it here.
 >
-> The three rows citing #2233 / #2266 are **not** flaky — they are deterministic
-> and branch-independent. `engage-case` returns HTTP 422 on the invite path
-> (`SvcEngageCaseUseCase failed: TransitionParticipantRMtoAccepted`), tracked as
-> #2233; the harness row is the assertion-scope gap tracked as #2266. They are
-> listed here because `pr-execute` records blocked jobs here regardless of
-> cause, and because #2216 — the issue they used to cite — is closed and no
-> longer the right pointer. Do not re-diagnose them as nondeterminism.
+> The rows citing **#2233 are not flaky** — they are deterministic and
+> branch-independent. `engage-case` returns HTTP 422 on the invite path
+> (`SvcEngageCaseUseCase failed: TransitionParticipantRMtoAccepted`), so the
+> event is never emitted; #2266 then promoted `engage_case` to a universal
+> invariant asserted in all nine scenarios, which turned one silent gap into a
+> red `Invariant Harness` job per scenario. Both are open. `origin/main`
+> `06bf60c2` fails **15** of these jobs on its own, so a PR that fails a subset
+> of them has not caused them.
+>
+> These rows are listed here because `pr-execute` records blocked jobs here
+> regardless of cause, and because #2216 and #2121 — the issues they used to
+> cite — are both closed and no longer the right pointer. Do not re-diagnose
+> them as nondeterminism, and do not "fix" them on a feature branch.
 
 ---
 

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -115,7 +115,7 @@ No open entries.
 | `fcvcv Invariant Harness` | #2233 | 2026-08-13 |
 | `fcv-reject Invariant Harness` | #2233 | 2026-08-13 |
 | `fv Invariant Harness` | #2233 | 2026-08-13 |
-| `fv Demo Integration` | — | 2026-08-13 |
+| `fv Demo Integration` | #2241 | 2026-08-13 |
 
 > `fv Demo Integration` is a different animal from the #2233 rows below it, and
 > from the async-race rows above. It passed at `dc31b6c6` and failed at
@@ -127,9 +127,15 @@ No open entries.
 > exception, so control falls through and raises
 > `UnboundLocalError: cannot access local variable 'result'`, which buries the
 > real 422 under a traceback pointing at the wrong line. Pre-existing base code
-> (last touched by #1387, #543), unrelated to #2279's ledger-dump change —
-> though that path throws its own secondary error at `ledger_dump.py:434` in the
-> same run.
+> (last touched by #1387, #543).
+>
+> **#2241 already owns this pattern** — "assignment inside a swallowing
+> `demo_check` block then used after it" — so this row cites it rather than a new
+> issue. The concrete callsite and run evidence are recorded there; note the
+> pattern reaches `demo_step` too, not just `demo_check`. The related reporting
+> failure is #2240. The `ValueError: No case ledger entries` later in the same run
+> is *not* a second bug: `ledger_dump.py:434` raises it deliberately because the
+> run died before any ledger was written. See also #2281.
 >
 > The rows with no issue number fail intermittently due to inter-container HTTP
 > delivery timeouts (async race windows). Root cause documented in

--- a/plan/incoming/learnings/20260812-cs-hypercube-premise-was-wrong.md
+++ b/plan/incoming/learnings/20260812-cs-hypercube-premise-was-wrong.md
@@ -1,8 +1,9 @@
 ---
 title: The "completely orphaned" premise in #2237 was wrong, and docs carried stale 64-state claims
-date: 2026-08-12
+timestamp: "2026-08-12"
 source: ISSUE-2237
 type: learning
+signal: process-issue
 tags: [case-states, legacy-code, documentation-drift, specs]
 ---
 

--- a/plan/incoming/learnings/20260812-cs-hypercube-premise-was-wrong.md
+++ b/plan/incoming/learnings/20260812-cs-hypercube-premise-was-wrong.md
@@ -1,13 +1,14 @@
 ---
 title: The "completely orphaned" premise in #2237 was wrong, and docs carried stale 64-state claims
-timestamp: "2026-08-12"
+timestamp: 2026-08-12T00:00:00Z
 source: ISSUE-2237
 type: learning
 signal: process-issue
-tags: [case-states, legacy-code, documentation-drift, specs]
 ---
 
 # The "completely orphaned" premise in #2237 was wrong
+
+*Areas: case states, legacy code, documentation drift, specs.*
 
 ## What happened
 

--- a/plan/incoming/learnings/20260812-cs-hypercube-premise-was-wrong.md
+++ b/plan/incoming/learnings/20260812-cs-hypercube-premise-was-wrong.md
@@ -1,0 +1,60 @@
+---
+title: The "completely orphaned" premise in #2237 was wrong, and docs carried stale 64-state claims
+date: 2026-08-12
+source: ISSUE-2237
+type: learning
+tags: [case-states, legacy-code, documentation-drift, specs]
+---
+
+# The "completely orphaned" premise in #2237 was wrong
+
+## What happened
+
+Issue #2237 described `vultron/core/case_states/` as completely orphaned,
+implying retirement was a deletion. Verification found **two live importers**
+outside its own tree:
+
+- `vultron/core/use_cases/query/action_rules.py` imports
+  `case_states.patterns.potential_actions`, reached from the live
+  `actors_get_action_rules` FastAPI endpoint.
+- `vultron/core/states/cs.py:26` imports `validations.ensure_valid_state` — the
+  authoritative module depends on the legacy one.
+
+That made retirement a **migration, not a deletion**, and drove ADR-0060's
+"keep, demoted" decision with two named prerequisites instead of the archive the
+issue anticipated.
+
+## Documentation drift found alongside it
+
+All four of these asserted a 64-state hypercube or a nonexistent path, and were
+corrected in the same PR:
+
+- `notes/case-state-model.md` — "2^6 = 64-node hypercube"; the truth is 32 valid
+  states, 58 valid transitions, 70 valid complete histories of 720 permutations.
+- `notes/codebase-structure.md` — listed a `vultron/case_states/enums/` directory
+  that does not exist.
+- `notes/documentation-strategy.md` — three stale `vultron/case_states/` paths.
+- `AGENTS.md` — Key Files Map had no entry for the authoritative
+  `vultron/core/states/cs.py`.
+
+## Also found: `references:` in specs YAML is silently dropped
+
+`specs/*.yaml` files accept a `references:` key that is **not** a field on
+`StatementSpec` (`vultron/metadata/specs/schema.py`). It is silently discarded by
+`spec-dump` with no lint error. Two pre-existing occurrences in
+`specs/inbox-orchestration.yaml` are equally dead. The real field is `adr:`,
+which `spec-lint` does validate against ADR filenames.
+
+## How to apply
+
+- Treat an issue's characterisation of code as a hypothesis. "Orphaned",
+  "unused", "dead" are claims to verify with an importer search before choosing
+  between deletion and migration — the answer changes the shape of the work.
+- When touching a model documented in `notes/`, grep for the model's headline
+  numbers, not just its symbol names. "64" was wrong in prose that named no
+  symbol at all, so a symbol grep would have missed it.
+- Adding a key to a spec YAML file proves nothing. Round-trip it through
+  `PYTHONPATH= uv run spec-dump` and confirm it appears, because unknown keys
+  vanish without complaint.
+
+Related: [[20260812-integration-timeout-tier]]

--- a/plan/incoming/learnings/20260812-integration-timeout-tier.md
+++ b/plan/incoming/learnings/20260812-integration-timeout-tier.md
@@ -1,13 +1,14 @@
 ---
 title: A timeout tuned for one test tier masquerades as flakiness in another
-timestamp: "2026-08-12"
-source: ISSUE-2237
+timestamp: 2026-08-12T00:00:00Z
+source: ISSUE-2270
 type: learning
 signal: tooling-issue
-tags: [testing, pytest, timeout, flaky-tests, triage]
 ---
 
 # A timeout tuned for one test tier masquerades as flakiness in another
+
+*Areas: testing, pytest, timeouts, flaky-test triage.*
 
 ## What happened
 
@@ -24,8 +25,8 @@ failure was **reliably red** (2/2 on clean `origin/main` 65fe33f1b); only the
 location was nondeterministic.
 
 Fixed by #2270: a two-tier ceiling — 60s for `integration`-marked tests via
-`test/conftest.py::apply_integration_timeout`, and the unit default raised 5s to
-20s in `pyproject.toml`.
+`test/conftest.py::apply_integration_timeout`, and the unit default raised from
+5s to 30s in `pyproject.toml`.
 
 ## This was diagnosed four times before it was fixed
 

--- a/plan/incoming/learnings/20260812-integration-timeout-tier.md
+++ b/plan/incoming/learnings/20260812-integration-timeout-tier.md
@@ -1,8 +1,9 @@
 ---
 title: A timeout tuned for one test tier masquerades as flakiness in another
-date: 2026-08-12
+timestamp: "2026-08-12"
 source: ISSUE-2237
 type: learning
+signal: tooling-issue
 tags: [testing, pytest, timeout, flaky-tests, triage]
 ---
 
@@ -22,8 +23,29 @@ slow test, a single spurious trip aborted the session. At the suite level the
 failure was **reliably red** (2/2 on clean `origin/main` 65fe33f1b); only the
 location was nondeterministic.
 
-Fixed by #2270: `test/conftest.py::apply_integration_timeout` gives
-`integration`-marked tests a 60s tier while the unit suite keeps 5s.
+Fixed by #2270: a two-tier ceiling — 60s for `integration`-marked tests via
+`test/conftest.py::apply_integration_timeout`, and the unit default raised 5s to
+20s in `pyproject.toml`.
+
+## This was diagnosed four times before it was fixed
+
+The same root cause was written up in three earlier learning files, each time as
+a workaround rather than a fix:
+
+| File | Source | What it concluded |
+|---|---|---|
+| `20260803-pytest-full-suite-timeout.md` | ISSUE-1925 | full suite "never finishes"; worked around with scoped runs |
+| `20260805-per-test-timeout-marginal-under-load.md` | ISSUE-1988 | AST ratchets at ~3.4s sit near the 5s ceiling; mitigated one ratchet with a prefilter |
+| `20260808-pytest-thread-timeout-fakes-nondeterminism.md` | ISSUE-2086 | thread-method aborts fake nondeterminism; cost real time chasing phantoms |
+
+Three sessions correctly identified that `timeout = 5` plus
+`timeout_method = "thread"` was the problem, and all three treated the ceiling as
+fixed background. The unit tier was raised to 20s in this session only because
+those three files were read together and the pattern became visible.
+
+Note the second file's finding is why widening only the integration tier would
+have been an incomplete fix: the *unit* suite has AST-walking ratchets at ~3.4s,
+so the 5s ceiling had a load-dependent margin there too.
 
 ## Why it matters
 
@@ -55,5 +77,10 @@ the opposite direction.
 - When widening a timeout, prefer widening the ceiling over switching
   `timeout_method` off `thread`. The signal method cannot interrupt code blocked
   in a C extension, so it converts a noisy abort into an invisible hang.
+- **A recurring workaround is a signal to read the earlier write-ups, not to add
+  another.** Three learning files independently named this root cause and each
+  worked around it. Before writing a learning file about tooling friction, grep
+  `plan/incoming/learnings/` for the same symptom — if it is already there, the
+  finding is not the symptom, it is that nobody fixed the cause.
 
 Related: [[20260812-cs-hypercube-premise-was-wrong]]

--- a/plan/incoming/learnings/20260812-integration-timeout-tier.md
+++ b/plan/incoming/learnings/20260812-integration-timeout-tier.md
@@ -1,0 +1,59 @@
+---
+title: A timeout tuned for one test tier masquerades as flakiness in another
+date: 2026-08-12
+source: ISSUE-2237
+type: learning
+tags: [testing, pytest, timeout, flaky-tests, triage]
+---
+
+# A timeout tuned for one test tier masquerades as flakiness in another
+
+## What happened
+
+While validating #2237, `uv run pytest -m integration` exited 1 with two
+`+++ Timeout +++` dumps and **no summary line**. Which test tripped it moved
+with the `pytest-randomly` seed, and `-p no:randomly` made the suite pass — the
+classic signature of a flaky test.
+
+It was not flaky. `timeout = 5` in `pyproject.toml` is sized for the unit suite,
+but several integration tests do 3.5-4.3s of honest work. Because
+`timeout_method = "thread"` kills the *whole pytest process* rather than the one
+slow test, a single spurious trip aborted the session. At the suite level the
+failure was **reliably red** (2/2 on clean `origin/main` 65fe33f1b); only the
+location was nondeterministic.
+
+Fixed by #2270: `test/conftest.py::apply_integration_timeout` gives
+`integration`-marked tests a 60s tier while the unit suite keeps 5s.
+
+## Why it matters
+
+A red integration run carried **no information about the branch**. That is worse
+than a failing test — it trains everyone to re-run rather than read, and it lets
+a genuinely broken branch be waved off as "the usual timeout".
+
+The near-miss: the ready-made move was to add two rows to
+`notes/flaky-tests.md` and proceed. That would have permanently catalogued a
+config defect as noise, which is exactly the error #2249 was filed to correct in
+the opposite direction.
+
+## How to apply
+
+- Before cataloguing a test as flaky, ask whether the test is nondeterministic
+  or whether the **ceiling** is wrong. Distinguish *suite reliably red* from
+  *test intermittently red*; if only the failure's location varies, suspect a
+  global resource limit, not the tests.
+- `-p no:randomly` flipping a suite green is not evidence of flakiness. It is
+  evidence of order- or timing-sensitivity, which a too-tight global timeout
+  produces.
+- Check for a summary line before concluding anything. A session aborted by
+  `timeout_method = "thread"` looks identical to a clean pass if you only count
+  `FAILED` lines. `notes/flaky-tests.md` already recorded this trap; it caught a
+  second victim anyway, so check for the `+++ Timeout +++` marker explicitly.
+- Timeouts are diagnostics, not correctness invariants. When a tier fires on
+  honest work rather than catching hangs, change the tier — do not contort the
+  tests or paper over it with scattered `@pytest.mark.timeout(N)`.
+- When widening a timeout, prefer widening the ceiling over switching
+  `timeout_method` off `thread`. The signal method cannot interrupt code blocked
+  in a C extension, so it converts a noisy abort into an invisible hang.
+
+Related: [[20260812-cs-hypercube-premise-was-wrong]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,29 @@ pythonpath = ["."]
 #
 # See AGENTS.md "Testing" section for full guidance.
 addopts = "-ra -q -m 'not integration'"
-timeout = 5
+# Unit-tier per-test timeout.  Raised 5 -> 30 in #2270.
+#
+# `timeout_method = "thread"` cannot cancel one test — it kills the whole pytest
+# process, so a trip yields no summary line at all.  That makes a too-tight
+# ceiling actively harmful: it converts a slow test into an uninformative
+# aborted session.  At 5s the margin was thin enough that AST-walking
+# architecture ratchets (~3.4s in isolation) tripped it nondeterministically
+# under full-suite load, and four separate sessions re-diagnosed it as flakiness
+# (ISSUE-1925, ISSUE-1988, ISSUE-2086, ISSUE-2237).
+#
+# Sized from measurement, not taste: the slowest unit test on an idle machine is
+# ~3.1s (`test_real_specs_load` setup), so this is ~10x headroom.  An
+# intermediate value of 20s was tried and still tripped once while a background
+# graphify rebuild competed for CPU — contention on a loaded dev box or CI
+# runner inflates these well beyond their idle cost.
+#
+# A generous ceiling costs nothing on a genuine hang: that test was never going
+# to finish, and 30s is still far below the CI job timeout.  The suite stays fast
+# because total runtime (~120s) is bounded by the tests, not by this ceiling.
+#
+# Integration tests get a wider tier; see `INTEGRATION_TIMEOUT_SECONDS` in
+# `test/conftest.py`.
+timeout = 30
 timeout_method = "thread"
 testpaths = [
     "test",

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -1453,3 +1453,140 @@ groups:
       spec_id: SDO-02-004
     - rel_type: refines
       spec_id: BTND-10-001
+
+- id: CSB-17
+  title: CS Compound State and History Validity
+  description: >-
+    CS-internal validity invariants over the compound (VFD x PXA) case state
+    and over whole case histories. Where CSB-16 validates a single write at
+    the persistence boundary, CSB-17 defines which compound states exist,
+    which single-event transitions between them are causally possible, and
+    which orderings of the six CS events a real case could have produced.
+    Mined from the legacy `vultron.core.case_states` hypercube model and
+    re-expressed against the current CS enums; see ADR-0060.
+  specs:
+  - id: CSB-17-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      An implementation MUST treat exactly 32 compound CS states as valid: the
+      cross product of the 4 valid VFD states (vfd, Vfd, VFd, VFD) and the 8
+      PXA states. A fix MUST NOT be ready while the vendor is unaware (vF is
+      impossible) and a fix MUST NOT be deployed that was never ready (fD is
+      impossible).
+    rationale: >-
+      The VFD dimension is a linear chain, not a free product of three bits:
+      readiness presupposes awareness and deployment presupposes readiness.
+      Enumerating only the reachable combinations makes the two impossible
+      combinations unrepresentable rather than merely rejected at runtime,
+      which is why `CS_vfd` has four members and not eight.
+    testable: true
+    postconditions:
+    - description: The CS enum has exactly 32 members, one per valid compound state
+    adr:
+    - ADR-0060
+
+  - id: CSB-17-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      A CS transition MUST change exactly one of the six CS dimensions, and
+      MUST change it from the not-yet-happened value to the happened value.
+      Transitions that change two or more dimensions at once, that reverse a
+      dimension, or that skip a VFD prerequisite MUST be rejected. There are
+      exactly 58 valid CS transitions.
+    rationale: >-
+      CS events are irreversible and are observed one at a time; a compound
+      state change of Hamming distance greater than one conflates two distinct
+      events and loses their ordering, which is exactly the information history
+      validity depends on.
+    testable: true
+    preconditions:
+    - description: A (source, destination) pair of compound CS states
+    steps:
+    - order: 1
+      actor: validator
+      action: >-
+        Identify the single dimension that differs between source and
+        destination; reject if zero or more than one differs.
+      expected: A single CS event accounts for the change
+    - order: 2
+      actor: validator
+      action: >-
+        Delegate to the changed dimension's own transition table
+        (is_valid_vfd_transition or is_valid_pxa_transition).
+      expected: Monotonicity and VFD prerequisite ordering are enforced
+    postconditions:
+    - description: Only Hamming-distance-1 monotone transitions are accepted
+    relationships:
+    - rel_type: constrains
+      spec_id: CSB-16-001
+    - rel_type: constrains
+      spec_id: CSB-16-002
+    adr:
+    - ADR-0060
+
+  - id: CSB-17-003
+    priority: MUST
+    kind: protocol
+    statement: >-
+      An implementation MUST treat the compound states vP (public aware while
+      the vendor is unaware) and pX (exploit public while the public is
+      unaware) as ephemeral. From a vP state the next CS event MUST be V; from
+      a pX state the next CS event MUST be P. Any other next event MUST be
+      rejected.
+    rationale: >-
+      Neither condition can persist in reality: public awareness reaches the
+      vendor, and a published exploit makes the public aware. Modelling these
+      as ephemeral rather than invalid preserves the causal ordering of the
+      events while forbidding the case from progressing in any other direction
+      first. The pX ephemeral rule is the pX to PX invariant of CSB-13-001
+      generalised from the entry cascade to every successor of a pX state.
+    testable: true
+    preconditions:
+    - description: The case is in one of the 12 ephemeral compound CS states
+    postconditions:
+    - description: Each ephemeral state has exactly one valid successor state
+    relationships:
+    - rel_type: extends
+      spec_id: CSB-13-001
+    adr:
+    - ADR-0060
+
+  - id: CSB-17-004
+    priority: SHOULD
+    kind: protocol
+    statement: >-
+      A consumer validating a reported CS history SHOULD validate it causally
+      by replaying the event sequence through CSB-17-002 and CSB-17-003 from
+      the initial state vfdpxa, rather than checking states point-in-time or
+      comparing wall-clock timestamps. A complete history contains all six CS
+      events exactly once; there are exactly 70 valid complete histories out of
+      720 orderings. An incomplete history MUST be validated as a prefix, which
+      MAY end in an ephemeral state.
+    rationale: >-
+      Validity of a case trajectory is a property of the whole ordered
+      sequence, not of any single state: VFDPXA and VFDXAP visit only valid
+      states, but only the first is a possible case history. Wall-clock
+      timestamps cannot substitute, because they may be missing, skewed, or
+      recorded by different participants. Real cases are usually still in
+      progress, so prefix validation is the common case and MUST NOT require
+      all six events.
+    testable: true
+    preconditions:
+    - description: An ordered sequence of CS events, possibly incomplete
+    steps:
+    - order: 1
+      actor: validator
+      action: Reject any event that occurs more than once in the sequence
+      expected: Each CS event happens at most once
+    - order: 2
+      actor: validator
+      action: >-
+        Replay the sequence from vfdpxa, requiring each step to satisfy
+        CSB-17-002 and CSB-17-003 given every event that preceded it.
+      expected: Causally impossible orderings are rejected
+    postconditions:
+    - description: A complete valid history terminates in VFDPXA
+    adr:
+    - ADR-0060

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -1483,6 +1483,13 @@ groups:
     testable: true
     postconditions:
     - description: The CS enum has exactly 32 members, one per valid compound state
+    relationships:
+    - rel_type: refines
+      spec_id: SM-09-002
+      note: >-
+        SM-09-002 states the vF/fD prohibition as a rejection rule; this
+        refines it to a structural guarantee by enumerating only the 32
+        reachable combinations, so the impossible ones are unrepresentable.
     adr:
     - ADR-0060
 
@@ -1493,8 +1500,9 @@ groups:
       A CS transition MUST change exactly one of the six CS dimensions, and
       MUST change it from the not-yet-happened value to the happened value.
       Transitions that change two or more dimensions at once, that reverse a
-      dimension, or that skip a VFD prerequisite MUST be rejected. There are
-      exactly 58 valid CS transitions.
+      dimension, or that skip a VFD prerequisite MUST be rejected. These three
+      conditions alone admit 72 transitions; applying the ephemeral-state rule
+      of CSB-17-003 as well leaves exactly 58 valid CS transitions.
     rationale: >-
       CS events are irreversible and are observed one at a time; a compound
       state change of Hamming distance greater than one conflates two distinct
@@ -1508,21 +1516,40 @@ groups:
       actor: validator
       action: >-
         Identify the single dimension that differs between source and
-        destination; reject if zero or more than one differs.
-      expected: A single CS event accounts for the change
+        destination; reject if more than one differs. If none differs, the
+        write is a same-state re-assertion, which CSB-16-001 and CSB-16-002
+        permit as a status confirmation: accept it only when the caller has
+        opted in (the allow_null parameter), and reject it otherwise, because a
+        transition validator's default answer for "no change" must be "that is
+        not a transition".
+      expected: A single CS event accounts for the change, or the caller has
+        explicitly asked for same-state writes to pass
     - order: 2
       actor: validator
       action: >-
         Delegate to the changed dimension's own transition table
         (is_valid_vfd_transition or is_valid_pxa_transition).
       expected: Monotonicity and VFD prerequisite ordering are enforced
+    - order: 3
+      actor: validator
+      action: >-
+        Apply the ephemeral-state rule of CSB-17-003 to the source state.
+      expected: A transition out of a vP or pX state fires only the event that
+        state requires
     postconditions:
     - description: Only Hamming-distance-1 monotone transitions are accepted
     relationships:
     - rel_type: constrains
       spec_id: CSB-16-001
+      note: >-
+        Adds the one-dimension-at-a-time and monotonicity constraints that a
+        per-dimension write validator cannot see. The same-state write CSB-16
+        permits is preserved via the opt-in described in step 1.
     - rel_type: constrains
       spec_id: CSB-16-002
+    - rel_type: depends_on
+      spec_id: CSB-17-003
+      note: The 58-transition count holds only with the ephemeral rule applied.
     adr:
     - ADR-0060
 
@@ -1550,6 +1577,17 @@ groups:
     relationships:
     - rel_type: extends
       spec_id: CSB-13-001
+    - rel_type: refines
+      spec_id: SM-09-001
+      note: >-
+        SM-09-001 governs the persistence boundary: an incoming status write
+        carrying vP or pX MUST be promoted to the forced form before it is
+        stored. CSB-17-003 governs trajectory validation, where the same two
+        conditions are modelled as ephemeral states with exactly one legal
+        successor. The two are consistent because they apply at different
+        boundaries: no vP or pX state is ever persisted, but such a state is
+        still a legal intermediate point in a replayed history, and CSB-17-004
+        therefore permits a history prefix to end in one.
     adr:
     - ADR-0060
 
@@ -1562,16 +1600,15 @@ groups:
       the initial state vfdpxa, rather than checking states point-in-time or
       comparing wall-clock timestamps. A complete history contains all six CS
       events exactly once; there are exactly 70 valid complete histories out of
-      720 orderings. An incomplete history MUST be validated as a prefix, which
-      MAY end in an ephemeral state.
+      720 orderings.
     rationale: >-
       Validity of a case trajectory is a property of the whole ordered
       sequence, not of any single state: VFDPXA and VFDXAP visit only valid
       states, but only the first is a possible case history. Wall-clock
       timestamps cannot substitute, because they may be missing, skewed, or
-      recorded by different participants. Real cases are usually still in
-      progress, so prefix validation is the common case and MUST NOT require
-      all six events.
+      recorded by different participants. SHOULD rather than MUST because a
+      consumer holding only a current state, with no event log to replay,
+      cannot do better.
     testable: true
     preconditions:
     - description: An ordered sequence of CS events, possibly incomplete
@@ -1588,5 +1625,46 @@ groups:
       expected: Causally impossible orderings are rejected
     postconditions:
     - description: A complete valid history terminates in VFDPXA
+    adr:
+    - ADR-0060
+
+  - id: CSB-17-005
+    priority: MUST
+    kind: protocol
+    statement: >-
+      An incomplete CS history MUST be validated as a prefix: validation MUST
+      NOT require all six CS events, and a prefix MAY end in an ephemeral
+      state. The accepted prefixes are exactly the prefixes of the 70 valid
+      complete histories of CSB-17-004, so every accepted prefix MUST have at
+      least one completion.
+    rationale: >-
+      Real cases are usually still in progress, so requiring six events would
+      reject every live case. Ending in an ephemeral state is unavoidable at the
+      prefix level: CSB-17-003's forced successor has not happened yet when the
+      prefix is cut, which is different from persisting an ephemeral state —
+      SM-09-001 still forbids that. Pinning acceptance to CSB-17-004's prefix
+      closure keeps both directions honest: a validator that merely never
+      rejects a genuine prefix could still accept dead ends.
+    testable: true
+    preconditions:
+    - description: An ordered sequence of CS events with fewer than six entries
+    steps:
+    - order: 1
+      actor: validator
+      action: >-
+        Apply CSB-17-004's replay to the sequence without requiring that it
+        terminate in VFDPXA.
+      expected: >-
+        The prefix is accepted iff it is a prefix of at least one valid
+        complete history
+    postconditions:
+    - description: >-
+        A prefix ending in an ephemeral state is accepted, and its forced
+        successor per CSB-17-003 is the only legal continuation
+    relationships:
+    - rel_type: refines
+      spec_id: CSB-17-004
+    - rel_type: depends_on
+      spec_id: CSB-17-003
     adr:
     - ADR-0060

--- a/specs/state-machine.yaml
+++ b/specs/state-machine.yaml
@@ -157,9 +157,11 @@ groups:
     statement: 'The CS state machine MUST enforce two forced (ephemeral) transitions at validation time: (1) `pX → PX` — exploit-public
       forces public-aware; (2) `vP → VP` — public-aware forces vendor-aware. Any incoming CS state that contains `pX` or `vP`
       MUST be promoted to the forced form before being persisted.'
-    rationale: These transitions are protocol-correctness invariants, not optional normalizations. A CS state of `pXa` (exploit
+    rationale: 'These transitions are protocol-correctness invariants, not optional normalizations. A CS state of `pXa` (exploit
       public, public unaware) is semantically impossible — the exploit being public implies the vulnerability is public. Enforced
-      by `vultron/core/case_states/validations.py` `TRANSITION_RULES`.
+      by `vultron/core/states/cs_invariants.py` (`is_ephemeral_cs_state`, `required_next_cs_events`). This requirement governs
+      the *persistence* boundary only; CSB-17-003 and CSB-17-005 cover trajectory validation, where an ephemeral state is a
+      legal prefix terminus.'
     relationships:
     - rel_type: implements
       spec_id: VP-14-001

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -43,10 +43,32 @@ uv run pytest test/test_semantic_activity_patterns.py -v
 
 ### Per-Test Timeout Guardrail
 
-Default 5-second timeout (`pytest-timeout`, `pyproject.toml`). When a test
-trips it: mock slow deps, avoid `time.sleep()`, restructure integration tests.
+Timeouts are **two-tier** (`pytest-timeout`):
+
+| Tier | Ceiling | Set in |
+|---|---|---|
+| Unit (default) | 5s | `timeout = 5`, `pyproject.toml` |
+| `@pytest.mark.integration` | 60s | `INTEGRATION_TIMEOUT_SECONDS`, `test/conftest.py` |
+
+`test/conftest.py::apply_integration_timeout` widens the ceiling for
+integration-marked tests at collection time. An explicit
+`@pytest.mark.timeout(N)` on a test always wins over the tier default.
+
+**Why two tiers** (#2270): `timeout_method = "thread"` kills the *whole pytest
+process*, not the one slow test. Several integration tests do 3.5-4.3s of
+honest work, so the 5s ceiling tripped nondeterministically and aborted the
+session with **no summary line** — a red integration run carried no information
+about the branch. The unit suite keeps 5s, where it is a genuinely useful hang
+detector.
+
+When a **unit** test trips 5s: mock slow deps, avoid `time.sleep()`, or move it
+behind the `integration` marker if it really does exercise the full stack.
 `@pytest.mark.timeout(N)` is a last resort and MUST have a comment explaining
 why. Do not use it to paper over slow tests.
+
+A timeout ceiling is a diagnostic tool, not a correctness invariant — if a tier
+is firing on honest work rather than catching hangs, change the tier rather
+than contorting the tests around it.
 
 ---
 

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -47,28 +47,43 @@ Timeouts are **two-tier** (`pytest-timeout`):
 
 | Tier | Ceiling | Set in |
 |---|---|---|
-| Unit (default) | 5s | `timeout = 5`, `pyproject.toml` |
+| Unit (default) | 30s | `timeout = 30`, `pyproject.toml` |
 | `@pytest.mark.integration` | 60s | `INTEGRATION_TIMEOUT_SECONDS`, `test/conftest.py` |
 
 `test/conftest.py::apply_integration_timeout` widens the ceiling for
 integration-marked tests at collection time. An explicit
 `@pytest.mark.timeout(N)` on a test always wins over the tier default.
 
-**Why two tiers** (#2270): `timeout_method = "thread"` kills the *whole pytest
-process*, not the one slow test. Several integration tests do 3.5-4.3s of
-honest work, so the 5s ceiling tripped nondeterministically and aborted the
-session with **no summary line** — a red integration run carried no information
-about the branch. The unit suite keeps 5s, where it is a genuinely useful hang
-detector.
+**Why these numbers** (#2270): `timeout_method = "thread"` kills the *whole
+pytest process*, not the one slow test, so a trip produces **no summary line**.
+A too-tight ceiling therefore does not surface a slow test — it converts the run
+into an uninformative abort. Both tiers used to be 5s, which was thin enough
+that honest work tripped it under load:
 
-When a **unit** test trips 5s: mock slow deps, avoid `time.sleep()`, or move it
+- integration tests doing 3.5-4.3s of real HTTP work, and
+- AST-walking architecture ratchets at ~3.4s in isolation.
+
+Four separate sessions re-diagnosed the result as flakiness (ISSUE-1925,
+ISSUE-1988, ISSUE-2086, ISSUE-2237) before the ceiling itself was fixed. Raising
+it costs nothing on a genuine hang — that test was never going to finish — and
+the suite stays fast because total runtime is bounded by the tests, not by this
+ceiling.
+
+Both tiers are sized from measurement: the slowest unit test is ~3.1s idle and
+the slowest integration test ~4.3s. The headroom is deliberately large because
+contention (a CI runner, or a background graphify rebuild) inflates these well
+beyond their idle cost — an intermediate unit value of 20s was tried and still
+tripped once under exactly that.
+
+When a test trips its tier: mock slow deps, avoid `time.sleep()`, or move it
 behind the `integration` marker if it really does exercise the full stack.
 `@pytest.mark.timeout(N)` is a last resort and MUST have a comment explaining
 why. Do not use it to paper over slow tests.
 
 A timeout ceiling is a diagnostic tool, not a correctness invariant — if a tier
 is firing on honest work rather than catching hangs, change the tier rather
-than contorting the tests around it.
+than contorting the tests around it. Do not add a row to
+`notes/flaky-tests.md` for a test that is merely near its ceiling.
 
 ---
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,7 +21,7 @@ Also registers the ``spec`` pytest marker and validates spec IDs referenced
 by ``@pytest.mark.spec`` against the loaded SpecRegistry (SR-05-001,
 SR-05-002).
 
-Finally, it applies the integration-tier per-test timeout. The 5-second
+Finally, it applies the integration-tier per-test timeout. The 30-second
 default in ``pyproject.toml`` is sized for the unit suite; integration tests
 exercise the full HTTP stack and legitimately need longer. See
 ``INTEGRATION_TIMEOUT_SECONDS`` and ``test/AGENTS.md`` § "Per-Test Timeout
@@ -47,15 +47,15 @@ from vultron.metadata.specs import (  # noqa: E402
 
 #: Per-test timeout for ``@pytest.mark.integration`` tests, in seconds.
 #:
-#: The global ``timeout = 5`` in ``pyproject.toml`` is sized for the unit
-#: suite, where 5s is a useful hang detector. It is far too tight for
-#: integration tests: several run at 3.5-4.3s of honest work, and because
-#: ``timeout_method = "thread"`` kills the *whole pytest process* rather than
-#: the one slow test, a single spurious trip aborted the session with no
-#: summary line — turning a red integration run into no signal at all. See
-#: issue #2270.
+#: The global ``timeout = 30`` in ``pyproject.toml`` is sized for the unit
+#: suite, where the slowest honest test runs at ~3.1s. It is still too tight
+#: for integration tests: several run at 3.5-4.3s of honest work against a
+#: much wider load-dependent spread, and because ``timeout_method = "thread"``
+#: kills the *whole pytest process* rather than the one slow test, a single
+#: spurious trip aborted the session with no summary line — turning a red
+#: integration run into no signal at all. See issue #2270.
 #:
-#: 60s is still a bounded hang detector (12x the unit ceiling) while leaving
+#: 60s is still a bounded hang detector (2x the unit ceiling) while leaving
 #: ample headroom over the slowest honest integration test. Tests needing more
 #: keep their own explicit ``@pytest.mark.timeout(N)``, which wins over this.
 INTEGRATION_TIMEOUT_SECONDS = 60

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,6 +20,12 @@ on-disk database files are created and the test suite stays fast.
 Also registers the ``spec`` pytest marker and validates spec IDs referenced
 by ``@pytest.mark.spec`` against the loaded SpecRegistry (SR-05-001,
 SR-05-002).
+
+Finally, it applies the integration-tier per-test timeout. The 5-second
+default in ``pyproject.toml`` is sized for the unit suite; integration tests
+exercise the full HTTP stack and legitimately need longer. See
+``INTEGRATION_TIMEOUT_SECONDS`` and ``test/AGENTS.md`` § "Per-Test Timeout
+Guardrail".
 """
 
 import os
@@ -39,6 +45,21 @@ from vultron.metadata.specs import (  # noqa: E402
     warn_unknown_spec_id,
 )
 
+#: Per-test timeout for ``@pytest.mark.integration`` tests, in seconds.
+#:
+#: The global ``timeout = 5`` in ``pyproject.toml`` is sized for the unit
+#: suite, where 5s is a useful hang detector. It is far too tight for
+#: integration tests: several run at 3.5-4.3s of honest work, and because
+#: ``timeout_method = "thread"`` kills the *whole pytest process* rather than
+#: the one slow test, a single spurious trip aborted the session with no
+#: summary line — turning a red integration run into no signal at all. See
+#: issue #2270.
+#:
+#: 60s is still a bounded hang detector (12x the unit ceiling) while leaving
+#: ample headroom over the slowest honest integration test. Tests needing more
+#: keep their own explicit ``@pytest.mark.timeout(N)``, which wins over this.
+INTEGRATION_TIMEOUT_SECONDS = 60
+
 
 def pytest_configure(config):
     """Register the ``spec`` marker (SR-05-001)."""
@@ -48,13 +69,36 @@ def pytest_configure(config):
     )
 
 
-def pytest_collection_modifyitems(session, config, items):
-    """Warn for unknown spec IDs in ``@pytest.mark.spec`` markers (SR-05-002).
+def apply_integration_timeout(items):
+    """Give ``integration``-marked tests the integration-tier timeout.
 
-    Emits :class:`~vultron.metadata.specs.UnknownSpecIdWarning` (non-blocking)
-    for any marker that references a spec ID not found in the registry.
-    Skips silently when no YAML files exist in ``specs/`` (e.g., before SR.6).
+    Applied to every item marked ``integration`` that does not already carry
+    an explicit ``timeout`` marker. An explicit marker always wins, so the
+    deliberate per-test values in the demo suite are left untouched.
+
+    Returns the number of items modified (for tests and diagnostics).
     """
+    modified = 0
+    for item in items:
+        if item.get_closest_marker("integration") is None:
+            continue
+        if item.get_closest_marker("timeout") is not None:
+            continue
+        item.add_marker(pytest.mark.timeout(INTEGRATION_TIMEOUT_SECONDS))
+        modified += 1
+    return modified
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """Apply the integration timeout, then warn for unknown spec IDs.
+
+    Spec-ID warnings (SR-05-002) emit
+    :class:`~vultron.metadata.specs.UnknownSpecIdWarning` (non-blocking) for
+    any ``@pytest.mark.spec`` marker referencing an ID not found in the
+    registry. Skips silently when no YAML files exist in ``specs/``.
+    """
+    apply_integration_timeout(items)
+
     spec_dir = Path(__file__).parent.parent / "specs"
     if not spec_dir.is_dir():
         return

--- a/test/core/states/test_cs_invariants.py
+++ b/test/core/states/test_cs_invariants.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for `vultron.core.states.cs_invariants`.
+
+The exhaustive tests here are the regression anchor for the re-expression of
+the legacy `vultron.core.case_states` rules against the current enum models
+(issue #2237, ADR-0060).  They compare the new implementation against the
+legacy string-pattern implementation over the *whole* state space — 64
+candidate states, 32x32 candidate transitions, and all 720 event
+permutations — so any drift between the two is caught immediately, and the
+legacy module can be retired only once these comparisons are deliberately
+removed.
+"""
+
+from itertools import permutations
+
+import pytest
+
+from vultron.core.case_states.validations import (
+    is_valid_history as legacy_is_valid_history,
+    is_valid_state as legacy_is_valid_state,
+    is_valid_transition as legacy_is_valid_transition,
+)
+from vultron.core.states.cs import (
+    CS,
+    CS_pxa,
+    CS_vfd,
+    PXA_Trigger,
+    VFD_Trigger,
+    is_vfd_vendor_aware,
+)
+from vultron.core.states.cs_invariants import (
+    CS_EVENT_TO_PXA_TRIGGER,
+    CS_EVENT_TO_VFD_TRIGGER,
+    CS_EVENTS,
+    CSEvent,
+    PXA_EVENTS,
+    VFD_EVENTS,
+    apply_cs_event,
+    cs_dimensions,
+    cs_from_dimensions,
+    cs_transition_event,
+    ensure_valid_cs_history,
+    ensure_valid_cs_transition,
+    is_ephemeral_cs_state,
+    is_valid_cs_history,
+    is_valid_cs_history_prefix,
+    is_valid_cs_transition,
+    next_cs_states,
+    replay_cs_history,
+    required_next_cs_events,
+    valid_cs_histories,
+)
+from vultron.errors import (
+    ValidationError as LegacyValidationError,
+    VultronInvalidStateTransitionError,
+    VultronValidationError,
+)
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _all_candidate_state_strings() -> list[str]:
+    """Every one of the 2**6 vfdpxa letter combinations, valid or not."""
+    combos = []
+    for i in range(2**6):
+        bits = format(i, "06b")
+        combos.append(
+            "".join(
+                letter.upper() if bit == "1" else letter
+                for letter, bit in zip("vfdpxa", bits)
+            )
+        )
+    return combos
+
+
+def _legacy_valid_states() -> set[str]:
+    valid = set()
+    for candidate in _all_candidate_state_strings():
+        try:
+            legacy_is_valid_state(candidate)
+        except LegacyValidationError:
+            continue
+        valid.add(candidate)
+    return valid
+
+
+def _legacy_valid_transitions() -> set[tuple[str, str]]:
+    states = sorted(_legacy_valid_states())
+    edges = set()
+    for src in states:
+        for dst in states:
+            try:
+                legacy_is_valid_transition(src, dst)
+            except LegacyValidationError:
+                continue
+            edges.add((src, dst))
+    return edges
+
+
+def _legacy_valid_histories() -> set[str]:
+    valid = set()
+    for perm in permutations("VFDPXA"):
+        history = "".join(perm)
+        try:
+            legacy_is_valid_history(history)
+        except LegacyValidationError:
+            continue
+        valid.add(history)
+    return valid
+
+
+def _as_string(history) -> str:
+    return "".join(event.value for event in history)
+
+
+# --- CSEvent ---------------------------------------------------------------
+
+
+def test_cs_events_are_canonical_order():
+    assert _as_string(CS_EVENTS) == "VFDPXA"
+
+
+def test_event_dimension_partition():
+    assert VFD_EVENTS | PXA_EVENTS == set(CS_EVENTS)
+    assert not VFD_EVENTS & PXA_EVENTS
+
+
+def test_event_trigger_maps_cover_their_dimensions():
+    assert set(CS_EVENT_TO_VFD_TRIGGER) == VFD_EVENTS
+    assert set(CS_EVENT_TO_PXA_TRIGGER) == PXA_EVENTS
+    assert set(CS_EVENT_TO_VFD_TRIGGER.values()) == set(VFD_Trigger)
+    assert set(CS_EVENT_TO_PXA_TRIGGER.values()) == set(PXA_Trigger)
+
+
+@pytest.mark.parametrize(
+    "event,trigger",
+    [
+        (CSEvent.V, VFD_Trigger.V),
+        (CSEvent.F, VFD_Trigger.F),
+        (CSEvent.D, VFD_Trigger.D),
+    ],
+)
+def test_vfd_trigger_map_pairs_by_letter(event, trigger):
+    assert CS_EVENT_TO_VFD_TRIGGER[event] is trigger
+
+
+@pytest.mark.parametrize(
+    "event,trigger",
+    [
+        (CSEvent.P, PXA_Trigger.P),
+        (CSEvent.X, PXA_Trigger.X),
+        (CSEvent.A, PXA_Trigger.A),
+    ],
+)
+def test_pxa_trigger_map_pairs_by_letter(event, trigger):
+    assert CS_EVENT_TO_PXA_TRIGGER[event] is trigger
+
+
+# --- compound state validity ----------------------------------------------
+
+
+def test_cs_enum_is_exactly_the_legacy_valid_state_set():
+    """The 32 CS members are the legacy model's 32 valid states.
+
+    This is the state-validity rule (`vF` and `fD` are impossible) expressed
+    structurally: `CS_vfd` has only four members, so the impossible
+    combinations cannot be constructed at all.
+    """
+    assert {state.name for state in CS} == _legacy_valid_states()
+
+
+def test_cs_has_32_states():
+    assert len(list(CS)) == 32
+
+
+def test_impossible_vfd_combinations_are_not_constructible():
+    """No CS_vfd member has F without V, or D without F."""
+    for state in CS_vfd:
+        vendor_aware, fix_ready, fix_deployed = (
+            char.isupper() for char in state.name
+        )
+        assert not (fix_ready and not vendor_aware)
+        assert not (fix_deployed and not fix_ready)
+
+
+def test_dimension_round_trip():
+    for state in CS:
+        assert cs_from_dimensions(*cs_dimensions(state)) is state
+
+
+def test_cs_from_dimensions_covers_the_full_cross_product():
+    pairs = {
+        cs_from_dimensions(vfd_state, pxa_state)
+        for vfd_state in CS_vfd
+        for pxa_state in CS_pxa
+    }
+    assert pairs == set(CS)
+
+
+# --- ephemeral states -----------------------------------------------------
+
+
+def test_ephemeral_states_are_the_twelve_vp_and_px_states():
+    ephemeral = {state.name for state in CS if is_ephemeral_cs_state(state)}
+    expected = {
+        state.name
+        for state in CS
+        # vP: public aware, vendor unaware
+        if (state.name[3] == "P" and state.name[0] == "v")
+        # pX: exploit public, public unaware
+        or (state.name[4] == "X" and state.name[3] == "p")
+    }
+    assert ephemeral == expected
+    assert len(ephemeral) == 12
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        (CS.vfdPxa, {CSEvent.V}),
+        (CS.vfdPXA, {CSEvent.V}),
+        (CS.vfdpXa, {CSEvent.P}),
+        (CS.VFDpXA, {CSEvent.P}),
+        (CS.vfdpxa, set()),
+        (CS.VfdPxa, set()),
+        (CS.VFDPXA, set()),
+    ],
+)
+def test_required_next_cs_events(state, expected):
+    assert required_next_cs_events(state) == frozenset(expected)
+
+
+def test_the_two_ephemeral_rules_are_mutually_exclusive():
+    """vP requires P set; pX requires P unset — they cannot both apply."""
+    for state in CS:
+        required = required_next_cs_events(state)
+        assert len(required) <= 1
+
+
+def test_ephemeral_states_have_exactly_one_successor():
+    for state in CS:
+        if is_ephemeral_cs_state(state):
+            assert len(next_cs_states(state)) == 1
+
+
+# --- transition validity --------------------------------------------------
+
+
+def test_transition_set_matches_legacy_exactly():
+    """The re-expressed transition rule admits the legacy model's 58 edges."""
+    new_edges = {
+        (src.name, dst.name)
+        for src in CS
+        for dst in CS
+        if is_valid_cs_transition(src, dst)
+    }
+    assert new_edges == _legacy_valid_transitions()
+
+
+def test_there_are_58_valid_transitions():
+    count = sum(
+        1 for src in CS for dst in CS if is_valid_cs_transition(src, dst)
+    )
+    assert count == 58
+
+
+def test_every_transition_changes_exactly_one_dimension():
+    for src in CS:
+        for dst in next_cs_states(src):
+            assert cs_transition_event(src, dst) is not None
+
+
+def test_transitions_are_monotone():
+    """No transition ever un-sets a bit; CS events are irreversible."""
+    for src in CS:
+        for dst in next_cs_states(src):
+            for before, after in zip(src.name, dst.name):
+                assert not (before.isupper() and after.islower())
+
+
+def test_null_transition_rejected_by_default_and_allowed_when_asked():
+    assert not is_valid_cs_transition(CS.Vfdpxa, CS.Vfdpxa)
+    assert is_valid_cs_transition(CS.Vfdpxa, CS.Vfdpxa, allow_null=True)
+
+
+def test_ensure_valid_cs_transition_allows_null_when_asked():
+    ensure_valid_cs_transition(CS.Vfdpxa, CS.Vfdpxa, allow_null=True)
+
+
+@pytest.mark.parametrize(
+    "src,dst",
+    [
+        (CS.vfdpxa, CS.Vfdpxa),  # V
+        (CS.Vfdpxa, CS.VFdpxa),  # F
+        (CS.VFdpxa, CS.VFDpxa),  # D
+        (CS.Vfdpxa, CS.VfdPxa),  # P
+        (CS.VfdPxa, CS.VfdPXa),  # X
+        (CS.VfdPxa, CS.VfdPxA),  # A
+        (CS.vfdPxa, CS.VfdPxa),  # ephemeral vP resolved by V
+        (CS.vfdpXa, CS.vfdPXa),  # ephemeral pX resolved by P
+    ],
+)
+def test_valid_transitions(src, dst):
+    assert is_valid_cs_transition(src, dst)
+    ensure_valid_cs_transition(src, dst)
+
+
+@pytest.mark.parametrize(
+    "src,dst,reason",
+    [
+        (CS.Vfdpxa, CS.vfdpxa, "not monotone"),
+        (CS.vfdpxa, CS.VfdPxa, "two dimensions change"),
+        (CS.vfdpxa, CS.VFdpxa, "F requires V first"),
+        (CS.Vfdpxa, CS.VFDpxa, "F and D cannot both fire at once"),
+        (CS.vfdpxa, CS.VFDPXA, "everything changes at once"),
+        (CS.vfdPxa, CS.vfdPxA, "vP requires V next"),
+        (CS.vfdPxa, CS.vfdPXa, "vP requires V next"),
+        (CS.vfdpXa, CS.vfdpXA, "pX requires P next"),
+        (CS.VFDpXa, CS.VFDpXA, "pX requires P next"),
+    ],
+)
+def test_invalid_transitions(src, dst, reason):
+    assert not is_valid_cs_transition(
+        src, dst
+    ), f"{src.name} -> {dst.name} should be rejected: {reason}"
+    with pytest.raises(VultronInvalidStateTransitionError):
+        ensure_valid_cs_transition(src, dst)
+
+
+def test_ephemeral_rejection_message_names_the_required_event():
+    with pytest.raises(VultronInvalidStateTransitionError) as exc_info:
+        ensure_valid_cs_transition(CS.vfdpXa, CS.vfdpXA)
+    message = str(exc_info.value)
+    assert "ephemeral" in message
+    assert "'P'" in message
+
+
+def test_terminal_state_has_no_successors():
+    assert next_cs_states(CS.VFDPXA) == ()
+
+
+def test_initial_state_successors():
+    """From vfdpxa only V, P, X and A can fire — F and D need prerequisites."""
+    events = {
+        cs_transition_event(CS.vfdpxa, dst)
+        for dst in next_cs_states(CS.vfdpxa)
+    }
+    assert events == {CSEvent.V, CSEvent.P, CSEvent.X, CSEvent.A}
+
+
+def test_cs_transition_event_returns_none_for_non_unit_diffs():
+    assert cs_transition_event(CS.vfdpxa, CS.vfdpxa) is None
+    assert cs_transition_event(CS.vfdpxa, CS.VfdPxa) is None
+
+
+def test_cs_transition_event_identifies_the_changed_dimension():
+    assert cs_transition_event(CS.vfdpxa, CS.Vfdpxa) is CSEvent.V
+    assert cs_transition_event(CS.vfdpxa, CS.vfdpxA) is CSEvent.A
+
+
+# --- apply_cs_event -------------------------------------------------------
+
+
+def test_apply_cs_event_advances_the_state():
+    assert apply_cs_event(CS.vfdpxa, CSEvent.V) is CS.Vfdpxa
+    assert apply_cs_event(CS.Vfdpxa, CSEvent.F) is CS.VFdpxa
+    assert apply_cs_event(CS.vfdpXa, CSEvent.P) is CS.vfdPXa
+
+
+def test_apply_cs_event_agrees_with_the_transition_predicate():
+    for state in CS:
+        for event in CS_EVENTS:
+            try:
+                result = apply_cs_event(state, event)
+            except VultronInvalidStateTransitionError:
+                assert not any(
+                    cs_transition_event(state, dst) is event
+                    for dst in next_cs_states(state)
+                )
+                continue
+            assert is_valid_cs_transition(state, result)
+            assert cs_transition_event(state, result) is event
+
+
+def test_apply_cs_event_rejects_a_repeated_event():
+    with pytest.raises(VultronInvalidStateTransitionError, match="already"):
+        apply_cs_event(CS.Vfdpxa, CSEvent.V)
+
+
+def test_apply_cs_event_rejects_an_unmet_prerequisite():
+    with pytest.raises(
+        VultronInvalidStateTransitionError, match="prerequisite"
+    ):
+        apply_cs_event(CS.vfdpxa, CSEvent.F)
+
+
+def test_apply_cs_event_rejects_a_violated_ephemeral_rule():
+    with pytest.raises(VultronInvalidStateTransitionError, match="ephemeral"):
+        apply_cs_event(CS.vfdpXa, CSEvent.A)
+
+
+def test_apply_cs_event_reports_the_nearest_blocker_when_several_apply():
+    """F from vfdpXa is blocked twice over: pX is ephemeral *and* V is unmet.
+
+    The message names the ephemeral rule, because that is the constraint the
+    caller has to satisfy first.
+    """
+    with pytest.raises(VultronInvalidStateTransitionError) as excinfo:
+        apply_cs_event(CS.vfdpXa, CSEvent.F)
+
+    message = str(excinfo.value)
+    assert "ephemeral" in message
+    assert "prerequisite" not in message
+    # Both blockers really are live, so this is a precedence choice, not luck.
+    assert required_next_cs_events(CS.vfdpXa) == frozenset({CSEvent.P})
+    assert not is_vfd_vendor_aware(cs_dimensions(CS.vfdpXa)[0])
+
+
+# --- history validity -----------------------------------------------------
+
+
+def test_valid_histories_match_legacy_exactly():
+    """The causal replay admits exactly the legacy model's 70 histories.
+
+    This is the equivalence proof for `is_valid_history`: the legacy
+    permutation-ordering formulation and the replay-through-transitions
+    formulation accept the same set.
+    """
+    new = {_as_string(history) for history in valid_cs_histories()}
+    assert new == _legacy_valid_histories()
+
+
+def test_there_are_70_valid_histories():
+    assert len(valid_cs_histories()) == 70
+
+
+def test_valid_histories_are_distinct():
+    histories = valid_cs_histories()
+    assert len(set(histories)) == len(histories)
+
+
+def test_is_valid_cs_history_agrees_with_legacy_on_every_permutation():
+    legacy = _legacy_valid_histories()
+    for perm in permutations(CS_EVENTS):
+        assert is_valid_cs_history(list(perm)) == (_as_string(perm) in legacy)
+
+
+def test_is_valid_cs_history_agrees_with_valid_cs_histories():
+    enumerated = set(valid_cs_histories())
+    for perm in permutations(CS_EVENTS):
+        assert is_valid_cs_history(list(perm)) == (perm in enumerated)
+
+
+@pytest.mark.parametrize(
+    "history",
+    [
+        "VFDPXA",
+        "VPFXDA",
+        "PVFDXA",  # V immediately follows P
+        "VFXPDA",  # P immediately follows X
+        "AVFDPX",
+    ],
+)
+def test_accepted_histories(history):
+    events = [CSEvent(char) for char in history]
+    assert is_valid_cs_history(events)
+    ensure_valid_cs_history(events)
+
+
+@pytest.mark.parametrize(
+    "history,reason",
+    [
+        ("FVDPXA", "V must precede F"),
+        ("VDFPXA", "F must precede D"),
+        ("VFDXAP", "P must precede X or immediately follow it"),
+        ("PAVFDX", "V must precede P or immediately follow it"),
+        ("XAPVFD", "P must immediately follow X"),
+    ],
+)
+def test_rejected_histories(history, reason):
+    events = [CSEvent(char) for char in history]
+    assert not is_valid_cs_history(
+        events
+    ), f"{history} should be rejected: {reason}"
+    with pytest.raises(
+        (VultronValidationError, VultronInvalidStateTransitionError)
+    ):
+        ensure_valid_cs_history(events)
+
+
+def test_every_valid_history_reaches_the_terminal_state():
+    for history in valid_cs_histories():
+        assert replay_cs_history(history) is CS.VFDPXA
+
+
+def test_is_valid_cs_history_rejects_incomplete_and_repeated_sequences():
+    assert not is_valid_cs_history([CSEvent.V, CSEvent.F])
+    assert not is_valid_cs_history([CSEvent.V] * 6)
+
+
+def test_ensure_valid_cs_history_reports_missing_events():
+    with pytest.raises(VultronValidationError, match="missing"):
+        ensure_valid_cs_history([CSEvent.V, CSEvent.F, CSEvent.D])
+
+
+def test_ensure_valid_cs_history_reports_repeated_events():
+    with pytest.raises(VultronValidationError, match="more than once"):
+        ensure_valid_cs_history([CSEvent.V, CSEvent.V])
+
+
+# --- history prefixes -----------------------------------------------------
+
+
+def test_empty_prefix_is_valid():
+    assert is_valid_cs_history_prefix([])
+
+
+def test_every_prefix_of_every_valid_history_is_valid():
+    for history in valid_cs_histories():
+        for length in range(len(history) + 1):
+            assert is_valid_cs_history_prefix(history[:length])
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        [CSEvent.V],
+        [CSEvent.V, CSEvent.F],
+        [CSEvent.X],  # ends in ephemeral pX — nothing has come next yet
+        [CSEvent.P],  # ends in ephemeral vP
+        [CSEvent.A, CSEvent.V],
+    ],
+)
+def test_accepted_prefixes(prefix):
+    assert is_valid_cs_history_prefix(prefix)
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        [CSEvent.F],  # F before V
+        [CSEvent.D],  # D before F
+        [CSEvent.X, CSEvent.A],  # pX requires P next
+        [CSEvent.P, CSEvent.A],  # vP requires V next
+        [CSEvent.V, CSEvent.V],  # repeated event
+    ],
+)
+def test_rejected_prefixes(prefix):
+    assert not is_valid_cs_history_prefix(prefix)
+
+
+def test_prefix_can_start_from_a_non_initial_state():
+    assert is_valid_cs_history_prefix([CSEvent.F], start=CS.Vfdpxa)
+    assert not is_valid_cs_history_prefix([CSEvent.V], start=CS.Vfdpxa)
+
+
+def test_replay_from_a_non_initial_state():
+    assert replay_cs_history([CSEvent.F], start=CS.Vfdpxa) is CS.VFdpxa
+
+
+def test_replay_rejects_repeated_events():
+    with pytest.raises(VultronValidationError, match="more than once"):
+        replay_cs_history([CSEvent.V, CSEvent.P, CSEvent.V])
+
+
+def test_replay_of_empty_sequence_returns_the_start_state():
+    assert replay_cs_history([]) is CS.vfdpxa
+    assert replay_cs_history([], start=CS.VFdPxa) is CS.VFdPxa

--- a/test/core/states/test_cs_invariants.py
+++ b/test/core/states/test_cs_invariants.py
@@ -172,6 +172,7 @@ def test_pxa_trigger_map_pairs_by_letter(event, trigger):
 # --- compound state validity ----------------------------------------------
 
 
+@pytest.mark.spec("CSB-17-001")
 def test_cs_enum_is_exactly_the_legacy_valid_state_set():
     """The 32 CS members are the legacy model's 32 valid states.
 
@@ -239,6 +240,7 @@ def test_ephemeral_states_are_the_twelve_vp_and_px_states():
         (CS.VFDPXA, set()),
     ],
 )
+@pytest.mark.spec("CSB-17-003")
 def test_required_next_cs_events(state, expected):
     assert required_next_cs_events(state) == frozenset(expected)
 
@@ -259,6 +261,7 @@ def test_ephemeral_states_have_exactly_one_successor():
 # --- transition validity --------------------------------------------------
 
 
+@pytest.mark.spec("CSB-17-002")
 def test_transition_set_matches_legacy_exactly():
     """The re-expressed transition rule admits the legacy model's 58 edges."""
     new_edges = {
@@ -432,6 +435,7 @@ def test_apply_cs_event_reports_the_nearest_blocker_when_several_apply():
 # --- history validity -----------------------------------------------------
 
 
+@pytest.mark.spec("CSB-17-004")
 def test_valid_histories_match_legacy_exactly():
     """The causal replay admits exactly the legacy model's 70 histories.
 
@@ -528,10 +532,56 @@ def test_empty_prefix_is_valid():
     assert is_valid_cs_history_prefix([])
 
 
+@pytest.mark.spec("CSB-17-005")
 def test_every_prefix_of_every_valid_history_is_valid():
     for history in valid_cs_histories():
         for length in range(len(history) + 1):
             assert is_valid_cs_history_prefix(history[:length])
+
+
+@pytest.mark.spec("CSB-17-005")
+def test_accepted_prefixes_are_exactly_the_prefixes_of_valid_histories():
+    """The converse of the test above — the half that gives the API meaning.
+
+    One direction alone would also be satisfied by a predicate that accepts
+    everything. This pins the accepted set to *exactly* the prefix-closure of
+    the 70 valid histories, so every accepted prefix is a trajectory some real
+    case could actually be on, and no legal in-progress case is rejected.
+    """
+    closure = {
+        history[:length]
+        for history in valid_cs_histories()
+        for length in range(len(history) + 1)
+    }
+
+    accepted = {
+        candidate
+        for length in range(len(CS_EVENTS) + 1)
+        for candidate in permutations(CS_EVENTS, length)
+        if is_valid_cs_history_prefix(list(candidate))
+    }
+
+    assert accepted == closure
+
+
+@pytest.mark.spec("CSB-17-005")
+def test_every_accepted_prefix_extends_to_a_complete_valid_history():
+    """No accepted prefix is a dead end.
+
+    Stated the way a caller cares about it: a case sitting on any prefix the
+    predicate accepts always has some legal route left to `VFDPXA`. Note that
+    the accepted set is derived from the predicate, not from
+    `valid_cs_histories()`, so this is not a restatement of the closure test.
+    """
+    completions = valid_cs_histories()
+
+    for length in range(len(CS_EVENTS) + 1):
+        for candidate in permutations(CS_EVENTS, length):
+            if not is_valid_cs_history_prefix(list(candidate)):
+                continue
+            assert any(
+                history[:length] == candidate for history in completions
+            ), f"accepted prefix {_as_string(candidate)} has no completion"
 
 
 @pytest.mark.parametrize(
@@ -544,6 +594,7 @@ def test_every_prefix_of_every_valid_history_is_valid():
         [CSEvent.A, CSEvent.V],
     ],
 )
+@pytest.mark.spec("CSB-17-005")
 def test_accepted_prefixes(prefix):
     assert is_valid_cs_history_prefix(prefix)
 
@@ -579,3 +630,62 @@ def test_replay_rejects_repeated_events():
 def test_replay_of_empty_sequence_returns_the_start_state():
     assert replay_cs_history([]) is CS.vfdpxa
     assert replay_cs_history([], start=CS.VFdPxa) is CS.VFdPxa
+
+
+# --- input coercion -------------------------------------------------------
+#
+# `CSEvent` is a StrEnum, and the legacy `case_states.validations` API this
+# module replaces took plain strings ("VFDPXA"), so a migrating caller will
+# naturally pass them. These pin that the string form works and that garbage
+# makes the predicates answer False rather than raise.
+
+
+@pytest.mark.parametrize(
+    "history,expected",
+    [
+        ("VFDPXA", True),
+        ("FVDPXA", False),  # F before V
+        ("VDFPXA", False),  # D before F
+        ("VFDXPA", True),  # X then P — pX satisfied by the adjacent P
+        ("PVFDXA", True),  # P then V — vP satisfied by the adjacent V
+    ],
+)
+def test_string_histories_match_the_enum_form(history, expected):
+    assert is_valid_cs_history(history) is expected
+    assert is_valid_cs_history([CSEvent(c) for c in history]) is expected
+
+
+def test_string_prefixes_are_accepted():
+    assert is_valid_cs_history_prefix("VF")
+    assert is_valid_cs_history_prefix(["V", "F"])
+    assert not is_valid_cs_history_prefix("F")
+
+
+def test_apply_cs_event_accepts_the_string_form():
+    assert apply_cs_event(CS.vfdpxa, "V") is CS.Vfdpxa
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        ["Z"],  # not a CS event letter
+        ["v"],  # lowercase is a state letter, not an event
+        [None],
+        [1],
+        [["V"]],  # unhashable
+    ],
+)
+def test_predicates_reject_non_events_without_raising(events):
+    """A predicate must answer, not explode, on bad input."""
+    assert is_valid_cs_history_prefix(events) is False
+    assert is_valid_cs_history(events) is False
+
+
+def test_ensure_valid_cs_history_names_the_offending_value():
+    with pytest.raises(VultronValidationError, match="is not a CS event"):
+        ensure_valid_cs_history(["Z", "F", "D", "P", "X", "A"])
+
+
+def test_replay_rejects_non_events():
+    with pytest.raises(VultronValidationError, match="is not a CS event"):
+        replay_cs_history(["V", "Z"])

--- a/test/core/states/test_cs_invariants.py
+++ b/test/core/states/test_cs_invariants.py
@@ -39,6 +39,8 @@ from vultron.core.states.cs import (
     CS_vfd,
     PXA_Trigger,
     VFD_Trigger,
+    is_valid_pxa_transition,
+    is_valid_vfd_transition,
     is_vfd_vendor_aware,
 )
 from vultron.core.states.cs_invariants import (
@@ -278,6 +280,56 @@ def test_there_are_58_valid_transitions():
         1 for src in CS for dst in CS if is_valid_cs_transition(src, dst)
     )
     assert count == 58
+
+
+def _satisfies_structural_conditions(src: CS, dst: CS) -> bool:
+    """Conditions 1-3 of CSB-17-002, *without* the ephemeral rule (condition 4).
+
+    Distance-1, monotone, and permitted by the changed dimension's own table —
+    but indifferent to whether *src* is ephemeral.
+    """
+    if src is dst:
+        return False
+    event = cs_transition_event(src, dst)
+    if event is None:
+        return False
+
+    src_vfd, src_pxa = cs_dimensions(src)
+    dst_vfd, dst_pxa = cs_dimensions(dst)
+    if event in VFD_EVENTS:
+        return src_pxa is dst_pxa and is_valid_vfd_transition(src_vfd, dst_vfd)
+    return src_vfd is dst_vfd and is_valid_pxa_transition(src_pxa, dst_pxa)
+
+
+@pytest.mark.spec("CSB-17-002")
+def test_structural_conditions_alone_admit_72_transitions():
+    """Pins CSB-17-002's attribution of the 72 -> 58 reduction.
+
+    The 58 figure needs all four conditions. Conditions 1-3 alone admit 72;
+    the ephemeral rule of CSB-17-003 removes the other 14. CSB-17-002's
+    statement restates both counts, and a restated count next to a
+    requirement reference drifts silently unless something asserts it
+    (see `20260812-restated-counts-in-spec-cross-references-drift.md`).
+    """
+    structural = {
+        (src, dst)
+        for src in CS
+        for dst in CS
+        if _satisfies_structural_conditions(src, dst)
+    }
+    valid = {
+        (src, dst)
+        for src in CS
+        for dst in CS
+        if is_valid_cs_transition(src, dst)
+    }
+
+    assert len(structural) == 72
+    assert len(valid) == 58
+
+    # The 14 removed edges all leave an ephemeral state by the wrong event.
+    assert valid < structural
+    assert all(is_ephemeral_cs_state(src) for src, _ in structural - valid)
 
 
 def test_every_transition_changes_exactly_one_dimension():

--- a/test/test_integration_timeout_tier.py
+++ b/test/test_integration_timeout_tier.py
@@ -123,3 +123,39 @@ class TestIntegrationTimeoutValue:
 
     def test_is_still_a_bounded_hang_detector(self):
         assert INTEGRATION_TIMEOUT_SECONDS <= 300
+
+
+class TestUnitTierTimeout:
+    """Pin the unit-tier ceiling in ``pyproject.toml`` (issue #2270).
+
+    Four sessions re-diagnosed a too-tight unit ceiling as flakiness before it
+    was raised. These assertions make a silent revert fail loudly.
+    """
+
+    @staticmethod
+    def _configured_timeout(pytestconfig):
+        return int(pytestconfig.getini("timeout"))
+
+    def test_unit_tier_clears_the_slowest_ast_ratchet(self, pytestconfig):
+        """AST-walking architecture ratchets run ~3.4s in isolation.
+
+        Under full-suite load they were tripping a 5s ceiling. Require enough
+        headroom that load variance cannot reach it.
+        """
+        assert self._configured_timeout(pytestconfig) >= 15
+
+    def test_unit_tier_is_still_a_bounded_hang_detector(self, pytestconfig):
+        assert self._configured_timeout(pytestconfig) <= 60
+
+    def test_integration_tier_is_wider_than_the_unit_tier(self, pytestconfig):
+        assert INTEGRATION_TIMEOUT_SECONDS > self._configured_timeout(
+            pytestconfig
+        )
+
+    def test_thread_method_is_still_in_use(self, pytestconfig):
+        """Documents the coupling the tier values depend on.
+
+        If this ever changes to "signal", a timeout fails one test instead of
+        aborting the session, and the generous ceilings above can be revisited.
+        """
+        assert pytestconfig.getini("timeout_method") == "thread"

--- a/test/test_integration_timeout_tier.py
+++ b/test/test_integration_timeout_tier.py
@@ -1,0 +1,125 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+Tests for the integration-tier per-test timeout (issue #2270).
+
+The global ``timeout = 5`` in ``pyproject.toml`` is sized for the unit suite.
+``test/conftest.py`` widens it for ``integration``-marked tests only. These
+tests pin that behaviour so the 5s ceiling cannot silently creep back onto the
+integration suite and abort the session again.
+"""
+
+import pytest
+
+from test.conftest import (
+    INTEGRATION_TIMEOUT_SECONDS,
+    apply_integration_timeout,
+)
+
+
+class FakeItem:
+    """Minimal stand-in for a pytest ``Item``.
+
+    Only the two marker operations the hook uses are implemented:
+    ``get_closest_marker`` and ``add_marker``.
+    """
+
+    def __init__(self, *marker_names, timeout=None):
+        self.names = set(marker_names)
+        self.added = []
+        self.explicit_timeout = timeout
+
+    def get_closest_marker(self, name):
+        if name == "timeout":
+            if self.explicit_timeout is not None:
+                return pytest.mark.timeout(self.explicit_timeout).mark
+            for mark in self.added:
+                if mark.name == "timeout":
+                    return mark
+            return None
+        return (
+            pytest.mark.__getattr__(name).mark if name in self.names else None
+        )
+
+    def add_marker(self, marker):
+        self.added.append(marker.mark)
+
+    @property
+    def applied_timeout(self):
+        for mark in self.added:
+            if mark.name == "timeout":
+                return mark.args[0]
+        return None
+
+
+class TestApplyIntegrationTimeout:
+    def test_integration_item_gets_the_integration_tier_timeout(self):
+        item = FakeItem("integration")
+
+        assert apply_integration_timeout([item]) == 1
+        assert item.applied_timeout == INTEGRATION_TIMEOUT_SECONDS
+
+    def test_unit_item_is_left_at_the_global_default(self):
+        item = FakeItem()
+
+        assert apply_integration_timeout([item]) == 0
+        assert item.applied_timeout is None
+
+    def test_explicit_timeout_marker_wins(self):
+        """A deliberate per-test value must not be overwritten."""
+        item = FakeItem("integration", timeout=180)
+
+        assert apply_integration_timeout([item]) == 0
+        assert item.applied_timeout is None
+
+    def test_explicit_shorter_timeout_also_wins(self):
+        """Tests that assert on a timeout firing must keep their short value."""
+        item = FakeItem("integration", timeout=1)
+
+        assert apply_integration_timeout([item]) == 0
+        assert item.applied_timeout is None
+
+    def test_mixed_collection_only_touches_integration_items(self):
+        integration = FakeItem("integration")
+        unit = FakeItem()
+        explicit = FakeItem("integration", timeout=10)
+
+        assert apply_integration_timeout([integration, unit, explicit]) == 1
+        assert integration.applied_timeout == INTEGRATION_TIMEOUT_SECONDS
+        assert unit.applied_timeout is None
+        assert explicit.applied_timeout is None
+
+    def test_applying_twice_is_idempotent(self):
+        """Re-running the hook must not stack duplicate timeout markers."""
+        item = FakeItem("integration")
+
+        apply_integration_timeout([item])
+        assert apply_integration_timeout([item]) == 0
+        assert [m.name for m in item.added].count("timeout") == 1
+
+    def test_empty_collection_is_a_no_op(self):
+        assert apply_integration_timeout([]) == 0
+
+
+class TestIntegrationTimeoutValue:
+    def test_is_comfortably_above_the_slowest_honest_integration_test(self):
+        """The slowest honest integration test measured ~4.3s (issue #2270).
+
+        A ceiling that is merely a little above that is what caused the
+        original spurious aborts, so require real headroom.
+        """
+        assert INTEGRATION_TIMEOUT_SECONDS >= 30
+
+    def test_is_still_a_bounded_hang_detector(self):
+        assert INTEGRATION_TIMEOUT_SECONDS <= 300

--- a/test/test_integration_timeout_tier.py
+++ b/test/test_integration_timeout_tier.py
@@ -14,11 +14,19 @@
 """
 Tests for the integration-tier per-test timeout (issue #2270).
 
-The global ``timeout = 5`` in ``pyproject.toml`` is sized for the unit suite.
+The global ``timeout = 30`` in ``pyproject.toml`` is sized for the unit suite.
 ``test/conftest.py`` widens it for ``integration``-marked tests only. These
-tests pin that behaviour so the 5s ceiling cannot silently creep back onto the
-integration suite and abort the session again.
+tests pin both tiers so neither ceiling can silently creep back down and abort
+the session again.
+
+``TestApplyIntegrationTimeout`` exercises the hook against a stub item, which
+pins its own contract but cannot show that pytest-timeout honours a marker
+added at collection time. ``TestResolvedTimeoutsUnderRealPytest`` closes that
+gap by running a real pytest session and reading the timeout each item
+actually resolved to.
 """
+
+import json
 
 import pytest
 
@@ -26,6 +34,8 @@ from test.conftest import (
     INTEGRATION_TIMEOUT_SECONDS,
     apply_integration_timeout,
 )
+
+pytest_plugins = ["pytester"]
 
 
 class FakeItem:
@@ -110,6 +120,95 @@ class TestApplyIntegrationTimeout:
 
     def test_empty_collection_is_a_no_op(self):
         assert apply_integration_timeout([]) == 0
+
+
+_UNIT_TIER_FOR_PROBE = 30
+
+_PROBE_CONFTEST = """
+import json
+import pathlib
+
+import pytest_timeout
+
+from test.conftest import apply_integration_timeout
+
+_resolved = {}
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "integration: integration test")
+
+
+def pytest_collection_modifyitems(items):
+    apply_integration_timeout(items)
+
+
+def pytest_runtest_setup(item):
+    _resolved[item.name] = pytest_timeout._get_item_settings(item).timeout
+
+
+def pytest_sessionfinish(session, exitstatus):
+    pathlib.Path(session.config.rootpath / "resolved.json").write_text(
+        json.dumps(_resolved)
+    )
+"""
+
+_PROBE_TESTS = """
+import pytest
+
+
+@pytest.mark.integration
+def test_integration_tier():
+    pass
+
+
+def test_unit_tier():
+    pass
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(7)
+def test_explicit_marker_wins():
+    pass
+"""
+
+
+class TestResolvedTimeoutsUnderRealPytest:
+    """Assert the timeout each item *actually* resolves to (issue #2270).
+
+    The stub-based tests above verify the hook's own logic. This one runs a
+    real pytest session and asks pytest-timeout what it resolved for each
+    item, which is the only way to catch a hook-ordering regression: the
+    marker is added at collection time, but pytest-timeout reads it much
+    later, in ``pytest_runtest_protocol``.
+    """
+
+    @pytest.fixture
+    def resolved(self, pytester):
+        pytester.makeconftest(_PROBE_CONFTEST)
+        pytester.makepyfile(test_probe=_PROBE_TESTS)
+
+        result = pytester.runpytest(
+            "-p",
+            "no:randomly",
+            "-o",
+            f"timeout={_UNIT_TIER_FOR_PROBE}",
+            "-o",
+            "timeout_method=thread",
+        )
+        result.assert_outcomes(passed=3)
+
+        return json.loads((pytester.path / "resolved.json").read_text())
+
+    def test_integration_item_resolves_to_the_integration_tier(self, resolved):
+        assert resolved["test_integration_tier"] == INTEGRATION_TIMEOUT_SECONDS
+
+    def test_unit_item_resolves_to_the_unit_tier(self, resolved):
+        assert resolved["test_unit_tier"] == _UNIT_TIER_FOR_PROBE
+
+    def test_explicit_marker_beats_the_tier_default(self, resolved):
+        """The demo suite's deliberate values (10, 180) depend on this."""
+        assert resolved["test_explicit_marker_wins"] == 7
 
 
 class TestIntegrationTimeoutValue:

--- a/vultron/core/states/__init__.py
+++ b/vultron/core/states/__init__.py
@@ -37,6 +37,8 @@ from vultron.core.states.cs import (
 from vultron.core.states.cs_invariants import (
     CSEvent,
     CS_EVENTS,
+    CS_EVENT_TO_PXA_TRIGGER,
+    CS_EVENT_TO_VFD_TRIGGER,
     PXA_EVENTS,
     VFD_EVENTS,
     apply_cs_event,

--- a/vultron/core/states/__init__.py
+++ b/vultron/core/states/__init__.py
@@ -34,6 +34,26 @@ from vultron.core.states.cs import (
     state_string_to_enums,
     vfd,
 )
+from vultron.core.states.cs_invariants import (
+    CSEvent,
+    CS_EVENTS,
+    PXA_EVENTS,
+    VFD_EVENTS,
+    apply_cs_event,
+    cs_dimensions,
+    cs_from_dimensions,
+    cs_transition_event,
+    ensure_valid_cs_history,
+    ensure_valid_cs_transition,
+    is_ephemeral_cs_state,
+    is_valid_cs_history,
+    is_valid_cs_history_prefix,
+    is_valid_cs_transition,
+    next_cs_states,
+    replay_cs_history,
+    required_next_cs_events,
+    valid_cs_histories,
+)
 from vultron.core.states.em import (
     EM,
     EM_EMBARGO_ACTIVE,

--- a/vultron/core/states/cs_invariants.py
+++ b/vultron/core/states/cs_invariants.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""CS-internal validity, transition, and history invariants.
+
+This module expresses the Case State (CS) validity rules of the MPCVD
+state-based model against the current enum models in
+`vultron.core.states.cs` — `CS`, `CS_vfd`, `CS_pxa`, and the per-dimension
+transition tables that back `VfdDimension` / `PxaDimension`.
+
+Three rule families live here:
+
+Compound state validity
+    The 32 members of `CS` *are* the valid compound states.  The two
+    impossible-combination rules of the formal model (`vF` — a fix ready
+    while the vendor is unaware; `fD` — a fix deployed that was never ready)
+    are enforced structurally by `CS_vfd` having only four members, so no
+    runtime predicate is needed.  `test_cs_invariants.py` ratchets the enum
+    against an independent derivation of the rule.
+
+Transition validity (`is_valid_cs_transition`)
+    A CS transition changes exactly one of the six dimensions, always from
+    the not-yet-happened to the happened value, and must respect the two
+    *ephemeral state* rules below.
+
+Ephemeral states (`is_ephemeral_cs_state`, `required_next_cs_events`)
+    Two compound states are transient in the formal model and constrain the
+    very next event rather than being forbidden outright:
+
+    - ``vP`` (public aware, vendor unaware) — the next event MUST be ``V``.
+    - ``pX`` (exploit public, public unaware) — the next event MUST be ``P``.
+
+History validity (`is_valid_cs_history`, `is_valid_cs_history_prefix`)
+    A *history* is the order in which the six events occurred.  History
+    validity is a **causal** property of a whole sequence, not a
+    point-in-time or wall-clock one: it is what lets a consumer reject a
+    reported case trajectory that no real case could have produced.
+
+The complete-history ordering rules
+
+- ``V ≺ F ≺ D``
+- ``P ≺ X`` or ``P`` immediately follows ``X``
+- ``V ≺ P`` or ``V`` immediately follows ``P``
+
+are provably equivalent to replaying the sequence through
+`is_valid_cs_transition` from `CS.vfdpxa`; both admit exactly the same 70
+histories.  `test_cs_invariants.py` asserts that equivalence directly, so
+the two formulations cannot drift apart.
+
+Reference: Householder, A. D., and Spring, J.
+*A State-Based Model for Multi-Party Coordinated Vulnerability Disclosure
+(MPCVD)*, CMU/SEI-2021-SR-021. <https://doi.org/10.1184/R1/16416771>
+
+Spec: `specs/cs-behavior.yaml` CSB-17.  Decision: ADR-0060.
+"""
+
+from collections.abc import Iterable, Sequence
+from enum import StrEnum
+
+from vultron.core.states.cs import (
+    CS,
+    CS_pxa,
+    CS_vfd,
+    PXA_Trigger,
+    VFD_Trigger,
+    is_pxa_exploit_public,
+    is_pxa_public_aware,
+    is_valid_pxa_transition,
+    is_valid_vfd_transition,
+    is_vfd_vendor_aware,
+)
+from vultron.errors import (
+    VultronInvalidStateTransitionError,
+    VultronValidationError,
+)
+
+
+class CSEvent(StrEnum):
+    """The six CS transition events, in canonical dimension order.
+
+    Each event flips exactly one CS dimension from its not-yet-happened value
+    to its happened value.  Events are irreversible and occur at most once in
+    a case history.
+    """
+
+    V = "V"
+    """Vendor becomes aware."""
+    F = "F"
+    """Fix becomes ready."""
+    D = "D"
+    """Fix is deployed."""
+    P = "P"
+    """Public becomes aware."""
+    X = "X"
+    """Exploit is made public."""
+    A = "A"
+    """Attacks are observed."""
+
+
+CS_EVENTS: tuple[CSEvent, ...] = tuple(CSEvent)
+"""All six CS events in canonical (`VFDPXA`) order."""
+
+VFD_EVENTS: frozenset[CSEvent] = frozenset({CSEvent.V, CSEvent.F, CSEvent.D})
+"""The CS events belonging to the vendor fix path (VFD) dimension."""
+
+PXA_EVENTS: frozenset[CSEvent] = frozenset({CSEvent.P, CSEvent.X, CSEvent.A})
+"""The CS events belonging to the public/exploit/attack (PXA) dimension."""
+
+CS_EVENT_TO_VFD_TRIGGER: dict[CSEvent, VFD_Trigger] = {
+    CSEvent.V: VFD_Trigger.V,
+    CSEvent.F: VFD_Trigger.F,
+    CSEvent.D: VFD_Trigger.D,
+}
+"""Maps a VFD-dimension CS event to the `VfdDimension.transition()` trigger."""
+
+CS_EVENT_TO_PXA_TRIGGER: dict[CSEvent, PXA_Trigger] = {
+    CSEvent.P: PXA_Trigger.P,
+    CSEvent.X: PXA_Trigger.X,
+    CSEvent.A: PXA_Trigger.A,
+}
+"""Maps a PXA-dimension CS event to the `PxaDimension.transition()` trigger."""
+
+
+def cs_dimensions(state: CS) -> tuple[CS_vfd, CS_pxa]:
+    """Return the (VFD, PXA) dimension states of a compound CS state.
+
+    Examples::
+
+        cs_dimensions(CS.vfdpxa)  # (CS_vfd.vfd, CS_pxa.pxa)
+        cs_dimensions(CS.VFdPXa)  # (CS_vfd.VFd, CS_pxa.PXa)
+    """
+    compound = state.value
+    return compound.vfd_state, compound.pxa_state
+
+
+def cs_from_dimensions(vfd_state: CS_vfd, pxa_state: CS_pxa) -> CS:
+    """Return the compound `CS` member for a (VFD, PXA) dimension pair.
+
+    Every one of the 4 x 8 combinations is a valid compound state, so this
+    never fails for well-typed inputs.
+
+    Examples::
+
+        cs_from_dimensions(CS_vfd.VFd, CS_pxa.Pxa)  # CS.VFdPxa
+    """
+    return CS[f"{vfd_state.name}{pxa_state.name}"]
+
+
+def is_ephemeral_cs_state(state: CS) -> bool:
+    """Return True if *state* is transient and constrains the next event.
+
+    A state is ephemeral when the formal model requires a specific event to
+    fire next: ``vP`` requires ``V``, ``pX`` requires ``P``.  The two
+    conditions are mutually exclusive, because ``vP`` needs ``P`` set and
+    ``pX`` needs it unset.
+
+    Examples::
+
+        is_ephemeral_cs_state(CS.vfdPxa)  # True  (public aware, vendor unaware)
+        is_ephemeral_cs_state(CS.vfdpXa)  # True  (exploit public, public unaware)
+        is_ephemeral_cs_state(CS.VfdPxa)  # False
+    """
+    return bool(required_next_cs_events(state))
+
+
+def required_next_cs_events(state: CS) -> frozenset[CSEvent]:
+    """Return the events that *state* permits as its immediate successor.
+
+    An empty set means the state is not ephemeral and imposes no
+    next-event requirement of its own — any event still available under the
+    per-dimension machines may fire.
+
+    Examples::
+
+        required_next_cs_events(CS.vfdPxa)  # frozenset({CSEvent.V})
+        required_next_cs_events(CS.vfdpXa)  # frozenset({CSEvent.P})
+        required_next_cs_events(CS.VfdPxa)  # frozenset()
+    """
+    vfd_state, pxa_state = cs_dimensions(state)
+
+    # vP: the public is aware but the vendor is not -> V must fire next.
+    if is_pxa_public_aware(pxa_state) and not is_vfd_vendor_aware(vfd_state):
+        return frozenset({CSEvent.V})
+
+    # pX: an exploit is public but the public is not aware -> P must fire next.
+    if is_pxa_exploit_public(pxa_state) and not is_pxa_public_aware(pxa_state):
+        return frozenset({CSEvent.P})
+
+    return frozenset()
+
+
+def cs_transition_event(src: CS, dst: CS) -> CSEvent | None:
+    """Return the single event that distinguishes *src* from *dst*.
+
+    Returns None when the two states differ in zero or more than one
+    dimension bit, i.e. when no single event can account for the change.
+
+    Examples::
+
+        cs_transition_event(CS.vfdpxa, CS.Vfdpxa)  # CSEvent.V
+        cs_transition_event(CS.vfdpxa, CS.vfdpxa)  # None (no change)
+        cs_transition_event(CS.vfdpxa, CS.VfdPxa)  # None (two bits changed)
+    """
+    changed = [
+        event
+        for event, before, after in zip(CS_EVENTS, src.name, dst.name)
+        if before != after
+    ]
+    if len(changed) != 1:
+        return None
+    return changed[0]
+
+
+def is_valid_cs_transition(
+    src: CS, dst: CS, *, allow_null: bool = False
+) -> bool:
+    """Return True if (src -> dst) is a legal CS transition.
+
+    A legal transition satisfies all of:
+
+    1. Exactly one of the six dimensions changes (Hamming distance 1).
+    2. The change is monotone — from the not-yet-happened to the happened
+       value; CS events are irreversible.
+    3. The changed dimension's per-machine transition table permits it
+       (`is_valid_vfd_transition` / `is_valid_pxa_transition`).
+    4. If *src* is ephemeral, *dst* must be reached by its required event.
+
+    Args:
+        src: the source compound state
+        dst: the destination compound state
+        allow_null: if True, treat ``src is dst`` as valid.  Use for
+            same-state status re-assertions, which are bookkeeping rather
+            than transitions.
+
+    Examples::
+
+        is_valid_cs_transition(CS.vfdpxa, CS.Vfdpxa)  # True
+        is_valid_cs_transition(CS.vfdPxa, CS.vfdPxA)  # False (vP needs V next)
+        is_valid_cs_transition(CS.vfdpXa, CS.vfdpXA)  # False (pX needs P next)
+        is_valid_cs_transition(CS.Vfdpxa, CS.vfdpxa)  # False (not monotone)
+    """
+    if src is dst:
+        return allow_null
+
+    event = cs_transition_event(src, dst)
+    if event is None:
+        return False
+
+    src_vfd, src_pxa = cs_dimensions(src)
+    dst_vfd, dst_pxa = cs_dimensions(dst)
+
+    if event in VFD_EVENTS:
+        if src_pxa is not dst_pxa:
+            return False
+        if not is_valid_vfd_transition(src_vfd, dst_vfd):
+            return False
+    else:
+        if src_vfd is not dst_vfd:
+            return False
+        if not is_valid_pxa_transition(src_pxa, dst_pxa):
+            return False
+
+    required = required_next_cs_events(src)
+    if required and event not in required:
+        return False
+
+    return True
+
+
+def ensure_valid_cs_transition(
+    src: CS, dst: CS, *, allow_null: bool = False
+) -> None:
+    """Raise unless (src -> dst) is a legal CS transition.
+
+    Raises:
+        VultronInvalidStateTransitionError: if the transition is not legal.
+    """
+    if is_valid_cs_transition(src, dst, allow_null=allow_null):
+        return
+
+    required = required_next_cs_events(src)
+    if required:
+        detail = (
+            f" — {src.name} is ephemeral and requires event(s)"
+            f" {sorted(e.value for e in required)} next"
+        )
+    else:
+        detail = ""
+    raise VultronInvalidStateTransitionError(
+        f"CS: transition {src.name} -> {dst.name} is not permitted{detail}."
+    )
+
+
+def next_cs_states(state: CS) -> tuple[CS, ...]:
+    """Return every compound state reachable from *state* in one transition.
+
+    Examples::
+
+        next_cs_states(CS.VFDPXA)  # () — terminal state
+        len(next_cs_states(CS.vfdPxa))  # 1 — ephemeral, V only
+    """
+    return tuple(
+        candidate
+        for candidate in CS
+        if is_valid_cs_transition(state, candidate)
+    )
+
+
+def apply_cs_event(state: CS, event: CSEvent) -> CS:
+    """Return the state reached by applying *event* to *state*.
+
+    Args:
+        state: the current compound state
+        event: the event to apply
+
+    Returns:
+        the resulting compound state
+
+    Raises:
+        VultronInvalidStateTransitionError: if *event* cannot fire from
+            *state* — because it already happened, because its dimension
+            machine forbids it, or because *state* is ephemeral and requires
+            a different event next.
+
+    Examples::
+
+        apply_cs_event(CS.vfdpxa, CSEvent.V)  # CS.Vfdpxa
+    """
+    for candidate in CS:
+        if cs_transition_event(state, candidate) is not event:
+            continue
+        if is_valid_cs_transition(state, candidate):
+            return candidate
+        break
+
+    raise VultronInvalidStateTransitionError(
+        f"CS: event '{event.value}' cannot fire from {state.name}:"
+        f" {_why_event_blocked(state, event)}."
+    )
+
+
+def _why_event_blocked(state: CS, event: CSEvent) -> str:
+    """Explain why *event* cannot fire from *state*.
+
+    Only called on the failure path of `apply_cs_event`, where at least one of
+    three things is true: the event already happened, the state is ephemeral
+    and demands a different event, or the event's dimension prerequisite is
+    unmet (F before V, D before F).
+
+    More than one can hold at once — e.g. ``F`` from ``vfdpXa`` is blocked both
+    by the ``pX`` ephemeral rule and by ``V`` not having occurred.  The checks
+    run in order of proximity and report the first that applies, so the message
+    names the constraint the caller must satisfy first rather than every
+    constraint outstanding.
+    """
+    if state.name[CS_EVENTS.index(event)].isupper():
+        return "it has already occurred"
+
+    required = required_next_cs_events(state)
+    if required:
+        return (
+            f"{state.name} is ephemeral and requires event(s)"
+            f" {sorted(e.value for e in required)} next"
+        )
+
+    return "its dimension's prerequisite events have not occurred"
+
+
+def _ensure_distinct_events(events: Sequence[CSEvent]) -> None:
+    seen: set[CSEvent] = set()
+    for event in events:
+        if event in seen:
+            raise VultronValidationError(
+                f"CS history: event '{event.value}' occurs more than once;"
+                " CS events are irreversible and happen at most once."
+            )
+        seen.add(event)
+
+
+def replay_cs_history(
+    events: Iterable[CSEvent], *, start: CS = CS.vfdpxa
+) -> CS:
+    """Replay *events* from *start* and return the resulting state.
+
+    This is the causal check over a whole trajectory: each event must be
+    legal given every event that preceded it.
+
+    Args:
+        events: the ordered CS events to apply
+        start: the state to replay from, default `CS.vfdpxa`
+
+    Returns:
+        the compound state after the last event
+
+    Raises:
+        VultronValidationError: if an event repeats.
+        VultronInvalidStateTransitionError: if an event cannot fire at its
+            position in the sequence.
+
+    Examples::
+
+        replay_cs_history([CSEvent.V, CSEvent.F])  # CS.VFdpxa
+    """
+    sequence = list(events)
+    _ensure_distinct_events(sequence)
+
+    state = start
+    for event in sequence:
+        state = apply_cs_event(state, event)
+    return state
+
+
+def is_valid_cs_history_prefix(
+    events: Sequence[CSEvent], *, start: CS = CS.vfdpxa
+) -> bool:
+    """Return True if *events* is a legal (possibly incomplete) trajectory.
+
+    Use this on real case histories, which are usually still in progress.
+    An empty sequence is trivially valid.
+
+    Note that a prefix ending in an ephemeral state is accepted: the
+    ephemeral rules constrain what may come *next*, and nothing has come
+    next yet.
+
+    Examples::
+
+        is_valid_cs_history_prefix([CSEvent.V, CSEvent.F])          # True
+        is_valid_cs_history_prefix([CSEvent.F])                     # False
+        is_valid_cs_history_prefix([CSEvent.X])                     # True  (pX)
+        is_valid_cs_history_prefix([CSEvent.X, CSEvent.A])          # False
+    """
+    try:
+        replay_cs_history(events, start=start)
+    except (VultronValidationError, VultronInvalidStateTransitionError):
+        return False
+    return True
+
+
+def is_valid_cs_history(events: Sequence[CSEvent]) -> bool:
+    """Return True if *events* is a complete, legal case history.
+
+    A complete history contains all six events exactly once and reaches
+    `CS.VFDPXA`.  Equivalent to the ordering rules ``V ≺ F ≺ D``,
+    ``P ≺ X`` or ``XP`` adjacent, and ``V ≺ P`` or ``PV`` adjacent.
+
+    Examples::
+
+        is_valid_cs_history(list(CSEvent))                    # True  (VFDPXA)
+        is_valid_cs_history([CSEvent.F, CSEvent.V, ...])      # False (F before V)
+    """
+    if len(events) != len(CS_EVENTS):
+        return False
+    if set(events) != set(CS_EVENTS):
+        return False
+    return is_valid_cs_history_prefix(events)
+
+
+def ensure_valid_cs_history(events: Sequence[CSEvent]) -> None:
+    """Raise unless *events* is a complete, legal case history.
+
+    Raises:
+        VultronValidationError: if the history is incomplete or its events
+            are not a permutation of the six CS events.
+        VultronInvalidStateTransitionError: if the ordering is causally
+            impossible.
+    """
+    _ensure_distinct_events(events)
+
+    missing = sorted(e.value for e in set(CS_EVENTS) - set(events))
+    if missing:
+        raise VultronValidationError(
+            f"CS history: incomplete, missing event(s) {missing}."
+        )
+
+    replay_cs_history(events)
+
+
+def valid_cs_histories() -> tuple[tuple[CSEvent, ...], ...]:
+    """Return every complete, legal case history.
+
+    There are 70 of them.  Ordering is deterministic (depth-first over `CS`
+    member order) so callers may rely on it in tests.
+
+    Examples::
+
+        len(valid_cs_histories())  # 70
+    """
+    histories: list[tuple[CSEvent, ...]] = []
+
+    def walk(state: CS, acc: tuple[CSEvent, ...]) -> None:
+        if state is CS.VFDPXA:
+            histories.append(acc)
+            return
+        for candidate in next_cs_states(state):
+            event = cs_transition_event(state, candidate)
+            assert event is not None  # guaranteed by is_valid_cs_transition
+            walk(candidate, acc + (event,))
+
+    walk(CS.vfdpxa, ())
+    return tuple(histories)

--- a/vultron/core/states/cs_invariants.py
+++ b/vultron/core/states/cs_invariants.py
@@ -122,14 +122,23 @@ CS_EVENT_TO_VFD_TRIGGER: dict[CSEvent, VFD_Trigger] = {
     CSEvent.F: VFD_Trigger.F,
     CSEvent.D: VFD_Trigger.D,
 }
-"""Maps a VFD-dimension CS event to the `VfdDimension.transition()` trigger."""
+"""Maps a VFD-dimension CS event to the `VfdDimension.transition()` trigger.
+
+Exported for callers that drive the dimension machines directly rather than
+going through `apply_cs_event` — e.g. emit-time guards that already hold a
+`VfdDimension` and need the trigger for a CS event.
+"""
 
 CS_EVENT_TO_PXA_TRIGGER: dict[CSEvent, PXA_Trigger] = {
     CSEvent.P: PXA_Trigger.P,
     CSEvent.X: PXA_Trigger.X,
     CSEvent.A: PXA_Trigger.A,
 }
-"""Maps a PXA-dimension CS event to the `PxaDimension.transition()` trigger."""
+"""Maps a PXA-dimension CS event to the `PxaDimension.transition()` trigger.
+
+The PXA counterpart of `CS_EVENT_TO_VFD_TRIGGER`; see that map for the
+rationale.
+"""
 
 
 def cs_dimensions(state: CS) -> tuple[CS_vfd, CS_pxa]:
@@ -317,17 +326,44 @@ def next_cs_states(state: CS) -> tuple[CS, ...]:
     )
 
 
-def apply_cs_event(state: CS, event: CSEvent) -> CS:
+def _as_cs_event(value: CSEvent | str) -> CSEvent:
+    """Coerce *value* to a `CSEvent`.
+
+    `CSEvent` is a `StrEnum`, so the single-letter strings of the legacy
+    string-pattern API (``"V"``, ``"F"``, ...) are accepted.  This keeps the
+    bool-returning predicates total: callers migrating from
+    `case_states.validations` naturally pass strings, and a validator must
+    answer their question rather than raise on the input type.
+
+    Raises:
+        VultronValidationError: if *value* is not a CS event.
+    """
+    try:
+        return CSEvent(value)
+    except ValueError as exc:
+        raise VultronValidationError(
+            f"CS history: {value!r} is not a CS event; expected one of"
+            f" {[e.value for e in CS_EVENTS]}."
+        ) from exc
+    except TypeError as exc:
+        raise VultronValidationError(
+            f"CS history: {value!r} is not a CS event (unhashable or"
+            " non-string type)."
+        ) from exc
+
+
+def apply_cs_event(state: CS, event: CSEvent | str) -> CS:
     """Return the state reached by applying *event* to *state*.
 
     Args:
         state: the current compound state
-        event: the event to apply
+        event: the event to apply, as a `CSEvent` or its string value
 
     Returns:
         the resulting compound state
 
     Raises:
+        VultronValidationError: if *event* is not a CS event.
         VultronInvalidStateTransitionError: if *event* cannot fire from
             *state* — because it already happened, because its dimension
             machine forbids it, or because *state* is ephemeral and requires
@@ -337,8 +373,12 @@ def apply_cs_event(state: CS, event: CSEvent) -> CS:
 
         apply_cs_event(CS.vfdpxa, CSEvent.V)  # CS.Vfdpxa
     """
+    event = _as_cs_event(event)
+
     for candidate in CS:
-        if cs_transition_event(state, candidate) is not event:
+        # `!=`, not `is not`: CSEvent is a StrEnum, so a plain string compares
+        # equal without being identical.
+        if cs_transition_event(state, candidate) != event:
             continue
         if is_valid_cs_transition(state, candidate):
             return candidate
@@ -389,7 +429,7 @@ def _ensure_distinct_events(events: Sequence[CSEvent]) -> None:
 
 
 def replay_cs_history(
-    events: Iterable[CSEvent], *, start: CS = CS.vfdpxa
+    events: Iterable[CSEvent | str], *, start: CS = CS.vfdpxa
 ) -> CS:
     """Replay *events* from *start* and return the resulting state.
 
@@ -397,22 +437,24 @@ def replay_cs_history(
     legal given every event that preceded it.
 
     Args:
-        events: the ordered CS events to apply
+        events: the ordered CS events to apply, as `CSEvent` members or their
+            string values (so ``"VFDPXA"`` and ``list(CSEvent)`` both work)
         start: the state to replay from, default `CS.vfdpxa`
 
     Returns:
         the compound state after the last event
 
     Raises:
-        VultronValidationError: if an event repeats.
+        VultronValidationError: if an event repeats or is not a CS event.
         VultronInvalidStateTransitionError: if an event cannot fire at its
             position in the sequence.
 
     Examples::
 
         replay_cs_history([CSEvent.V, CSEvent.F])  # CS.VFdpxa
+        replay_cs_history("VF")                    # CS.VFdpxa
     """
-    sequence = list(events)
+    sequence = [_as_cs_event(event) for event in events]
     _ensure_distinct_events(sequence)
 
     state = start
@@ -422,12 +464,14 @@ def replay_cs_history(
 
 
 def is_valid_cs_history_prefix(
-    events: Sequence[CSEvent], *, start: CS = CS.vfdpxa
+    events: Sequence[CSEvent | str], *, start: CS = CS.vfdpxa
 ) -> bool:
     """Return True if *events* is a legal (possibly incomplete) trajectory.
 
     Use this on real case histories, which are usually still in progress.
-    An empty sequence is trivially valid.
+    An empty sequence is trivially valid.  Events may be `CSEvent` members or
+    their string values.  Anything that is not a CS event makes the sequence
+    invalid rather than raising — this is a predicate, so it always answers.
 
     Note that a prefix ending in an ephemeral state is accepted: the
     ephemeral rules constrain what may come *next*, and nothing has come
@@ -439,6 +483,7 @@ def is_valid_cs_history_prefix(
         is_valid_cs_history_prefix([CSEvent.F])                     # False
         is_valid_cs_history_prefix([CSEvent.X])                     # True  (pX)
         is_valid_cs_history_prefix([CSEvent.X, CSEvent.A])          # False
+        is_valid_cs_history_prefix("VF")                            # True
     """
     try:
         replay_cs_history(events, start=start)
@@ -447,16 +492,20 @@ def is_valid_cs_history_prefix(
     return True
 
 
-def is_valid_cs_history(events: Sequence[CSEvent]) -> bool:
+def is_valid_cs_history(events: Sequence[CSEvent | str]) -> bool:
     """Return True if *events* is a complete, legal case history.
 
     A complete history contains all six events exactly once and reaches
     `CS.VFDPXA`.  Equivalent to the ordering rules ``V ≺ F ≺ D``,
     ``P ≺ X`` or ``XP`` adjacent, and ``V ≺ P`` or ``PV`` adjacent.
 
+    Accepts the string form of the legacy `case_states.validations` API as
+    well as `CSEvent` members.
+
     Examples::
 
         is_valid_cs_history(list(CSEvent))                    # True  (VFDPXA)
+        is_valid_cs_history("VFDPXA")                         # True
         is_valid_cs_history([CSEvent.F, CSEvent.V, ...])      # False (F before V)
     """
     if len(events) != len(CS_EVENTS):
@@ -466,24 +515,26 @@ def is_valid_cs_history(events: Sequence[CSEvent]) -> bool:
     return is_valid_cs_history_prefix(events)
 
 
-def ensure_valid_cs_history(events: Sequence[CSEvent]) -> None:
+def ensure_valid_cs_history(events: Sequence[CSEvent | str]) -> None:
     """Raise unless *events* is a complete, legal case history.
 
     Raises:
-        VultronValidationError: if the history is incomplete or its events
-            are not a permutation of the six CS events.
+        VultronValidationError: if the history is incomplete, contains a
+            value that is not a CS event, or its events are not a
+            permutation of the six CS events.
         VultronInvalidStateTransitionError: if the ordering is causally
             impossible.
     """
-    _ensure_distinct_events(events)
+    sequence = [_as_cs_event(event) for event in events]
+    _ensure_distinct_events(sequence)
 
-    missing = sorted(e.value for e in set(CS_EVENTS) - set(events))
+    missing = sorted(e.value for e in set(CS_EVENTS) - set(sequence))
     if missing:
         raise VultronValidationError(
             f"CS history: incomplete, missing event(s) {missing}."
         )
 
-    replay_cs_history(events)
+    replay_cs_history(sequence)
 
 
 def valid_cs_histories() -> tuple[tuple[CSEvent, ...], ...]:


### PR DESCRIPTION
- Closes #2237
- Fixes #2270

## Summary

Mines the legacy `vultron/core/case_states/` hypercube for still-valid CS
invariants and re-expresses the survivors against the current enum models, with
the legacy module's status decided and recorded. Also fixes the global 5s
per-test timeout that was aborting the integration suite.

## Changes

- **`vultron/core/states/cs_invariants.py`** (new): the CS validity library.
  Compound state validity (the 32 `CS` members *are* the valid states; `vF` and
  `fD` are structurally impossible), transition validity that **delegates to the
  per-dimension transition tables** so it cannot drift from what `VfdDimension` /
  `PxaDimension` enforce, the two ephemeral-state rules (`vP` requires `V` next,
  `pX` requires `P` next), and history validity by **causal replay**. Every entry
  point accepts either `CSEvent` members or the legacy single-letter strings.
- **`test/core/states/test_cs_invariants.py`** (new, 110 tests): ratchets the
  re-expression against an independent derivation of the legacy string-pattern
  rules — 32 states, 58 transitions (from 72 before the ephemeral rule), 70 of
  720 permutations, and agreement with the legacy oracle on **every**
  permutation in both input forms. Slowest test 0.07s.
- **`docs/adr/0060-...md`** (new): the legacy module is **kept as a demoted
  reference model**, not retired. Its two named retirement prerequisites are
  recorded.
- **`specs/cs-behavior.yaml`**: adds group CSB-17 (5 specs), extending CSB-13,
  constraining CSB-16, and refining SM-09-001/002.
- **`specs/state-machine.yaml`**: SM-09-001's rationale repointed from the legacy
  module at `cs_invariants.py`, and scoped explicitly to the persistence boundary.
- **`test/conftest.py`**, **`test/test_integration_timeout_tier.py`** (new, 16
  tests), **`test/AGENTS.md`**: two-tier per-test timeout (#2270).
- **`notes/case-state-model.md`**, **`notes/codebase-structure.md`**,
  **`notes/documentation-strategy.md`**, **`notes/flaky-tests.md`**,
  **`docs/reference/glossary.md`**: correct stale 64-state and
  `vultron/case_states/` claims.
- **`AGENTS.md`**: adds a **Case States** entry to the codebase map that routes
  new protocol-path work to `cs_invariants.py` and records what the legacy tree
  is still for (oracle in the equivalence tests; two live importers). Also
  relocates a dangling `ISSUE-1784` reference to the rebase bullet it belongs to.

## Two findings that changed the shape of the work

**The issue's "completely orphaned" premise was wrong.** There are two live
importers outside the legacy tree: `vultron/core/use_cases/query/action_rules.py`
(reached from the live `actors_get_action_rules` endpoint) and
`vultron/core/states/cs.py:26`, which imports `validations.ensure_valid_state` —
the authoritative module depends on the legacy one. Retirement is therefore a
migration, not a deletion, which is why ADR-0060 chose "keep, demoted" over the
archive the issue anticipated.

**Causal replay over index comparison.** The legacy `is_valid_history` compares
event indices, which only works on a complete six-event history. Replaying
through `is_valid_cs_transition` is provably equivalent on complete histories
(asserted directly, over all 720 permutations) and additionally generalises to
**prefixes** — which is what real, in-progress cases actually are. CSB-17-005
pins the prefix rule in both directions: the accepted set is exactly the
prefix-closure of the 70 valid histories, so no accepted prefix is a dead end.

## Reconciling with SM-09-001

The `vP → VP` and `pX → PX` rules were already a pre-existing MUST (SM-09-001),
which requires promotion **before persisting**. CSB-17-003 restates the same two
conditions as trajectory-validation rules, where an ephemeral state is a legal
intermediate point, and CSB-17-005 lets a history prefix end in one. The two are
consistent because they bind at different boundaries; SM-09-001's rationale and
ADR-0060 now say so explicitly rather than claiming the rule was "covered by no
spec."

## The timeout fix (#2270)

`uv run pytest -m integration` exited 1 on clean `origin/main` with **no summary
line**: several integration tests do 3.5-4.3s of honest work against a 5s
ceiling, and `timeout_method = "thread"` kills the whole pytest process rather
than the one slow test. A red integration run therefore carried no information
about the branch.

Timeouts are now **two-tier**, both sized from measurement:

| Tier | Was | Now | Slowest honest test |
|---|---|---|---|
| Unit (default) | 5s | **30s** | ~3.1s (`test_real_specs_load` setup) |
| `@pytest.mark.integration` | 5s | **60s** | ~4.3s (`test_decision_audit_inventory`) |

Explicit `@pytest.mark.timeout(N)` always wins, so the demo suite's deliberate
values (10, 180) are untouched. Regression tests pin both tiers, the
`timeout_method` they depend on, and — via a real nested pytest session — the
timeout each item **actually resolves to**, which is the only way to catch a
hook-ordering regression: the marker is added at collection time, but
pytest-timeout reads it in `pytest_runtest_protocol`.

Three judgment calls worth flagging:

- **Widened the ceiling rather than switching `timeout_method` off `thread`.**
  The signal method cannot interrupt code blocked in a C extension, so it would
  convert a noisy abort into an invisible hang.
- **Raised the unit tier too, which is beyond the reported failure.** The unit
  suite has AST-walking architecture ratchets at ~3.4s against the same 5s
  ceiling. Three earlier learning files (ISSUE-1925, ISSUE-1988, ISSUE-2086)
  each documented this root cause and worked around it; fixing only the
  integration tier would have left the pattern intact. An intermediate value of
  20s was tried and still tripped once while a background graphify rebuild
  competed for CPU, hence 30s.
- **30s is not proof against arbitrary CPU starvation.** While verifying this
  branch, two full-suite runs aborted at the 30s unit ceiling with a 1-minute
  load average near 30 on 20 cores (a background graphify rebuild). The same
  suite passed twice at 116s with the machine idle. The tier values are sized
  against *honest* test duration, not against an oversubscribed host; a red run
  with no summary line is still worth checking `loadavg` against before
  diagnosing it as a code failure.

## Cross-machine rules handed to #2236

Per the issue's scope, the cross-machine rules were fed to #2236 rather than
implemented here — see [this comment](https://github.com/CERTCC/Vultron/issues/2236#issuecomment-5272872480).
The substantive finding: the legacy tree contains **no RM rules at all**, so
#2236's headline entailment (`F` implies `RM in {ACCEPTED, DEFERRED, CLOSED}`)
is not derivable from the hypercube and must come from `rm_em_cs.md`. It does
contain a genuine CS -> EM table (`patterns/embargo.py`), and five advisory
tables that must **not** become emit guards.

## Verification

- Unit suite: **6714 passed**, 370 skipped, 1104 deselected, 2 xfailed, 5552
  subtests passed — 2 consecutive clean runs at 116s, 0 timeout aborts.
- Integration suite: **1101 passed**, 2 xfailed, 1 xpassed, exit 0 — was
  aborting with exit 1 on clean `origin/main` before this branch.
- xfail ratchet: all 4 xfail/xpass reasons reference live open issues
  (#1991, #1992, #1898/#2150, #1993, #1994).
- Black, flake8, markdownlint, notes/ADR frontmatter validators clean.
- `spec-lint` exit 0 at the pre-existing 62-warning baseline, no CSB-17
  findings; `adr-index --check` in sync; `mkdocs build --strict` exit 0.
- Re-validated after merging `origin/main` `06bf60c2`.

## Note for reviewers

Running `-m integration` locally writes `devlogs/`, which un-skips
`test/ci/invariants/test_fv_invariants.py` in the **unit** suite and produces 4
failures unrelated to this branch. Both modes are already tracked in #2273;
`rm -rf devlogs/` restores green. This PR makes that interaction more likely by
letting the integration suite finish, which is noted on #2273.
