### PR TITLE
Promote engage_case to a universal invariant-harness event type across all nine scenarios

### DIFF
--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -81,14 +81,15 @@ not the duplication worth fixing.
 ## Per-Scenario Expected Event Types (DEMOMA-16)
 
 **Problem**: All per-scenario `_XXX_EXPECTED_EVENT_TYPES` lists historically
-contained only the four universal types (`validate_report`,
-`add_participant_status_to_participant`, `close_case`, `add_note_to_case`),
+contained only the four types then treated as universal (`validate_report`,
+`add_participant_status_to_participant`, `close_case`, `add_note_to_case` —
+`engage_case` became the fifth in ISSUE-2266),
 regardless of the scenario's actual protocol coverage. This allowed
 scenario-specific phases to regress silently (e.g. `invite_actor_to_case`
 missing from a scenario that requires it).
 
 **Design**: Each scenario defines its own required event-type list that
-extends the four universal types with scenario-specific required phases.
+extends the five universal types with scenario-specific required phases.
 The spec requirements in `specs/multi-actor-demo.yaml` DEMOMA-16-001 through
 DEMOMA-16-011 are the normative source; the test constants implement them.
 
@@ -100,9 +101,9 @@ CONCERN-2243 (three rows understated their required types; the FCCV-extension
 and FCV-reject rows were absent entirely), which is exactly the drift
 DEMOMA-16-008 exists to prevent.
 
-| Scenario | Spec | Universal 4 | Additional required |
+| Scenario | Spec | Universal 5 | Additional required |
 |---|---|---|---|
-| FV | DEMOMA-16-002 | validate_report, add_participant_status_to_participant, close_case, add_note_to_case | (none) |
+| FV | DEMOMA-16-002 | validate_report, add_participant_status_to_participant, close_case, add_note_to_case, engage_case | (none) |
 | FVV | DEMOMA-16-003 | same | invite_actor_to_case, accept_invite_actor_to_case |
 | FVCV-extension | DEMOMA-16-004 | same | invite_actor_to_case, offer_case_participant, accept_invite_actor_to_case, accept_actor_recommendation |
 | FVCV-handoff | DEMOMA-16-005 | same | invite_actor_to_case, accept_invite_actor_to_case |
@@ -166,7 +167,9 @@ step failed.
 ### `engage_case` is universal, not scenario-specific
 
 Every scenario drives an engage-case trigger, so `engage_case` is a universal
-required event type on the same footing as `validate_report`:
+required event type on the same footing as `validate_report` — it is the fifth
+type in DEMOMA-16-001 and appears in all nine `_XXX_EXPECTED_EVENT_TYPES`
+lists (ISSUE-2266). The three emission paths are:
 
 - `run_direct_path_rm_triage()` (`vultron/demo/helpers/workflow.py`) calls
   `receiver_engages_case()` for the report's direct receiver — used by all
@@ -179,6 +182,15 @@ required event type on the same footing as `validate_report`:
 Emission is therefore located in the **shared helper layer**, not at scenario
 call sites; grepping a single scenario file for `engage` finds nothing and
 invites the false conclusion that no code emits it.
+
+Before ISSUE-2266, only `test_fvcv_handoff_invariants.py` listed
+`engage_case` — added by PR #2018 as a scenario-specific type without amending
+the spec (a DEMOMA-16-008 violation), which left an engage-case regression
+silent in the other eight scenarios. The `fvcv-handoff`
+`check_event_type_count(..., "engage_case", min_count=2)` assertion remains
+scenario-specific: it asserts the *count* Vendor2's post-join triage cycle
+implies (CM-11-002), which is a stronger claim than the universal presence
+check.
 
 ---
 

--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -19,22 +19,32 @@ event types it exercises. Event types are those recorded as `event_type` in
 (`test_invariant_5_expected_event_types_present`) in each scenario's
 `test/ci/invariants/test_XXX_invariants.py` file.
 
-| Scenario | validate_report | add_participant_status_to_participant | close_case | add_note_to_case | invite_actor_to_case | offer_case_participant | accept_invite_actor_to_case | accept_actor_recommendation | reject_invite_actor_to_case |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| fv                | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |
-| fvv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
-| fvcv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| fvcv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
-| fccv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| fccv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
-| fcvcv             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| fcv               | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
-| fcv-reject        | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓ |
+| Scenario | validate_report | add_participant_status_to_participant | close_case | add_note_to_case | engage_case | invite_actor_to_case | offer_case_participant | accept_invite_actor_to_case | accept_actor_recommendation | reject_invite_actor_to_case |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| fv                | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |
+| fvv               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
+| fvcv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
+| fvcv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
+| fccv-extension    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
+| fccv-handoff      | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
+| fcvcv             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
+| fcv               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |
+| fcv-reject        | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓ |
 
 **Notes:**
 
-- The four universal types (`validate_report`, `add_participant_status_to_participant`,
-  `close_case`, `add_note_to_case`) appear in every scenario (DEMOMA-16-001).
+- The five universal types (`validate_report`, `add_participant_status_to_participant`,
+  `close_case`, `add_note_to_case`, `engage_case`) appear in every scenario
+  (DEMOMA-16-001).
+- `engage_case` is universal because emission lives in the shared demo helper
+  layer, not at scenario call sites: `run_direct_path_rm_triage()` calls
+  `receiver_engages_case()` for the direct receiver (all eight multi-actor
+  scenarios), `run_invite_path_rm_triage()` calls it again for the invited
+  participant (seven of them, CM-11-002), and `fv_demo.py` calls it via
+  `vendor_engages_case()`. It was promoted from a `fvcv-handoff`-only entry to
+  the fifth universal type in ISSUE-2266; see
+  `notes/demo-ci-invariants.md` § "`engage_case` is universal, not
+  scenario-specific".
 - Ownership transfer (`attributed_to` mutation via `AcceptCaseOwnershipTransferNode`)
   is exercised by `fvcv-handoff` and `fccv-handoff` but does **not** emit a
   `CaseLedgerEntry` with a named `event_type`. It is therefore not observable via
@@ -105,6 +115,7 @@ advance the CVD protocol state and are recorded in the replicated case ledger.
 | `add_participant_status_to_participant` | Participant status tracking |
 | `close_case` | Case closure |
 | `add_note_to_case` | Case note / information sharing |
