### PR TITLE
fix: always dump case ledgers, even when a phase dies

### DIFF
--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -39,6 +39,66 @@ invariant-harness (matrix: fv) → downloads artifact → runs pytest
 
 ---
 
+## Artifact Availability on Failure (DEMOCI-10)
+
+**Problem**: The separate-job pattern above only pays off if the artifact
+*exists* when the demo fails. It did not. Each `run_<name>_demo()` called
+`_phase_dump_case_ledgers()` as its last statement, so an assertion escaping a
+`demo_check`/`demo_gate` block skipped the dump; `main()`'s
+`finally: assert_demo_success()` still raised, so CI reported the demo failure
+but `devlogs/` was empty. The `invariant-harness` job then died on **artifact
+download** — the run that most needed forensics produced none, and the harness
+reported a plumbing error instead of an invariant result (issue #2239).
+
+**Design**: three pieces, spec'd as DEMOCI-10-001 through DEMOCI-10-004.
+
+1. **A shared harness owns the ordering.**
+   `vultron/demo/helpers/harness.py` provides `scenario_harness(demo_name)`.
+   Every `run_<name>_demo()` body runs inside it: it resets the failure
+   accumulator, always dumps the case ledgers on the way out (normal return or
+   any `BaseException`), then calls `assert_demo_success()` last. Scenarios
+   register their dump with `harness.dump_with(...)` as soon as a case exists,
+   so every later phase can fail without costing the ledgers. `main()` no longer
+   wraps the run in `try/finally: assert_demo_success()` — a second owner of the
+   accumulator would assert before the dump had run. See DEMOMA-23.
+
+2. **The dump always leaves a manifest.**
+   `vultron/demo/helpers/ledger_dump.py::dump_case_ledgers()` writes
+   `devlogs/<demo>/dump-manifest.json` from a `finally`, recording `demoName`,
+   `caseId`, `ledgerFileCount`, `targetCount`, an optional top-level `reason`,
+   and a per-actor list naming each missing actor with the reason it was
+   missing. So the artifact is non-empty even when there were no ledgers at all
+   to capture — including the "died before any case existed" case, where the
+   manifest records `ledgerFileCount: 0` and the reason why.
+
+3. **`load_devlogs()` fails instead of skipping when a dump happened.**
+   Previously a missing/empty `devlogs/` meant "no test data" → `pytest.skip`,
+   which reads green. Now `load_devlogs()` distinguishes the two cases:
+
+   | State of the downloaded artifact | Outcome |
+   |---|---|
+   | no `devlogs/`, or no `devlogs/<demo>/` | `skip` — the demo genuinely did not run |
+   | no ledger files **and** no `dump-manifest.json` | `skip` — same |
+   | no ledger files **but** a manifest exists | **`fail`** — real invariant failure |
+   | manifest present but unparseable | **`fail`** |
+   | ledger files present | load and check normally |
+
+   The failure message reproduces the manifest's own account — case ID, captured
+   *X* of *Y* targets, and one line per missing actor with its route key and
+   reason — so the harness output explains *why* there are no ledgers rather
+   than leaving a reviewer to guess.
+
+**A dump failure must not mask the scenario failure.** Errors raised inside the
+dump are recorded in the manifest's `reason` field and swallowed; the harness
+re-raises the original exception with the accumulated `demo_check` failures
+attached as exception notes (DEMOCI-10-004).
+
+Regression coverage: `test/demo/test_issue_2239_ledger_dump_in_finally.py`
+(all nine scenarios), `test/demo/test_scenario_harness.py`, and
+`test/ci/invariants/test_common.py::TestLoadDevlogsManifestHandling`.
+
+---
+
 ## Harness File Conventions
 
 Each scenario gets **one self-contained harness file**,
@@ -48,7 +108,9 @@ existing nine:
 
 1. Declare `_DEMO_NAME = "<scenario>"` at module scope.
 2. Load replicas with `load_devlogs(demo_name=_DEMO_NAME)`, imported from
-   `test/ci/invariants/common.py`.
+   `test/ci/invariants/common.py`. It skips when the demo did not run and
+   **fails** when the demo ran, dumped, and still produced no ledgers — see
+   "Artifact Availability on Failure" above.
 3. Declare `_CHAIN_ACTORS` (scenario-role names, not docker service names) and
    `_<SCENARIO>_EXPECTED_EVENT_TYPES`.
 4. Call the shared check functions from `common.py`; keep scenario-specific

--- a/plan/incoming/learnings/20260812-artifact-dump-belongs-in-the-failure-path.md
+++ b/plan/incoming/learnings/20260812-artifact-dump-belongs-in-the-failure-path.md
@@ -1,0 +1,36 @@
+---
+title: "No spec required forensic artifacts to survive the failure they document"
+type: learning
+timestamp: "2026-08-12T00:00:00Z"
+source: ISSUE-2239
+signal: spec-gap
+---
+
+DEMOCI-04 requires the demo job to upload `devlogs/` as an artifact and the
+invariant harness to run as a separate `if: always()` job. Both were implemented
+correctly. Nothing anywhere required the *producer* of that artifact to run on
+the failing path, so all nine scenarios ended `run_<name>_demo()` with a plain
+call to `_phase_dump_case_ledgers()` — code that by construction runs only when
+nothing went wrong. The workflow-side requirement (`if: always()`) and the
+application-side placement (after the last phase) were each locally reasonable
+and jointly guaranteed that the run most in need of forensics produced none.
+
+The gap is a shape, not a line: **an artifact whose only purpose is diagnosing
+failures must be produced from a path that failure cannot skip.** Filled as
+DEMOCI-10-001/-002 (dump from a path that runs on failure; always write a
+manifest) and DEMOMA-23-001/-003 (`scenario_harness()` owns the ordering;
+register the dump as soon as a case exists).
+
+The related trap, worth stating separately because it survived the first fix
+attempt: the invariant harness treated a missing/empty `devlogs/` as "no test
+data" and called `pytest.skip`. A skip that means *"the thing I was going to
+assert on is absent"* is a false green whenever the absence **is** the failure.
+Distinguishing the two needs evidence from the producer, which is why the dump
+now always writes `dump-manifest.json` — the manifest is what turns "nothing to
+check" into "the demo ran, dumped, and had no ledgers, and here is why per
+actor" (DEMOCI-10-003).
+
+Generalisable check for any future skip-on-missing-input fixture: can the input
+be missing *because* the system under test broke? If yes, the fixture needs a
+positive signal that the producer ran, and it must fail — not skip — when that
+signal is present and the data is not.

--- a/plan/incoming/learnings/20260812-harness-propagates-the-cause-not-a-summary.md
+++ b/plan/incoming/learnings/20260812-harness-propagates-the-cause-not-a-summary.md
@@ -1,0 +1,44 @@
+---
+title: "The harness propagates the original exception and attaches accumulated failures as notes"
+type: learning
+timestamp: "2026-08-12T00:00:00Z"
+source: ISSUE-2239
+signal: design-question
+---
+
+ISSUE-2239 specified the shape — "run phases, always dump ledgers, then assert.
+The dump belongs in the `finally`" — but not what the failing path should raise.
+Two behaviours are defensible and they differ in what a CI reader sees:
+
+- Call `assert_demo_success()` unconditionally on the way out. Consistent, but
+  on the failing path it replaces the exception that actually ended the run with
+  a generic `DemoFailureError("N demo failure(s)")` — exactly the unusable
+  reporting #2240 is about.
+- Let the original exception propagate untouched and attach the accumulated
+  `demo_check` failures via `exc.add_note()`.
+
+`scenario_harness()` does the second. The traceback still points at the phase
+that died; the soft failures that `demo_check` had recorded and would otherwise
+be dropped ride along as `__notes__` (DEMOMA-23-004, SHOULD-level). Only the
+succeeding path calls `assert_demo_success()`.
+
+Two consequences worth knowing before touching this:
+
+- **A dump error must not become the reported failure.** The dump runs inside
+  `demo_step`, which records and continues, so a dump that dies still leaves the
+  scenario's own exception in charge — and a scenario that otherwise succeeded
+  but failed to dump does fail, as an accumulated failure rather than a raise.
+- **The backstop manifest is written only when the dump raised.** Writing it
+  from an unconditional `finally` looked equivalent and was not: `dump_case_ledgers`
+  writes its own manifest, so the backstop only ever fires when the dump never
+  got that far. Unconditionally, it stamped the "dump crashed" reason onto runs
+  whose dump was fine — including unit tests that stub the dump out, which then
+  wrote a spurious manifest into the repo-root `devlogs/` and turned the local
+  invariant harness's skips into failures. Pinned by
+  `test_no_crash_manifest_when_the_dump_succeeds`.
+
+Unresolved and already tracked, noted here so it is not mistaken for settled:
+AGENTS.md, DEMOCI-01-007 and ADR-0058 all describe `demo_gate` as the primitive
+that stops dependent steps, and it still does not exist in code (#2201, #2203).
+The harness makes an escaping assertion survivable; it does not make the ~20
+unguarded `wait_for_case_participants` call sites causal.

--- a/plan/incoming/learnings/20260812-pytest-timeout-stack-names-the-victim-not-the-culprit.md
+++ b/plan/incoming/learnings/20260812-pytest-timeout-stack-names-the-victim-not-the-culprit.md
@@ -1,0 +1,46 @@
+---
+title: "A pytest-timeout stack names the victim, not the culprit — and the spec registry was the cost"
+type: learning
+timestamp: "2026-08-12T00:00:00Z"
+source: ISSUE-2239
+signal: tooling-issue
+---
+
+Validating the ISSUE-2239 branch, the full suite aborted at 82% with a
+`+++ Timeout +++` stack dump, no `N passed / M failed` summary, and exit 1. Two
+things about that were misleading enough to record:
+
+1. **The reported test moves.** `timeout = 5` with `timeout_method = "thread"`
+   in `pyproject.toml` kills the whole process; the stack is dumped wherever the
+   alarm happened to fire, so the named test is whichever one was running, not
+   necessarily the expensive one. Across runs it landed in
+   `test_docs_render.py`, `test_decision_audit_inventory.py`, and
+   `test_pcr_late_joiner.py` (#2270). Diagnosing from the test name leads
+   nowhere; timing the shared call in the stack does.
+
+2. **A 5-run A/B beats one run.** With `specs/` stashed the flaky test passed
+   0/5 failures; with the branch's two spec-file additions it failed 2/5. That
+   looks causal and is not — the same test was already 3.5–4.3 s against a 5 s
+   ceiling on clean `main`. Eight new spec entries out of 2355 (0.3%) only moved
+   it across a line it was already sitting on.
+
+Where the cost actually was, measured per stage:
+
+| Stage | Time |
+|---|---|
+| `yaml.safe_load` of all `specs/*.yaml` (1.18 MB) | 2.73 s |
+| `SpecFile.model_validate` for every file | 0.024 s |
+| `load_registry()` total, uncached, per call | 3.44 s |
+
+`pyyaml` silently falls back to the pure-Python `SafeLoader`; this environment
+ships `libyaml`. Selecting `yaml.CSafeLoader` when present (identical
+SafeLoader semantics) took `load_registry()` from 3.44 s to 0.35 s and the flaky
+test from 2/5 to 0/5. Two lines, in
+`vultron/metadata/specs/registry.py`.
+
+Two durable takeaways: **when a validation step is 100× cheaper than the parse
+step in front of it, check which loader the parser picked** — the 10× is free
+and applies to every `yaml.safe_load` of a large file in this repo. And the
+underlying fragility is untouched: any test doing real work is one slow
+container away from aborting the session while `timeout_method = "thread"` is
+global, which is #2270's actual fix (parented to #2089).

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -6,7 +6,7 @@ description: >-
   when the demo fails — closing the gap where tests pass while the demo produces
   silent failures. Includes requirements for the invariant harness to run as an
   independent CI gate so failures are visible even when the demo itself also fails.
-version: 1.7.0
+version: 1.8.0
 scope:
   - prototype
   - production
@@ -865,3 +865,86 @@ groups:
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-05-001
+
+  - id: DEMOCI-10
+    title: Case-Ledger Artifact Availability on Failure
+    specs:
+      - id: DEMOCI-10-001
+        priority: MUST
+        kind: project
+        statement: >-
+          Every demo scenario MUST export its case ledgers from a path that runs
+          whether or not the scenario's phases succeeded — in practice, from the
+          shared scenario harness's exception path as well as its success path
+          (see DEMOMA-23-001). A scenario MUST NOT place the ledger dump only
+          after its last phase, where any escaping exception skips it.
+        rationale: >-
+          `demo_check` and `demo_step` accumulate rather than raise, so the
+          exceptions that do escape a scenario are the ones that most need
+          forensics — and those were exactly the runs that uploaded nothing,
+          because the dump sat inline after the last phase. Losing the ledgers on
+          failure inverts the value of the artifact.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-04-001
+
+      - id: DEMOCI-10-002
+        priority: MUST
+        kind: project
+        statement: >-
+          The case-ledger dump MUST always write a `dump-manifest.json` under
+          `devlogs/<demo-name>/`, even when it captured no ledgers at all. The
+          manifest MUST record `demoName`, `caseId`, `ledgerFileCount`,
+          `targetCount`, an optional top-level `reason`, and one `actors[]` entry
+          per dump target carrying `actorName`, `routeKey`, `captured`,
+          `entryCount`, `ledgerFile`, and `reason`.
+        rationale: >-
+          The `upload-artifact` step and the `invariant-harness` job's download
+          both need the artifact to exist. An always-present manifest makes the
+          download succeed unconditionally and turns "nothing was uploaded" into
+          a machine-readable statement of which actors were missing and why, so
+          the invariant harness can report a real invariant result instead of a
+          download error.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-10-001
+
+      - id: DEMOCI-10-003
+        priority: MUST
+        kind: project
+        statement: >-
+          `test/ci/invariants/common.py::load_devlogs()` MUST fail — not skip —
+          when a `dump-manifest.json` is present under the scenario's devlogs
+          directory but no `*-case-ledger.jsonl` file is, and MUST fail when a
+          manifest is present but unparseable. It MUST skip only when there is no
+          evidence the demo ran: no `devlogs/`, no scenario sub-directory, or
+          neither ledger files nor a manifest.
+        rationale: >-
+          Skipping on absent data is right for a developer who has not run the
+          demo and wrong for CI, where absent data means the scenario died. The
+          manifest is the evidence that distinguishes the two cases; without it
+          the harness reported green for scenarios that produced no ledger at
+          all.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-04-001
+          - rel_type: implements
+            spec_id: DEMOCI-10-002
+
+      - id: DEMOCI-10-004
+        priority: MUST
+        kind: project
+        statement: >-
+          A failure inside the case-ledger dump MUST NOT replace the exception
+          that ended the scenario. The dump MUST record its own failure through
+          the accumulator and the manifest, and the original exception MUST
+          propagate unchanged.
+        rationale: >-
+          A dump that runs on the failure path runs precisely when the system is
+          already unhealthy, so it is the most likely thing to fail second. If it
+          raises over the first exception, the fix that preserves the artifacts
+          destroys the diagnosis instead — the same class of masking as the
+          `try/finally: assert_demo_success()` shape it replaces.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-10-001

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -6,7 +6,7 @@ description: >-
   when the demo fails — closing the gap where tests pass while the demo produces
   silent failures. Includes requirements for the invariant harness to run as an
   independent CI gate so failures are visible even when the demo itself also fails.
-version: 1.8.0
+version: 1.9.0
 scope:
   - prototype
   - production

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -4,7 +4,7 @@ description: >-
   Requirements for multi-actor demo scenarios, Docker Compose orchestration, actor isolation,
   acceptance testing, and reproducibility. Includes per-scenario required
   event-type lists for the case-ledger invariant harness.
-version: 1.3.0
+version: 1.4.0
 scope:
 
 - prototype
@@ -2947,3 +2947,82 @@ groups:
     tags:
     - demo
     - documentation
+- id: DEMOMA-23
+  title: Shared Scenario Harness
+  specs:
+  - id: DEMOMA-23-001
+    priority: MUST
+    kind: project
+    statement: >-
+      Every `run_<name>_demo()` orchestrator MUST run its phase body inside the
+      shared `scenario_harness("<demo-name>")` context manager from
+      `vultron.demo.helpers.harness`, which resets the failure accumulator, always
+      dumps the case ledgers, and only then asserts demo success. The scenario's
+      `main()` MUST NOT wrap the run in `try: ... finally: assert_demo_success()`.
+    rationale: >-
+      Each scenario previously repeated the same three responsibilities in a
+      slightly different order, and the `finally: assert_demo_success()` shape in
+      `main()` substituted a generic `DemoFailureError` for whatever actually went
+      wrong. One harness fixes the order once for all scenarios: run phases,
+      always dump, then assert.
+    relationships:
+    - rel_type: implements
+      spec_id: DEMOCI-10-001
+    - rel_type: refines
+      spec_id: DEMOMA-17-001
+    tags:
+    - demo
+    - testing
+  - id: DEMOMA-23-002
+    priority: MUST
+    kind: project
+    statement: >-
+      A scenario's `_phase_dump_case_ledgers()` MUST be a thin wrapper over
+      `vultron.demo.helpers.ledger_dump.dump_case_ledgers()`, declaring only that
+      scenario's dump targets (actor name, client, route key, and any fallback).
+      Per-actor fetching, 404 handling, JSONL writing, and manifest writing MUST
+      live in the shared helper, not in the scenario module.
+    rationale: >-
+      Nine copies of the same export loop is exactly the copy-paste that
+      DEMOMA-17-001 forbids, and it is why a defect in the dump had to be fixed
+      nine times. Keeping the scenario-specific participant map in the scenario
+      and the mechanics in the helper puts each fact in one place.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-17-001
+    tags:
+    - demo
+  - id: DEMOMA-23-003
+    priority: MUST
+    kind: project
+    statement: >-
+      A scenario MUST register its dump with `harness.dump_with(...)` as soon as
+      a case exists — immediately after the report-submission phase returns —
+      rather than at the end of the run.
+    rationale: >-
+      The harness can only dump what it has been given. Registering the dump at
+      the first point where a case exists is what makes every later phase failure
+      survivable: the ledgers that existed at the moment of failure are still
+      exported.
+    relationships:
+    - rel_type: implements
+      spec_id: DEMOCI-10-001
+    tags:
+    - demo
+  - id: DEMOMA-23-004
+    priority: SHOULD
+    kind: project
+    statement: >-
+      When a scenario body raises, the harness SHOULD attach the accumulated
+      `demo_step`/`demo_check` failures to the propagating exception as notes
+      rather than raising `DemoFailureError` in their place.
+    rationale: >-
+      The accumulated soft failures are usually downstream consequences of the
+      exception, so they are context, not the cause. Attaching them as notes keeps
+      both: the reader sees the failure that stopped the run and every check that
+      had already failed.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-10-004
+    tags:
+    - demo

--- a/test/ci/invariants/common.py
+++ b/test/ci/invariants/common.py
@@ -33,6 +33,7 @@ from pathlib import Path
 import pytest
 
 from vultron.core.states.participant_embargo_consent import PEC
+from vultron.demo.helpers.ledger_dump import DUMP_MANIFEST_FILENAME
 from vultron.enums.roles import CVDRole
 
 # ---------------------------------------------------------------------------
@@ -115,6 +116,72 @@ def participant_status_identity_and_rm(
 # ---------------------------------------------------------------------------
 
 
+def _read_dump_manifests(search_root: Path) -> list[dict]:
+    """Return every readable ``dump-manifest.json`` under *search_root*.
+
+    A manifest is the scenario's own record that its case-ledger dump ran —
+    see ``vultron.demo.helpers.ledger_dump``.  Its presence is what lets this
+    module tell "the demo never ran" apart from "the demo ran and produced no
+    ledger entries" (DEMOCI-10-001).
+
+    Raises:
+        Failed: When a manifest exists but cannot be parsed, since a corrupt
+            manifest is itself evidence that something went wrong.
+    """
+    manifests: list[dict] = []
+    candidates = [
+        search_root / DUMP_MANIFEST_FILENAME,
+        *sorted(search_root.glob(f"**/{DUMP_MANIFEST_FILENAME}")),
+    ]
+    for path in dict.fromkeys(candidates):
+        if not path.is_file():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            pytest.fail(
+                f"{path} is unreadable ({type(exc).__name__}: {exc}) — the "
+                "demo dumped a manifest but it cannot be parsed, so the "
+                "invariant result cannot be trusted"
+            )
+        if isinstance(data, dict):
+            manifests.append(data)
+    return manifests
+
+
+def _fail_no_ledgers_despite_dump(
+    search_root: Path,
+    manifests: list[dict],
+) -> None:
+    """Fail with the manifests' account of why no ledger files were captured."""
+    lines = [
+        f"No case-ledger files under {search_root}, but "
+        f"{len(manifests)} dump manifest(s) show the demo ran and dumped. "
+        "This is a real invariant failure, not missing test data."
+    ]
+    for manifest in manifests:
+        lines.append(
+            f"- demo {manifest.get('demoName', '?')!r}: "
+            f"case={manifest.get('caseId')!r} "
+            f"captured={manifest.get('ledgerFileCount', 0)}"
+            f"/{manifest.get('targetCount', 0)} actors"
+        )
+        reason = manifest.get("reason")
+        if reason:
+            lines.append(f"    reason: {reason}")
+        actors = manifest.get("actors")
+        if isinstance(actors, list):
+            for actor in actors:
+                if not isinstance(actor, dict) or actor.get("captured"):
+                    continue
+                lines.append(
+                    f"    missing {actor.get('actorName', '?')!r} "
+                    f"(route {actor.get('routeKey', '?')!r}): "
+                    f"{actor.get('reason') or 'no reason recorded'}"
+                )
+    pytest.fail("\n".join(lines))
+
+
 def load_devlogs(
     demo_name: str | None = None,
 ) -> dict[str, list[dict]]:
@@ -125,8 +192,14 @@ def load_devlogs(
     Groups entries by the containing actor directory name and sorts each
     actor's entries by ``log_index`` ascending.
 
-    Calls ``pytest.skip`` when ``devlogs/`` is absent, empty, or (when
-    ``demo_name`` is given) the scenario sub-directory is absent or empty.
+    Calls ``pytest.skip`` when there is no evidence the demo ever ran:
+    ``devlogs/`` absent, the scenario sub-directory absent, or no ledger files
+    *and* no ``dump-manifest.json``.
+
+    Calls ``pytest.fail`` when a ``dump-manifest.json`` is present but no
+    ledger files are: the scenario ran, dumped, and still produced no ledger
+    entries, which is a real invariant failure that must not be skipped over
+    (DEMOCI-10-001, ISSUE-2239).
 
     Returns:
         ``{actor_name: [sorted entry dicts, ...]}``.
@@ -150,10 +223,14 @@ def load_devlogs(
         replicas.setdefault(actor_name, []).extend(load_jsonl(jsonl_file))
 
     if not replicas:
+        manifests = _read_dump_manifests(search_root)
+        if manifests:
+            _fail_no_ledgers_despite_dump(search_root, manifests)
         skip_hint = f"devlogs/{demo_name}/" if demo_name else "devlogs/"
         pytest.skip(
-            f"No *-case-ledger.jsonl files found under {skip_hint} — "
-            "run the demo first (see test/ci/README-case-log-ratchet.md)"
+            f"No *-case-ledger.jsonl files found under {skip_hint} and no "
+            f"{DUMP_MANIFEST_FILENAME} — run the demo first "
+            "(see test/ci/README-case-log-ratchet.md)"
         )
 
     for actor in replicas:

--- a/test/ci/invariants/common.py
+++ b/test/ci/invariants/common.py
@@ -33,7 +33,10 @@ from pathlib import Path
 import pytest
 
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.demo.helpers.ledger_dump import DUMP_MANIFEST_FILENAME
+from vultron.demo.helpers.ledger_dump import (
+    DUMP_MANIFEST_FILENAME,
+    default_devlogs_root,
+)
 from vultron.enums.roles import CVDRole
 
 # ---------------------------------------------------------------------------
@@ -41,8 +44,11 @@ from vultron.enums.roles import CVDRole
 # ---------------------------------------------------------------------------
 
 _SHA256_HEX_PATTERN = re.compile(r"^[0-9a-f]{64}$")
-_REPO_ROOT: Path = Path(__file__).resolve().parents[3]
-_DEVLOGS_DIR: Path = _REPO_ROOT / "devlogs"
+
+#: Where the harness looks for the ledgers the demo dumped. Resolved by the same
+#: helper the dump writes through, so pointing ``DEVLOGS_DIR`` somewhere else
+#: cannot silently turn this harness into a no-op skip (DEMOMA-17-001).
+_DEVLOGS_DIR: Path = default_devlogs_root()
 
 
 # ---------------------------------------------------------------------------
@@ -144,8 +150,13 @@ def _read_dump_manifests(search_root: Path) -> list[dict]:
                 "demo dumped a manifest but it cannot be parsed, so the "
                 "invariant result cannot be trusted"
             )
-        if isinstance(data, dict):
-            manifests.append(data)
+        if not isinstance(data, dict):
+            pytest.fail(
+                f"{path} parsed as {type(data).__name__}, not an object — the "
+                "demo dumped a manifest but it cannot be interpreted, so the "
+                "invariant result cannot be trusted"
+            )
+        manifests.append(data)
     return manifests
 
 
@@ -222,8 +233,12 @@ def load_devlogs(
         actor_name = jsonl_file.parent.name
         replicas.setdefault(actor_name, []).extend(load_jsonl(jsonl_file))
 
+    # Read the manifests unconditionally: DEMOCI-10-003 fails on a manifest that
+    # is present but unparseable whatever else the dump produced, so this check
+    # cannot live inside the `not replicas` branch below.
+    manifests = _read_dump_manifests(search_root)
+
     if not replicas:
-        manifests = _read_dump_manifests(search_root)
         if manifests:
             _fail_no_ledgers_despite_dump(search_root, manifests)
         skip_hint = f"devlogs/{demo_name}/" if demo_name else "devlogs/"

--- a/test/ci/invariants/test_common.py
+++ b/test/ci/invariants/test_common.py
@@ -11,7 +11,12 @@ AC-1 of ISSUE-1976.
 from __future__ import annotations
 
 import hashlib
+import json
 
+import pytest
+from _pytest.outcomes import Failed, Skipped
+
+from test.ci.invariants import common
 from test.ci.invariants.common import (
     check_cross_actor_hash_agreement,
     check_cross_actor_payload_actor_agreement,
@@ -30,6 +35,7 @@ from test.ci.invariants.common import (
     check_payload_context_uses_case_uri,
     check_rm_closed_termination,
 )
+from vultron.demo.helpers.ledger_dump import DUMP_MANIFEST_FILENAME
 
 CASE_URI = "https://example.org/cases/test-case"
 _SHA256 = lambda s: hashlib.sha256(s.encode()).hexdigest()  # noqa: E731
@@ -588,3 +594,158 @@ class TestAllInvariantsPassOnValidChain:
         self, single_actor_replicas
     ):
         assert check_cs_state_transitions_observed(single_actor_replicas) == []
+
+
+# ---------------------------------------------------------------------------
+# load_devlogs() artifact handling (ISSUE-2239)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDevlogsManifestHandling:
+    """``load_devlogs`` must fail — not skip — once a demo has dumped.
+
+    Before ISSUE-2239, a scenario that died mid-phase uploaded nothing, so the
+    invariant harness could not tell "the demo never ran" apart from "the demo
+    ran and produced no ledger entries" and skipped in both cases (a false
+    green).  The dump now always writes ``dump-manifest.json``, which is the
+    evidence that distinguishes the two.
+    """
+
+    def test_skips_when_devlogs_dir_is_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path / "nope")
+        with pytest.raises(Skipped) as excinfo:
+            common.load_devlogs("fvv")
+        assert "devlogs/" in str(excinfo.value)
+
+    def test_skips_when_scenario_ran_no_dump(self, tmp_path, monkeypatch):
+        """No manifest means the dump never ran, so there is nothing to judge."""
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
+        (tmp_path / "fvv").mkdir()
+        with pytest.raises(Skipped) as excinfo:
+            common.load_devlogs("fvv")
+        assert "run the" in str(excinfo.value)
+
+    def test_fails_when_manifest_reports_no_ledgers(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
+        demo_dir = tmp_path / "fvv"
+        demo_dir.mkdir()
+        (demo_dir / DUMP_MANIFEST_FILENAME).write_text(
+            json.dumps(
+                {
+                    "demoName": "fvv",
+                    "caseId": None,
+                    "ledgerFileCount": 0,
+                    "targetCount": 0,
+                    "reason": "The scenario failed before a case existed.",
+                    "actors": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(Failed) as excinfo:
+            common.load_devlogs("fvv")
+        message = excinfo.value.msg or ""
+        assert "no case-ledger" in message.lower()
+        assert "The scenario failed before a case existed." in message
+
+    def test_failure_message_names_each_missing_actor(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
+        demo_dir = tmp_path / "fvv"
+        demo_dir.mkdir()
+        (demo_dir / DUMP_MANIFEST_FILENAME).write_text(
+            json.dumps(
+                {
+                    "demoName": "fvv",
+                    "caseId": CASE_URI,
+                    "ledgerFileCount": 0,
+                    "targetCount": 2,
+                    "reason": None,
+                    "actors": [
+                        {
+                            "actorName": "finder",
+                            "routeKey": "finder",
+                            "captured": False,
+                            "entryCount": 0,
+                            "ledgerFile": None,
+                            "reason": "ValueError: No case ledger entries",
+                        },
+                        {
+                            "actorName": "vendor",
+                            "routeKey": "vendor",
+                            "captured": False,
+                            "entryCount": 0,
+                            "ledgerFile": None,
+                            "reason": None,
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(Failed) as excinfo:
+            common.load_devlogs("fvv")
+        message = excinfo.value.msg or ""
+        assert "finder" in message
+        assert "ValueError: No case ledger entries" in message
+        assert "vendor" in message
+
+    def test_fails_when_manifest_is_unreadable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
+        demo_dir = tmp_path / "fvv"
+        demo_dir.mkdir()
+        (demo_dir / DUMP_MANIFEST_FILENAME).write_text(
+            "{not json", encoding="utf-8"
+        )
+        with pytest.raises(Failed) as excinfo:
+            common.load_devlogs("fvv")
+        assert "unreadable" in (excinfo.value.msg or "")
+
+    def test_returns_entries_when_ledger_files_exist(
+        self, tmp_path, monkeypatch, single_actor_replicas
+    ):
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
+        actor_dir = tmp_path / "fvv" / "case-actor"
+        actor_dir.mkdir(parents=True)
+        (tmp_path / "fvv" / DUMP_MANIFEST_FILENAME).write_text(
+            json.dumps({"demoName": "fvv", "ledgerFileCount": 1}),
+            encoding="utf-8",
+        )
+        entries = single_actor_replicas["case-actor"]
+        (actor_dir / "test-case-case-ledger.jsonl").write_text(
+            "".join(json.dumps(e) + "\n" for e in entries), encoding="utf-8"
+        )
+
+        replicas = common.load_devlogs("fvv")
+
+        assert list(replicas) == ["case-actor"]
+        assert [common.log_index(e) for e in replicas["case-actor"]] == list(
+            range(len(entries))
+        )
+
+    def test_skip_survives_when_no_demo_name_and_no_manifest(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
+        (tmp_path / "unrelated").mkdir()
+        with pytest.raises(Skipped) as excinfo:
+            common.load_devlogs()
+        assert "devlogs/" in str(excinfo.value)
+
+    def test_fails_when_any_scenario_manifest_reports_no_ledgers(
+        self, tmp_path, monkeypatch
+    ):
+        """Un-scoped loads look for a manifest anywhere beneath devlogs/."""
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
+        demo_dir = tmp_path / "fvv"
+        demo_dir.mkdir()
+        (demo_dir / DUMP_MANIFEST_FILENAME).write_text(
+            json.dumps({"demoName": "fvv", "ledgerFileCount": 0}),
+            encoding="utf-8",
+        )
+        with pytest.raises(Failed) as excinfo:
+            common.load_devlogs()
+        assert "no case-ledger" in (excinfo.value.msg or "").lower()

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -36,6 +36,7 @@ import vultron.demo.scenario.fv_demo as demo
 from test.demo._helpers import make_client, make_testclient_call
 from vultron.adapters.utils import strip_id_prefix
 from vultron.demo.cli import main
+from vultron.errors import DemoFailureError
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
@@ -1157,6 +1158,16 @@ class TestVerifyM1State:
 class TestRunTwoActorDemo:
     """Test the complete FV workflow via run_fv_demo."""
 
+    # The single-container in-process harness never commits CaseLedgerEntry
+    # records, so SYNC-2 replica verification cannot pass here (issue #2267).
+    # The multi-container demo CI job does commit them, so this gap is specific
+    # to this test.
+    KNOWN_IN_PROCESS_SYNC_GAP = (
+        "CHECK FAILED: Finder replica state matches authoritative Vendor "
+        "state — Replica has no CaseLedgerEntry records for the case — "
+        "SYNC-2 replication did not complete"
+    )
+
     def test_full_workflow_succeeds(
         self, client: TestClient, base: str, caplog
     ):
@@ -1166,14 +1177,24 @@ class TestRunTwoActorDemo:
         finder_id = f"{base}/actors/finder-full-test"
         vendor_id = f"{base}/actors/vendor-full-test"
 
+        # run_fv_demo() now asserts demo success from inside the shared
+        # scenario harness (ISSUE-2239), which surfaces the in-process SYNC-2
+        # gap that previous runs accumulated and dropped on the floor. Assert
+        # on that one known failure exactly, so any *other* phase failure still
+        # fails this test. Drop the pytest.raises() once #2267 is fixed.
         with caplog.at_level(logging.ERROR):
-            demo.run_fv_demo(
-                finder_client=finder_client,
-                vendor_client=vendor_client,
-                finder_id=finder_id,
-                vendor_id=vendor_id,
-            )
+            with pytest.raises(DemoFailureError) as excinfo:
+                demo.run_fv_demo(
+                    finder_client=finder_client,
+                    vendor_client=vendor_client,
+                    finder_id=finder_id,
+                    vendor_id=vendor_id,
+                )
 
+        assert excinfo.value.failures == [self.KNOWN_IN_PROCESS_SYNC_GAP], (
+            "FV workflow failed for reasons beyond the known in-process "
+            f"SYNC-2 gap (#2267): {excinfo.value.failures}"
+        )
         assert "ERROR SUMMARY" not in caplog.text, (
             "Expected demo to succeed, but got errors:\n" + caplog.text
         )

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -1169,13 +1169,20 @@ class TestRunTwoActorDemo:
     )
 
     def test_full_workflow_succeeds(
-        self, client: TestClient, base: str, caplog
+        self, client: TestClient, base: str, caplog, tmp_path, monkeypatch
     ):
         finder_client = make_client(base)
         vendor_client = make_client(base)
 
         finder_id = f"{base}/actors/finder-full-test"
         vendor_id = f"{base}/actors/vendor-full-test"
+
+        # run_fv_demo() now always dumps the ledgers (ISSUE-2239), so this test
+        # has to say where. Without this the dump lands in the repo-root
+        # devlogs/ (#2274) — and on a CI runner it cannot land at all, which
+        # adds four "STEP FAILED: Dumping case ledger …" entries to the
+        # accumulator and breaks the exact-match assertion below.
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
 
         # run_fv_demo() now asserts demo success from inside the shared
         # scenario harness (ISSUE-2239), which surfaces the in-process SYNC-2

--- a/test/demo/test_issue_2239_ledger_dump_in_finally.py
+++ b/test/demo/test_issue_2239_ledger_dump_in_finally.py
@@ -1,0 +1,233 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Regression tests for ISSUE-2239: an escaping assertion must not destroy the
+scenario's case-ledger artifacts.
+
+Before the fix, ``_phase_dump_case_ledgers`` was the last plain statement in
+every ``run_*_demo()``.  An exception escaping any earlier phase — for example
+one of the unguarded ``wait_for_case_participants`` calls — skipped the dump
+entirely.  ``main()``'s ``finally: assert_demo_success()`` still raised, so the
+demo job failed with an **empty** ``devlogs/`` directory; the separate
+invariant-harness job then died on artifact download and reported nothing about
+the protocol.
+
+Two guarantees are asserted here:
+
+1. A scenario that dies *after* the case exists still dumps every ledger it had
+   (``TestDumpRunsAfterMidPhaseFailure``).
+2. A scenario that dies *before* the case exists still produces a dump manifest,
+   so the case-log artifact always exists and the invariant harness reports a
+   real result rather than an artifact-download error
+   (``TestManifestWrittenWhenScenarioDiesEarly``).
+
+See ``specs/demo-ci.yaml`` DEMOCI-10 and ``specs/multi-actor-demo.yaml``
+DEMOMA-23.
+"""
+
+import importlib
+import inspect
+import json
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vultron.demo.helpers.ledger_dump import DUMP_MANIFEST_FILENAME
+from vultron.demo.utils import reset_demo_failures
+from vultron.errors import DemoFailureError
+
+# (module path, run function name, devlogs sub-directory name)
+SCENARIOS: list[tuple[str, str, str]] = [
+    ("vultron.demo.scenario.fv_demo", "run_fv_demo", "fv"),
+    ("vultron.demo.scenario.fvv_demo", "run_fvv_demo", "fvv"),
+    ("vultron.demo.scenario.fcv_demo", "run_fcv_demo", "fcv"),
+    (
+        "vultron.demo.scenario.fcv_reject_demo",
+        "run_fcv_reject_demo",
+        "fcv-reject",
+    ),
+    ("vultron.demo.scenario.fcvcv_demo", "run_fcvcv_demo", "fcvcv"),
+    (
+        "vultron.demo.scenario.fccv_extension_demo",
+        "run_fccv_extension_demo",
+        "fccv-extension",
+    ),
+    (
+        "vultron.demo.scenario.fvcv_extension_demo",
+        "run_fvcv_extension_demo",
+        "fvcv-extension",
+    ),
+    (
+        "vultron.demo.scenario.fccv_handoff_demo",
+        "run_fccv_handoff_demo",
+        "fccv-handoff",
+    ),
+    (
+        "vultron.demo.scenario.fvcv_handoff_demo",
+        "run_fvcv_handoff_demo",
+        "fvcv-handoff",
+    ),
+]
+
+
+def _client_kwargs(run_fn) -> dict[str, MagicMock]:
+    """Build a MagicMock for every ``*_client`` parameter of *run_fn*."""
+    return {
+        name: MagicMock()
+        for name in inspect.signature(run_fn).parameters
+        if name.endswith("_client")
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clean_failure_accumulator():
+    """Isolate the module-level demo failure accumulator between tests."""
+    reset_demo_failures()
+    yield
+    reset_demo_failures()
+
+
+class TestManifestWrittenWhenScenarioDiesEarly:
+    """A scenario that dies before the case exists still produces an artifact."""
+
+    @pytest.mark.parametrize(
+        "module_path, run_name, demo_name",
+        SCENARIOS,
+        ids=[demo_name for _, _, demo_name in SCENARIOS],
+    )
+    def test_manifest_written_when_first_phase_raises(
+        self,
+        module_path: str,
+        run_name: str,
+        demo_name: str,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        module: ModuleType = importlib.import_module(module_path)
+        run_fn = getattr(module, run_name)
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        with patch.object(
+            module,
+            "_phase_report_submission",
+            side_effect=RuntimeError("phase 1 exploded"),
+        ):
+            with pytest.raises((RuntimeError, DemoFailureError)):
+                run_fn(**_client_kwargs(run_fn))
+
+        manifest = tmp_path / demo_name / DUMP_MANIFEST_FILENAME
+        assert manifest.exists(), (
+            f"{run_name} produced no dump manifest, so the case-log artifact "
+            "would be empty and the invariant harness would fail on artifact "
+            "download instead of reporting an invariant result"
+        )
+
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+        assert payload["demoName"] == demo_name
+        assert payload["ledgerFileCount"] == 0
+        # The manifest is the evidence that the demo ran; without it the
+        # harness cannot tell "nobody ran the demo" from "the demo produced
+        # nothing".
+        assert payload["reason"]
+
+
+class TestDumpRunsAfterMidPhaseFailure:
+    """A scenario that dies after the case exists still dumps its ledgers."""
+
+    def test_fvv_dumps_ledgers_when_a_later_phase_raises(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        module = importlib.import_module("vultron.demo.scenario.fvv_demo")
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        case = module.as_VulnerabilityCase(
+            id_="https://example.org/cases/issue-2239"
+        )
+        # fvv phase 1 returns
+        # (finder, vendor, vendor_in_vendor, vendor2, report, offer, case).
+        phase_one_result = (
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            case,
+        )
+
+        with (
+            patch.object(
+                module,
+                "_phase_report_submission",
+                return_value=phase_one_result,
+            ),
+            patch.object(module, "get_actor_by_id", return_value=MagicMock()),
+            patch.object(
+                module,
+                "_phase_sync_verification",
+                side_effect=RuntimeError("wait_for_case_participants timeout"),
+            ),
+            patch.object(module, "_phase_dump_case_ledgers") as dump,
+        ):
+            with pytest.raises((RuntimeError, DemoFailureError)):
+                run_fn = module.run_fvv_demo
+                run_fn(**_client_kwargs(run_fn))
+
+        assert dump.called, (
+            "run_fvv_demo skipped the case-ledger dump when a phase raised; "
+            "the forensic artifacts the invariant harness needs were lost"
+        )
+        assert dump.call_args.kwargs["case"] is case
+
+    def test_dump_failure_does_not_mask_the_phase_exception(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A broken dump must not replace the exception that caused the failure."""
+        module = importlib.import_module("vultron.demo.scenario.fvv_demo")
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        case = module.as_VulnerabilityCase(
+            id_="https://example.org/cases/issue-2239-mask"
+        )
+        phase_one_result = (
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            case,
+        )
+
+        with (
+            patch.object(
+                module,
+                "_phase_report_submission",
+                return_value=phase_one_result,
+            ),
+            patch.object(module, "get_actor_by_id", return_value=MagicMock()),
+            patch.object(
+                module,
+                "_phase_sync_verification",
+                side_effect=RuntimeError("the real cause"),
+            ),
+            patch.object(
+                module,
+                "_phase_dump_case_ledgers",
+                side_effect=OSError("devlogs volume is read-only"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="the real cause"):
+                run_fn = module.run_fvv_demo
+                run_fn(**_client_kwargs(run_fn))

--- a/test/demo/test_scenario_harness.py
+++ b/test/demo/test_scenario_harness.py
@@ -1,0 +1,165 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for the shared scenario harness (ISSUE-2239, DEMOMA-23).
+
+These exercise the real ``demo_step`` / ``demo_check`` context managers rather
+than patching them out with ``nullcontext`` — patching them out is what let the
+gap in ADR-0058's gating primitive go unnoticed, and it would defeat the point
+here, since the harness's whole job is to control what happens when a phase
+raises.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import DUMP_MANIFEST_FILENAME
+from vultron.demo.utils import demo_check, reset_demo_failures
+from vultron.errors import DemoFailureError
+
+
+@pytest.fixture(autouse=True)
+def _devlogs(tmp_path, monkeypatch):
+    """Point the dump at a temporary devlogs root and isolate failure state."""
+    monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+    reset_demo_failures()
+    yield tmp_path
+    reset_demo_failures()
+
+
+def _manifest(devlogs, demo_name="unit"):
+    return json.loads(
+        (devlogs / demo_name / DUMP_MANIFEST_FILENAME).read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+class TestDumpAlwaysRuns:
+    def test_dump_runs_on_the_happy_path(self, _devlogs) -> None:
+        dump = MagicMock()
+        with scenario_harness("unit") as harness:
+            harness.dump_with(dump)
+        dump.assert_called_once_with()
+
+    def test_dump_runs_when_the_body_raises(self, _devlogs) -> None:
+        dump = MagicMock()
+        with pytest.raises(RuntimeError, match="phase blew up"):
+            with scenario_harness("unit") as harness:
+                harness.dump_with(dump)
+                raise RuntimeError("phase blew up")
+        dump.assert_called_once_with()
+
+    def test_manifest_written_when_no_dump_was_registered(
+        self, _devlogs
+    ) -> None:
+        with pytest.raises(RuntimeError):
+            with scenario_harness("unit"):
+                raise RuntimeError("died before the case existed")
+
+        payload = _manifest(_devlogs)
+        assert payload["demoName"] == "unit"
+        assert payload["ledgerFileCount"] == 0
+        assert payload["actors"] == []
+        assert "before a case existed" in payload["reason"]
+
+    def test_no_crash_manifest_when_the_dump_succeeds(self, _devlogs) -> None:
+        """A dump that ran is never retroactively reported as having crashed.
+
+        The real dump writes its own manifest, so the harness's backstop must
+        fire only on the failing path — otherwise every run whose dump wrote no
+        manifest (a stubbed dump, in practice) gets stamped with the
+        "dump crashed" reason it never earned.
+        """
+        with scenario_harness("unit") as harness:
+            harness.dump_with(MagicMock())
+
+        assert not (_devlogs / "unit" / DUMP_MANIFEST_FILENAME).exists()
+
+    def test_manifest_written_when_the_dump_itself_crashes(
+        self, _devlogs
+    ) -> None:
+        """A dump that dies before recording anything still leaves an artifact."""
+        with pytest.raises(RuntimeError, match="original cause"):
+            with scenario_harness("unit") as harness:
+                harness.dump_with(MagicMock(side_effect=OSError("no disk")))
+                raise RuntimeError("original cause")
+
+        payload = _manifest(_devlogs)
+        assert payload["ledgerFileCount"] == 0
+        assert payload["reason"]
+
+
+class TestExceptionPropagation:
+    def test_body_exception_is_not_masked_by_a_dump_failure(
+        self, _devlogs
+    ) -> None:
+        with pytest.raises(RuntimeError, match="original cause") as exc_info:
+            with scenario_harness("unit") as harness:
+                harness.dump_with(MagicMock(side_effect=OSError("no disk")))
+                raise RuntimeError("original cause")
+
+        assert not isinstance(exc_info.value, DemoFailureError)
+
+    def test_body_exception_carries_accumulated_failures_as_notes(
+        self, _devlogs
+    ) -> None:
+        """Soft failures are still reported, without replacing the real cause."""
+        with pytest.raises(RuntimeError, match="original cause") as exc_info:
+            with scenario_harness("unit") as harness:
+                harness.dump_with(MagicMock())
+                with demo_check("a soft precondition"):
+                    raise AssertionError("precondition not met")
+                raise RuntimeError("original cause")
+
+        notes = getattr(exc_info.value, "__notes__", [])
+        assert any("a soft precondition" in note for note in notes)
+
+    def test_accumulated_failures_raise_when_the_body_succeeds(
+        self, _devlogs
+    ) -> None:
+        with pytest.raises(DemoFailureError) as exc_info:
+            with scenario_harness("unit") as harness:
+                harness.dump_with(MagicMock())
+                with demo_check("a soft precondition"):
+                    raise AssertionError("precondition not met")
+
+        assert any(
+            "a soft precondition" in failure
+            for failure in exc_info.value.failures
+        )
+
+    def test_dump_failure_alone_fails_the_scenario(self, _devlogs) -> None:
+        """A successful run whose dump failed must not report success."""
+        with pytest.raises(DemoFailureError) as exc_info:
+            with scenario_harness("unit") as harness:
+                harness.dump_with(MagicMock(side_effect=OSError("no disk")))
+
+        assert any(
+            "Dumping case ledgers" in failure
+            for failure in exc_info.value.failures
+        )
+
+
+class TestFailureAccumulatorReset:
+    def test_harness_clears_failures_from_a_previous_run(
+        self, _devlogs
+    ) -> None:
+        with demo_check("stale failure from an earlier run"):
+            raise AssertionError("stale")
+
+        with scenario_harness("unit") as harness:
+            harness.dump_with(MagicMock())

--- a/test/demo/test_scenario_harness.py
+++ b/test/demo/test_scenario_harness.py
@@ -154,6 +154,61 @@ class TestExceptionPropagation:
         )
 
 
+class TestUnwritableDevlogsRoot:
+    """The dump root is not always writable, and that must not lose the cause.
+
+    This is the shape that turned the ``Tests (pytest)`` job red: the default
+    devlogs root pointed at a container path, so on a CI runner every write
+    raised. A dump that cannot write anywhere is still only ever a *reported*
+    failure — never a substitute for the scenario's own exception
+    (DEMOCI-10-004, DEMOMA-23-004).
+    """
+
+    @pytest.fixture
+    def unwritable(self, tmp_path, monkeypatch):
+        """Point DEVLOGS_DIR under a regular file, so every mkdir raises."""
+        blocker = tmp_path / "not-a-directory"
+        blocker.write_text("", encoding="utf-8")
+        monkeypatch.setenv("DEVLOGS_DIR", str(blocker / "devlogs"))
+        return blocker
+
+    def test_manifest_failure_does_not_mask_the_body_exception(
+        self, unwritable
+    ) -> None:
+        """The no-dump-registered path writes its manifest bare — guard it."""
+        with pytest.raises(RuntimeError, match="original cause"):
+            with scenario_harness("unit"):
+                raise RuntimeError("original cause")
+
+    def test_manifest_failure_does_not_mask_a_registered_dump_failure(
+        self, unwritable
+    ) -> None:
+        with pytest.raises(RuntimeError, match="original cause"):
+            with scenario_harness("unit") as harness:
+                harness.dump_with(MagicMock(side_effect=OSError("no disk")))
+                raise RuntimeError("original cause")
+
+    def test_backstop_failure_does_not_replace_the_dump_error(
+        self, unwritable
+    ) -> None:
+        """The recorded failure is the dump's, not the backstop manifest's."""
+        with pytest.raises(DemoFailureError) as exc_info:
+            with scenario_harness("unit") as harness:
+                harness.dump_with(MagicMock(side_effect=OSError("no disk")))
+
+        assert any(
+            "no disk" in failure for failure in exc_info.value.failures
+        ), exc_info.value.failures
+
+    def test_unwritable_root_is_reported_not_raised(self, unwritable) -> None:
+        """A clean body with an unwritable root fails loudly, via the accumulator."""
+        with pytest.raises(DemoFailureError) as exc_info:
+            with scenario_harness("unit"):
+                pass
+
+        assert exc_info.value.failures
+
+
 class TestFailureAccumulatorReset:
     def test_harness_clears_failures_from_a_previous_run(
         self, _devlogs

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -309,3 +309,56 @@ labels (`actor1`–`actor4`) so the compose file is scenario-agnostic. Until
 then, use the existing services with role-alias bindings.
 
 <!-- Source: ISSUE-1216, plan/incoming/learnings/20260722-fccv-handoff-container-remapping.md -->
+
+---
+
+### The Ledger Dump Belongs in the Failure Path, Not After the Last Phase
+
+A scenario's forensic artifacts are worth the most in exactly the run that
+fails. Code placed *after* the last phase runs only when nothing went wrong.
+Before #2239, every `run_<name>_demo()` called `_phase_dump_case_ledgers()` as
+its final statement, so any assertion escaping a `demo_check`/`demo_gate` block
+skipped the dump entirely — `main()`'s `finally: assert_demo_success()` still
+raised, CI still failed, but `devlogs/` was empty and the `invariant-harness`
+job died on artifact download instead of reporting an invariant result.
+
+**Why:** A demo that fails without artifacts is indistinguishable from a demo
+that never ran. Worse, the invariant harness *skipped* on a missing directory,
+so the pipeline read green for the wrong reason.
+
+**How to apply:**
+
+1. **Run the scenario inside `scenario_harness()`.** Wrap the whole body of
+   `run_<name>_demo()` in `with scenario_harness("<demo-name>") as harness:`.
+   The harness resets the failure accumulator on entry, always dumps on the way
+   out (success or exception), and calls `assert_demo_success()` last
+   (DEMOMA-23-001).
+2. **Register the dump the moment a case exists.** Immediately after the phase
+   that creates the case, call `harness.dump_with(lambda: _phase_dump_case_ledgers(...))`.
+   Every phase below that line can then fail without costing the ledgers
+   (DEMOMA-23-003).
+3. **Do not re-add `try/finally: assert_demo_success()` in `main()`.** The
+   harness owns the accumulator; a second owner reintroduces the bug by
+   asserting before the dump has run (DEMOMA-23-001).
+4. **Keep `_phase_dump_case_ledgers` thin.** It builds
+   `LedgerDumpTarget`s and delegates to
+   `vultron.demo.helpers.ledger_dump.dump_case_ledgers()`. No per-scenario
+   fetch/write loops (DEMOMA-23-002, DEMOMA-17-001).
+5. **The manifest is not optional.** `dump_case_ledgers()` writes
+   `devlogs/<demo>/dump-manifest.json` from a `finally`, recording the case ID,
+   how many ledger files were captured, and for each missing actor *why*. That
+   file is what lets the invariant harness fail on a real "no ledger entries"
+   assertion rather than on a download error (DEMOCI-10-002, DEMOCI-10-003).
+6. **A dump failure must never replace the scenario's exception.** The harness
+   swallows dump errors into the manifest's `reason` field and re-raises the
+   original failure with the accumulated `demo_check` failures attached as
+   exception notes (DEMOCI-10-004, DEMOMA-23-004).
+
+**Testing this:** patch a mid-scenario phase to raise, point `DEVLOGS_DIR` at a
+`tmp_path`, and assert the manifest exists. See
+`test/demo/test_issue_2239_ledger_dump_in_finally.py`.
+
+See `specs/demo-ci.yaml` DEMOCI-10, `specs/multi-actor-demo.yaml` DEMOMA-23,
+and [notes/demo-ci-invariants.md](../../notes/demo-ci-invariants.md).
+
+<!-- Source: ISSUE-2239 -->

--- a/vultron/demo/helpers/harness.py
+++ b/vultron/demo/helpers/harness.py
@@ -1,0 +1,184 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Shared scenario harness: run phases, always dump ledgers, then assert.
+
+Every ``run_*_demo()`` used to end with a plain call to its
+``_phase_dump_case_ledgers``. That made the forensic dump conditional on the
+scenario succeeding: an assertion escaping any earlier phase — an unguarded
+``wait_for_*`` timeout, say — skipped the dump, while ``main()``'s
+``assert_demo_success()`` still failed the job. The demo therefore failed with
+an empty ``devlogs/`` directory and the invariant-harness job died on artifact
+download, reporting nothing about the protocol (ISSUE-2239).
+
+:func:`scenario_harness` fixes the shape rather than the nine call sites. It
+owns the order the whole demo suite needs (DEMOMA-23-001):
+
+1. reset the failure accumulator,
+2. run the phases,
+3. **always** dump the ledgers — in a ``finally``, guarded so a dump error can
+   never replace the exception that caused the failure,
+4. assert success.
+
+Usage from a scenario module::
+
+    def run_fvv_demo(...) -> None:
+        with scenario_harness("fvv") as harness:
+            finder, vendor, ..., case = _phase_report_submission(...)
+            harness.dump_with(
+                lambda: _phase_dump_case_ledgers(
+                    finder_client=finder_client, ..., case=case
+                )
+            )
+            _phase_sync_verification(...)
+            ...
+
+The dump is registered as a callable the moment the case exists, so any later
+phase can die and the harness still has something to dump. Before that point
+the harness writes a manifest-only artifact, which is enough for the invariant
+harness to distinguish "the demo produced no ledgers" from "the demo never
+ran".
+"""
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Callable, Generator
+
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpReport,
+    ensure_dump_manifest,
+    write_dump_manifest,
+)
+from vultron.demo.utils import (
+    assert_demo_success,
+    demo_step,
+    reset_demo_failures,
+)
+from vultron.errors import DemoFailureError
+
+logger = logging.getLogger(__name__)
+
+NO_CASE_REASON = (
+    "The scenario failed before a case existed, so no participant ledgers "
+    "could be exported."
+)
+
+DUMP_CRASHED_REASON = (
+    "The case-ledger dump raised before it could record per-actor results."
+)
+
+
+@dataclass
+class ScenarioHarness:
+    """Per-run state shared between a scenario body and its harness.
+
+    Attributes:
+        demo_name: Scenario name; the devlogs sub-directory the dump writes to.
+        dump: Zero-argument callable that performs the ledger dump, or ``None``
+            while the scenario has not reached a dumpable state yet.
+    """
+
+    demo_name: str
+    dump: Callable[[], None] | None = None
+
+    def dump_with(self, dump: Callable[[], None]) -> None:
+        """Register the ledger dump to run when the scenario ends.
+
+        Call this as soon as the case and its participants exist — before the
+        phases that might fail — so a mid-scenario failure still yields the
+        ledgers collected so far.
+
+        Args:
+            dump: Callable invoked by the harness on the way out, however the
+                scenario ends.
+        """
+        self.dump = dump
+
+
+def _run_dump(harness: ScenarioHarness) -> None:
+    """Dump ledgers, guaranteeing a manifest and never raising.
+
+    The dump runs inside ``demo_step``, which records the failure and continues
+    (DEMOCI-01-003). That is what makes this safe to call from a ``finally``:
+    the accumulated failure is still reported, but it cannot mask the exception
+    that ended the scenario.
+    """
+    if harness.dump is None:
+        write_dump_manifest(
+            LedgerDumpReport(
+                demo_name=harness.demo_name, reason=NO_CASE_REASON
+            )
+        )
+        return
+
+    with demo_step(f"Dumping case ledgers for the {harness.demo_name} demo"):
+        try:
+            harness.dump()
+        except BaseException:
+            # ``dump_case_ledgers`` writes its own manifest from a ``finally``,
+            # so this backstop only fires when the dump died before getting
+            # that far. Writing it unconditionally would stamp the "dump
+            # crashed" reason onto runs whose dump was fine.
+            ensure_dump_manifest(harness.demo_name, DUMP_CRASHED_REASON)
+            raise
+
+
+def _note_accumulated_failures(exc: BaseException) -> None:
+    """Attach any accumulated demo failures to *exc* as notes.
+
+    On the failing path the harness lets the original exception propagate
+    rather than calling ``assert_demo_success()``, which would replace the real
+    cause with a generic ``DemoFailureError``. The accumulated soft failures
+    are still worth reporting, so they ride along as exception notes.
+    """
+    try:
+        assert_demo_success()
+    except DemoFailureError as accumulated:
+        for failure in accumulated.failures:
+            exc.add_note(failure)
+
+
+@contextmanager
+def scenario_harness(
+    demo_name: str,
+) -> Generator[ScenarioHarness, None, None]:
+    """Run a scenario body with an always-executed case-ledger dump.
+
+    Args:
+        demo_name: Scenario name, e.g. ``"fvv"``. Becomes the devlogs
+            sub-directory the dump and manifest are written to.
+
+    Yields:
+        The :class:`ScenarioHarness` the body registers its dump with.
+
+    Raises:
+        DemoFailureError: When the body completed but ``demo_step`` or
+            ``demo_check`` recorded failures.
+        BaseException: Whatever the body raised, unchanged — the dump runs
+            first but never substitutes its own error for the body's.
+    """
+    reset_demo_failures()
+    harness = ScenarioHarness(demo_name=demo_name)
+    try:
+        yield harness
+    except BaseException as exc:
+        logger.error(
+            "%s demo failed mid-run; dumping case ledgers before propagating",
+            demo_name,
+        )
+        _run_dump(harness)
+        _note_accumulated_failures(exc)
+        raise
+    _run_dump(harness)
+    assert_demo_success()

--- a/vultron/demo/helpers/harness.py
+++ b/vultron/demo/helpers/harness.py
@@ -106,6 +106,28 @@ class ScenarioHarness:
         self.dump = dump
 
 
+def _backstop_manifest(demo_name: str) -> None:
+    """Write the fallback manifest for *demo_name*, swallowing any error.
+
+    ``dump_case_ledgers`` writes its own manifest from a ``finally``, so this
+    backstop only fires when the dump died before getting that far. Writing it
+    unconditionally would stamp the "dump crashed" reason onto runs whose dump
+    was fine.
+
+    It must not raise: it runs while the dump's own exception is in flight, and
+    an error here would replace that exception with a less informative one
+    (DEMOCI-10-004).
+    """
+    try:
+        ensure_dump_manifest(demo_name, DUMP_CRASHED_REASON)
+    except BaseException:
+        logger.exception(
+            "Could not write the fallback dump manifest for the %s demo; "
+            "reporting the dump's own failure instead",
+            demo_name,
+        )
+
+
 def _run_dump(harness: ScenarioHarness) -> None:
     """Dump ledgers, guaranteeing a manifest and never raising.
 
@@ -113,25 +135,44 @@ def _run_dump(harness: ScenarioHarness) -> None:
     (DEMOCI-01-003). That is what makes this safe to call from a ``finally``:
     the accumulated failure is still reported, but it cannot mask the exception
     that ended the scenario.
-    """
-    if harness.dump is None:
-        write_dump_manifest(
-            LedgerDumpReport(
-                demo_name=harness.demo_name, reason=NO_CASE_REASON
-            )
-        )
-        return
 
-    with demo_step(f"Dumping case ledgers for the {harness.demo_name} demo"):
-        try:
-            harness.dump()
-        except BaseException:
-            # ``dump_case_ledgers`` writes its own manifest from a ``finally``,
-            # so this backstop only fires when the dump died before getting
-            # that far. Writing it unconditionally would stamp the "dump
-            # crashed" reason onto runs whose dump was fine.
-            ensure_dump_manifest(harness.demo_name, DUMP_CRASHED_REASON)
-            raise
+    Every path — including the manifest-only path taken when no dump was ever
+    registered, and a ``BaseException`` that ``demo_step`` does not catch — is
+    contained here. ``_run_dump`` never propagates, because its caller still
+    has the scenario's own exception to re-raise (DEMOCI-10-004,
+    DEMOMA-23-004).
+    """
+    try:
+        if harness.dump is None:
+            with demo_step(
+                f"Recording the {harness.demo_name} dump manifest "
+                "(no case to export)"
+            ):
+                write_dump_manifest(
+                    LedgerDumpReport(
+                        demo_name=harness.demo_name, reason=NO_CASE_REASON
+                    )
+                )
+            return
+
+        with demo_step(
+            f"Dumping case ledgers for the {harness.demo_name} demo"
+        ):
+            try:
+                harness.dump()
+            except BaseException:
+                _backstop_manifest(harness.demo_name)
+                raise
+    except BaseException:
+        # ``demo_step`` already recorded anything deriving from ``Exception``;
+        # this only catches what it lets through (``KeyboardInterrupt``,
+        # ``SystemExit``). Either way the scenario's own outcome is the one
+        # worth reporting, so the dump's failure stops here.
+        logger.exception(
+            "Case-ledger dump for the %s demo failed; reporting the "
+            "scenario's own outcome instead",
+            harness.demo_name,
+        )
 
 
 def _note_accumulated_failures(exc: BaseException) -> None:

--- a/vultron/demo/helpers/ledger_dump.py
+++ b/vultron/demo/helpers/ledger_dump.py
@@ -59,8 +59,10 @@ logger = logging.getLogger(__name__)
 DUMP_MANIFEST_FILENAME = "dump-manifest.json"
 """Name of the per-scenario manifest written on every dump attempt."""
 
-DEFAULT_OUTPUT_ROOT = "/app/devlogs"
-"""Fallback devlogs root used when ``DEVLOGS_DIR`` is unset."""
+#: Repo root, used to resolve the default ``devlogs/`` directory. This module
+#: lives at ``vultron/demo/helpers/ledger_dump.py`` → ``parents[3]`` is the
+#: repository root.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 
 LEDGER_FILE_SUFFIX = "-case-ledger.jsonl"
 
@@ -156,6 +158,32 @@ class LedgerDumpReport:
         }
 
 
+def default_devlogs_root() -> pathlib.Path:
+    """Return ``DEVLOGS_DIR`` when set, else ``<repo root>/devlogs``.
+
+    The single resolution of the devlogs root for the whole project;
+    :func:`vultron.demo.report.default_input_dir` and the invariant harness
+    both delegate here so a writer and a reader can never disagree about where
+    the ledgers live (DEMOMA-17-001).
+
+    The default must not be a container path. ``docker-compose-multi-actor.yml``
+    sets ``DEVLOGS_DIR=/app/devlogs`` explicitly for the demo runner, so the
+    fallback only ever fires *outside* the container — on a CI runner or a
+    developer checkout, where ``/app`` cannot be created and ``mkdir`` raises
+    ``PermissionError`` (ISSUE-2239).
+
+    An empty ``DEVLOGS_DIR`` counts as unset; ``pathlib.Path("")`` is the
+    current directory, which is never what an empty env var means.
+
+    Returns:
+        The directory under which per-scenario dump sub-directories live.
+    """
+    env = os.environ.get("DEVLOGS_DIR")
+    if env:
+        return pathlib.Path(env)
+    return _REPO_ROOT / "devlogs"
+
+
 def resolve_output_root(
     output_root: pathlib.Path | None = None,
 ) -> pathlib.Path:
@@ -169,7 +197,7 @@ def resolve_output_root(
     """
     if output_root is not None:
         return output_root
-    return pathlib.Path(os.environ.get("DEVLOGS_DIR", DEFAULT_OUTPUT_ROOT))
+    return default_devlogs_root()
 
 
 def case_id_slug(case_id: str) -> str:

--- a/vultron/demo/helpers/ledger_dump.py
+++ b/vultron/demo/helpers/ledger_dump.py
@@ -1,0 +1,414 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Shared case-ledger dump for demo scenarios.
+
+Every scenario exports each participant's view of the case ledger to
+``{DEVLOGS_DIR}/{demo_name}/{actor_name}/{case_id_slug}-case-ledger.jsonl``.
+The invariant harness (``test/ci/invariants/``) reads those files from the
+uploaded ``*-case-logs`` artifact, so the dump is the *only* forensic record a
+failed demo leaves behind.
+
+Two rules follow from that, and this module exists to hold them in one place
+rather than in nine near-identical scenario functions (DEMOMA-17-001):
+
+1. **The dump always writes a manifest.** ``DUMP_MANIFEST_FILENAME`` records
+   which actors were captured and why the others were not, so
+   ``{DEVLOGS_DIR}/{demo_name}/`` exists even when the scenario died before it
+   had a case. The artifact upload then always has something to upload, and the
+   invariant harness reports a real invariant result instead of failing on
+   artifact download (ISSUE-2239, DEMOCI-10-001).
+
+2. **A per-actor dump failure is recorded, not raised.** Each actor's dump runs
+   inside ``demo_step``, which accumulates the failure and continues
+   (DEMOCI-01-003), so one unreachable container cannot cost us the other
+   containers' ledgers.
+
+The scenario-facing entry point is :func:`dump_case_ledgers`; the harness in
+:mod:`vultron.demo.harness` calls :func:`write_dump_manifest` directly when a
+scenario failed before a case existed.
+"""
+
+import json
+import logging
+import os
+import pathlib
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx2 as httpx
+
+from vultron.adapters.utils import strip_id_prefix
+from vultron.demo.utils import DataLayerClient, demo_step
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
+
+logger = logging.getLogger(__name__)
+
+DUMP_MANIFEST_FILENAME = "dump-manifest.json"
+"""Name of the per-scenario manifest written on every dump attempt."""
+
+DEFAULT_OUTPUT_ROOT = "/app/devlogs"
+"""Fallback devlogs root used when ``DEVLOGS_DIR`` is unset."""
+
+LEDGER_FILE_SUFFIX = "-case-ledger.jsonl"
+
+
+@dataclass(frozen=True)
+class LedgerDumpTarget:
+    """One actor whose case-ledger view should be exported.
+
+    Args:
+        actor_name: Output sub-directory name, e.g. ``"vendor2"``. This is the
+            name the invariant harness uses to identify the replica.
+        client: DataLayerClient for the container that holds the ledger.
+        route_key: In-container actor route key used to build the log path.
+        fallback_client: Optional second container to try when *client* returns
+            404 or an empty ledger.
+        fallback_route_key: Route key to use with *fallback_client*.
+    """
+
+    actor_name: str
+    client: DataLayerClient
+    route_key: str
+    fallback_client: DataLayerClient | None = None
+    fallback_route_key: str | None = None
+
+
+@dataclass
+class ActorLedgerRecord:
+    """Outcome of one actor's dump attempt, as recorded in the manifest."""
+
+    actor_name: str
+    route_key: str
+    captured: bool = False
+    entry_count: int = 0
+    ledger_file: str | None = None
+    reason: str | None = None
+
+    def as_manifest_entry(self) -> dict[str, Any]:
+        """Return the JSON-serializable manifest form of this record."""
+        return {
+            "actorName": self.actor_name,
+            "routeKey": self.route_key,
+            "captured": self.captured,
+            "entryCount": self.entry_count,
+            "ledgerFile": self.ledger_file,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class LedgerDumpReport:
+    """Aggregate result of a scenario's ledger dump."""
+
+    demo_name: str
+    case_id: str | None = None
+    records: list[ActorLedgerRecord] = field(default_factory=list)
+    reason: str | None = None
+    """Explicit summary; overrides the one derived from *records*."""
+
+    @property
+    def ledger_file_count(self) -> int:
+        """Number of actors whose ledger was written to disk."""
+        return sum(1 for record in self.records if record.captured)
+
+    def summary(self) -> str:
+        """Return a one-line human-readable explanation of the outcome."""
+        if self.reason:
+            return self.reason
+        if not self.records:
+            return (
+                "No dump targets: the scenario failed before a case existed, "
+                "so there were no participant ledgers to export."
+            )
+        missing = [r.actor_name for r in self.records if not r.captured]
+        if not missing:
+            return (
+                f"Captured case ledgers for all {len(self.records)} "
+                "participants."
+            )
+        return (
+            f"Captured {self.ledger_file_count} of {len(self.records)} "
+            f"participant case ledgers; missing: {', '.join(missing)}."
+        )
+
+    def as_manifest(self) -> dict[str, Any]:
+        """Return the JSON-serializable manifest for this report."""
+        return {
+            "demoName": self.demo_name,
+            "caseId": self.case_id,
+            "ledgerFileCount": self.ledger_file_count,
+            "targetCount": len(self.records),
+            "reason": self.summary(),
+            "actors": [record.as_manifest_entry() for record in self.records],
+        }
+
+
+def resolve_output_root(
+    output_root: pathlib.Path | None = None,
+) -> pathlib.Path:
+    """Return the devlogs root, honouring the ``DEVLOGS_DIR`` environment var.
+
+    Args:
+        output_root: Explicit root; when given it is returned unchanged.
+
+    Returns:
+        The directory under which per-scenario dump sub-directories live.
+    """
+    if output_root is not None:
+        return output_root
+    return pathlib.Path(os.environ.get("DEVLOGS_DIR", DEFAULT_OUTPUT_ROOT))
+
+
+def case_id_slug(case_id: str) -> str:
+    """Convert a case URI into a filesystem-safe slug.
+
+    Args:
+        case_id: The case's ``id_`` URI, e.g. ``https://example.org/cases/x``.
+
+    Returns:
+        The slug used in ledger file names, e.g. ``example.org_cases_x``.
+    """
+    return (
+        case_id.replace("://", "_")
+        .replace("/", "_")
+        .replace(":", "_")
+        .strip("_")
+    )
+
+
+def resolve_case_actor_route_key(case: as_VulnerabilityCase) -> str | None:
+    """Return the in-container route key of the case's case-actor, if any.
+
+    The case-actor is a sub-actor created inside whichever container owns the
+    case; its route key is discoverable only from the case's participant index.
+
+    Args:
+        case: The case whose participants are scanned.
+
+    Returns:
+        The case-actor's route key, or ``None`` when the case has no case-actor
+        participant.
+    """
+    return next(
+        (
+            strip_id_prefix(actor_id)
+            for actor_id in case.actor_participant_index
+            if strip_id_prefix(actor_id).startswith("case-actor")
+        ),
+        None,
+    )
+
+
+def write_dump_manifest(
+    report: LedgerDumpReport,
+    output_root: pathlib.Path | None = None,
+) -> pathlib.Path:
+    """Write *report* to ``{output_root}/{demo_name}/dump-manifest.json``.
+
+    Called on every dump attempt — including the degenerate attempt made when a
+    scenario failed before it had a case — so the case-log artifact is never
+    empty (DEMOCI-10-001).
+
+    Args:
+        report: The dump outcome to record.
+        output_root: Devlogs root; defaults to ``DEVLOGS_DIR``.
+
+    Returns:
+        Path to the manifest that was written.
+    """
+    out_dir = resolve_output_root(output_root) / report.demo_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = out_dir / DUMP_MANIFEST_FILENAME
+    manifest_path.write_text(
+        json.dumps(report.as_manifest(), indent=2) + "\n", encoding="utf-8"
+    )
+    logger.info(
+        "Wrote dump manifest → %s (%s)", manifest_path, report.summary()
+    )
+    return manifest_path
+
+
+def ensure_dump_manifest(
+    demo_name: str,
+    reason: str,
+    output_root: pathlib.Path | None = None,
+) -> pathlib.Path | None:
+    """Write a fallback manifest for *demo_name* only if none exists yet.
+
+    Backstop for a dump that died before :func:`dump_case_ledgers` could write
+    its own manifest. Guarantees the case-log artifact is non-empty whatever
+    happened during the run.
+
+    Args:
+        demo_name: Scenario name; the devlogs sub-directory to check.
+        reason: Explanation recorded when a fallback manifest is written.
+        output_root: Devlogs root; defaults to ``DEVLOGS_DIR``.
+
+    Returns:
+        Path to the manifest written, or ``None`` if one already existed.
+    """
+    root = resolve_output_root(output_root)
+    if (root / demo_name / DUMP_MANIFEST_FILENAME).exists():
+        return None
+    return write_dump_manifest(
+        LedgerDumpReport(demo_name=demo_name, reason=reason), output_root=root
+    )
+
+
+def _fetch_entries(
+    client: DataLayerClient, log_path: str, actor_name: str
+) -> list[dict[str, Any]]:
+    """Fetch ledger entries, treating a 404 as an empty ledger.
+
+    A 404 means the container does not hold this case at all, which is a
+    legitimate outcome for a dedicated case-actor container (see the fallback in
+    :func:`dump_case_ledgers`) and for a scenario that never delivered the case
+    to that participant. Any other HTTP error is a real failure and propagates.
+
+    Args:
+        client: Container client to read from.
+        log_path: Case-log route on that container.
+        actor_name: Actor name, for logging.
+
+    Returns:
+        The ledger entries, or an empty list on 404.
+    """
+    try:
+        return client.get_list(log_path)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 404:
+            raise
+        logger.info(
+            "Case not found on %s container (HTTP 404); treating as empty.",
+            actor_name,
+        )
+        return []
+
+
+def _write_ledger_file(
+    entries: list[dict[str, Any]],
+    out_dir: pathlib.Path,
+    slug: str,
+) -> pathlib.Path:
+    """Write *entries* as JSONL and return the path written."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / f"{slug}{LEDGER_FILE_SUFFIX}"
+    with out_file.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+    logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    return out_file
+
+
+def dump_case_ledgers(
+    demo_name: str,
+    case: as_VulnerabilityCase,
+    targets: list[LedgerDumpTarget],
+    output_root: pathlib.Path | None = None,
+) -> LedgerDumpReport:
+    """Export every target's case-ledger view, then write the dump manifest.
+
+    Each target's export runs inside ``demo_step``, so a failure is accumulated
+    and reported by ``assert_demo_success()`` without preventing the remaining
+    targets — or the manifest — from being written.
+
+    Args:
+        demo_name: Scenario name; becomes the devlogs sub-directory.
+        case: The case whose ledgers are exported.
+        targets: Actors to export, in output order.
+        output_root: Devlogs root; defaults to ``DEVLOGS_DIR``.
+
+    Returns:
+        The dump report, also persisted as the manifest.
+    """
+    logger.info("─" * 80)
+    logger.info("Phase: Case log JSONL export")
+    logger.info("─" * 80)
+
+    root = resolve_output_root(output_root)
+    case_id = case.id_ or ""
+    slug = case_id_slug(case_id)
+    case_key = strip_id_prefix(case_id)
+
+    report = LedgerDumpReport(demo_name=demo_name, case_id=case_id or None)
+    try:
+        for target in targets:
+            record = ActorLedgerRecord(
+                actor_name=target.actor_name, route_key=target.route_key
+            )
+            report.records.append(record)
+            with demo_step(f"Dumping case ledger for {target.actor_name}"):
+                # Record why a dump failed before demo_step swallows the
+                # exception, so the manifest explains every missing ledger.
+                try:
+                    _dump_one_target(
+                        target=target,
+                        record=record,
+                        case_key=case_key,
+                        case_id=case_id,
+                        out_dir=root / demo_name / target.actor_name,
+                        slug=slug,
+                    )
+                except Exception as exc:
+                    record.reason = f"{type(exc).__name__}: {exc}"
+                    raise
+    finally:
+        write_dump_manifest(report, output_root=root)
+
+    return report
+
+
+def _dump_one_target(
+    target: LedgerDumpTarget,
+    record: ActorLedgerRecord,
+    case_key: str,
+    case_id: str,
+    out_dir: pathlib.Path,
+    slug: str,
+) -> None:
+    """Export one target's ledger and update *record* in place.
+
+    Raises:
+        ValueError: When the container returned no ledger entries. This is a
+            real invariant failure — a participant of the case should have a
+            ledger — so it is reported rather than silently tolerated.
+    """
+    entries = _fetch_entries(
+        target.client,
+        f"/actors/{target.route_key}/demo/cases/{case_key}/log",
+        target.actor_name,
+    )
+    if not entries and target.fallback_client is not None:
+        logger.info(
+            "Primary %s log unavailable; falling back to route key '%s'",
+            target.actor_name,
+            target.fallback_route_key,
+        )
+        entries = _fetch_entries(
+            target.fallback_client,
+            f"/actors/{target.fallback_route_key}/demo/cases/{case_key}/log",
+            target.actor_name,
+        )
+    if not entries:
+        raise ValueError(
+            f"No case ledger entries for actor={target.actor_name!r}, "
+            f"case_id={case_id!r}"
+        )
+
+    out_file = _write_ledger_file(entries, out_dir, slug)
+    record.captured = True
+    record.entry_count = len(entries)
+    record.ledger_file = f"{target.actor_name}/{out_file.name}"

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -52,7 +52,6 @@ import argparse
 import html
 import json
 import logging
-import os
 import sys
 import webbrowser
 from collections import defaultdict
@@ -63,13 +62,10 @@ from typing import Any, Iterable
 from pydantic import BaseModel, Field
 
 from vultron.core.models.events.base import MessageSemantics
+from vultron.demo.helpers.ledger_dump import default_devlogs_root
 from vultron.semantic_registry import lookup_entry
 
 logger = logging.getLogger(__name__)
-
-#: Repo root, used to resolve the default ``devlogs/`` directory. This module
-#: lives at ``vultron/demo/report.py`` → ``parents[2]`` is the repository root.
-_REPO_ROOT: Path = Path(__file__).resolve().parents[2]
 
 #: Glob for the per-actor case-ledger replica files.
 _LEDGER_GLOB = "**/*-case-ledger.jsonl"
@@ -1101,11 +1097,13 @@ def generate_report(input_dir: Path, fmt: str) -> str:
 
 
 def default_input_dir() -> Path:
-    """Return the default input directory (``DEVLOGS_DIR`` env, else ``devlogs/``)."""
-    env = os.environ.get("DEVLOGS_DIR")
-    if env:
-        return Path(env)
-    return _REPO_ROOT / "devlogs"
+    """Return the default input directory (``DEVLOGS_DIR`` env, else ``devlogs/``).
+
+    Delegates to :func:`vultron.demo.helpers.ledger_dump.default_devlogs_root`
+    so this reader and the dump that writes the ledgers cannot disagree about
+    where they live (DEMOMA-17-001).
+    """
+    return default_devlogs_root()
 
 
 def default_output_path(input_dir: Path, fmt: str) -> Path:

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -15,9 +15,13 @@
 
 Parses the JSONL case-ledger replica files produced by demo scenario runs
 (``{DEVLOGS_DIR}/{demo}/{actor}/{case_slug}-case-ledger.jsonl``, written by
-:func:`vultron.demo.scenario.two_actor_demo._phase_dump_case_ledgers`) and
-renders a selective, human-readable report — "who did what to whom, with what
-activity, in what order."
+:func:`vultron.demo.helpers.ledger_dump.dump_case_ledgers`) and renders a
+selective, human-readable report — "who did what to whom, with what activity,
+in what order."
+
+The ``dump-manifest.json`` file that ``dump_case_ledgers`` writes alongside the
+replicas (ISSUE-2239) is not part of this tool's input; ``discover_replicas``
+globs only ``**/*-case-ledger.jsonl``.
 
 The tool is intentionally standalone (its own ``__main__`` entry point,
 invokable as ``python -m vultron.demo.report`` or via the

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -896,6 +896,7 @@ def run_fccv_extension_demo(
                 c2_client=c2_client,
                 vendor_client=vendor_client,
                 case=case,
+                demo_name=harness.demo_name,
             )
         )
 

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -34,15 +34,10 @@ Container mapping (reuses docker-compose-multi-actor.yml services):
 Spec: DEMOMA-13 (GitHub issue #1620).
 """
 
-import json
 import logging
 import os
-import pathlib
 import sys
 
-import httpx2 as httpx
-
-from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
@@ -74,6 +69,12 @@ from vultron.demo.helpers.actions import (
     actor_closes_case,
     actor_notifies_fix_ready,
     actor_notifies_published,
+)
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpTarget,
+    dump_case_ledgers,
+    resolve_case_actor_route_key,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
@@ -818,70 +819,30 @@ def _phase_dump_case_ledgers(
     case: as_VulnerabilityCase,
     demo_name: str = "fccv-extension",
 ) -> None:
-    """Dump case ledger entries from each actor container to JSONL files."""
-    logger.info("─" * 80)
-    logger.info("Phase: Case log JSONL export")
-    logger.info("─" * 80)
+    """Dump case ledger entries from each actor container to JSONL files.
 
-    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
-    case_id = case.id_ or ""
-    case_id_slug = (
-        case_id.replace("://", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .strip("_")
-    )
-
-    case_actor_sub_actor_key = next(
-        (
-            strip_id_prefix(actor_id)
-            for actor_id in case.actor_participant_index
-            if strip_id_prefix(actor_id).startswith("case-actor")
-        ),
-        None,
-    )
-
-    actors: list[tuple[str, DataLayerClient, str]] = [
-        ("finder", finder_client, "finder"),
+    Thin scenario-specific wrapper over
+    :func:`~vultron.demo.helpers.ledger_dump.dump_case_ledgers`, which owns the
+    per-actor export, the 404 handling, and the dump manifest. This function
+    only names FCCV-extension's participants and where each ledger lives.
+    """
+    targets = [
+        LedgerDumpTarget("finder", finder_client, "finder"),
         # C1 is on the coordinator container; route key is "coordinator".
-        ("vendor", c1_client, "coordinator"),
+        LedgerDumpTarget("vendor", c1_client, "coordinator"),
         # C2 is on actor5; route key is "coordinator2".
-        ("coordinator", c2_client, "coordinator2"),
+        LedgerDumpTarget("coordinator", c2_client, "coordinator2"),
         # Vendor is on the vendor container.
-        ("vendor2", vendor_client, "vendor"),
+        LedgerDumpTarget("vendor2", vendor_client, "vendor"),
     ]
-    if case_actor_sub_actor_key is not None:
-        actors.append(("case-actor", c1_client, case_actor_sub_actor_key))
+    # The case-actor is a sub-actor inside the C1 container.
+    case_actor_route_key = resolve_case_actor_route_key(case)
+    if case_actor_route_key is not None:
+        targets.append(
+            LedgerDumpTarget("case-actor", c1_client, case_actor_route_key)
+        )
 
-    for actor_name, client, actor_route_key in actors:
-        with demo_step(f"Dumping case ledger for {actor_name}"):
-            case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            try:
-                entries = client.get_list(log_path)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code != 404:
-                    raise
-                logger.info(
-                    "Case not found on %s container (HTTP 404); skipping.",
-                    actor_name,
-                )
-                entries = []
-            if not entries:
-                raise ValueError(
-                    f"No case ledger entries for actor={actor_name!r}, "
-                    f"case_id={case_id!r}"
-                )
-
-            out_dir = output_root / demo_name / actor_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
-
-            with out_file.open("w", encoding="utf-8") as fh:
-                for entry in entries:
-                    fh.write(json.dumps(entry) + "\n")
-
-            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    dump_case_ledgers(demo_name=demo_name, case=case, targets=targets)
 
 
 def run_fccv_extension_demo(
@@ -905,103 +866,109 @@ def run_fccv_extension_demo(
     logger.info("C2 container:     %s", c2_client.base_url)
     logger.info("Vendor container: %s", vendor_client.base_url)
 
-    (
-        finder,
-        c1,
-        c1_in_c1,
-        c2_in_c2,
-        vendor,
-        report,
-        offer,
-        case,
-    ) = _phase_report_submission(
-        finder_client,
-        c1_client,
-        c2_client,
-        vendor_client,
-        finder_id,
-        c1_id,
-        c2_id,
-        vendor_id,
-    )
+    with scenario_harness("fccv-extension") as harness:
+        (
+            finder,
+            c1,
+            c1_in_c1,
+            c2_in_c2,
+            vendor,
+            report,
+            offer,
+            case,
+        ) = _phase_report_submission(
+            finder_client,
+            c1_client,
+            c2_client,
+            vendor_client,
+            finder_id,
+            c1_id,
+            c2_id,
+            vendor_id,
+        )
 
-    vendor_in_vendor = get_actor_by_id(vendor_client, vendor.id_)
+        # Register the dump as soon as there is a case to dump, so every phase
+        # below can fail without costing us the ledgers (ISSUE-2239).
+        harness.dump_with(
+            lambda: _phase_dump_case_ledgers(
+                finder_client=finder_client,
+                c1_client=c1_client,
+                c2_client=c2_client,
+                vendor_client=vendor_client,
+                case=case,
+            )
+        )
 
-    _phase_c2_suggests_vendor(
-        finder_client=finder_client,
-        c1_client=c1_client,
-        c2_client=c2_client,
-        vendor_client=vendor_client,
-        c1_in_c1=c1_in_c1,
-        c2_in_c2=c2_in_c2,
-        vendor=vendor,
-        vendor_in_vendor=vendor_in_vendor,
-        case=case,
-        offer=offer,
-        report=report,
-        finder=finder,
-    )
+        vendor_in_vendor = get_actor_by_id(vendor_client, vendor.id_)
 
-    finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+        _phase_c2_suggests_vendor(
+            finder_client=finder_client,
+            c1_client=c1_client,
+            c2_client=c2_client,
+            vendor_client=vendor_client,
+            c1_in_c1=c1_in_c1,
+            c2_in_c2=c2_in_c2,
+            vendor=vendor,
+            vendor_in_vendor=vendor_in_vendor,
+            case=case,
+            offer=offer,
+            report=report,
+            finder=finder,
+        )
 
-    _phase_sync_verification(
-        finder_client,
-        c1_client,
-        c2_client,
-        vendor_client,
-        c1,
-        finder,
-        case,
-    )
-    _phase_notes_exchange(
-        finder_client=finder_client,
-        c1_client=c1_client,
-        c2_client=c2_client,
-        vendor_client=vendor_client,
-        finder_in_finder=finder_in_finder,
-        c1_in_c1=c1_in_c1,
-        c2_in_c2=c2_in_c2,
-        vendor_in_vendor=vendor_in_vendor,
-        case=case,
-    )
-    _phase_fix_lifecycle(
-        c1_client,
-        vendor_client,
-        vendor,
-        vendor_in_vendor,
-        case,
-    )
-    _phase_publication(
-        finder_client,
-        c1_client,
-        c2_client,
-        vendor_client,
-        c1,
-        c1_in_c1,
-        c2_in_c2,
-        vendor,
-        vendor_in_vendor,
-        finder_in_finder,
-        case,
-    )
-    _phase_case_closure(
-        finder_client,
-        c1_client,
-        c2_client,
-        vendor_client,
-        c1_in_c1,
-        c2_in_c2,
-        vendor_in_vendor,
-        finder_in_finder,
-        case,
-    )
-    _phase_dump_case_ledgers(
-        finder_client=finder_client,
-        c1_client=c1_client,
-        c2_client=c2_client,
-        vendor_client=vendor_client,
-        case=case,
-    )
+        finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+
+        _phase_sync_verification(
+            finder_client,
+            c1_client,
+            c2_client,
+            vendor_client,
+            c1,
+            finder,
+            case,
+        )
+        _phase_notes_exchange(
+            finder_client=finder_client,
+            c1_client=c1_client,
+            c2_client=c2_client,
+            vendor_client=vendor_client,
+            finder_in_finder=finder_in_finder,
+            c1_in_c1=c1_in_c1,
+            c2_in_c2=c2_in_c2,
+            vendor_in_vendor=vendor_in_vendor,
+            case=case,
+        )
+        _phase_fix_lifecycle(
+            c1_client,
+            vendor_client,
+            vendor,
+            vendor_in_vendor,
+            case,
+        )
+        _phase_publication(
+            finder_client,
+            c1_client,
+            c2_client,
+            vendor_client,
+            c1,
+            c1_in_c1,
+            c2_in_c2,
+            vendor,
+            vendor_in_vendor,
+            finder_in_finder,
+            case,
+        )
+        _phase_case_closure(
+            finder_client,
+            c1_client,
+            c2_client,
+            vendor_client,
+            c1_in_c1,
+            c2_in_c2,
+            vendor_in_vendor,
+            finder_in_finder,
+            case,
+        )
 
     logger.info("=" * 80)
     logger.info("FCCV-EXTENSION DEMO COMPLETE ✓  (VFDPxa full lifecycle)")
@@ -1037,8 +1004,6 @@ def main(
         c2_id: Optional deterministic URI for the C2 actor.
         vendor_id: Optional deterministic URI for the Vendor actor.
     """
-    reset_demo_failures()
-
     f_url = finder_url or FINDER_BASE_URL
     c1_resolved = c1_url or C1_BASE_URL
     c2_resolved = c2_url or C2_BASE_URL
@@ -1068,19 +1033,19 @@ def main(
                 logger.error("=" * 80)
                 sys.exit(1)
 
-    try:
-        run_fccv_extension_demo(
-            finder_client=finder_client,
-            c1_client=c1_client,
-            c2_client=c2_client,
-            vendor_client=vendor_client,
-            finder_id=finder_id,
-            c1_id=c1_id,
-            c2_id=c2_id,
-            vendor_id=vendor_id,
-        )
-    finally:
-        assert_demo_success()
+    # scenario_harness() inside run_fccv_extension_demo() owns the failure
+    # accumulator: it resets it, always dumps the case ledgers, and asserts
+    # success — so a failure here never costs us the artifacts (ISSUE-2239).
+    run_fccv_extension_demo(
+        finder_client=finder_client,
+        c1_client=c1_client,
+        c2_client=c2_client,
+        vendor_client=vendor_client,
+        finder_id=finder_id,
+        c1_id=c1_id,
+        c2_id=c2_id,
+        vendor_id=vendor_id,
+    )
 
 
 if __name__ == "__main__":

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -1020,6 +1020,7 @@ def run_fccv_handoff_demo(
                 c2_client=c2_client,
                 vendor_client=vendor_client,
                 case=case,
+                demo_name=harness.demo_name,
             )
         )
 

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -28,16 +28,11 @@ Container mapping (reuses docker-compose-multi-actor.yml services):
 Spec: GitHub issue #1216 (DEMOMA-14).
 """
 
-import json
 import logging
 import os
-import pathlib
 import sys
 import time
 
-import httpx2 as httpx
-
-from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
@@ -71,6 +66,12 @@ from vultron.demo.helpers.actions import (
     actor_closes_case,
     actor_notifies_fix_ready,
     actor_notifies_published,
+)
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpTarget,
+    dump_case_ledgers,
+    resolve_case_actor_route_key,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
@@ -937,67 +938,27 @@ def _phase_dump_case_ledgers(
     case: as_VulnerabilityCase,
     demo_name: str = "fccv-handoff",
 ) -> None:
-    """Dump case ledger entries from each actor container to JSONL files."""
-    logger.info("─" * 80)
-    logger.info("Phase: Case log JSONL export")
-    logger.info("─" * 80)
+    """Dump case ledger entries from each actor container to JSONL files.
 
-    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
-    case_id = case.id_ or ""
-    case_id_slug = (
-        case_id.replace("://", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .strip("_")
-    )
-
-    case_actor_sub_actor_key = next(
-        (
-            strip_id_prefix(actor_id)
-            for actor_id in case.actor_participant_index
-            if strip_id_prefix(actor_id).startswith("case-actor")
-        ),
-        None,
-    )
-
-    actors: list[tuple[str, DataLayerClient, str]] = [
-        ("finder", finder_client, "finder"),
-        ("vendor", c1_client, "vendor"),
-        ("coordinator", c2_client, "coordinator"),
-        ("vendor2", vendor_client, "vendor2"),
+    Thin scenario-specific wrapper over
+    :func:`~vultron.demo.helpers.ledger_dump.dump_case_ledgers`, which owns the
+    per-actor export, the 404 handling, and the dump manifest. This function
+    only names FCCV-handoff's participants and where each ledger lives.
+    """
+    targets = [
+        LedgerDumpTarget("finder", finder_client, "finder"),
+        LedgerDumpTarget("vendor", c1_client, "vendor"),
+        LedgerDumpTarget("coordinator", c2_client, "coordinator"),
+        LedgerDumpTarget("vendor2", vendor_client, "vendor2"),
     ]
-    if case_actor_sub_actor_key is not None:
-        actors.append(("case-actor", c1_client, case_actor_sub_actor_key))
+    # The case-actor is a sub-actor inside the C1 container.
+    case_actor_route_key = resolve_case_actor_route_key(case)
+    if case_actor_route_key is not None:
+        targets.append(
+            LedgerDumpTarget("case-actor", c1_client, case_actor_route_key)
+        )
 
-    for actor_name, client, actor_route_key in actors:
-        with demo_step(f"Dumping case ledger for {actor_name}"):
-            case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            try:
-                entries = client.get_list(log_path)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code != 404:
-                    raise
-                logger.info(
-                    "Case not found on %s container (HTTP 404); skipping.",
-                    actor_name,
-                )
-                entries = []
-            if not entries:
-                raise ValueError(
-                    f"No case ledger entries for actor={actor_name!r}, "
-                    f"case_id={case_id!r}"
-                )
-
-            out_dir = output_root / demo_name / actor_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
-
-            with out_file.open("w", encoding="utf-8") as fh:
-                for entry in entries:
-                    fh.write(json.dumps(entry) + "\n")
-
-            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    dump_case_ledgers(demo_name=demo_name, case=case, targets=targets)
 
 
 # ---------------------------------------------------------------------------
@@ -1018,154 +979,162 @@ def run_fccv_handoff_demo(
     vendor_id: str | None = None,
 ) -> None:
     """Orchestrate the FCCV-handoff CVD workflow."""
-    logger.info("=" * 80)
-    logger.info("FCCV-HANDOFF DEMO: Finder + C1 → C2 (ownership) + Vendor")
-    logger.info("=" * 80)
-    logger.info("Finder container:    %s", finder_client.base_url)
-    logger.info("C1 container:        %s", c1_client.base_url)
-    logger.info("C2 container:        %s", c2_client.base_url)
-    logger.info("CaseActor container: %s", case_actor_client.base_url)
-    logger.info("Vendor container:    %s", vendor_client.base_url)
+    with scenario_harness("fccv-handoff") as harness:
+        logger.info("=" * 80)
+        logger.info("FCCV-HANDOFF DEMO: Finder + C1 → C2 (ownership) + Vendor")
+        logger.info("=" * 80)
+        logger.info("Finder container:    %s", finder_client.base_url)
+        logger.info("C1 container:        %s", c1_client.base_url)
+        logger.info("C2 container:        %s", c2_client.base_url)
+        logger.info("CaseActor container: %s", case_actor_client.base_url)
+        logger.info("Vendor container:    %s", vendor_client.base_url)
 
-    (
-        finder,
-        c1,
-        c1_in_c1,
-        c2,
-        c2_in_c2,
-        vendor,
-        report,
-        offer,
-        case,
-    ) = _phase_report_submission(
-        finder_client,
-        c1_client,
-        c2_client,
-        case_actor_client,
-        vendor_client,
-        finder_id,
-        c1_id,
-        c2_id,
-        vendor_id,
-    )
-
-    # Discover the CaseActor's dynamic sub-actor ID before the handoff phase.
-    dynamic_case_actor_id = find_case_actor_participant_id(c1_client, case.id_)
-    if dynamic_case_actor_id is None:
-        raise AssertionError(
-            "CaseActor participant not found in case — cannot route Vendor Accept"
-        )
-    logger.info("CaseActor participant ID: %s", dynamic_case_actor_id)
-
-    vendor_in_vendor = get_actor_by_id(vendor_client, vendor.id_)
-    finder_in_finder = get_actor_by_id(finder_client, finder.id_)
-
-    case = _phase_ownership_handoff(
-        c1_client=c1_client,
-        c2_client=c2_client,
-        c1=c1,
-        c1_in_c1=c1_in_c1,
-        c2=c2,
-        c2_in_c2=c2_in_c2,
-        case=case,
-    )
-
-    _phase_c2_invites_vendor(
-        finder_client=finder_client,
-        c1_client=c1_client,
-        c2_client=c2_client,
-        vendor_client=vendor_client,
-        c2=c2,
-        c2_in_c2=c2_in_c2,
-        case_actor_id=dynamic_case_actor_id,
-        vendor=vendor,
-        vendor_in_vendor=vendor_in_vendor,
-        case=case,
-        offer=offer,
-        report=report,
-        finder=finder,
-    )
-
-    # Verify case active now that all participants have joined.
-    with demo_check(
-        "M1: required participants (≥5), EM.ACTIVE, finder + c2 have replicas"
-    ):
-        verify_case_active(
-            receiver_client=c1_client,
-            reporter_client=finder_client,
-            case_id=case.id_,
-            receiver_actor_id=c1.id_,
-            reporter_actor_id=finder.id_,
+        (
+            finder,
+            c1,
+            c1_in_c1,
+            c2,
+            c2_in_c2,
+            vendor,
+            report,
+            offer,
+            case,
+        ) = _phase_report_submission(
+            finder_client,
+            c1_client,
+            c2_client,
+            case_actor_client,
+            vendor_client,
+            finder_id,
+            c1_id,
+            c2_id,
+            vendor_id,
         )
 
-    _phase_sync_verification(
-        finder_client,
-        c1_client,
-        c2_client,
-        vendor_client,
-        c1,
-        finder,
-        c2,
-        vendor,
-        case,
-    )
-    _phase_notes_exchange(
-        finder_client,
-        c1_client,
-        c2_client,
-        vendor_client,
-        finder_in_finder,
-        c1_in_c1,
-        c2_in_c2,
-        vendor_in_vendor,
-        case,
-    )
-    _phase_fix_lifecycle(
-        finder_client,
-        c1_client,
-        vendor_client,
-        c1,
-        vendor,
-        vendor_in_vendor,
-        case,
-    )
-    _phase_publication(
-        finder_client,
-        c1_client,
-        c2_client,
-        vendor_client,
-        c1,
-        c1_in_c1,
-        c2,
-        c2_in_c2,
-        finder,
-        finder_in_finder,
-        vendor,
-        vendor_in_vendor,
-        case,
-    )
-    _phase_case_closure(
-        finder_client,
-        c1_client,
-        c2_client,
-        vendor_client,
-        c1,
-        c1_in_c1,
-        c2,
-        c2_in_c2,
-        finder,
-        finder_in_finder,
-        vendor,
-        vendor_in_vendor,
-        case,
-    )
-    _phase_dump_case_ledgers(
-        finder_client=finder_client,
-        c1_client=c1_client,
-        c2_client=c2_client,
-        vendor_client=vendor_client,
-        case=case,
-    )
+        # Register the dump as soon as there is a case to dump, so every phase
+        # below can fail without costing us the ledgers (ISSUE-2239).
+        harness.dump_with(
+            lambda: _phase_dump_case_ledgers(
+                finder_client=finder_client,
+                c1_client=c1_client,
+                c2_client=c2_client,
+                vendor_client=vendor_client,
+                case=case,
+            )
+        )
+
+        # Discover the CaseActor's dynamic sub-actor ID before the handoff phase.
+        dynamic_case_actor_id = find_case_actor_participant_id(
+            c1_client, case.id_
+        )
+        if dynamic_case_actor_id is None:
+            raise AssertionError(
+                "CaseActor participant not found in case — cannot route Vendor Accept"
+            )
+        logger.info("CaseActor participant ID: %s", dynamic_case_actor_id)
+
+        vendor_in_vendor = get_actor_by_id(vendor_client, vendor.id_)
+        finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+
+        case = _phase_ownership_handoff(
+            c1_client=c1_client,
+            c2_client=c2_client,
+            c1=c1,
+            c1_in_c1=c1_in_c1,
+            c2=c2,
+            c2_in_c2=c2_in_c2,
+            case=case,
+        )
+
+        _phase_c2_invites_vendor(
+            finder_client=finder_client,
+            c1_client=c1_client,
+            c2_client=c2_client,
+            vendor_client=vendor_client,
+            c2=c2,
+            c2_in_c2=c2_in_c2,
+            case_actor_id=dynamic_case_actor_id,
+            vendor=vendor,
+            vendor_in_vendor=vendor_in_vendor,
+            case=case,
+            offer=offer,
+            report=report,
+            finder=finder,
+        )
+
+        # Verify case active now that all participants have joined.
+        with demo_check(
+            "M1: required participants (≥5), EM.ACTIVE, finder + c2 have replicas"
+        ):
+            verify_case_active(
+                receiver_client=c1_client,
+                reporter_client=finder_client,
+                case_id=case.id_,
+                receiver_actor_id=c1.id_,
+                reporter_actor_id=finder.id_,
+            )
+
+        _phase_sync_verification(
+            finder_client,
+            c1_client,
+            c2_client,
+            vendor_client,
+            c1,
+            finder,
+            c2,
+            vendor,
+            case,
+        )
+        _phase_notes_exchange(
+            finder_client,
+            c1_client,
+            c2_client,
+            vendor_client,
+            finder_in_finder,
+            c1_in_c1,
+            c2_in_c2,
+            vendor_in_vendor,
+            case,
+        )
+        _phase_fix_lifecycle(
+            finder_client,
+            c1_client,
+            vendor_client,
+            c1,
+            vendor,
+            vendor_in_vendor,
+            case,
+        )
+        _phase_publication(
+            finder_client,
+            c1_client,
+            c2_client,
+            vendor_client,
+            c1,
+            c1_in_c1,
+            c2,
+            c2_in_c2,
+            finder,
+            finder_in_finder,
+            vendor,
+            vendor_in_vendor,
+            case,
+        )
+        _phase_case_closure(
+            finder_client,
+            c1_client,
+            c2_client,
+            vendor_client,
+            c1,
+            c1_in_c1,
+            c2,
+            c2_in_c2,
+            finder,
+            finder_in_finder,
+            vendor,
+            vendor_in_vendor,
+            case,
+        )
 
     logger.info("=" * 80)
     logger.info(
@@ -1207,8 +1176,6 @@ def main(
         case_actor_id: Optional deterministic URI for the CaseActor actor.
         vendor_id: Optional deterministic URI for the Vendor actor.
     """
-    reset_demo_failures()
-
     f_url = finder_url or FINDER_BASE_URL
     _c1_url = c1_url or C1_BASE_URL
     _c2_url = c2_url or C2_BASE_URL
@@ -1241,21 +1208,21 @@ def main(
                 logger.error("=" * 80)
                 sys.exit(1)
 
-    try:
-        run_fccv_handoff_demo(
-            finder_client=finder_client,
-            c1_client=c1_client,
-            c2_client=c2_client,
-            case_actor_client=case_actor_client,
-            vendor_client=vendor_client,
-            finder_id=finder_id,
-            c1_id=c1_id,
-            c2_id=c2_id,
-            case_actor_id=case_actor_id,
-            vendor_id=vendor_id,
-        )
-    finally:
-        assert_demo_success()
+    # scenario_harness() inside run_fccv_handoff_demo() owns the failure
+    # accumulator: it resets it, always dumps the case ledgers, and asserts
+    # success — so a failure here never costs us the artifacts (ISSUE-2239).
+    run_fccv_handoff_demo(
+        finder_client=finder_client,
+        c1_client=c1_client,
+        c2_client=c2_client,
+        case_actor_client=case_actor_client,
+        vendor_client=vendor_client,
+        finder_id=finder_id,
+        c1_id=c1_id,
+        c2_id=c2_id,
+        case_actor_id=case_actor_id,
+        vendor_id=vendor_id,
+    )
 
 
 if __name__ == "__main__":

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -754,6 +754,7 @@ def run_fcv_demo(
                 coordinator_client=coordinator_client,
                 vendor_client=vendor_client,
                 case=case,
+                demo_name=harness.demo_name,
             )
         )
 

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -28,15 +28,10 @@ VFDPxa closure.  Coordinator closes the case.
 Spec: DEMOMA-12 (GitHub issue #1593).
 """
 
-import json
 import logging
 import os
-import pathlib
 import sys
 
-import httpx2 as httpx
-
-from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
@@ -66,6 +61,12 @@ from vultron.demo.helpers.actions import (
     actor_closes_case,
     actor_notifies_fix_ready,
     actor_notifies_published,
+)
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpTarget,
+    dump_case_ledgers,
+    resolve_case_actor_route_key,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
@@ -682,68 +683,28 @@ def _phase_dump_case_ledgers(
     case: as_VulnerabilityCase,
     demo_name: str = "fcv",
 ) -> None:
-    """Dump case ledger entries from each actor container to JSONL files."""
-    logger.info("─" * 80)
-    logger.info("Phase: Case log JSONL export")
-    logger.info("─" * 80)
+    """Dump case ledger entries from each actor container to JSONL files.
 
-    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
-    case_id = case.id_ or ""
-    case_id_slug = (
-        case_id.replace("://", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .strip("_")
-    )
-
-    case_actor_sub_actor_key = next(
-        (
-            strip_id_prefix(actor_id)
-            for actor_id in case.actor_participant_index
-            if strip_id_prefix(actor_id).startswith("case-actor")
-        ),
-        None,
-    )
-
-    actors: list[tuple[str, DataLayerClient, str]] = [
-        ("finder", finder_client, "finder"),
-        ("coordinator", coordinator_client, "coordinator"),
-        ("vendor", vendor_client, "vendor"),
+    Thin scenario-specific wrapper over
+    :func:`~vultron.demo.helpers.ledger_dump.dump_case_ledgers`, which owns the
+    per-actor export, the 404 handling, and the dump manifest. This function
+    only names FCV's participants and where each one's ledger lives.
+    """
+    targets = [
+        LedgerDumpTarget("finder", finder_client, "finder"),
+        LedgerDumpTarget("coordinator", coordinator_client, "coordinator"),
+        LedgerDumpTarget("vendor", vendor_client, "vendor"),
     ]
-    if case_actor_sub_actor_key is not None:
-        actors.append(
-            ("case-actor", coordinator_client, case_actor_sub_actor_key)
+    # The case-actor is a sub-actor inside the coordinator container.
+    case_actor_route_key = resolve_case_actor_route_key(case)
+    if case_actor_route_key is not None:
+        targets.append(
+            LedgerDumpTarget(
+                "case-actor", coordinator_client, case_actor_route_key
+            )
         )
 
-    for actor_name, client, actor_route_key in actors:
-        with demo_step(f"Dumping case ledger for {actor_name}"):
-            case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            try:
-                entries = client.get_list(log_path)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code != 404:
-                    raise
-                logger.info(
-                    "Case not found on %s container (HTTP 404); skipping.",
-                    actor_name,
-                )
-                entries = []
-            if not entries:
-                raise ValueError(
-                    f"No case ledger entries for actor={actor_name!r}, "
-                    f"case_id={case_id!r}"
-                )
-
-            out_dir = output_root / demo_name / actor_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
-
-            with out_file.open("w", encoding="utf-8") as fh:
-                for entry in entries:
-                    fh.write(json.dumps(entry) + "\n")
-
-            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    dump_case_ledgers(demo_name=demo_name, case=case, targets=targets)
 
 
 def run_fcv_demo(
@@ -765,92 +726,97 @@ def run_fcv_demo(
     if case_actor_client is not None:
         logger.info("CaseActor container:   %s", case_actor_client.base_url)
 
-    (
-        finder,
-        finder_in_finder,
-        coordinator,
-        coordinator_in_coordinator,
-        vendor_obj,
-        report,
-        offer,
-        case,
-    ) = _phase_report_submission(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        case_actor_client=case_actor_client,
-        finder_id=finder_id,
-        coordinator_id=coordinator_id,
-        vendor_id=vendor_id,
-    )
+    with scenario_harness("fcv") as harness:
+        (
+            finder,
+            finder_in_finder,
+            coordinator,
+            coordinator_in_coordinator,
+            vendor_obj,
+            report,
+            offer,
+            case,
+        ) = _phase_report_submission(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
+            vendor_client=vendor_client,
+            case_actor_client=case_actor_client,
+            finder_id=finder_id,
+            coordinator_id=coordinator_id,
+            vendor_id=vendor_id,
+        )
 
-    vendor_in_vendor = _phase_invite_vendor(
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        finder_client=finder_client,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        vendor=vendor_obj,
-        case=case,
-        offer=offer,
-        report=report,
-        finder=finder,
-    )
+        # Register the dump as soon as there is a case to dump, so every phase
+        # below can fail without costing us the ledgers (ISSUE-2239).
+        harness.dump_with(
+            lambda: _phase_dump_case_ledgers(
+                finder_client=finder_client,
+                coordinator_client=coordinator_client,
+                vendor_client=vendor_client,
+                case=case,
+            )
+        )
 
-    _phase_sync_verification(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        finder=finder,
-        coordinator=coordinator,
-        case=case,
-    )
+        vendor_in_vendor = _phase_invite_vendor(
+            coordinator_client=coordinator_client,
+            vendor_client=vendor_client,
+            finder_client=finder_client,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            vendor=vendor_obj,
+            case=case,
+            offer=offer,
+            report=report,
+            finder=finder,
+        )
 
-    _phase_notes_exchange(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        finder_in_finder=finder_in_finder,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        vendor_in_vendor=vendor_in_vendor,
-        case=case,
-    )
+        _phase_sync_verification(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
+            vendor_client=vendor_client,
+            finder=finder,
+            coordinator=coordinator,
+            case=case,
+        )
 
-    _phase_fix_lifecycle(
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        coordinator=coordinator,
-        vendor=vendor_obj,
-        vendor_in_vendor=vendor_in_vendor,
-        case=case,
-    )
+        _phase_notes_exchange(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
+            vendor_client=vendor_client,
+            finder_in_finder=finder_in_finder,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            vendor_in_vendor=vendor_in_vendor,
+            case=case,
+        )
 
-    _phase_publication(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        coordinator=coordinator,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        vendor_in_vendor=vendor_in_vendor,
-        finder_in_finder=finder_in_finder,
-        case=case,
-    )
+        _phase_fix_lifecycle(
+            coordinator_client=coordinator_client,
+            vendor_client=vendor_client,
+            coordinator=coordinator,
+            vendor=vendor_obj,
+            vendor_in_vendor=vendor_in_vendor,
+            case=case,
+        )
 
-    _phase_case_closure(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        vendor_in_vendor=vendor_in_vendor,
-        finder_in_finder=finder_in_finder,
-        case=case,
-    )
+        _phase_publication(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
+            vendor_client=vendor_client,
+            coordinator=coordinator,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            vendor_in_vendor=vendor_in_vendor,
+            finder_in_finder=finder_in_finder,
+            case=case,
+        )
 
-    _phase_dump_case_ledgers(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        case=case,
-    )
+        _phase_case_closure(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
+            vendor_client=vendor_client,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            vendor_in_vendor=vendor_in_vendor,
+            finder_in_finder=finder_in_finder,
+            case=case,
+        )
 
     logger.info("=" * 80)
     logger.info("FCV DEMO COMPLETE ✓  (VFDPxa full lifecycle)")
@@ -884,8 +850,6 @@ def main(
         coordinator_id: Optional deterministic URI for the Coordinator actor.
         vendor_id: Optional deterministic URI for the Vendor actor.
     """
-    reset_demo_failures()
-
     f_url = finder_url or FINDER_BASE_URL
     c_url = coordinator_url or COORDINATOR_BASE_URL
     v_url = vendor_url or VENDOR_BASE_URL
@@ -915,18 +879,18 @@ def main(
                 logger.error("=" * 80)
                 sys.exit(1)
 
-    try:
-        run_fcv_demo(
-            finder_client=finder_client,
-            coordinator_client=coordinator_client,
-            vendor_client=vendor_client,
-            case_actor_client=case_actor_client,
-            finder_id=finder_id,
-            coordinator_id=coordinator_id,
-            vendor_id=vendor_id,
-        )
-    finally:
-        assert_demo_success()
+    # scenario_harness() inside run_fcv_demo() owns the failure accumulator: it
+    # resets it, always dumps the case ledgers, and asserts success — so a
+    # failure here never costs us the artifacts (ISSUE-2239).
+    run_fcv_demo(
+        finder_client=finder_client,
+        coordinator_client=coordinator_client,
+        vendor_client=vendor_client,
+        case_actor_client=case_actor_client,
+        finder_id=finder_id,
+        coordinator_id=coordinator_id,
+        vendor_id=vendor_id,
+    )
 
 
 if __name__ == "__main__":

--- a/vultron/demo/scenario/fcv_reject_demo.py
+++ b/vultron/demo/scenario/fcv_reject_demo.py
@@ -29,15 +29,10 @@ becomes a case participant and has no case ledger replica.
 Spec: GitHub issue #2047 (fcv-reject demo scenario).
 """
 
-import json
 import logging
 import os
-import pathlib
 import sys
 
-import httpx2 as httpx
-
-from vultron.adapters.utils import strip_id_prefix
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_TransitiveActivity,
 )
@@ -65,6 +60,12 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
 from vultron.demo.helpers.actions import (
     actor_closes_case,
     actor_notifies_published,
+)
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpTarget,
+    dump_case_ledgers,
+    resolve_case_actor_route_key,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
@@ -464,67 +465,25 @@ def _phase_dump_case_ledgers(
 
     Vendor is intentionally excluded: it rejected the invitation and was never
     added as a case participant, so it has no case ledger replica.
+
+    Thin scenario-specific wrapper over
+    :func:`~vultron.demo.helpers.ledger_dump.dump_case_ledgers`, which owns the
+    per-actor export, the 404 handling, and the dump manifest.
     """
-    logger.info("─" * 80)
-    logger.info("Phase: Case log JSONL export")
-    logger.info("─" * 80)
-
-    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
-    case_id = case.id_ or ""
-    case_id_slug = (
-        case_id.replace("://", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .strip("_")
-    )
-
-    case_actor_sub_actor_key = next(
-        (
-            strip_id_prefix(actor_id)
-            for actor_id in case.actor_participant_index
-            if strip_id_prefix(actor_id).startswith("case-actor")
-        ),
-        None,
-    )
-
-    actors: list[tuple[str, DataLayerClient, str]] = [
-        ("finder", finder_client, "finder"),
-        ("coordinator", coordinator_client, "coordinator"),
+    targets = [
+        LedgerDumpTarget("finder", finder_client, "finder"),
+        LedgerDumpTarget("coordinator", coordinator_client, "coordinator"),
     ]
-    if case_actor_sub_actor_key is not None:
-        actors.append(
-            ("case-actor", coordinator_client, case_actor_sub_actor_key)
+    # The case-actor is a sub-actor inside the coordinator container.
+    case_actor_route_key = resolve_case_actor_route_key(case)
+    if case_actor_route_key is not None:
+        targets.append(
+            LedgerDumpTarget(
+                "case-actor", coordinator_client, case_actor_route_key
+            )
         )
 
-    for actor_name, client, actor_route_key in actors:
-        with demo_step(f"Dumping case ledger for {actor_name}"):
-            case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            try:
-                entries = client.get_list(log_path)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code != 404:
-                    raise
-                logger.info(
-                    "Case not found on %s container (HTTP 404); skipping.",
-                    actor_name,
-                )
-                entries = []
-            if not entries:
-                raise ValueError(
-                    f"No case ledger entries for actor={actor_name!r}, "
-                    f"case_id={case_id!r}"
-                )
-
-            out_dir = output_root / demo_name / actor_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
-
-            with out_file.open("w", encoding="utf-8") as fh:
-                for entry in entries:
-                    fh.write(json.dumps(entry) + "\n")
-
-            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    dump_case_ledgers(demo_name=demo_name, case=case, targets=targets)
 
 
 def run_fcv_reject_demo(
@@ -548,62 +507,67 @@ def run_fcv_reject_demo(
     if case_actor_client is not None:
         logger.info("CaseActor container:   %s", case_actor_client.base_url)
 
-    (
-        _finder,
-        finder_in_finder,
-        _coordinator,
-        coordinator_in_coordinator,
-        vendor_obj,
-        _report,
-        _offer,
-        case,
-    ) = _phase_report_submission(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        case_actor_client=case_actor_client,
-        finder_id=finder_id,
-        coordinator_id=coordinator_id,
-        vendor_id=vendor_id,
-    )
+    with scenario_harness("fcv-reject") as harness:
+        (
+            _finder,
+            finder_in_finder,
+            _coordinator,
+            coordinator_in_coordinator,
+            vendor_obj,
+            _report,
+            _offer,
+            case,
+        ) = _phase_report_submission(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
+            vendor_client=vendor_client,
+            case_actor_client=case_actor_client,
+            finder_id=finder_id,
+            coordinator_id=coordinator_id,
+            vendor_id=vendor_id,
+        )
 
-    _phase_invite_vendor_reject(
-        coordinator_client=coordinator_client,
-        vendor_client=vendor_client,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        vendor=vendor_obj,
-        case=case,
-    )
+        # Register the dump as soon as there is a case to dump, so every phase
+        # below can fail without costing us the ledgers (ISSUE-2239).
+        harness.dump_with(
+            lambda: _phase_dump_case_ledgers(
+                finder_client=finder_client,
+                coordinator_client=coordinator_client,
+                case=case,
+            )
+        )
 
-    _phase_notes_exchange(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        finder_in_finder=finder_in_finder,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        case=case,
-    )
+        _phase_invite_vendor_reject(
+            coordinator_client=coordinator_client,
+            vendor_client=vendor_client,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            vendor=vendor_obj,
+            case=case,
+        )
 
-    _phase_publication(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        finder_in_finder=finder_in_finder,
-        case=case,
-    )
+        _phase_notes_exchange(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
+            finder_in_finder=finder_in_finder,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            case=case,
+        )
 
-    _phase_case_closure(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        finder_in_finder=finder_in_finder,
-        case=case,
-    )
+        _phase_publication(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            finder_in_finder=finder_in_finder,
+            case=case,
+        )
 
-    _phase_dump_case_ledgers(
-        finder_client=finder_client,
-        coordinator_client=coordinator_client,
-        case=case,
-    )
+        _phase_case_closure(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            finder_in_finder=finder_in_finder,
+            case=case,
+        )
 
     logger.info("=" * 80)
     logger.info(
@@ -639,8 +603,6 @@ def main(
         coordinator_id: Optional deterministic URI for the Coordinator actor.
         vendor_id: Optional deterministic URI for the Vendor actor.
     """
-    reset_demo_failures()
-
     f_url = finder_url or FINDER_BASE_URL
     c_url = coordinator_url or COORDINATOR_BASE_URL
     v_url = vendor_url or VENDOR_BASE_URL
@@ -670,18 +632,18 @@ def main(
                 logger.error("=" * 80)
                 sys.exit(1)
 
-    try:
-        run_fcv_reject_demo(
-            finder_client=finder_client,
-            coordinator_client=coordinator_client,
-            vendor_client=vendor_client,
-            case_actor_client=case_actor_client,
-            finder_id=finder_id,
-            coordinator_id=coordinator_id,
-            vendor_id=vendor_id,
-        )
-    finally:
-        assert_demo_success()
+    # scenario_harness() inside run_fcv_reject_demo() owns the failure
+    # accumulator: it resets it, always dumps the case ledgers, and asserts
+    # success — so a failure here never costs us the artifacts (ISSUE-2239).
+    run_fcv_reject_demo(
+        finder_client=finder_client,
+        coordinator_client=coordinator_client,
+        vendor_client=vendor_client,
+        case_actor_client=case_actor_client,
+        finder_id=finder_id,
+        coordinator_id=coordinator_id,
+        vendor_id=vendor_id,
+    )
 
 
 if __name__ == "__main__":

--- a/vultron/demo/scenario/fcv_reject_demo.py
+++ b/vultron/demo/scenario/fcv_reject_demo.py
@@ -534,6 +534,7 @@ def run_fcv_reject_demo(
                 finder_client=finder_client,
                 coordinator_client=coordinator_client,
                 case=case,
+                demo_name=harness.demo_name,
             )
         )
 

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -1086,6 +1086,7 @@ def run_fcvcv_demo(
                 c2_client=c2_client,
                 v2_client=v2_client,
                 case=case,
+                demo_name=harness.demo_name,
             )
         )
 

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -36,15 +36,10 @@ Container mapping (docker-compose-multi-actor.yml services):
 Spec: DEMOMA-19 (GitHub issue #1925).
 """
 
-import json
 import logging
 import os
-import pathlib
 import sys
 
-import httpx2 as httpx
-
-from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
@@ -77,6 +72,12 @@ from vultron.demo.helpers.actions import (
     actor_notifies_fix_deployed,
     actor_notifies_fix_ready,
     actor_notifies_published,
+)
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpTarget,
+    dump_case_ledgers,
+    resolve_case_actor_route_key,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
@@ -995,75 +996,35 @@ def _phase_dump_case_ledgers(
     case: as_VulnerabilityCase,
     demo_name: str = "fcvcv",
 ) -> None:
-    """Dump case ledger entries from each actor container to JSONL files."""
-    logger.info("─" * 80)
-    logger.info("Phase 8: Case log JSONL export")
-    logger.info("─" * 80)
+    """Dump case ledger entries from each actor container to JSONL files.
 
-    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
-    case_id = case.id_ or ""
-    case_id_slug = (
-        case_id.replace("://", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .strip("_")
-    )
-
-    case_actor_sub_actor_key = next(
-        (
-            strip_id_prefix(actor_id)
-            for actor_id in case.actor_participant_index
-            if strip_id_prefix(actor_id).startswith("case-actor")
-        ),
-        None,
-    )
-
+    Thin scenario-specific wrapper over
+    :func:`~vultron.demo.helpers.ledger_dump.dump_case_ledgers`, which owns the
+    per-actor export, the 404 handling, and the dump manifest. This function
+    only names FCVCV's participants and where each one's ledger lives.
+    """
     # Devlog directory names use scenario-role names (DEMOMA-19-007):
     # finder, c1, v1, c2, v2, case-actor.
     # Container routing keys must match actual docker-compose service/actor paths.
-    actors: list[tuple[str, DataLayerClient, str]] = [
-        ("finder", finder_client, "finder"),
+    targets = [
+        LedgerDumpTarget("finder", finder_client, "finder"),
         # C1 is on the coordinator container; route key is "coordinator".
-        ("c1", c1_client, "coordinator"),
+        LedgerDumpTarget("c1", c1_client, "coordinator"),
         # V1 is on the vendor container; route key is "vendor".
-        ("v1", v1_client, "vendor"),
+        LedgerDumpTarget("v1", v1_client, "vendor"),
         # C2 is on actor5; route key is "vendor2" (actor5 seed).
-        ("c2", c2_client, "vendor2"),
+        LedgerDumpTarget("c2", c2_client, "vendor2"),
         # V2 is on actor6; route key is "vendor-deployer".
-        ("v2", v2_client, "vendor-deployer"),
+        LedgerDumpTarget("v2", v2_client, "vendor-deployer"),
     ]
-    if case_actor_sub_actor_key is not None:
-        actors.append(("case-actor", c1_client, case_actor_sub_actor_key))
+    # The case-actor is a sub-actor inside the C1 container.
+    case_actor_route_key = resolve_case_actor_route_key(case)
+    if case_actor_route_key is not None:
+        targets.append(
+            LedgerDumpTarget("case-actor", c1_client, case_actor_route_key)
+        )
 
-    for actor_name, client, actor_route_key in actors:
-        with demo_step(f"Dumping case ledger for {actor_name}"):
-            case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            try:
-                entries = client.get_list(log_path)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code != 404:
-                    raise
-                logger.info(
-                    "Case not found on %s container (HTTP 404); skipping.",
-                    actor_name,
-                )
-                entries = []
-            if not entries:
-                raise ValueError(
-                    f"No case ledger entries for actor={actor_name!r}, "
-                    f"case_id={case_id!r}"
-                )
-
-            out_dir = output_root / demo_name / actor_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
-
-            with out_file.open("w", encoding="utf-8") as fh:
-                for entry in entries:
-                    fh.write(json.dumps(entry) + "\n")
-
-            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    dump_case_ledgers(demo_name=demo_name, case=case, targets=targets)
 
 
 def run_fcvcv_demo(
@@ -1090,118 +1051,124 @@ def run_fcvcv_demo(
     logger.info("C2 container:     %s", c2_client.base_url)
     logger.info("V2 container:     %s", v2_client.base_url)
 
-    (
-        finder,
-        c1,
-        c1_in_c1,
-        v1,
-        v1_in_v1,
-        c2_in_c2,
-        v2,
-        report,
-        offer,
-        case,
-    ) = _phase_report_submission(
-        finder_client,
-        c1_client,
-        v1_client,
-        c2_client,
-        v2_client,
-        finder_id,
-        c1_id,
-        v1_id,
-        c2_id,
-        v2_id,
-    )
+    with scenario_harness("fcvcv") as harness:
+        (
+            finder,
+            c1,
+            c1_in_c1,
+            v1,
+            v1_in_v1,
+            c2_in_c2,
+            v2,
+            report,
+            offer,
+            case,
+        ) = _phase_report_submission(
+            finder_client,
+            c1_client,
+            v1_client,
+            c2_client,
+            v2_client,
+            finder_id,
+            c1_id,
+            v1_id,
+            c2_id,
+            v2_id,
+        )
 
-    _phase_c2_suggests_v2(
-        finder_client=finder_client,
-        c1_client=c1_client,
-        c2_client=c2_client,
-        v2_client=v2_client,
-        c1_in_c1=c1_in_c1,
-        c2_in_c2=c2_in_c2,
-        v2=v2,
-        case=case,
-        offer=offer,
-        report=report,
-        finder=finder,
-    )
+        # Register the dump as soon as there is a case to dump, so every phase
+        # below can fail without costing us the ledgers (ISSUE-2239).
+        harness.dump_with(
+            lambda: _phase_dump_case_ledgers(
+                finder_client=finder_client,
+                c1_client=c1_client,
+                v1_client=v1_client,
+                c2_client=c2_client,
+                v2_client=v2_client,
+                case=case,
+            )
+        )
 
-    v2_in_v2 = get_actor_by_id(v2_client, v2.id_)
-    finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+        _phase_c2_suggests_v2(
+            finder_client=finder_client,
+            c1_client=c1_client,
+            c2_client=c2_client,
+            v2_client=v2_client,
+            c1_in_c1=c1_in_c1,
+            c2_in_c2=c2_in_c2,
+            v2=v2,
+            case=case,
+            offer=offer,
+            report=report,
+            finder=finder,
+        )
 
-    _phase_sync_verification(
-        finder_client,
-        c1_client,
-        v1_client,
-        c2_client,
-        v2_client,
-        c1,
-        finder,
-        case,
-    )
-    _phase_notes_exchange(
-        finder_client=finder_client,
-        c1_client=c1_client,
-        v1_client=v1_client,
-        c2_client=c2_client,
-        v2_client=v2_client,
-        finder_in_finder=finder_in_finder,
-        c1_in_c1=c1_in_c1,
-        v1_in_v1=v1_in_v1,
-        c2_in_c2=c2_in_c2,
-        v2_in_v2=v2_in_v2,
-        case=case,
-    )
-    _phase_fix_lifecycle(
-        c1_client,
-        v1_client,
-        v2_client,
-        finder_client,
-        v1,
-        v1_in_v1,
-        v2,
-        v2_in_v2,
-        case,
-    )
-    _phase_publication(
-        finder_client,
-        c1_client,
-        v1_client,
-        c2_client,
-        v2_client,
-        c1,
-        c1_in_c1,
-        c2_in_c2,
-        v1,
-        v1_in_v1,
-        v2,
-        v2_in_v2,
-        finder_in_finder,
-        case,
-    )
-    _phase_case_closure(
-        finder_client,
-        c1_client,
-        v1_client,
-        c2_client,
-        v2_client,
-        c1_in_c1,
-        v1_in_v1,
-        c2_in_c2,
-        v2_in_v2,
-        finder_in_finder,
-        case,
-    )
-    _phase_dump_case_ledgers(
-        finder_client=finder_client,
-        c1_client=c1_client,
-        v1_client=v1_client,
-        c2_client=c2_client,
-        v2_client=v2_client,
-        case=case,
-    )
+        v2_in_v2 = get_actor_by_id(v2_client, v2.id_)
+        finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+
+        _phase_sync_verification(
+            finder_client,
+            c1_client,
+            v1_client,
+            c2_client,
+            v2_client,
+            c1,
+            finder,
+            case,
+        )
+        _phase_notes_exchange(
+            finder_client=finder_client,
+            c1_client=c1_client,
+            v1_client=v1_client,
+            c2_client=c2_client,
+            v2_client=v2_client,
+            finder_in_finder=finder_in_finder,
+            c1_in_c1=c1_in_c1,
+            v1_in_v1=v1_in_v1,
+            c2_in_c2=c2_in_c2,
+            v2_in_v2=v2_in_v2,
+            case=case,
+        )
+        _phase_fix_lifecycle(
+            c1_client,
+            v1_client,
+            v2_client,
+            finder_client,
+            v1,
+            v1_in_v1,
+            v2,
+            v2_in_v2,
+            case,
+        )
+        _phase_publication(
+            finder_client,
+            c1_client,
+            v1_client,
+            c2_client,
+            v2_client,
+            c1,
+            c1_in_c1,
+            c2_in_c2,
+            v1,
+            v1_in_v1,
+            v2,
+            v2_in_v2,
+            finder_in_finder,
+            case,
+        )
+        _phase_case_closure(
+            finder_client,
+            c1_client,
+            v1_client,
+            c2_client,
+            v2_client,
+            c1_in_c1,
+            v1_in_v1,
+            c2_in_c2,
+            v2_in_v2,
+            finder_in_finder,
+            case,
+        )
 
     logger.info("=" * 80)
     logger.info("FCVCV DEMO COMPLETE ✓  (full 5-actor lifecycle)")
@@ -1241,8 +1208,6 @@ def main(
         c2_id: Optional deterministic URI for the C2 actor.
         v2_id: Optional deterministic URI for the V2 actor.
     """
-    reset_demo_failures()
-
     f_url = finder_url or FINDER_BASE_URL
     c1_resolved = c1_url or C1_BASE_URL
     v1_resolved = v1_url or V1_BASE_URL
@@ -1275,21 +1240,21 @@ def main(
                 logger.error("=" * 80)
                 sys.exit(1)
 
-    try:
-        run_fcvcv_demo(
-            finder_client=finder_client,
-            c1_client=c1_client,
-            v1_client=v1_client,
-            c2_client=c2_client,
-            v2_client=v2_client,
-            finder_id=finder_id or FINDER_ACTOR_ID,
-            c1_id=c1_id or C1_ACTOR_ID,
-            v1_id=v1_id or V1_ACTOR_ID,
-            c2_id=c2_id or C2_ACTOR_ID,
-            v2_id=v2_id or V2_ACTOR_ID,
-        )
-    finally:
-        assert_demo_success()
+    # scenario_harness() inside run_fcvcv_demo() owns the failure accumulator:
+    # it resets it, always dumps the case ledgers, and asserts success — so a
+    # failure here never costs us the artifacts (ISSUE-2239).
+    run_fcvcv_demo(
+        finder_client=finder_client,
+        c1_client=c1_client,
+        v1_client=v1_client,
+        c2_client=c2_client,
+        v2_client=v2_client,
+        finder_id=finder_id or FINDER_ACTOR_ID,
+        c1_id=c1_id or C1_ACTOR_ID,
+        v1_id=v1_id or V1_ACTOR_ID,
+        c2_id=c2_id or C2_ACTOR_ID,
+        v2_id=v2_id or V2_ACTOR_ID,
+    )
 
 
 if __name__ == "__main__":

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -21,16 +21,11 @@ milestone logic to the generic helper modules under ``vultron.demo.helpers``
 while preserving the public API used by the existing test suite.
 """
 
-import json
 import logging
 import os
-import pathlib
 import sys
 from typing import Optional, Tuple
 
-import httpx2 as httpx
-
-from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
@@ -67,6 +62,12 @@ from vultron.demo.helpers.actions import (  # noqa: F401
     actor_notifies_fix_ready,
     actor_notifies_published,
     actor_notifies_state_change,
+)
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpTarget,
+    dump_case_ledgers,
+    resolve_case_actor_route_key,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
@@ -871,16 +872,15 @@ def _phase_dump_case_ledgers(
 ) -> None:
     """Dump case ledger entries from each actor container to JSONL files.
 
-    Reads ``DEVLOGS_DIR`` from the environment (default ``/app/devlogs``) and
-    writes one JSONL file per actor under::
-
-        {DEVLOGS_DIR}/{demo_name}/{actor_name}/{case_id_slug}-case-ledger.jsonl
+    Thin scenario-specific wrapper over
+    :func:`~vultron.demo.helpers.ledger_dump.dump_case_ledgers`, which owns the
+    per-actor export, the 404 handling, and the dump manifest written under
+    ``{DEVLOGS_DIR}/{demo_name}/``. This function only names FV's participants
+    and where each one's ledger lives.
 
     The case-actor log is always included: from *case_actor_client* when a
     dedicated case-actor service is configured, otherwise from the vendor
-    container using the in-container case-actor sub-actor route key. Each
-    dump step is wrapped in ``demo_step`` so that a failure is recorded and
-    ultimately surfaced by ``assert_demo_success()``.
+    container using the in-container case-actor sub-actor route key.
 
     Args:
         finder_client: DataLayerClient for the Finder container.
@@ -891,87 +891,32 @@ def _phase_dump_case_ledgers(
         case_actor_client: Optional DataLayerClient for the CaseActor container.
         demo_name: Sub-directory name under the output root (default ``"fv"``).
     """
-    logger.info("─" * 80)
-    logger.info("Phase: Case log JSONL export")
-    logger.info("─" * 80)
-
-    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
-    case_id = case.id_ or ""
-    case_id_slug = (
-        case_id.replace("://", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .strip("_")
-    )
-
-    case_actor_sub_actor_key = next(
-        (
-            strip_id_prefix(actor_id)
-            for actor_id in case.actor_participant_index
-            if strip_id_prefix(actor_id).startswith("case-actor")
-        ),
-        None,
-    )
-
-    actors: list[tuple[str, DataLayerClient, str]] = [
-        ("finder", finder_client, "finder"),
-        ("vendor", vendor_client, "vendor"),
+    targets = [
+        LedgerDumpTarget("finder", finder_client, "finder"),
+        LedgerDumpTarget("vendor", vendor_client, "vendor"),
     ]
+    case_actor_route_key = resolve_case_actor_route_key(case)
     if case_actor_client is not None:
-        actors.append(("case-actor", case_actor_client, "case-actor"))
-    elif case_actor_sub_actor_key is not None:
-        actors.append(("case-actor", vendor_client, case_actor_sub_actor_key))
+        # D5-2: the dedicated case-actor container may not hold the case — the
+        # case-actor can be a sub-actor inside the vendor container instead —
+        # so fall back to the vendor container's sub-actor route key.
+        targets.append(
+            LedgerDumpTarget(
+                "case-actor",
+                case_actor_client,
+                "case-actor",
+                fallback_client=(
+                    vendor_client if case_actor_route_key is not None else None
+                ),
+                fallback_route_key=case_actor_route_key,
+            )
+        )
+    elif case_actor_route_key is not None:
+        targets.append(
+            LedgerDumpTarget("case-actor", vendor_client, case_actor_route_key)
+        )
 
-    for actor_name, client, actor_route_key in actors:
-        with demo_step(f"Dumping case ledger for {actor_name}"):
-            case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            try:
-                entries = client.get_list(log_path)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code != 404:
-                    raise
-                # D5-2: the dedicated case-actor container does not hold the
-                # case; the case-actor sub-actor runs inside the vendor
-                # container. Treat 404 the same as an empty list so the
-                # sub-actor fallback below can supply the entries.
-                logger.info(
-                    "Case not found on dedicated %s container (HTTP 404, D5-2);"
-                    " will attempt vendor sub-actor fallback.",
-                    actor_name,
-                )
-                entries = []
-            if (
-                not entries
-                and actor_name == "case-actor"
-                and client is case_actor_client
-                and case_actor_sub_actor_key is not None
-            ):
-                fallback_path = (
-                    "/actors/"
-                    f"{case_actor_sub_actor_key}/demo/cases/{case_key}/log"
-                )
-                logger.info(
-                    "Dedicated case-actor log unavailable; "
-                    "falling back to vendor sub-actor route key '%s'",
-                    case_actor_sub_actor_key,
-                )
-                entries = vendor_client.get_list(fallback_path)
-            if not entries:
-                raise ValueError(
-                    f"No case ledger entries for actor={actor_name!r}, "
-                    f"case_id={case_id!r}"
-                )
-
-            out_dir = output_root / demo_name / actor_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
-
-            with out_file.open("w", encoding="utf-8") as fh:
-                for entry in entries:
-                    fh.write(json.dumps(entry) + "\n")
-
-            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    dump_case_ledgers(demo_name=demo_name, case=case, targets=targets)
 
 
 def run_fv_demo(
@@ -990,65 +935,72 @@ def run_fv_demo(
     if case_actor_client is not None:
         logger.info("CaseActor container: %s", case_actor_client.base_url)
 
-    finder, vendor, vendor_in_vendor, report, offer, case = (
-        _phase_report_submission(
+    with scenario_harness("fv") as harness:
+        finder, vendor, vendor_in_vendor, report, offer, case = (
+            _phase_report_submission(
+                finder_client,
+                vendor_client,
+                case_actor_client,
+                finder_id,
+                vendor_id,
+            )
+        )
+
+        # Register the dump as soon as there is a case to dump, so every phase
+        # below can fail without costing us the ledgers (ISSUE-2239).
+        harness.dump_with(
+            lambda: _phase_dump_case_ledgers(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                finder=finder,
+                vendor=vendor,
+                case=case,
+                case_actor_client=case_actor_client,
+            )
+        )
+
+        _phase_sync_verification(
             finder_client,
             vendor_client,
+            vendor,
+            finder,
+            case,
             case_actor_client,
-            finder_id,
-            vendor_id,
         )
-    )
-    _phase_sync_verification(
-        finder_client,
-        vendor_client,
-        vendor,
-        finder,
-        case,
-        case_actor_client,
-    )
-    _, _, _, finder_in_finder = _phase_notes_exchange(
-        finder_client,
-        vendor_client,
-        finder,
-        vendor,
-        vendor_in_vendor,
-        case,
-        report,
-    )
-    _phase_fix_lifecycle(
-        finder_client,
-        vendor_client,
-        vendor,
-        vendor_in_vendor,
-        case,
-    )
-    _phase_publication(
-        finder_client,
-        vendor_client,
-        vendor,
-        vendor_in_vendor,
-        finder,
-        finder_in_finder,
-        case,
-    )
-    _phase_case_closure(
-        finder_client,
-        vendor_client,
-        vendor,
-        vendor_in_vendor,
-        finder,
-        finder_in_finder,
-        case,
-    )
-    _phase_dump_case_ledgers(
-        finder_client=finder_client,
-        vendor_client=vendor_client,
-        finder=finder,
-        vendor=vendor,
-        case=case,
-        case_actor_client=case_actor_client,
-    )
+        _, _, _, finder_in_finder = _phase_notes_exchange(
+            finder_client,
+            vendor_client,
+            finder,
+            vendor,
+            vendor_in_vendor,
+            case,
+            report,
+        )
+        _phase_fix_lifecycle(
+            finder_client,
+            vendor_client,
+            vendor,
+            vendor_in_vendor,
+            case,
+        )
+        _phase_publication(
+            finder_client,
+            vendor_client,
+            vendor,
+            vendor_in_vendor,
+            finder,
+            finder_in_finder,
+            case,
+        )
+        _phase_case_closure(
+            finder_client,
+            vendor_client,
+            vendor,
+            vendor_in_vendor,
+            finder,
+            finder_in_finder,
+            case,
+        )
 
     logger.info("=" * 80)
     logger.info("FV DEMO COMPLETE ✓  (VFDPxa full lifecycle)")
@@ -1079,8 +1031,6 @@ def main(
         finder_id: Optional deterministic URI for the Finder actor.
         vendor_id: Optional deterministic URI for the Vendor actor.
     """
-    reset_demo_failures()
-
     f_url = finder_url or FINDER_BASE_URL
     v_url = vendor_url or VENDOR_BASE_URL
     c_url = case_actor_url or CASE_ACTOR_BASE_URL
@@ -1108,16 +1058,16 @@ def main(
                 logger.error("=" * 80)
                 sys.exit(1)
 
-    try:
-        run_fv_demo(
-            finder_client=finder_client,
-            vendor_client=vendor_client,
-            case_actor_client=case_actor_client,
-            finder_id=finder_id,
-            vendor_id=vendor_id,
-        )
-    finally:
-        assert_demo_success()
+    # scenario_harness() inside run_fv_demo() owns the failure accumulator: it
+    # resets it, always dumps the case ledgers, and asserts success — so a
+    # failure here never costs us the artifacts (ISSUE-2239).
+    run_fv_demo(
+        finder_client=finder_client,
+        vendor_client=vendor_client,
+        case_actor_client=case_actor_client,
+        finder_id=finder_id,
+        vendor_id=vendor_id,
+    )
 
 
 if __name__ == "__main__":

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -956,6 +956,7 @@ def run_fv_demo(
                 vendor=vendor,
                 case=case,
                 case_actor_client=case_actor_client,
+                demo_name=harness.demo_name,
             )
         )
 

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -918,10 +918,11 @@ def run_fvcv_extension_demo(
             vendor2_id,
         )
 
-        vendor2_in_vendor2 = get_actor_by_id(vendor2_client, vendor2.id_)
-
         # Register the dump as soon as there is a case to dump, so every phase
-        # below can fail without costing us the ledgers (ISSUE-2239).
+        # below can fail without costing us the ledgers (ISSUE-2239,
+        # DEMOMA-23-003). This must stay above the get_actor_by_id() lookup
+        # below: that is a network call, and if it fails the case already exists
+        # with ledgers worth keeping.
         harness.dump_with(
             lambda: _phase_dump_case_ledgers(
                 finder_client=finder_client,
@@ -931,10 +932,13 @@ def run_fvcv_extension_demo(
                 finder=finder,
                 vendor=vendor,
                 coordinator=coordinator,
-                vendor2=vendor2_in_vendor2,
+                vendor2=vendor2,
                 case=case,
+                demo_name=harness.demo_name,
             )
         )
+
+        vendor2_in_vendor2 = get_actor_by_id(vendor2_client, vendor2.id_)
 
         _phase_coordinator_suggests_vendor2(
             finder_client=finder_client,

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -23,15 +23,10 @@ suggest-actor flow; Vendor1 approves; CaseActor invites Vendor2.
 Spec: D5-6 (GitHub issue #1535).
 """
 
-import json
 import logging
 import os
-import pathlib
 import sys
 
-import httpx2 as httpx
-
-from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
@@ -63,6 +58,12 @@ from vultron.demo.helpers.actions import (
     actor_closes_case,
     actor_notifies_fix_ready,
     actor_notifies_published,
+)
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpTarget,
+    dump_case_ledgers,
+    resolve_case_actor_route_key,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
@@ -851,67 +852,27 @@ def _phase_dump_case_ledgers(
     case: as_VulnerabilityCase,
     demo_name: str = "fvcv-extension",
 ) -> None:
-    """Dump case ledger entries from each actor container to JSONL files."""
-    logger.info("─" * 80)
-    logger.info("Phase: Case log JSONL export")
-    logger.info("─" * 80)
+    """Dump case ledger entries from each actor container to JSONL files.
 
-    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
-    case_id = case.id_ or ""
-    case_id_slug = (
-        case_id.replace("://", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .strip("_")
-    )
-
-    case_actor_sub_actor_key = next(
-        (
-            strip_id_prefix(actor_id)
-            for actor_id in case.actor_participant_index
-            if strip_id_prefix(actor_id).startswith("case-actor")
-        ),
-        None,
-    )
-
-    actors: list[tuple[str, DataLayerClient, str]] = [
-        ("finder", finder_client, "finder"),
-        ("vendor", vendor_client, "vendor"),
-        ("coordinator", coordinator_client, "coordinator"),
-        ("vendor2", vendor2_client, "vendor2"),
+    Thin scenario-specific wrapper over
+    :func:`~vultron.demo.helpers.ledger_dump.dump_case_ledgers`, which owns the
+    per-actor export, the 404 handling, and the dump manifest. This function
+    only names FVCV-extension's participants and where each ledger lives.
+    """
+    targets = [
+        LedgerDumpTarget("finder", finder_client, "finder"),
+        LedgerDumpTarget("vendor", vendor_client, "vendor"),
+        LedgerDumpTarget("coordinator", coordinator_client, "coordinator"),
+        LedgerDumpTarget("vendor2", vendor2_client, "vendor2"),
     ]
-    if case_actor_sub_actor_key is not None:
-        actors.append(("case-actor", vendor_client, case_actor_sub_actor_key))
+    # The case-actor is a sub-actor inside the vendor1 container.
+    case_actor_route_key = resolve_case_actor_route_key(case)
+    if case_actor_route_key is not None:
+        targets.append(
+            LedgerDumpTarget("case-actor", vendor_client, case_actor_route_key)
+        )
 
-    for actor_name, client, actor_route_key in actors:
-        with demo_step(f"Dumping case ledger for {actor_name}"):
-            case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            try:
-                entries = client.get_list(log_path)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code != 404:
-                    raise
-                logger.info(
-                    "Case not found on %s container (HTTP 404); skipping.",
-                    actor_name,
-                )
-                entries = []
-            if not entries:
-                raise ValueError(
-                    f"No case ledger entries for actor={actor_name!r}, "
-                    f"case_id={case_id!r}"
-                )
-
-            out_dir = output_root / demo_name / actor_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
-
-            with out_file.open("w", encoding="utf-8") as fh:
-                for entry in entries:
-                    fh.write(json.dumps(entry) + "\n")
-
-            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    dump_case_ledgers(demo_name=demo_name, case=case, targets=targets)
 
 
 def run_fvcv_extension_demo(
@@ -935,120 +896,126 @@ def run_fvcv_extension_demo(
     logger.info("Coordinator container: %s", coordinator_client.base_url)
     logger.info("Vendor2 container:     %s", vendor2_client.base_url)
 
-    (
-        finder,
-        vendor,
-        vendor_in_vendor,
-        coordinator,
-        coordinator_in_coordinator,
-        vendor2,
-        report,
-        offer,
-        case,
-    ) = _phase_report_submission(
-        finder_client,
-        vendor_client,
-        coordinator_client,
-        vendor2_client,
-        finder_id,
-        vendor_id,
-        coordinator_id,
-        vendor2_id,
-    )
+    with scenario_harness("fvcv-extension") as harness:
+        (
+            finder,
+            vendor,
+            vendor_in_vendor,
+            coordinator,
+            coordinator_in_coordinator,
+            vendor2,
+            report,
+            offer,
+            case,
+        ) = _phase_report_submission(
+            finder_client,
+            vendor_client,
+            coordinator_client,
+            vendor2_client,
+            finder_id,
+            vendor_id,
+            coordinator_id,
+            vendor2_id,
+        )
 
-    vendor2_in_vendor2 = get_actor_by_id(vendor2_client, vendor2.id_)
+        vendor2_in_vendor2 = get_actor_by_id(vendor2_client, vendor2.id_)
 
-    _phase_coordinator_suggests_vendor2(
-        finder_client=finder_client,
-        vendor_client=vendor_client,
-        coordinator_client=coordinator_client,
-        vendor2_client=vendor2_client,
-        vendor=vendor,
-        vendor_in_vendor=vendor_in_vendor,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        vendor2=vendor2,
-        vendor2_in_vendor2=vendor2_in_vendor2,
-        case=case,
-        offer=offer,
-        report=report,
-        finder=finder,
-    )
+        # Register the dump as soon as there is a case to dump, so every phase
+        # below can fail without costing us the ledgers (ISSUE-2239).
+        harness.dump_with(
+            lambda: _phase_dump_case_ledgers(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                coordinator_client=coordinator_client,
+                vendor2_client=vendor2_client,
+                finder=finder,
+                vendor=vendor,
+                coordinator=coordinator,
+                vendor2=vendor2_in_vendor2,
+                case=case,
+            )
+        )
 
-    finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+        _phase_coordinator_suggests_vendor2(
+            finder_client=finder_client,
+            vendor_client=vendor_client,
+            coordinator_client=coordinator_client,
+            vendor2_client=vendor2_client,
+            vendor=vendor,
+            vendor_in_vendor=vendor_in_vendor,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            vendor2=vendor2,
+            vendor2_in_vendor2=vendor2_in_vendor2,
+            case=case,
+            offer=offer,
+            report=report,
+            finder=finder,
+        )
 
-    _phase_sync_verification(
-        finder_client,
-        vendor_client,
-        coordinator_client,
-        vendor2_client,
-        vendor,
-        finder,
-        coordinator,
-        vendor2,
-        case,
-    )
-    _phase_notes_exchange(
-        finder_client=finder_client,
-        vendor_client=vendor_client,
-        coordinator_client=coordinator_client,
-        vendor2_client=vendor2_client,
-        finder_in_finder=finder_in_finder,
-        vendor_in_vendor=vendor_in_vendor,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        vendor2_in_vendor2=vendor2_in_vendor2,
-        case=case,
-    )
-    _phase_fix_lifecycle(
-        finder_client,
-        vendor_client,
-        vendor2_client,
-        vendor,
-        vendor_in_vendor,
-        vendor2,
-        vendor2_in_vendor2,
-        case,
-    )
-    _phase_publication(
-        finder_client,
-        vendor_client,
-        coordinator_client,
-        vendor2_client,
-        vendor,
-        vendor_in_vendor,
-        vendor2,
-        vendor2_in_vendor2,
-        finder,
-        finder_in_finder,
-        coordinator,
-        coordinator_in_coordinator,
-        case,
-    )
-    _phase_case_closure(
-        finder_client,
-        vendor_client,
-        coordinator_client,
-        vendor2_client,
-        vendor,
-        vendor_in_vendor,
-        vendor2,
-        vendor2_in_vendor2,
-        finder,
-        finder_in_finder,
-        coordinator,
-        coordinator_in_coordinator,
-        case,
-    )
-    _phase_dump_case_ledgers(
-        finder_client=finder_client,
-        vendor_client=vendor_client,
-        coordinator_client=coordinator_client,
-        vendor2_client=vendor2_client,
-        finder=finder,
-        vendor=vendor,
-        coordinator=coordinator,
-        vendor2=vendor2_in_vendor2,
-        case=case,
-    )
+        finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+
+        _phase_sync_verification(
+            finder_client,
+            vendor_client,
+            coordinator_client,
+            vendor2_client,
+            vendor,
+            finder,
+            coordinator,
+            vendor2,
+            case,
+        )
+        _phase_notes_exchange(
+            finder_client=finder_client,
+            vendor_client=vendor_client,
+            coordinator_client=coordinator_client,
+            vendor2_client=vendor2_client,
+            finder_in_finder=finder_in_finder,
+            vendor_in_vendor=vendor_in_vendor,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            vendor2_in_vendor2=vendor2_in_vendor2,
+            case=case,
+        )
+        _phase_fix_lifecycle(
+            finder_client,
+            vendor_client,
+            vendor2_client,
+            vendor,
+            vendor_in_vendor,
+            vendor2,
+            vendor2_in_vendor2,
+            case,
+        )
+        _phase_publication(
+            finder_client,
+            vendor_client,
+            coordinator_client,
+            vendor2_client,
+            vendor,
+            vendor_in_vendor,
+            vendor2,
+            vendor2_in_vendor2,
+            finder,
+            finder_in_finder,
+            coordinator,
+            coordinator_in_coordinator,
+            case,
+        )
+        _phase_case_closure(
+            finder_client,
+            vendor_client,
+            coordinator_client,
+            vendor2_client,
+            vendor,
+            vendor_in_vendor,
+            vendor2,
+            vendor2_in_vendor2,
+            finder,
+            finder_in_finder,
+            coordinator,
+            coordinator_in_coordinator,
+            case,
+        )
 
     logger.info("=" * 80)
     logger.info("FVCV-EXTENSION DEMO COMPLETE ✓  (VFDPxa full lifecycle)")
@@ -1084,8 +1051,6 @@ def main(
         coordinator_id: Optional deterministic URI for the Coordinator actor.
         vendor2_id: Optional deterministic URI for the Vendor2 actor.
     """
-    reset_demo_failures()
-
     f_url = finder_url or FINDER_BASE_URL
     v_url = vendor_url or VENDOR_BASE_URL
     c_url = coordinator_url or COORDINATOR_BASE_URL
@@ -1115,19 +1080,19 @@ def main(
                 logger.error("=" * 80)
                 sys.exit(1)
 
-    try:
-        run_fvcv_extension_demo(
-            finder_client=finder_client,
-            vendor_client=vendor_client,
-            coordinator_client=coordinator_client,
-            vendor2_client=vendor2_client,
-            finder_id=finder_id,
-            vendor_id=vendor_id,
-            coordinator_id=coordinator_id,
-            vendor2_id=vendor2_id,
-        )
-    finally:
-        assert_demo_success()
+    # scenario_harness() inside run_fvcv_extension_demo() owns the failure
+    # accumulator: it resets it, always dumps the case ledgers, and asserts
+    # success — so a failure here never costs us the artifacts (ISSUE-2239).
+    run_fvcv_extension_demo(
+        finder_client=finder_client,
+        vendor_client=vendor_client,
+        coordinator_client=coordinator_client,
+        vendor2_client=vendor2_client,
+        finder_id=finder_id,
+        vendor_id=vendor_id,
+        coordinator_id=coordinator_id,
+        vendor2_id=vendor2_id,
+    )
 
 
 if __name__ == "__main__":

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -1057,6 +1057,7 @@ def run_fvcv_handoff_demo(
                 coordinator_client=coordinator_client,
                 vendor2_client=vendor2_client,
                 case=case,
+                demo_name=harness.demo_name,
             )
         )
 

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -23,16 +23,11 @@ trigger endpoints (TRIG-11-001/TRIG-11-002), then Coordinator invites Vendor2.
 Spec: GitHub issue #1561.
 """
 
-import json
 import logging
 import os
-import pathlib
 import sys
 import time
 
-import httpx2 as httpx
-
-from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_TransitiveActivity,
@@ -64,6 +59,12 @@ from vultron.demo.helpers.actions import (
 )
 from vultron.demo.helpers.notes import (
     participant_adds_note_to_case,
+)
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpTarget,
+    dump_case_ledgers,
+    resolve_case_actor_route_key,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
@@ -972,67 +973,27 @@ def _phase_dump_case_ledgers(
     case: as_VulnerabilityCase,
     demo_name: str = "fvcv-handoff",
 ) -> None:
-    """Dump case ledger entries from each actor container to JSONL files."""
-    logger.info("─" * 80)
-    logger.info("Phase: Case log JSONL export")
-    logger.info("─" * 80)
+    """Dump case ledger entries from each actor container to JSONL files.
 
-    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
-    case_id = case.id_ or ""
-    case_id_slug = (
-        case_id.replace("://", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .strip("_")
-    )
-
-    case_actor_sub_actor_key = next(
-        (
-            strip_id_prefix(actor_id)
-            for actor_id in case.actor_participant_index
-            if strip_id_prefix(actor_id).startswith("case-actor")
-        ),
-        None,
-    )
-
-    actors: list[tuple[str, DataLayerClient, str]] = [
-        ("finder", finder_client, "finder"),
-        ("vendor", vendor_client, "vendor"),
-        ("coordinator", coordinator_client, "coordinator"),
-        ("vendor2", vendor2_client, "vendor2"),
+    Thin scenario-specific wrapper over
+    :func:`~vultron.demo.helpers.ledger_dump.dump_case_ledgers`, which owns the
+    per-actor export, the 404 handling, and the dump manifest. This function
+    only names FVCV-handoff's participants and where each ledger lives.
+    """
+    targets = [
+        LedgerDumpTarget("finder", finder_client, "finder"),
+        LedgerDumpTarget("vendor", vendor_client, "vendor"),
+        LedgerDumpTarget("coordinator", coordinator_client, "coordinator"),
+        LedgerDumpTarget("vendor2", vendor2_client, "vendor2"),
     ]
-    if case_actor_sub_actor_key is not None:
-        actors.append(("case-actor", vendor_client, case_actor_sub_actor_key))
+    # The case-actor is a sub-actor inside the vendor1 container.
+    case_actor_route_key = resolve_case_actor_route_key(case)
+    if case_actor_route_key is not None:
+        targets.append(
+            LedgerDumpTarget("case-actor", vendor_client, case_actor_route_key)
+        )
 
-    for actor_name, client, actor_route_key in actors:
-        with demo_step(f"Dumping case ledger for {actor_name}"):
-            case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            try:
-                entries = client.get_list(log_path)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code != 404:
-                    raise
-                logger.info(
-                    "Case not found on %s container (HTTP 404); skipping.",
-                    actor_name,
-                )
-                entries = []
-            if not entries:
-                raise ValueError(
-                    f"No case ledger entries for actor={actor_name!r}, "
-                    f"case_id={case_id!r}"
-                )
-
-            out_dir = output_root / demo_name / actor_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
-
-            with out_file.open("w", encoding="utf-8") as fh:
-                for entry in entries:
-                    fh.write(json.dumps(entry) + "\n")
-
-            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    dump_case_ledgers(demo_name=demo_name, case=case, targets=targets)
 
 
 # ---------------------------------------------------------------------------
@@ -1053,160 +1014,167 @@ def run_fvcv_handoff_demo(
     vendor2_id: str | None = None,
 ) -> None:
     """Orchestrate the FVCV-handoff CVD workflow."""
-    logger.info("=" * 80)
-    logger.info(
-        "FVCV-HANDOFF DEMO: Finder + Vendor1 → Coordinator (ownership) + Vendor2"
-    )
-    logger.info("=" * 80)
-    logger.info("Finder container:      %s", finder_client.base_url)
-    logger.info("Vendor1 container:     %s", vendor_client.base_url)
-    logger.info("Coordinator container: %s", coordinator_client.base_url)
-    logger.info("CaseActor container:   %s", case_actor_client.base_url)
-    logger.info("Vendor2 container:     %s", vendor2_client.base_url)
-
-    (
-        finder,
-        vendor,
-        vendor_in_vendor,
-        coordinator,
-        coordinator_in_coordinator,
-        vendor2,
-        report,
-        offer,
-        case,
-    ) = _phase_report_submission(
-        finder_client,
-        vendor_client,
-        coordinator_client,
-        case_actor_client,
-        vendor2_client,
-        finder_id,
-        vendor_id,
-        coordinator_id,
-        vendor2_id,
-    )
-
-    # The CaseActor is a dynamic sub-actor on the vendor container (not the
-    # case-actor service).  Discover its ID from the case data before proceeding.
-    dynamic_case_actor_id = find_case_actor_participant_id(
-        vendor_client, case.id_
-    )
-    if dynamic_case_actor_id is None:
-        raise AssertionError(
-            "CaseActor participant not found in case — cannot route Vendor2 Accept"
+    with scenario_harness("fvcv-handoff") as harness:
+        logger.info("=" * 80)
+        logger.info(
+            "FVCV-HANDOFF DEMO: Finder + Vendor1 → Coordinator (ownership) + Vendor2"
         )
-    logger.info("CaseActor participant ID: %s", dynamic_case_actor_id)
+        logger.info("=" * 80)
+        logger.info("Finder container:      %s", finder_client.base_url)
+        logger.info("Vendor1 container:     %s", vendor_client.base_url)
+        logger.info("Coordinator container: %s", coordinator_client.base_url)
+        logger.info("CaseActor container:   %s", case_actor_client.base_url)
+        logger.info("Vendor2 container:     %s", vendor2_client.base_url)
 
-    vendor2_in_vendor2 = get_actor_by_id(vendor2_client, vendor2.id_)
-    finder_in_finder = get_actor_by_id(finder_client, finder.id_)
-
-    case = _phase_ownership_handoff(
-        vendor_client=vendor_client,
-        coordinator_client=coordinator_client,
-        vendor=vendor,
-        vendor_in_vendor=vendor_in_vendor,
-        coordinator=coordinator,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        case=case,
-    )
-
-    _phase_coordinator_invites_vendor2(
-        finder_client=finder_client,
-        vendor_client=vendor_client,
-        coordinator_client=coordinator_client,
-        vendor2_client=vendor2_client,
-        coordinator=coordinator,
-        coordinator_in_coordinator=coordinator_in_coordinator,
-        case_actor_id=dynamic_case_actor_id,
-        vendor2=vendor2,
-        vendor2_in_vendor2=vendor2_in_vendor2,
-        case=case,
-        offer=offer,
-        report=report,
-        finder=finder,
-    )
-
-    # Verify case active now that all participants have joined.
-    with demo_check(
-        "M1: required participants (≥5), EM.ACTIVE, finder + coordinator have replicas"
-    ):
-        verify_case_active(
-            receiver_client=vendor_client,
-            reporter_client=finder_client,
-            case_id=case.id_,
-            receiver_actor_id=vendor.id_,
-            reporter_actor_id=finder.id_,
+        (
+            finder,
+            vendor,
+            vendor_in_vendor,
+            coordinator,
+            coordinator_in_coordinator,
+            vendor2,
+            report,
+            offer,
+            case,
+        ) = _phase_report_submission(
+            finder_client,
+            vendor_client,
+            coordinator_client,
+            case_actor_client,
+            vendor2_client,
+            finder_id,
+            vendor_id,
+            coordinator_id,
+            vendor2_id,
         )
 
-    _phase_sync_verification(
-        finder_client,
-        vendor_client,
-        coordinator_client,
-        vendor2_client,
-        vendor,
-        finder,
-        coordinator,
-        vendor2,
-        case,
-    )
-    _phase_notes_exchange(
-        finder_client,
-        vendor_client,
-        coordinator_client,
-        vendor2_client,
-        finder_in_finder,
-        vendor_in_vendor,
-        coordinator_in_coordinator,
-        vendor2_in_vendor2,
-        case,
-    )
-    _phase_fix_lifecycle(
-        finder_client,
-        vendor_client,
-        vendor2_client,
-        vendor,
-        vendor_in_vendor,
-        vendor2,
-        vendor2_in_vendor2,
-        case,
-    )
-    _phase_publication(
-        finder_client,
-        vendor_client,
-        coordinator_client,
-        vendor2_client,
-        vendor,
-        vendor_in_vendor,
-        vendor2,
-        vendor2_in_vendor2,
-        finder,
-        finder_in_finder,
-        coordinator,
-        coordinator_in_coordinator,
-        case,
-    )
-    _phase_case_closure(
-        finder_client,
-        vendor_client,
-        coordinator_client,
-        vendor2_client,
-        vendor,
-        vendor_in_vendor,
-        vendor2,
-        vendor2_in_vendor2,
-        finder,
-        finder_in_finder,
-        coordinator,
-        coordinator_in_coordinator,
-        case,
-    )
-    _phase_dump_case_ledgers(
-        finder_client=finder_client,
-        vendor_client=vendor_client,
-        coordinator_client=coordinator_client,
-        vendor2_client=vendor2_client,
-        case=case,
-    )
+        # Register the dump as soon as there is a case to dump, so every phase
+        # below can fail without costing us the ledgers (ISSUE-2239).
+        harness.dump_with(
+            lambda: _phase_dump_case_ledgers(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                coordinator_client=coordinator_client,
+                vendor2_client=vendor2_client,
+                case=case,
+            )
+        )
+
+        # The CaseActor is a dynamic sub-actor on the vendor container (not the
+        # case-actor service).  Discover its ID from the case data before
+        # proceeding.
+        dynamic_case_actor_id = find_case_actor_participant_id(
+            vendor_client, case.id_
+        )
+        if dynamic_case_actor_id is None:
+            raise AssertionError(
+                "CaseActor participant not found in case — cannot route Vendor2 Accept"
+            )
+        logger.info("CaseActor participant ID: %s", dynamic_case_actor_id)
+
+        vendor2_in_vendor2 = get_actor_by_id(vendor2_client, vendor2.id_)
+        finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+
+        case = _phase_ownership_handoff(
+            vendor_client=vendor_client,
+            coordinator_client=coordinator_client,
+            vendor=vendor,
+            vendor_in_vendor=vendor_in_vendor,
+            coordinator=coordinator,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            case=case,
+        )
+
+        _phase_coordinator_invites_vendor2(
+            finder_client=finder_client,
+            vendor_client=vendor_client,
+            coordinator_client=coordinator_client,
+            vendor2_client=vendor2_client,
+            coordinator=coordinator,
+            coordinator_in_coordinator=coordinator_in_coordinator,
+            case_actor_id=dynamic_case_actor_id,
+            vendor2=vendor2,
+            vendor2_in_vendor2=vendor2_in_vendor2,
+            case=case,
+            offer=offer,
+            report=report,
+            finder=finder,
+        )
+
+        # Verify case active now that all participants have joined.
+        with demo_check(
+            "M1: required participants (≥5), EM.ACTIVE, finder + coordinator have replicas"
+        ):
+            verify_case_active(
+                receiver_client=vendor_client,
+                reporter_client=finder_client,
+                case_id=case.id_,
+                receiver_actor_id=vendor.id_,
+                reporter_actor_id=finder.id_,
+            )
+
+        _phase_sync_verification(
+            finder_client,
+            vendor_client,
+            coordinator_client,
+            vendor2_client,
+            vendor,
+            finder,
+            coordinator,
+            vendor2,
+            case,
+        )
+        _phase_notes_exchange(
+            finder_client,
+            vendor_client,
+            coordinator_client,
+            vendor2_client,
+            finder_in_finder,
+            vendor_in_vendor,
+            coordinator_in_coordinator,
+            vendor2_in_vendor2,
+            case,
+        )
+        _phase_fix_lifecycle(
+            finder_client,
+            vendor_client,
+            vendor2_client,
+            vendor,
+            vendor_in_vendor,
+            vendor2,
+            vendor2_in_vendor2,
+            case,
+        )
+        _phase_publication(
+            finder_client,
+            vendor_client,
+            coordinator_client,
+            vendor2_client,
+            vendor,
+            vendor_in_vendor,
+            vendor2,
+            vendor2_in_vendor2,
+            finder,
+            finder_in_finder,
+            coordinator,
+            coordinator_in_coordinator,
+            case,
+        )
+        _phase_case_closure(
+            finder_client,
+            vendor_client,
+            coordinator_client,
+            vendor2_client,
+            vendor,
+            vendor_in_vendor,
+            vendor2,
+            vendor2_in_vendor2,
+            finder,
+            finder_in_finder,
+            coordinator,
+            coordinator_in_coordinator,
+            case,
+        )
 
     logger.info("=" * 80)
     logger.info(
@@ -1248,8 +1216,6 @@ def main(
         case_actor_id: Optional deterministic URI for the CaseActor actor.
         vendor2_id: Optional deterministic URI for the Vendor2 actor.
     """
-    reset_demo_failures()
-
     f_url = finder_url or FINDER_BASE_URL
     v_url = vendor_url or VENDOR_BASE_URL
     c_url = coordinator_url or COORDINATOR_BASE_URL
@@ -1282,21 +1248,21 @@ def main(
                 logger.error("=" * 80)
                 sys.exit(1)
 
-    try:
-        run_fvcv_handoff_demo(
-            finder_client=finder_client,
-            vendor_client=vendor_client,
-            coordinator_client=coordinator_client,
-            case_actor_client=case_actor_client,
-            vendor2_client=vendor2_client,
-            finder_id=finder_id,
-            vendor_id=vendor_id,
-            coordinator_id=coordinator_id,
-            case_actor_id=case_actor_id,
-            vendor2_id=vendor2_id,
-        )
-    finally:
-        assert_demo_success()
+    # scenario_harness() inside run_fvcv_handoff_demo() owns the failure
+    # accumulator: it resets it, always dumps the case ledgers, and asserts
+    # success — so a failure here never costs us the artifacts (ISSUE-2239).
+    run_fvcv_handoff_demo(
+        finder_client=finder_client,
+        vendor_client=vendor_client,
+        coordinator_client=coordinator_client,
+        case_actor_client=case_actor_client,
+        vendor2_client=vendor2_client,
+        finder_id=finder_id,
+        vendor_id=vendor_id,
+        coordinator_id=coordinator_id,
+        case_actor_id=case_actor_id,
+        vendor2_id=vendor2_id,
+    )
 
 
 if __name__ == "__main__":

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -752,6 +752,7 @@ def run_fvv_demo(
                 vendor=vendor,
                 vendor2=vendor2,
                 case=case,
+                demo_name=harness.demo_name,
             )
         )
 

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -24,15 +24,10 @@ authoritative Vendor1 state.
 Spec: D5-5 (GitHub issue #1265).
 """
 
-import json
 import logging
 import os
-import pathlib
 import sys
 
-import httpx2 as httpx
-
-from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
@@ -64,6 +59,12 @@ from vultron.demo.helpers.actions import (
     actor_closes_case,
     actor_notifies_fix_ready,
     actor_notifies_published,
+)
+from vultron.demo.helpers.harness import scenario_harness
+from vultron.demo.helpers.ledger_dump import (
+    LedgerDumpTarget,
+    dump_case_ledgers,
+    resolve_case_actor_route_key,
 )
 from vultron.demo.helpers.milestones import (
     verify_case_active,
@@ -690,66 +691,26 @@ def _phase_dump_case_ledgers(
     case: as_VulnerabilityCase,
     demo_name: str = "fvv",
 ) -> None:
-    """Dump case ledger entries from each actor container to JSONL files."""
-    logger.info("─" * 80)
-    logger.info("Phase: Case log JSONL export")
-    logger.info("─" * 80)
+    """Dump case ledger entries from each actor container to JSONL files.
 
-    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
-    case_id = case.id_ or ""
-    case_id_slug = (
-        case_id.replace("://", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .strip("_")
-    )
-
-    case_actor_sub_actor_key = next(
-        (
-            strip_id_prefix(actor_id)
-            for actor_id in case.actor_participant_index
-            if strip_id_prefix(actor_id).startswith("case-actor")
-        ),
-        None,
-    )
-
-    actors: list[tuple[str, DataLayerClient, str]] = [
-        ("finder", finder_client, "finder"),
-        ("vendor", vendor_client, "vendor"),
-        ("vendor2", vendor2_client, "vendor2"),
+    Thin scenario-specific wrapper over
+    :func:`~vultron.demo.helpers.ledger_dump.dump_case_ledgers`, which owns the
+    per-actor export, the 404 handling, and the dump manifest. This function
+    only names FVV's participants and where each one's ledger lives.
+    """
+    targets = [
+        LedgerDumpTarget("finder", finder_client, "finder"),
+        LedgerDumpTarget("vendor", vendor_client, "vendor"),
+        LedgerDumpTarget("vendor2", vendor2_client, "vendor2"),
     ]
-    if case_actor_sub_actor_key is not None:
-        actors.append(("case-actor", vendor_client, case_actor_sub_actor_key))
+    # The case-actor is a sub-actor inside the vendor1 container.
+    case_actor_route_key = resolve_case_actor_route_key(case)
+    if case_actor_route_key is not None:
+        targets.append(
+            LedgerDumpTarget("case-actor", vendor_client, case_actor_route_key)
+        )
 
-    for actor_name, client, actor_route_key in actors:
-        with demo_step(f"Dumping case ledger for {actor_name}"):
-            case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            try:
-                entries = client.get_list(log_path)
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code != 404:
-                    raise
-                logger.info(
-                    "Case not found on %s container (HTTP 404); skipping.",
-                    actor_name,
-                )
-                entries = []
-            if not entries:
-                raise ValueError(
-                    f"No case ledger entries for actor={actor_name!r}, "
-                    f"case_id={case_id!r}"
-                )
-
-            out_dir = output_root / demo_name / actor_name
-            out_dir.mkdir(parents=True, exist_ok=True)
-            out_file = out_dir / f"{case_id_slug}-case-ledger.jsonl"
-
-            with out_file.open("w", encoding="utf-8") as fh:
-                for entry in entries:
-                    fh.write(json.dumps(entry) + "\n")
-
-            logger.info("Wrote %d log entries → %s", len(entries), out_file)
+    dump_case_ledgers(demo_name=demo_name, case=case, targets=targets)
 
 
 def run_fvv_demo(
@@ -768,81 +729,87 @@ def run_fvv_demo(
     logger.info("Vendor1 container: %s", vendor_client.base_url)
     logger.info("Vendor2 container: %s", vendor2_client.base_url)
 
-    finder, vendor, vendor_in_vendor, vendor2, report, offer, case = (
-        _phase_report_submission(
+    with scenario_harness("fvv") as harness:
+        finder, vendor, vendor_in_vendor, vendor2, report, offer, case = (
+            _phase_report_submission(
+                finder_client,
+                vendor_client,
+                vendor2_client,
+                finder_id,
+                vendor_id,
+                vendor2_id,
+            )
+        )
+
+        # Register the dump as soon as there is a case to dump, so every phase
+        # below can fail without costing us the ledgers (ISSUE-2239).
+        harness.dump_with(
+            lambda: _phase_dump_case_ledgers(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                vendor2_client=vendor2_client,
+                finder=finder,
+                vendor=vendor,
+                vendor2=vendor2,
+                case=case,
+            )
+        )
+
+        vendor2_in_vendor2 = get_actor_by_id(vendor2_client, vendor2.id_)
+        finder_in_finder = get_actor_by_id(finder_client, finder.id_)
+
+        _phase_sync_verification(
             finder_client,
             vendor_client,
             vendor2_client,
-            finder_id,
-            vendor_id,
-            vendor2_id,
+            vendor,
+            finder,
+            vendor2,
+            case,
         )
-    )
-
-    vendor2_in_vendor2 = get_actor_by_id(vendor2_client, vendor2.id_)
-    finder_in_finder = get_actor_by_id(finder_client, finder.id_)
-
-    _phase_sync_verification(
-        finder_client,
-        vendor_client,
-        vendor2_client,
-        vendor,
-        finder,
-        vendor2,
-        case,
-    )
-    _phase_notes_exchange(
-        finder_client=finder_client,
-        vendor_client=vendor_client,
-        vendor2_client=vendor2_client,
-        finder_in_finder=finder_in_finder,
-        vendor_in_vendor=vendor_in_vendor,
-        vendor2_in_vendor2=vendor2_in_vendor2,
-        case=case,
-    )
-    _phase_fix_lifecycle(
-        finder_client,
-        vendor_client,
-        vendor2_client,
-        vendor,
-        vendor_in_vendor,
-        vendor2,
-        vendor2_in_vendor2,
-        case,
-    )
-    _phase_publication(
-        finder_client,
-        vendor_client,
-        vendor2_client,
-        vendor,
-        vendor_in_vendor,
-        vendor2,
-        vendor2_in_vendor2,
-        finder,
-        finder_in_finder,
-        case,
-    )
-    _phase_case_closure(
-        finder_client,
-        vendor_client,
-        vendor2_client,
-        vendor,
-        vendor_in_vendor,
-        vendor2,
-        vendor2_in_vendor2,
-        finder,
-        finder_in_finder,
-        case,
-    )
-    _phase_dump_case_ledgers(
-        finder_client=finder_client,
-        vendor_client=vendor_client,
-        vendor2_client=vendor2_client,
-        finder=finder,
-        vendor=vendor,
-        vendor2=vendor2,
-        case=case,
-    )
+        _phase_notes_exchange(
+            finder_client=finder_client,
+            vendor_client=vendor_client,
+            vendor2_client=vendor2_client,
+            finder_in_finder=finder_in_finder,
+            vendor_in_vendor=vendor_in_vendor,
+            vendor2_in_vendor2=vendor2_in_vendor2,
+            case=case,
+        )
+        _phase_fix_lifecycle(
+            finder_client,
+            vendor_client,
+            vendor2_client,
+            vendor,
+            vendor_in_vendor,
+            vendor2,
+            vendor2_in_vendor2,
+            case,
+        )
+        _phase_publication(
+            finder_client,
+            vendor_client,
+            vendor2_client,
+            vendor,
+            vendor_in_vendor,
+            vendor2,
+            vendor2_in_vendor2,
+            finder,
+            finder_in_finder,
+            case,
+        )
+        _phase_case_closure(
+            finder_client,
+            vendor_client,
+            vendor2_client,
+            vendor,
+            vendor_in_vendor,
+            vendor2,
+            vendor2_in_vendor2,
+            finder,
+            finder_in_finder,
+            case,
+        )
 
     logger.info("=" * 80)
     logger.info("FVV DEMO COMPLETE ✓  (VFDPxa full lifecycle)")
@@ -875,8 +842,6 @@ def main(
         vendor_id: Optional deterministic URI for the Vendor1 actor.
         vendor2_id: Optional deterministic URI for the Vendor2 actor.
     """
-    reset_demo_failures()
-
     f_url = finder_url or FINDER_BASE_URL
     v_url = vendor_url or VENDOR_BASE_URL
     v2_url = vendor2_url or VENDOR2_BASE_URL
@@ -903,17 +868,17 @@ def main(
                 logger.error("=" * 80)
                 sys.exit(1)
 
-    try:
-        run_fvv_demo(
-            finder_client=finder_client,
-            vendor_client=vendor_client,
-            vendor2_client=vendor2_client,
-            finder_id=finder_id,
-            vendor_id=vendor_id,
-            vendor2_id=vendor2_id,
-        )
-    finally:
-        assert_demo_success()
+    # scenario_harness() inside run_fvv_demo() owns the failure accumulator: it
+    # resets it, always dumps the case ledgers, and asserts success — so a
+    # failure here never costs us the artifacts (ISSUE-2239).
+    run_fvv_demo(
+        finder_client=finder_client,
+        vendor_client=vendor_client,
+        vendor2_client=vendor2_client,
+        finder_id=finder_id,
+        vendor_id=vendor_id,
+        vendor2_id=vendor2_id,
+    )
 
 
 if __name__ == "__main__":

--- a/vultron/metadata/specs/registry.py
+++ b/vultron/metadata/specs/registry.py
@@ -29,6 +29,12 @@ except ImportError as exc:  # pragma: no cover
         "Install it with: pip install pyyaml"
     ) from exc
 
+# libyaml-backed loader when the wheel provides it, else the pure-Python one.
+# Same SafeLoader semantics either way; the C loader parses the ~1.2 MB spec
+# corpus about 10x faster, which matters because ``load_registry()`` is
+# uncached and several tests run under a 5 s per-test timeout.
+_SafeLoader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+
 
 def effective_scope(
     spec: Spec, group: SpecGroup, file: SpecFile
@@ -229,7 +235,7 @@ def load_registry(
 
     files = []
     for yaml_path in sorted(spec_dir.glob("*.yaml")):
-        raw = yaml.safe_load(yaml_path.read_text())
+        raw = yaml.load(yaml_path.read_text(), Loader=_SafeLoader)
         files.append(SpecFile.model_validate(raw))
 
     return SpecRegistry(files=files)


### PR DESCRIPTION
- Closes #2239

## Summary

The case-ledger dump ran as the last statement of every `run_*_demo()`, so any assertion escaping a `demo_check` block skipped it while `main()`'s `finally: assert_demo_success()` still failed the job — the demo failed with an empty `devlogs/` and the `invariant-harness` job died on artifact download instead of reporting an invariant result. A shared harness now owns the ordering: run phases, **always** dump, then assert.

## Changes

- **`vultron/demo/helpers/harness.py`** (new): `scenario_harness(demo_name)` resets the failure accumulator, always dumps the ledgers on the way out, and calls `assert_demo_success()` last. On the failing path the original exception propagates unchanged with the accumulated `demo_check` failures attached via `add_note()` — a dump error can never replace the real cause (DEMOMA-23-001/-004, DEMOCI-10-004). `_run_dump()` is total: the no-dump-registered manifest write runs inside `demo_step`, `_backstop_manifest()` logs and swallows its own failure rather than displacing the dump error already in flight, and every path — including a `BaseException` that `demo_step` does not catch — is contained.
- **`vultron/demo/helpers/ledger_dump.py`** (new): the one implementation of the dump. Writes `devlogs/<demo>/dump-manifest.json` from a `finally`, recording the case ID, captured/total targets, and each missing actor with its route key and reason — so the artifact exists even when there were no ledgers to capture (DEMOCI-10-002, DEMOMA-17-001). `default_devlogs_root()` is the single resolution of where `devlogs/` lives: `DEVLOGS_DIR` when set, else a repo-root-relative default. `vultron/demo/report.py` and `test/ci/invariants/common.py` both delegate to it, so the writer, the reader, and the invariant harness cannot disagree.
- **All nine `vultron/demo/scenario/*_demo.py`**: body wrapped in `with scenario_harness("<demo>") as harness:`; the dump is registered via `harness.dump_with(...)` as soon as the case exists — before any subsequent network call — so every later phase can fail without costing the ledgers. Each `_phase_dump_case_ledgers` is now a thin wrapper over `dump_case_ledgers()` and takes `demo_name=harness.demo_name`, making the harness's name authoritative; `main()` no longer owns the accumulator (DEMOMA-23-002/-003).
- **`test/ci/invariants/common.py`**: `load_devlogs()` no longer skips when the demo ran, dumped, and produced nothing. Manifests are read unconditionally, so a manifest with no ledger files — or one that parses as something other than an object — `pytest.fail`s whatever else the dump produced, and reproduces the manifest's own per-actor account of what was missing and why. It still skips when there is genuinely no artifact (DEMOCI-10-003).
- **`test/demo/test_fv_demo.py`**: the harness's honest `assert_demo_success()` surfaced a masked, pre-existing in-process SYNC-2 check failure that earlier runs accumulated and dropped. The test now asserts on that one known failure exactly, so any *other* phase failure still fails it (tracked in #2267), and pins `DEVLOGS_DIR` to `tmp_path` so the always-dump change does not write into the repo root (#2274).
- **`vultron/metadata/specs/registry.py`**: select `yaml.CSafeLoader` when available. `load_registry()` goes 3.44s → 0.35s, which stops spec-metadata tests from tripping the global 5s thread timeout that this PR's spec additions were pushing over the edge. Partial mitigation for #2270 (measurements in [this comment](https://github.com/CERTCC/Vultron/issues/2270#issuecomment-5273027116)); the `timeout_method = "thread"` fragility itself is untouched.
- **`specs/demo-ci.yaml`** (1.9.0) and **`specs/multi-actor-demo.yaml`** (1.4.0): new groups DEMOCI-10 "Case-Ledger Artifact Availability on Failure" and DEMOMA-23 "Shared Scenario Harness".
- **`vultron/demo/AGENTS.md`**, **`notes/demo-ci-invariants.md`**, **`vultron/demo/report.py`**: new pitfall section, the fail-vs-skip design note, and a stale docstring pointing at a module deleted long ago.

## Verification

Run at `bdc5442a`, after merging `origin/main` (`2f1a9354`).

- Unit suite (`uv run pytest`): **6611 passed, 335 skipped, 2 xfailed, 5552 subtests passed, 1 failed** in 89.7s. The one failure is `test_fv_invariants.py::test_invariant_5_expected_event_types_present[validate_report]` — it reads the gitignored local `devlogs/fv/` left by an earlier demo run and is #2273/#2274, not this branch. With a fresh devlogs root (`DEVLOGS_DIR=$(mktemp -d)`) the whole file skips, and the path `test/ci/invariants/common.py` resolves is byte-identical to the pre-branch one, so no behaviour changed here. CI runs on a fresh checkout, and the `Python application` workflow is green at this commit.
- Integration suite (`uv run pytest -m integration`): **1129 tests, exit 0**.
- Every `XFAIL` in both suites references a live open issue (#1991, #1992, #1898, #1993); the one `XPASS` references open #1994.
- New tests: 21 in `test/demo/test_issue_2239_ledger_dump_in_finally.py` + `test/demo/test_scenario_harness.py`; the first parametrizes all nine scenarios, patching a phase to raise and asserting the manifest lands. `TestUnwritableDevlogsRoot` adds four covering both `_run_dump` branches against a devlogs root that genuinely cannot be written — the exact shape that would otherwise turn the pytest job red. 8 new tests in `test/ci/invariants/test_common.py` cover every fail/skip branch (49 there in total).
- `black`, `flake8`, `mypy` (667 files, no issues), `pyright` (0 errors), `spec-lint` all clean.

### CI state

`Python application`, `Spec Check`, and `Lint Markdown` are green. `Demo Integration` is red, and every red job on it is red on `main` at the same base commit (`2f1a9354`) with the same root cause: `422 Unprocessable Content` on `trigger/engage-case`, tracked in **#2233**. Nothing on this branch regressed a demo job.

That red is also the evidence this PR works. `fvcv-handoff Invariant Harness` used to die on artifact download without asserting anything; it now runs and reports **39 passed, 2 failed** against the dumped ledgers, failing on a real protocol claim (`Expected eventType 'engage_case' not found in case-actor log`). `fcvcv Invariant Harness` is green even though `fcvcv Demo Integration` failed — the ledgers survived the failure, which is exactly what #2239 asked for.

## Follow-ups already tracked

- **#2281** (filed from this PR's triage): the dump is still skipped when a scenario dies *before* `scenario_harness()` is entered — a health-check `sys.exit(1)`, an import error, or a `docker compose` startup failure. The residual hole in DEMOCI-10-002; needs its own design pass because a tolerant download step alone would reintroduce the false-green skip DEMOCI-10-003 forbids.
- Pre-existing and independent: #2233 (`engage-case` 422), #2201/#2203 (`demo_gate` is documented in AGENTS.md, DEMOCI-01-007 and ADR-0058 but does not exist in code, leaving ~20 unguarded `wait_for_case_participants` calls), #2267 (in-process tests must assert on accumulated failures), #2270 (global 5s thread timeout, now parented to #2089), #2273 and #2274 (devlogs pollution and the missing `validate_report` event). #2270 and #2273 had no parent epic and now do.