+| `engage_case` | RM engagement (RM state: valid → accepted) |
 | `invite_actor_to_case` | Actor invitation |
 | `offer_case_participant` | Suggest-actor flow (ADR-0026) |
 | `accept_invite_actor_to_case` | Invitation acceptance |
@@ -124,7 +135,7 @@ advance the CVD protocol state and are recorded in the replicated case ledger.
 ### Why the minimum set is sufficient
 
 The 4-scenario minimum set (`fv`, `fvcv-handoff`, `fcvcv`, `fcv-reject`) covers
-all 9 `event_type` columns and the ownership-transfer path. The additional
+all 10 `event_type` columns and the ownership-transfer path. The additional
 dimensions (CVD role variation, multi-vendor fix paths, embargo phases) are
 either:
 
@@ -145,7 +156,7 @@ the minimum set's event-type and protocol-path coverage. (`fcv-reject` is the
 
 | Scenario | Covered by minimum set | Rationale |
 |---|:---:|---|
-| fv | ✓ (member) | 2-actor baseline; covers all 4 universal event types with no invitation phases |
+| fv | ✓ (member) | 2-actor baseline; covers all 5 universal event types with no invitation phases |
 | fvcv-handoff | ✓ (member) | Adds `invite_actor_to_case` + `accept_invite_actor_to_case` + ownership-transfer protocol path |
 | fcvcv | ✓ (member) | Adds `offer_case_participant` + `accept_actor_recommendation` + ≥3-actor invite/accept chains |
 | fcv-reject | ✓ (member) | Adds `reject_invite_actor_to_case` — the only scenario where the Vendor sends `Reject(Invite(actor, case))` (invitation-layer rejection) |
@@ -157,7 +168,7 @@ the minimum set's event-type and protocol-path coverage. (`fcv-reject` is the
 
 ### Coverage proof
 
-The minimum set of 4 scenarios covers all 9 distinct event types:
+The minimum set of 4 scenarios covers all 10 distinct event types:
 
 | Event type | Covered by |
 |---|---|
@@ -165,6 +176,7 @@ The minimum set of 4 scenarios covers all 9 distinct event types:
 | add_participant_status_to_participant | fv |
 | close_case | fv |
 | add_note_to_case | fv |
+| engage_case | fv |
 | invite_actor_to_case | fvcv-handoff |
 | accept_invite_actor_to_case | fvcv-handoff |
 | offer_case_participant | fcvcv |

--- a/plan/incoming/learnings/20260812-integration-suite-pollutes-devlogs-for-later-unit-runs.md
+++ b/plan/incoming/learnings/20260812-integration-suite-pollutes-devlogs-for-later-unit-runs.md
@@ -1,0 +1,51 @@
+---
+title: The integration suite writes repo-root devlogs/, so a later unit run fails the FV invariant harness
+type: learning
+timestamp: 2026-08-12
+source: ISSUE-2266
+signal: pre-existing-failure
+---
+
+## Observation
+
+Phase 6 validation for #2266 was green in the documented order (unit, then
+integration) but red when the unit suite was re-run afterwards:
+four failures in `test/ci/invariants/test_fv_invariants.py`
+(Invariant 1 for all three actors, and Invariant 5 for `validate_report`).
+
+`test/demo/test_fv_demo.py::TestRunTwoActorDemo::test_full_workflow_succeeds`
+drives `run_fv_demo()` in-process without setting `DEVLOGS_DIR`, so its final
+dump phase writes real ledger files into the repo-root `devlogs/fv/`
+(default `/app/devlogs`, `vultron/demo/scenario/fv_demo.py:898`). That makes
+`load_devlogs("fv")` stop skipping, and the FV harness then evaluates the
+in-process single-container ledger instead of the containerised artifact it was
+written for. Because the dump is keyed by case URN, a second run adds a second
+file to the same actor directory and `load_devlogs` concatenates both chains —
+which is where the Invariant 1 `prevLogHash` mismatches come from.
+
+Proven pre-existing: with the #2266 changes stashed, a pristine `origin/main`
+worktree produces the same four failures against the same polluted `devlogs/`.
+`devlogs/` is gitignored, so `git status` shows nothing and the failures read as
+a broken branch.
+
+## Why it matters
+
+CI never sees this — the unit job and the demo job run in separate containers —
+so it only bites locally, and it bites in the shape CONCERN-2243 warns about: a
+red invariant harness that is not evidence about the artifact under test. Any
+agent validating a branch after running the integration suite will attribute
+these four failures to its own change.
+
+Second, unrelated finding from the same evidence: a clean, "successful"
+in-process FV run dumps only 9 ledger entries per actor, with **no**
+`validate_report` and no `engage_case`. That is the in-process fidelity gap
+already tracked in #2271 (no `CaseLedgerEntry` records are committed in the
+single-container harness) and #2267 (the FV test can pass while accumulated
+demo failures are non-empty) — not new, and not evidence about the containerised
+FV demo. No issue filed for it.
+
+## Status
+
+Filed as **#2274** (Bug, parent Epic #2230, `size:S`). Until it lands, run
+`rm -rf devlogs` before validating a branch if the integration suite has run in
+that worktree.

--- a/plan/incoming/learnings/20260812-restated-counts-in-spec-cross-references-drift.md
+++ b/plan/incoming/learnings/20260812-restated-counts-in-spec-cross-references-drift.md
@@ -1,0 +1,44 @@
+---
+title: Promoting one event type required 12 coordinated spec edits because sibling requirements restate each other's counts
+type: learning
+timestamp: 2026-08-12
+source: ISSUE-2266
+signal: concern
+---
+
+## Observation
+
+ISSUE-2266's AC-1 asked for one amendment: DEMOMA-16-001, four universal event types →
+five. The phrase "the four universal types (DEMOMA-16-001)" turned out to be copied into
+nine sibling statements (DEMOMA-16-002 … -16-011) and into two requirements in a
+*different* spec file (DEMOCI-04-004, DEMOCI-06-002). Twelve coordinated edits, eleven of
+them outside the literal acceptance criteria.
+
+Doing only AC-1 would have left ten MUST-level statements asserting a count the spec
+itself contradicts, and every guard would have stayed green: the registry linter validates
+that `DEMOMA-16-001` resolves as a cross-reference target, not the prose wrapped around
+it. A reader of `specs/demo-ci.yaml` alone would have had no signal at all.
+
+## Why it matters
+
+This is spec-vs-spec drift, one level above the spec-vs-code drift DEMOMA-16-008 and
+CONCERN-2243 exist to fight — and strictly harder to detect, because no test can fail.
+Code drift eventually shows up as a red assertion; prose drift just means whoever reads
+the wrong statement first is misinformed. The engage-case story in CONCERN-2243 started
+with someone reasonably concluding, from a document that was locally self-consistent,
+that `engage_case` was scenario-specific.
+
+The restated count carries no normative force. "The universal types (DEMOMA-16-001)"
+says exactly as much and cannot drift. That is the cheap structural fix; the expensive one
+is a linter that understands number-words next to requirement references.
+
+## Status
+
+Filed as **#2277** (Concern, `size:M`, Someday) with the two-option direction: strip
+restated counts from cross-references repo-wide plus a convention note, or lint for
+counts adjacent to a requirement id.
+
+Partial coverage landed with #2266: `test/ci/invariants/test_universal_event_types.py`
+pins DEMOMA-16-001's enumeration against the nine harness constants. The ten sibling
+statements and the two DEMOCI statements remain unguarded prose — see
+`20260812-universal-event-type-ratchet-not-specified.md`.

--- a/plan/incoming/learnings/20260812-universal-event-type-ratchet-not-specified.md
+++ b/plan/incoming/learnings/20260812-universal-event-type-ratchet-not-specified.md
@@ -1,0 +1,43 @@
+---
+title: A structural ratchet was added for DEMOMA-16-008 because no obtainable CI signal could verify it
+type: learning
+timestamp: 2026-08-12
+source: ISSUE-2266
+signal: design-question
+---
+
+## Decision
+
+ISSUE-2266 asked for a spec amendment (AC-1), nine test-constant edits (AC-2/AC-3),
+and two notes-table updates (AC-4) — no new test file. It also stated that a green
+`Invariant Harness` job is not obtainable and MUST NOT be the verification bar, and
+that AC-2/AC-3 should be verified "by inspection and by unit tests over `common.py`".
+
+Inspection alone is not a regression guard, and `common.py` unit tests cannot see the
+per-scenario constants — `check_event_type_present()` is given the list, it does not
+own it. So the acceptance criteria as written would have landed with nothing able to
+fail if a tenth scenario arrived without the universal block, or if `engage_case` were
+dropped from one harness again. That is the same hole that let PR #2018 add
+`engage_case` to one harness without amending the spec.
+
+Added `test/ci/invariants/test_universal_event_types.py`: it reads
+`.github/demo-scenarios.json`, imports each named harness module, and asserts the
+constant opens with the five DEMOMA-16-001 types (each exactly once), plus that
+DEMOMA-16-001's statement still enumerates exactly those five. It runs in the ordinary
+unit suite with no devlogs and no demo, so it is a signal that is actually obtainable
+locally and in CI — unlike the harness job it protects.
+
+## Why it matters
+
+DEMOMA-16-008 ("spec and test constants change in the same PR") was a prose rule with
+no enforcement for its whole life. Rules of that shape are what CONCERN-2243 is about:
+the belief that something is checked, where nothing checks it.
+
+The design constraint worth preserving: `notes/demo-ci-invariants.md` forbids a second
+scenario registry (a `conftest.py` mapping was specced in DEMOMA-19-008 and never
+existed — CONCERN-2004). Driving the ratchet off the CI matrix honors that; a hardcoded
+list of nine harness files inside the test would have re-created exactly the registry
+the notes prohibit. Anyone extending this test should keep reading the matrix.
+
+Verified the ratchet fails on drift before finalizing it, rather than trusting that a
+passing new test is a working new test.

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -408,11 +408,12 @@ groups:
           `test/ci/invariants/test_fv_invariants.py`) MUST include a
           per-scenario expected-event-types list that is comprehensive for that
           scenario: it MUST cover all protocol phases that the scenario is
-          designed to exercise, not only the four universal phases shared by
+          designed to exercise, not only the five universal phases shared by
           all scenarios.
         rationale: >-
-          A shared minimal list (validate_report, add_participant_status_to_participant,
-          close_case, add_note_to_case) does not guard against a scenario-specific
+          A shared minimal list (validate_report,
+          add_participant_status_to_participant, close_case, add_note_to_case,
+          engage_case) does not guard against a scenario-specific
           phase (e.g. notes-exchange) regressing silently. Each scenario's
           expected-event-types list must reflect what that scenario is designed
           to prove end-to-end.
@@ -574,7 +575,7 @@ groups:
           The minimum PR validation scenario set is `fv`, `fvcv-handoff`,
           `fcvcv`, and `fcv-reject`. Together these four scenarios cover all
           distinct protocol event types exercised by the full scenario suite:
-          the four universal types plus `invite_actor_to_case`,
+          the five universal types plus `invite_actor_to_case`,
           `offer_case_participant`, `accept_invite_actor_to_case`,
           `accept_actor_recommendation`, and `reject_invite_actor_to_case`.
           The `demo-integration.yml` workflow MUST use this 4-scenario set as

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1842,24 +1842,13 @@ groups:
       `add_note_to_case`, and `engage_case` — MUST appear at least once in the
       authoritative case-actor log for every multi-actor demo scenario.
     rationale: >-
-      These five types represent the minimal protocol coverage shared by all
-      scenarios: report validation, RM engagement (VALID → ACCEPTED),
-      participant state tracking, case closure, and at least one note
-      (notes-exchange phase). Any scenario that does not produce all five has
-      not completed the basic CVD lifecycle.
-
-      `engage_case` is as universal as `validate_report` because emission
-      lives in the shared demo helper layer rather than at scenario call
-      sites, via three paths: (1) `run_direct_path_rm_triage()`
-      (`vultron/demo/helpers/workflow.py`) calls `receiver_engages_case()`
-      for the report's direct receiver — used by all eight multi-actor
-      scenarios; (2) `run_invite_path_rm_triage()` calls it again for the
-      invited participant — used by seven of them (CM-11-002); and (3)
-      `fv_demo.py` calls `receiver_engages_case()` directly via
-      `vendor_engages_case()`. Because no scenario file names the trigger
-      itself, grepping a single scenario script for `engage` finds nothing and
-      invites the false conclusion that the event is scenario-specific
-      (CONCERN-2243).
+      These five types are the minimal coverage shared by all scenarios:
+      report validation, RM engagement (VALID → ACCEPTED), participant state
+      tracking, case closure, and at least one note. A scenario missing any of
+      the five has not completed the basic CVD lifecycle. `engage_case` is as
+      universal as `validate_report`: emission lives in the shared demo helper
+      layer, not at scenario call sites, so no scenario file names the trigger
+      itself (CONCERN-2243). Paths: see `notes/demo-ci-invariants.md`.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-03-002

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1837,16 +1837,29 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The four universal event types — `validate_report`,
-      `add_participant_status_to_participant`, `close_case`, and
-      `add_note_to_case` — MUST appear at least once in the authoritative
-      case-actor log for every multi-actor demo scenario.
+      The five universal event types — `validate_report`,
+      `add_participant_status_to_participant`, `close_case`,
+      `add_note_to_case`, and `engage_case` — MUST appear at least once in the
+      authoritative case-actor log for every multi-actor demo scenario.
     rationale: >-
-      These four types represent the minimal protocol coverage shared by all
-      scenarios: report validation, participant state tracking, case
-      closure, and at least one note (notes-exchange phase). Any scenario
-      that does not produce all four has not completed the basic CVD
-      lifecycle.
+      These five types represent the minimal protocol coverage shared by all
+      scenarios: report validation, RM engagement (VALID → ACCEPTED),
+      participant state tracking, case closure, and at least one note
+      (notes-exchange phase). Any scenario that does not produce all five has
+      not completed the basic CVD lifecycle.
+
+      `engage_case` is as universal as `validate_report` because emission
+      lives in the shared demo helper layer rather than at scenario call
+      sites, via three paths: (1) `run_direct_path_rm_triage()`
+      (`vultron/demo/helpers/workflow.py`) calls `receiver_engages_case()`
+      for the report's direct receiver — used by all eight multi-actor
+      scenarios; (2) `run_invite_path_rm_triage()` calls it again for the
+      invited participant — used by seven of them (CM-11-002); and (3)
+      `fv_demo.py` calls `receiver_engages_case()` directly via
+      `vendor_engages_case()`. Because no scenario file names the trigger
+      itself, grepping a single scenario script for `engage` finds nothing and
+      invites the false conclusion that the event is scenario-specific
+      (CONCERN-2243).
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-03-002
@@ -1855,7 +1868,7 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      In addition to the four universal types (DEMOMA-16-001), the FV scenario
+      In addition to the five universal types (DEMOMA-16-001), the FV scenario
       MUST verify that its expected-event-types list is restricted to types that
       the FV scenario actually produces. FV does not include an
       `invite_actor_to_case` phase; the Finder joins by submitting a report,
@@ -1872,7 +1885,7 @@ groups:
     statement: >-
       The FVV scenario expected-event-types list MUST include
       `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
-      to the four universal types (DEMOMA-16-001), because Vendor1 invites
+      to the five universal types (DEMOMA-16-001), because Vendor1 invites
       Vendor2 into the case and Vendor2 explicitly accepts via the
       `accept-case-invite` trigger.
     relationships:
@@ -1888,7 +1901,7 @@ groups:
       The FVCV-extension scenario expected-event-types list MUST include
       `invite_actor_to_case`, `offer_case_participant`,
       `accept_invite_actor_to_case`, and `accept_actor_recommendation` in
-      addition to the four universal types (DEMOMA-16-001), because Vendor1
+      addition to the five universal types (DEMOMA-16-001), because Vendor1
       invites Coordinator, Coordinator uses the ADR-0026 suggest-actor flow
       (`offer_case_participant`) to propose Vendor2, Vendor1 approves the
       recommendation (`accept_actor_recommendation`), CaseActor converts the
@@ -1906,7 +1919,7 @@ groups:
     statement: >-
       The FVCV-handoff scenario expected-event-types list MUST include
       `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
-      to the four universal types (DEMOMA-16-001), because Vendor1 invites
+      to the five universal types (DEMOMA-16-001), because Vendor1 invites
       Coordinator, the Coordinator accepts and becomes the new CASE_OWNER,
       and Coordinator then invites Vendor2 who also accepts.
     rationale: >-
@@ -1931,7 +1944,7 @@ groups:
     statement: >-
       The FCCV-handoff scenario expected-event-types list MUST include
       `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
-      to the four universal types (DEMOMA-16-001), because C1 invites C2,
+      to the five universal types (DEMOMA-16-001), because C1 invites C2,
       C2 accepts and becomes the new CASE_OWNER, and C2 then invites the
       Vendor who also accepts.
     relationships:
@@ -1946,7 +1959,7 @@ groups:
     statement: >-
       The FCV scenario expected-event-types list MUST include
       `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
-      to the four universal types (DEMOMA-16-001), because the Coordinator
+      to the five universal types (DEMOMA-16-001), because the Coordinator
       invites both the Finder and the Vendor into the case, and both Finder
       and Vendor explicitly accept via the `accept-case-invite` trigger.
     relationships:
@@ -1979,7 +1992,7 @@ groups:
       The FCVCV scenario expected-event-types list MUST include
       `invite_actor_to_case`, `offer_case_participant`,
       `accept_invite_actor_to_case`, and `accept_actor_recommendation` in
-      addition to the four universal types (DEMOMA-16-001).
+      addition to the five universal types (DEMOMA-16-001).
       `invite_actor_to_case` appears at least three times (C1 invites V1, C1
       invites C2, and CaseActor invites V2 via the ADR-0026 path);
       `offer_case_participant` appears at least once (C2 suggests V2 to C1
@@ -2018,7 +2031,7 @@ groups:
       The FCCV-extension scenario expected-event-types list MUST include
       `invite_actor_to_case`, `offer_case_participant`,
       `accept_invite_actor_to_case`, and `accept_actor_recommendation` in
-      addition to the four universal types (DEMOMA-16-001), because
+      addition to the five universal types (DEMOMA-16-001), because
       Coordinator1 invites Coordinator2, Coordinator2 uses the ADR-0026
       suggest-actor flow (`offer_case_participant`) to propose the Vendor,
       Coordinator1 approves the recommendation (`accept_actor_recommendation`),
@@ -2036,7 +2049,7 @@ groups:
     statement: >-
       The FCV-reject scenario expected-event-types list MUST include
       `invite_actor_to_case` and `reject_invite_actor_to_case` in addition to
-      the four universal types (DEMOMA-16-001), because the Coordinator invites
+      the five universal types (DEMOMA-16-001), because the Coordinator invites
       the Vendor and the Vendor sends `Reject(Invite(actor, case))` (an
       invitation-layer rejection), which triggers
       `RejectInviteActorToCaseReceivedUseCase` on the CaseActor and produces

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -334,7 +334,7 @@ CI job** from the demo run. When adding or modifying a scenario test file:
 
 **Per-scenario expected-event-types**: each `_XXX_EXPECTED_EVENT_TYPES` list
 must be comprehensive for its scenario (see `notes/demo-ci-invariants.md` and
-DEMOMA-16-001 through DEMOMA-16-008). When adding a new scenario phase that
+DEMOMA-16-001 through DEMOMA-16-011). When adding a new scenario phase that
 produces a new `event_type`, update both the spec requirement and the test
 constant in the same PR.
 

--- a/test/ci/README-case-log-ratchet.md
+++ b/test/ci/README-case-log-ratchet.md
@@ -9,12 +9,28 @@ universal invariant check functions live in
 `test/ci/invariants/common.py`; each scenario has its own test file under
 `test/ci/invariants/`.
 
-| Scenario | Test file |
-|----------|-----------|
-| FV | `test/ci/invariants/test_fv_invariants.py` |
-| FVV (three-actor) | `test/ci/invariants/test_fvv_invariants.py` |
-| FVCV-extension | `test/ci/invariants/test_fvcv_extension_invariants.py` |
-| FVCV-handoff | `test/ci/invariants/test_fvcv_handoff_invariants.py` |
+The nine scenarios and their harness files are registered in
+`.github/demo-scenarios.json`, which is the sole registry — the table below
+mirrors it and MUST be kept in step.
+
+| Scenario | Test file | In PR set |
+|----------|-----------|:---------:|
+| FV | `test/ci/invariants/test_fv_invariants.py` | ✓ |
+| FVCV-handoff | `test/ci/invariants/test_fvcv_handoff_invariants.py` | ✓ |
+| FCVCV | `test/ci/invariants/test_fcvcv_invariants.py` | ✓ |
+| FCV-reject | `test/ci/invariants/test_fcv_reject_invariants.py` | ✓ |
+| FVV (three-actor) | `test/ci/invariants/test_fvv_invariants.py` | |
+| FVCV-extension | `test/ci/invariants/test_fvcv_extension_invariants.py` | |
+| FCCV-extension | `test/ci/invariants/test_fccv_extension_invariants.py` | |
+| FCCV-handoff | `test/ci/invariants/test_fccv_handoff_invariants.py` | |
+| FCV | `test/ci/invariants/test_fcv_invariants.py` | |
+
+Scenarios marked *In PR set* run on `pull_request` events (the DEMOCI-06-002
+minimum validation set); all nine run on push-to-main and `workflow_dispatch`.
+
+A tenth file, `test/ci/invariants/test_universal_event_types.py`, is not a
+scenario harness: it is a structural ratchet over the harness constants and the
+DEMOMA-16-001 spec statement, and needs no demo artifacts.
 
 ---
 
@@ -58,7 +74,19 @@ to include in the regular unit-test run.
 ## Invariant List and Status
 
 Per-actor parametrized tests (1, 12–14) show status per actor role.
-`✅` = passing today, `⏳` = xfail (fix tracked in linked issue).
+`✅` = passing today, `⏳` = xfail (fix tracked in linked issue),
+`⚠️` = failing today and **not** xfailed, so the job is red (linked issue owns
+the fix).
+
+> **Invariant 5 is currently red, by design.** ISSUE-2266 promoted
+> `engage_case` to the fifth universal expected event type (DEMOMA-16-001)
+> across all nine harnesses. The event is driven by every scenario but never
+> reaches the ledger, because the engage-case trigger returns HTTP 422
+> (`SvcEngageCaseUseCase failed: TransitionParticipantRMtoAccepted`) — root
+> cause tracked in **#2233**. Until that lands, invariant 5 fails in every
+> scenario. It was deliberately left un-`xfail`ed rather than hidden: #2242
+> exists precisely because these harnesses reported green on confirmed-broken
+> scenarios. Do not "fix" it by editing the expected-event-types constants.
 
 | # | Description | case-actor | vendor | finder | Resolved by |
 |---|-------------|-----------|--------|--------|-------------|
@@ -66,7 +94,7 @@ Per-actor parametrized tests (1, 12–14) show status per actor role.
 | 2 | Cross-actor `entryHash` agreement per `logIndex` | ✅ | n/a | n/a | #789 |
 | 3 | Cross-actor `payloadSnapshot.actor` agreement | ✅ | n/a | n/a | #789 |
 | 4 | Every recorded entry has non-empty `payloadSnapshot` | ✅ | n/a | n/a | #789 |
-| 5 | All expected protocol `eventType`s present | ✅ | n/a | n/a | #1029, #1030 |
+| 5 | All expected protocol `eventType`s present | ⚠️ | n/a | n/a | #1029, #1030; `engage_case` blocked on #2233 |
 | 6 | No RM-state oscillation after `CLOSED` | ✅ | n/a | n/a | #936 |
 | 7 | Log terminates with all participants `RM=CLOSED` | ✅ | n/a | n/a | #789 |
 | 8 | Late-joining participants have full pre-join history | ✅ | n/a | n/a | #937 |

--- a/test/ci/invariants/test_fccv_extension_invariants.py
+++ b/test/ci/invariants/test_fccv_extension_invariants.py
@@ -66,6 +66,9 @@ _FCCV_EXTENSION_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
+    # DEMOMA-16-001: universal — the shared RM-triage helpers in
+    # vultron/demo/helpers/workflow.py engage the case in every scenario.
+    pytest.param("engage_case", id="engage_case"),
     # C1 invites C2, then CaseActor invites Vendor (via ADR-0026 path).
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
     # C2 suggests Vendor via the ADR-0026 suggest-actor flow.

--- a/test/ci/invariants/test_fccv_handoff_invariants.py
+++ b/test/ci/invariants/test_fccv_handoff_invariants.py
@@ -63,6 +63,9 @@ _FCCV_HANDOFF_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
+    # DEMOMA-16-001: universal — the shared RM-triage helpers in
+    # vultron/demo/helpers/workflow.py engage the case in every scenario.
+    pytest.param("engage_case", id="engage_case"),
     # DEMOMA-16-006: C1 invites C2 (and later Vendor);
     # C2 and Vendor both accept.
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),

--- a/test/ci/invariants/test_fcv_invariants.py
+++ b/test/ci/invariants/test_fcv_invariants.py
@@ -60,6 +60,9 @@ _FCV_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
+    # DEMOMA-16-001: universal — the shared RM-triage helpers in
+    # vultron/demo/helpers/workflow.py engage the case in every scenario.
+    pytest.param("engage_case", id="engage_case"),
     # DEMOMA-16-007: Coordinator invites both Finder and Vendor; both accept.
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
     pytest.param(

--- a/test/ci/invariants/test_fcv_reject_invariants.py
+++ b/test/ci/invariants/test_fcv_reject_invariants.py
@@ -60,6 +60,9 @@ _FCV_REJECT_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
+    # DEMOMA-16-001: universal — the shared RM-triage helpers in
+    # vultron/demo/helpers/workflow.py engage the case in every scenario.
+    pytest.param("engage_case", id="engage_case"),
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
     pytest.param(
         "reject_invite_actor_to_case", id="reject_invite_actor_to_case"

--- a/test/ci/invariants/test_fcvcv_invariants.py
+++ b/test/ci/invariants/test_fcvcv_invariants.py
@@ -67,6 +67,9 @@ _FCVCV_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
+    # DEMOMA-16-001: universal — the shared RM-triage helpers in
+    # vultron/demo/helpers/workflow.py engage the case in every scenario.
+    pytest.param("engage_case", id="engage_case"),
     # C1 invites V1, C1 invites C2, CaseActor invites V2 (ADR-0026).
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
     # C2 suggests V2 via the ADR-0026 suggest-actor flow.

--- a/test/ci/invariants/test_fv_invariants.py
+++ b/test/ci/invariants/test_fv_invariants.py
@@ -46,6 +46,9 @@ _FV_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
+    # DEMOMA-16-001: universal — the shared RM-triage helpers in
+    # vultron/demo/helpers/workflow.py engage the case in every scenario.
+    pytest.param("engage_case", id="engage_case"),
 ]
 
 #: Actors with per-actor hash-chain / contiguity / completeness checks.

--- a/test/ci/invariants/test_fvcv_extension_invariants.py
+++ b/test/ci/invariants/test_fvcv_extension_invariants.py
@@ -58,6 +58,9 @@ _FVCV_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
+    # DEMOMA-16-001: universal — the shared RM-triage helpers in
+    # vultron/demo/helpers/workflow.py engage the case in every scenario.
+    pytest.param("engage_case", id="engage_case"),
     # DEMOMA-16-004: Vendor1 invites Coordinator; Coordinator uses the
     # suggest-actor flow (offer_case_participant) to propose Vendor2;
     # CaseActor converts the offer to an invite; Vendor2 accepts.

--- a/test/ci/invariants/test_fvcv_handoff_invariants.py
+++ b/test/ci/invariants/test_fvcv_handoff_invariants.py
@@ -63,14 +63,15 @@ _FVCV_HANDOFF_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
+    # DEMOMA-16-001: universal — the shared RM-triage helpers in
+    # vultron/demo/helpers/workflow.py engage the case in every scenario.
+    pytest.param("engage_case", id="engage_case"),
     # DEMOMA-16-005: Vendor1 invites Coordinator (and later Vendor2);
     # Coordinator and Vendor2 both accept.
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
     pytest.param(
         "accept_invite_actor_to_case", id="accept_invite_actor_to_case"
     ),
-    # CM-11-002: Vendor2 runs the RM triage cycle after joining.
-    pytest.param("engage_case", id="engage_case"),
 ]
 
 #: Actors with per-actor chain / contiguity / completeness checks.

--- a/test/ci/invariants/test_fvv_invariants.py
+++ b/test/ci/invariants/test_fvv_invariants.py
@@ -56,6 +56,9 @@ _FVV_EXPECTED_EVENT_TYPES = [
     ),
     pytest.param("close_case", id="close_case"),
     pytest.param("add_note_to_case", id="add_note_to_case"),
+    # DEMOMA-16-001: universal — the shared RM-triage helpers in
+    # vultron/demo/helpers/workflow.py engage the case in every scenario.
+    pytest.param("engage_case", id="engage_case"),
     # DEMOMA-16-003: Vendor1 invites Vendor2; Vendor2 accepts.
     pytest.param("invite_actor_to_case", id="invite_actor_to_case"),
     pytest.param(

--- a/test/ci/invariants/test_universal_event_types.py
+++ b/test/ci/invariants/test_universal_event_types.py
@@ -1,0 +1,158 @@
+"""Ratchet: every scenario harness lists the five universal event types.
+
+DEMOMA-16-001 declares five event types — ``validate_report``,
+``add_participant_status_to_participant``, ``close_case``,
+``add_note_to_case``, and ``engage_case`` — that MUST appear in the
+authoritative case-actor log of *every* multi-actor demo scenario.  Each
+scenario harness implements that requirement as the leading entries of its
+``_XXX_EXPECTED_EVENT_TYPES`` constant.
+
+DEMOMA-16-008 requires the spec requirement and the test constants to change
+in the same PR.  Nothing enforced that structurally: ``engage_case`` was added
+to ``test_fvcv_handoff_invariants.py`` alone (PR #2018) without amending the
+spec, leaving an engage-case regression silent in the other eight scenarios
+(CONCERN-2243, ISSUE-2266).  These tests close that gap by checking, without
+running any demo, that
+
+1. all nine harnesses named by the CI matrix carry the universal block, and
+2. DEMOMA-16-001 still enumerates exactly the same five types.
+
+Scenario→harness mapping comes from ``.github/demo-scenarios.json``, which is
+the sole registry per ``notes/demo-ci-invariants.md``.  Do not add a second
+list of harness files here.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from _pytest.mark.structures import ParameterSet
+
+from vultron.metadata.specs.registry import load_registry
+
+_REPO_ROOT = Path(__file__).parents[3]
+_CI_SCENARIOS_JSON = _REPO_ROOT / ".github" / "demo-scenarios.json"
+_SPECS_DIR = _REPO_ROOT / "specs"
+
+#: The DEMOMA-16-001 universal event types, in the order the harnesses list
+#: them.  Amending this tuple requires amending DEMOMA-16-001 in the same PR
+#: (DEMOMA-16-008) — ``test_demoma_16_001_enumerates_the_universal_types``
+#: fails otherwise.
+_UNIVERSAL_EVENT_TYPES = (
+    "validate_report",
+    "add_participant_status_to_participant",
+    "close_case",
+    "add_note_to_case",
+    "engage_case",
+)
+
+_EXPECTED_CONST_RE = re.compile(r"^_[A-Z0-9_]+_EXPECTED_EVENT_TYPES$")
+
+
+def _harness_modules() -> list[ParameterSet]:
+    """One param per CI-matrix scenario: (demo name, harness module name)."""
+    entries = json.loads(_CI_SCENARIOS_JSON.read_text())
+    return [
+        pytest.param(
+            entry["demo"],
+            entry["test_file"].removesuffix(".py").replace("/", "."),
+            id=entry["demo"],
+        )
+        for entry in entries
+    ]
+
+
+def _expected_event_types_constant(
+    module: ModuleType,
+) -> tuple[str, list[str]]:
+    """Return the harness's single expected-event-types constant name + values.
+
+    Values are the ``eventType`` strings in declaration order.  Entries may be
+    ``pytest.param(...)`` (the convention in all nine harnesses) or a bare
+    string, which pytest also accepts.
+    """
+    names = [n for n in vars(module) if _EXPECTED_CONST_RE.match(n)]
+    assert len(names) == 1, (
+        f"{module.__name__} must declare exactly one "
+        f"_XXX_EXPECTED_EVENT_TYPES constant, found {sorted(names)}"
+    )
+    name = names[0]
+    event_types = []
+    for entry in getattr(module, name):
+        value = entry if isinstance(entry, str) else entry.values[0]
+        assert isinstance(
+            value, str
+        ), f"{name} entry {entry!r} does not wrap an eventType string"
+        event_types.append(value)
+    return name, event_types
+
+
+@pytest.mark.parametrize(("demo", "module_name"), _harness_modules())
+def test_harness_lists_universal_event_types_once(
+    demo: str, module_name: str
+) -> None:
+    """Each harness's universal block is the five DEMOMA-16-001 types.
+
+    The universal types lead the constant, in DEMOMA-16-001 order, and none is
+    repeated further down among the scenario-specific entries (AC-3 of
+    ISSUE-2266): a duplicated presence check adds no coverage and hides which
+    block owns the requirement.
+    """
+    module = importlib.import_module(module_name)
+    const_name, event_types = _expected_event_types_constant(module)
+    where = f"{const_name} ({demo})"
+
+    assert (
+        tuple(event_types[: len(_UNIVERSAL_EVENT_TYPES)])
+        == _UNIVERSAL_EVENT_TYPES
+    ), (
+        f"{where} must open with the DEMOMA-16-001 universal block "
+        f"{list(_UNIVERSAL_EVENT_TYPES)}; got {event_types}"
+    )
+
+    for event_type in _UNIVERSAL_EVENT_TYPES:
+        assert event_types.count(event_type) == 1, (
+            f"{where} lists {event_type!r} {event_types.count(event_type)} "
+            "times; universal types belong in the universal block exactly once"
+        )
+
+
+def test_all_ci_scenarios_have_a_harness_module() -> None:
+    """Every CI-matrix entry names a harness file that exists.
+
+    The count is pinned because the nine scenarios are enumerated by name in
+    DEMOMA-16-002…-011 and in the tables in ``notes/demo-ci-invariants.md`` and
+    ``notes/demo-ci-scenario-coverage.md``.  Adding a scenario means updating
+    those too, so it should not pass here silently.
+    """
+    entries = json.loads(_CI_SCENARIOS_JSON.read_text())
+    assert len(entries) == 9, (
+        f"expected 9 CI scenarios, got {len(entries)} — if a scenario was "
+        "added or removed, update DEMOMA-16 and the notes/ scenario tables"
+    )
+    missing = [
+        entry["test_file"]
+        for entry in entries
+        if not (_REPO_ROOT / entry["test_file"]).is_file()
+    ]
+    assert not missing, f"CI matrix names nonexistent harness files: {missing}"
+
+
+def test_demoma_16_001_enumerates_the_universal_types() -> None:
+    """DEMOMA-16-001's statement names exactly the five universal types.
+
+    Guards the spec side of DEMOMA-16-008: promoting or retiring a universal
+    event type in the harnesses without amending DEMOMA-16-001 fails here.
+    """
+    statement = load_registry(_SPECS_DIR).get("DEMOMA-16-001").statement
+    quoted = set(re.findall(r"`([a-z_]+)`", statement))
+    assert quoted == set(_UNIVERSAL_EVENT_TYPES), (
+        "DEMOMA-16-001 must enumerate exactly the universal event types "
+        f"{sorted(_UNIVERSAL_EVENT_TYPES)}; its statement names "
+        f"{sorted(quoted)}"
+    )


### PR DESCRIPTION
- Closes #2266

## Summary

Promotes `engage_case` to a fifth universal invariant-harness event type across
all nine multi-actor demo scenarios, amending DEMOMA-16-001 and all nine
`_XXX_EXPECTED_EVENT_TYPES` constants in the same PR as DEMOMA-16-008 requires.

`engage_case` is emitted by every scenario, but only `test_fvcv_handoff_invariants.py`
required it — added scenario-specific by PR #2018 without amending the spec (a
DEMOMA-16-008 violation), leaving an engage-case regression silent in the other
eight scenarios. Emission lives in the shared demo helper layer, not at scenario
call sites, so grepping a single scenario script for `engage` finds nothing and
invites the false conclusion that the event is scenario-specific (CONCERN-2243).

## Changes

- **`specs/multi-actor-demo.yaml`**: DEMOMA-16-001 now declares **five** universal
  event types. The nine sibling statements (DEMOMA-16-002…-011) updated from
  "four universal types" to "five". The rationale explains why `engage_case` is
  universal and points to `notes/demo-ci-invariants.md` for the three emission
  paths — `run_direct_path_rm_triage()` → `receiver_engages_case()` (all eight
  multi-actor scenarios), `run_invite_path_rm_triage()` (seven of them,
  CM-11-002), and `fv_demo.py` via `vendor_engages_case()`.
- **`specs/demo-ci.yaml`**: DEMOCI-04-004 and DEMOCI-06-002 updated to five
  universal phases/types.
- **All nine `test/ci/invariants/test_*_invariants.py`**: `engage_case` added to
  the universal block after `add_note_to_case`, with a DEMOMA-16-001 comment.
  Removed from `test_fvcv_handoff_invariants.py`'s scenario-specific block so it
  appears exactly once per harness (AC-3). DEMOMA-16-005 still needs no
  `engage_case` clause of its own.
- **`test/ci/invariants/test_universal_event_types.py`** (new): structural ratchet
  that verifies, without running any demo, that every harness named by the CI
  matrix opens its constant with the five universal types (each exactly once) and
  that DEMOMA-16-001's statement still enumerates exactly those five. Scenario→harness
  mapping is read from `.github/demo-scenarios.json`, the sole registry per
  `notes/demo-ci-invariants.md` — no second list of harness files.
- **`notes/demo-ci-invariants.md`**: scenario table column is now `Universal 5`
  with the FV row spelled out; the `engage_case` is universal section records that
  it is the fifth DEMOMA-16-001 type in all nine lists, and why the `fvcv-handoff`
  `min_count=2` assertion stays scenario-specific.
- **`notes/demo-ci-scenario-coverage.md`**: coverage matrix gains an `engage_case`
  column (✓ ×9) and the shared-helper emission note.
- **`test/ci/README-case-log-ratchet.md`**: invariant 5 marked ⚠️ (failing, not
  xfailed) with the #2233 explanation below; scenario table now mirrors all nine
  entries in `.github/demo-scenarios.json` and marks the DEMOCI-06-002 PR set.
- **`test/AGENTS.md`**: stale `DEMOMA-16-001 through DEMOMA-16-008` range
  corrected to `-011`.

`test_fvcv_handoff_vendor2_rm_triage_observed` and its
`check_event_type_count(..., "engage_case", min_count=2)` assertions are retained
unchanged (AC-6): the count claim is stronger than the universal presence check.

## Verification

- 6588 unit tests pass (370 skipped, 2 xfailed, 5552 subtests); **11 new tests**
  in `test_universal_event_types.py` (9 parametrized + 2), plus one new
  `engage_case` param on each of the nine harnesses
- 1101 integration tests pass
- Black, flake8, mypy (1200 files), pyright (0 errors), markdownlint, spec-lint clean

### Acceptance criteria

- [x] **AC-1**: DEMOMA-16-001 amended — `engage_case` is the fifth universal
      event type, with a rationale covering the three emission paths
- [x] **AC-2**: all nine `_XXX_EXPECTED_EVENT_TYPES` constants include
      `engage_case` (enforced by `test_harness_lists_universal_event_types_once`)
- [x] **AC-3**: `engage_case` appears in each universal block exactly once —
      removed from `fvcv-handoff`'s scenario-specific block; DEMOMA-16-005 gains
      no `engage_case` clause
- [x] **AC-4**: `notes/demo-ci-invariants.md` scenario table lists five universal
      types (`Universal 5` column); `Additional required` unchanged in substance
- [x] **AC-5**: the spec amendment and all nine test-constant edits land in this
      one PR, per DEMOMA-16-008
- [x] **AC-6**: `test_fvcv_handoff_vendor2_rm_triage_observed` and its
      `min_count=2` assertion retained unchanged

### Expected CI state — the Invariant Harness jobs stay red until #2233 lands

**This PR deliberately turns three currently-green harness jobs red.** Read this
before triaging the failures.

All four PR-gate `Invariant Harness` jobs now fail on the same assertion:

```
test_invariant_5_expected_event_types_present[engage_case]
AssertionError: Expected eventType 'engage_case' not found in case-actor log.
```

The cause is the pre-existing engage-case 422 —
`SvcEngageCaseUseCase failed: TransitionParticipantRMtoAccepted`, visible in the
`fcvcv` and `fvcv-handoff` Demo Integration logs — tracked in **#2233** and
explicitly out of scope for #2266. This PR changes **no production code**, so it
cannot have caused it.

Before this PR only `fvcv-handoff` failed these assertions (it has carried the
`engage_case` entry since PR #2018); `fv`, `fcv-reject` and `fcvcv` were green.
Promoting `engage_case` to universal takes that from 1/4 to **4/4** of the PR set,
and to 9/9 on push-to-main.

That widening is the intended outcome, not collateral damage: **#2242** exists
precisely because these harnesses reported green on confirmed-broken scenarios,
and per #2266's verification note a green harness "MUST NOT be treated as the
verification bar" for this change. The assertions were deliberately **not**
`xfail`ed — the repo's documented ratchet
(`test/ci/README-case-log-ratchet.md`) offers that escape hatch, but it has zero
live usages and using it here would restore exactly the false green #2242 is
about. `test/ci/README-case-log-ratchet.md` now records this, so the next reader
of a red job does not re-derive it (which is what CONCERN-2243 was filed about).

AC-2/AC-3 are therefore verified by inspection and by the new structural ratchet,
which runs in the always-green `Tests (pytest)` job, needs no demo artifacts, and
was confirmed to fail on drift before being finalized. When #2233 lands, invariant
5 goes green on its own with no change here.

Note: two full-suite runs during validation died with `+++ Timeout +++` on
unrelated tests (`test_conditions.py::test_is_rm_msg`, an ADR frontmatter load) —
the 5s `timeout_method = "thread"` tripping under host load, matching
`plan/incoming/learnings/20260803-pytest-full-suite-timeout.md`. The suite is
green at `--timeout=60` and at the default once load dropped.
