### PR TITLE
docs: plan issue #2260 — core→wire rendering port; remove alias_generator from all core-branch types

### DIFF
--- a/.agents/skills/archive-history/SKILL.md
+++ b/.agents/skills/archive-history/SKILL.md
@@ -16,7 +16,8 @@ Archive one completed work item to `plan/history/`, lint the new files, and
 commit + push them to the current branch.
 
 **Always invoke this skill AFTER the PR is opened** — so the PR URL can be
-embedded in the entry body. History entries are immutable once committed.
+embedded in the entry body. History entries become immutable once merged into
+`main` — see [Constraints](#constraints).
 
 ---
 
@@ -107,4 +108,9 @@ git push "https://x-access-token:$(gh auth token)@github.com/CERTCC/Vultron.git"
   `git add`, commit, and push are not needed (HM-08-004, HM-08-006).
 - **Do not call `git push` separately** — this skill always pushes as its final step (file mode only).
 - **Do not amend** — open a new commit via a fresh invocation rather than amending.
-- History files are **immutable** once pushed.
+- History files are **immutable once merged into main** — not once pushed. While the
+  entry is still on an unmerged branch it is ordinary working-branch content: if a
+  fact in it goes stale before the PR merges (a reparented epic, a renumbered
+  issue), correct it in place and commit the fix. Immutability starts at merge,
+  because that is when the entry becomes shared history others may cite. After the
+  merge, correct the record with a **new** entry rather than editing the old one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,20 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **`as_VulnerabilityCase` (wire) vs `VulnerabilityCase` (core)** — all classes
   in `vultron/wire/as2/vocab/objects/` use `as_` prefix. Bare name = core type.
   See ARCH-14-001.
+- **Never Reach for `alias_generator` or `by_alias=True` in Core to Get camelCase**
+  — core needs wire-shaped JSON only for `CaseLedgerEntry.payloadSnapshot`, and it
+  MUST get it from the `WireRenderPort` driven port, not from the domain model.
+  A core-side alias cannot express structural core/wire differences (nested
+  `consent: PecDimension` vs flat `emConsentState`), so it always accretes
+  per-field hand-patches that drift from `from_core()`. See ARCH-20-001,
+  CLP-07-009, CLP-07-010 and
+  [notes/core-wire-rendering-port.md](notes/core-wire-rendering-port.md).
+- **Deleting a Wire-Spelling Shim Without a Reject-Guard Is a Silent Data-Loss
+  Bug** — Pydantic v2 defaults to `extra="ignore"`, so removing a validator that
+  accepted a legacy key makes that key *silently dropped* and the field default
+  to its start value (a lost RM ladder, not an error). Always pair the deletion
+  with a `model_validator(mode="before")` built on `reject_wire_spelled_keys`
+  (`vultron/core/models/_wire_spelling.py`). See SDO-03-005, ARCH-15-002.
 - **Flat `nodes.py` in BT Areas Is Non-Compliant** — use `nodes/` subpackage;
   `__init__.py` MUST re-export all public names. See BTND-07-001, BTND-07-003.
 - **Splits Must Not Produce New God Modules** — submodules ≤500 lines; split

--- a/docs/adr/0063-wire-rendering-port-for-core-objects.md
+++ b/docs/adr/0063-wire-rendering-port-for-core-objects.md
@@ -1,0 +1,271 @@
+---
+status: accepted
+date: 2026-08-13
+deciders: Allen Householder
+consulted: Claude Code (planning agent for CONCERN-2260)
+informed: Vultron contributors
+---
+
+# Render Core Objects to Wire JSON Through a Driven Port; Remove `alias_generator` From All Core-Branch Types
+
+## Context and Problem Statement
+
+Eight `CoreObject` subclasses set `model_config = ConfigDict(alias_generator=to_camel)`:
+`ParticipantStatus`, `CaseStatus`, `VultronPerson`, `VultronOrganization`,
+`VultronService`, `VultronApplication`, `VultronGroup`, and
+`CoreActorCollection`. ARCH-12-003 forbids exactly this — `alias_generator=to_camel`
+is a wire-specific concern and core-branch types MUST NOT carry it. The
+violation has been tracked as a known deviation (#1991) behind an
+`xfail(strict=False)` ratchet in `test/architecture/test_hierarchy_invariants.py`
+for long enough that downstream code came to depend on it.
+
+`ParticipantStatus` compounds the problem with a `_migrate_flat_fields`
+`model_validator(mode="before")` that accepts flat wire spellings
+(`rm_state`/`rmState`, `vfd_state`/`vfdState`, `em_consent_state`/`emConsentState`)
+and rewrites them into the ADR-0036 dimension objects. SDO-03-003 says the old
+flat enum fields MUST NOT be retained as aliases or shim properties after the
+dimension migration — so this shim violates a MUST-level requirement
+independently of ARCH-12-003.
+
+The reason the alias generator is load-bearing rather than merely wrong is that
+core code needs camelCase JSON for one specific purpose: building
+`CaseLedgerEntry.payloadSnapshot` values. The case ledger's purpose is to wrap
+"things that were received or sent to/from the case manager in the course of
+managing the case", and those are by definition wire-shaped. CLP-07-001 requires
+the snapshot to be the verbatim AS2 activity or a deterministic canonical
+normalization of it, and CLP-01-003/CLP-01-004 make the ledger the replication
+substrate that receivers project into their own replica. A payload snapshot must
+therefore be valid wire JSON that a receiver can reconstitute — camelCase is
+correct *there*.
+
+So core reached for the nearest thing that produced camelCase: it set
+`alias_generator` on the core class and called `model_dump(by_alias=True)`. That
+is a wire concern implemented by mutating the domain model, and it does not even
+work correctly: `build_add_participant_status_snapshot` in
+`vultron/core/behaviors/case/ledger_snapshots.py` has to hand-patch
+`consent` → `emConsentState` after the dump, because a core `model_dump` cannot
+produce the wire's flat `emConsentState` field from the nested `PecDimension`.
+That hand-patch is a partial, drifting reimplementation of
+`as_ParticipantStatus.from_core()`.
+
+Two additional consumers depend on the same core-side aliasing:
+`_inline_snapshot_reference_value` in `vultron/core/use_cases/_helpers.py`
+(CLP-07-006 inline nesting of `dl.read()` results, which are core objects per
+DL-05-001), and `GET /actors/{id}` in
+`vultron/adapters/driving/fastapi/routers/actors/_routes.py`, which dumps a
+**core** actor class with `by_alias=True` straight into an `AS2JSONResponse`.
+
+A fifth consumer depends on the *shim* rather than the alias generator:
+`FilterParticipantStatusDimensionsNode._to_core_status` (added by ADR-0061)
+normalises a wire status by dumping it `by_alias=True` and revalidating through
+core `ParticipantStatus`, and its docstring names the dependency outright — "the
+core model's `_migrate_flat_fields` validator accepts that shape, so a
+dump-and-revalidate normalises both". The shim and that idiom have to retire
+together.
+
+The hand-patching is likewise not confined to one site: `_build_patch` in the
+same module writes `patch["caseStatus"] = {"emState": ..., "pxaState": ...}`,
+and `accept_invite.py`'s `_build_snapshot` hand-builds a wire-spelled fallback
+dict. Every new snapshot-producing site reinvents a little wire spelling, which
+is the strongest evidence that the capability is missing rather than misplaced.
+
+The question is not "how does core get camelCase" but "whose job is it to render
+a wire representation".
+
+## Decision Drivers
+
+- ARCH-12-003 (core MUST NOT carry `alias_generator=to_camel`) and SDO-03-003
+  (no flat-field shims) are both MUST-level and both currently violated.
+- CLP-07-001 requires payload snapshots to be valid, receiver-reconstitutable
+  wire JSON; ADR-0017's two-branch hierarchy already assigns wire shape to the
+  `as_*` branch, which has correct `from_core()` projections.
+- ARCH-01-001 forbids `core/` importing `wire/`; ARCH-01-004 says such
+  violations are remediated via driven ports rather than by relaxing the rule.
+- Piecemeal remediation of this area has repeatedly produced issue propagation
+  (#1991 → #2232 → #2260 → #2268). A partial fix that leaves some of the eight
+  classes aliased keeps the ratchet alive and keeps the asymmetry documented in
+  `CaseParticipant._reject_wire_spelled_keys` true.
+- The projection capability is reusable: emitters, sync fan-out, and AS2 HTTP
+  responses all need core → wire rendering.
+- Removing the shim is unsafe without a guard. `extra="ignore"` is the Pydantic
+  default, so deleting `_migrate_flat_fields` would make a flat `rm_state` key
+  *silently dropped*, defaulting `rm.state` to `RM.START` — precisely the #2232
+  defect class, and an ARCH-15-001/002 violation (silent `None` and fake
+  `SUCCESS` are the same bug).
+
+## Considered Options
+
+- **Amend ARCH-12-003** to permit `alias_generator` on core types that have wire
+  counterparts.
+- **Let core import the wire layer** for this one purpose (rendering what was
+  received on the wire).
+- **Driven port for core → wire rendering** (`WireRenderPort`), implemented by an
+  AS2 adapter that owns `from_core()` + `by_alias` dumping; remove
+  `alias_generator` from all eight classes and delete the flat-field shim behind
+  a rejecting guard.
+- **Narrow fix**: leave the port out, keep `alias_generator` on
+  `ParticipantStatus` only, and remediate the other seven.
+
+## Decision Outcome
+
+Chosen option: **"Driven port for core → wire rendering"**, applied to all eight
+classes in one change rather than incrementally.
+
+Concretely:
+
+1. **New driven port** `vultron/core/ports/wire_render.py` declaring a
+   `typing.Protocol` (matching `SyncActivityPort` / `ActivityEmitter` style):
+
+   ```python
+   @runtime_checkable
+   class WireRenderPort(Protocol):
+       def render(self, obj: Any) -> dict[str, Any]: ...
+   ```
+
+   `render()` returns wire-shaped JSON (camelCase, `exclude_none=True`) for a
+   core domain object. It raises `VultronValidationError` when no wire
+   counterpart exists, rather than falling back to a core-shaped dump — a
+   silently core-shaped snapshot is the failure mode this ADR exists to remove
+   (ARCH-15-002).
+
+2. **AS2 adapter** `vultron/adapters/driven/wire_render/as2.py` implements it by
+   looking the core `type_` up in the wire vocabulary, calling the wire class's
+   `from_core()`, and dumping with `by_alias=True, exclude_none=True`. All
+   knowledge of camelCase spelling, flat `emConsentState`, and the AS2 `@context`
+   lives here.
+
+3. **Port injection** follows the existing pattern: a `wire_render_port`
+   parameter on `BTBridge.__init__`, published to the blackboard under
+   `wire_render_port`, and passed through `execute_with_setup()`. Use-case
+   helpers that build snapshots take it as an argument.
+
+4. **`ledger_snapshots.py` is reduced to the port call.** `obj_to_inline_dict`
+   and the `consent` → `emConsentState` hand-patch are deleted; the synthesizers
+   that remain (case-proposal bootstrap, where no received activity exists to
+   capture verbatim) build a core object and hand it to the port.
+   `_inline_snapshot_reference_value` renders `dl.read()` results through the
+   same port, which fixes CLP-07-006 inlining for every type rather than only
+   for types that happen to be aliased.
+
+5. **`alias_generator` is removed from all eight classes**, and
+   `_migrate_flat_fields` is deleted. Each de-aliased class gains a rejecting
+   `model_validator(mode="before")` built on the existing
+   `reject_wire_spelled_keys` mechanism in
+   `vultron/core/models/_wire_spelling.py`, extended to cover the flat wire field
+   names (`rm_state`/`rmState`, `vfd_state`/`vfdState`,
+   `em_consent_state`/`emConsentState`) so that a wire-shaped payload raises
+   instead of being silently dropped. `_to_core_status` in
+   `behaviors/status/nodes/dimension_filter.py` is converted from
+   dump-and-revalidate to the `to_core()` boundary projection at the same time,
+   since the guard would otherwise make it raise (ARCH-20-007).
+
+6. **Actor HTTP responses are routed through wire projections.** `GET /actors/{id}`
+   and its sibling routes render via the `as_*` actor classes instead of dumping
+   a core actor with `by_alias=True`. The vestigial `CoreActor.to_json()` (no
+   callers) is removed.
+
+7. **The ratchet is retired.** The `xfail` on
+   `test_no_core_object_has_to_camel_alias_generator` becomes a plain passing
+   assertion, and #1991 is closed. The known-deviation paragraph in
+   `CaseParticipant._reject_wire_spelled_keys`'s docstring is rewritten, because
+   ARCH-12-003 then does hold throughout that subtree.
+
+**Persisted rows are unaffected.** `Record.from_obj` calls
+`obj.model_dump(mode="json", serialize_as_any=True)` with no `by_alias`, so rows
+are already snake_case. Removing `alias_generator` does not change the persisted
+key shape, and no persistence-schema migration is implied. The reject-guards
+raise `VultronValidationError`, which `DataLayer._from_row` already catches and
+routes into `_wire_object_from_row` → `_project_wire_row_to_core`
+(ADR-0062, #2232), so a wire-shaped legacy row still reads back correctly.
+
+### Consequences
+
+- Good, because ARCH-12-003 and SDO-03-003 both become true, verifiable, and
+  test-enforced rather than ratcheted.
+- Good, because wire spelling has exactly one home. The
+  `consent` → `emConsentState` hand-patch — a partial `from_core()` living in
+  core — disappears instead of drifting further.
+- Good, because CLP-07-006 inline snapshots become correct for all nested types,
+  not just the aliased ones; today a non-aliased nested object is inlined in
+  core shape and a receiver cannot reconstitute it.
+- Good, because the port is reusable by emitters and sync fan-out, which need
+  the same rendering.
+- Bad, because it is a wide change: eight model classes, a new port and adapter,
+  BT plumbing, ledger snapshot construction, and the actor HTTP routes. It
+  touches the ledger write path, which is hash-chained.
+- Bad, because every BT execution path that builds a payload snapshot must now
+  have the port injected. A path that forgets it fails loudly (by design) rather
+  than degrading to a core-shaped snapshot, so the cost surfaces as test
+  failures during implementation rather than as silent wire-shape drift.
+- Neutral, because the canonical commit stays exactly where it is. CLP-09-002
+  forbids bare canonical commits and CLP-10-005..008 constrain `execute()`, so
+  only entry *rendering* moves behind the port; the role-gated commit remains in
+  `CommitCaseLedgerEntryNode`.
+
+## Validation
+
+- `test_no_core_object_has_to_camel_alias_generator` passes without `xfail`.
+- A new architecture test asserts no `CoreObject` subclass declares an
+  `alias_generator`, and that no core module dumps with `by_alias=True`.
+- A round-trip test asserts that for each core type with a wire counterpart,
+  `WireRenderPort.render(core_obj)` equals
+  `as_X.from_core(core_obj).model_dump(by_alias=True, exclude_none=True)`, and
+  that the result revalidates through `as_X.model_validate` (CLP-07-001
+  reconstitutability).
+- A test asserts `ParticipantStatus.model_validate({"rm_state": "RECEIVED"})`
+  raises `VultronValidationError` rather than silently yielding `RM.START`.
+- Existing CM-18-006 assertions continue to hold: the wire projection, not the
+  core alias, is what produces `emConsentState`/`embargoAdherence`.
+
+## Pros and Cons of the Options
+
+### Amend ARCH-12-003 to permit `alias_generator` on core types
+
+- Good, because it is the smallest possible change.
+- Bad, because it legitimises the shape duality that produced #2232: the same
+  `type_` accepting two key spellings means whichever class reads a row decides
+  what the data means.
+- Bad, because it does not fix the `consent` → `emConsentState` hand-patch, which
+  exists precisely because core aliasing *cannot* produce the wire shape. The
+  amendment would sanction a mechanism that is already insufficient.
+
+### Let core import the wire layer for this purpose
+
+- Good, because it is direct and needs no injection plumbing; the argument that
+  "core is reflecting what was received on the wire" is genuinely reasonable.
+- Neutral, because ARCH-01-001 exists to keep domain logic replaceable, and
+  rendering a snapshot is arguably not domain logic.
+- Bad, because ARCH-01-004 already establishes driven ports as the remediation
+  for exactly this situation, and a one-off exemption is not testable — an
+  allow-listed import becomes an unbounded one.
+- Bad, because it forgoes reuse: emitters and the AS2 HTTP routes need the same
+  rendering, and a port serves all three.
+
+### Narrow fix: `ParticipantStatus` keeps its alias; remediate the other seven
+
+- Good, because it is much smaller and lower-risk in the ledger write path.
+- Bad, because it leaves the ratchet in place, so #1991 cannot close and the
+  documented asymmetry in `CaseParticipant` stays true.
+- Bad, because the class that keeps the alias is the one where the alias is
+  *demonstrably broken* (the hand-patch), so the narrow fix retains the worst
+  instance.
+- Bad, on stated project experience: incremental remediation of this area
+  generated #1991 → #2232 → #2260 → #2268, each fix creating the conditions for
+  the next report.
+
+## More Information
+
+- Source concern: #2260. Closes the long-standing violation tracked in #1991.
+- Related: #2232 (wire-shaped rows on the DataLayer read path, fixed by
+  ADR-0062), #2268 (the thirteen remaining wire-shadowing types on the write
+  path, not in scope here).
+- ADR-0017 establishes the two-branch hierarchy this decision leans on;
+  ADR-0036 establishes the dimension objects whose flat predecessors the shim
+  keeps alive; ADR-0062 establishes the persistence-boundary normalisation that
+  makes the reject-guards recoverable.
+- No data migration is required: this code has no production deployment and no
+  stale rows exist.
+
+Generated spec requirements: `architecture.yaml` ARCH-20-001 through
+ARCH-20-007; `case-ledger-processing.yaml` CLP-07-009 and CLP-07-010;
+`status-dimension-objects.yaml` SDO-03-005.

--- a/docs/adr/0063-wire-rendering-port-for-core-objects.md
+++ b/docs/adr/0063-wire-rendering-port-for-core-objects.md
@@ -48,12 +48,14 @@ produce the wire's flat `emConsentState` field from the nested `PecDimension`.
 That hand-patch is a partial, drifting reimplementation of
 `as_ParticipantStatus.from_core()`.
 
-Two additional consumers depend on the same core-side aliasing:
+Three additional consumers depend on the same core-side aliasing:
 `_inline_snapshot_reference_value` in `vultron/core/use_cases/_helpers.py`
 (CLP-07-006 inline nesting of `dl.read()` results, which are core objects per
-DL-05-001), and `GET /actors/{id}` in
+DL-05-001); `GET /actors/{id}` in
 `vultron/adapters/driving/fastapi/routers/actors/_routes.py`, which dumps a
-**core** actor class with `by_alias=True` straight into an `AS2JSONResponse`.
+**core** actor class with `by_alias=True` straight into an `AS2JSONResponse`;
+and `vultron/demo/utils.py`, which dumps core objects the same way for demo
+output.
 
 A fifth consumer depends on the *shim* rather than the alias generator:
 `FilterParticipantStatusDimensionsNode._to_core_status` (added by ADR-0061)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -131,6 +131,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0059 Buffer Pre-Genesis `Announce(CaseLedgerEntry)` and Drain on Case Seed](0059-buffer-pre-genesis-ledger-entries.md)
 - [ADR-0061 Adjudicate Received `ParticipantStatus` Per Dimension, Not as a Unit](0061-per-dimension-partial-accept.md)
 - [ADR-0062 Normalise Wire → Core at Ingress, and Enforce It Again at the Persistence Boundary](0062-normalise-wire-to-core-at-both-ingress-and-persistence.md)
+- [ADR-0063 Render Core Objects to Wire JSON Through a Driven Port; Remove `alias_generator` From All Core-Branch Types](0063-wire-rendering-port-for-core-objects.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -279,6 +279,7 @@ nav:
       - Buffer Pre-Genesis Announce(CaseLedgerEntry) and Drain on Case Seed: 'adr/0059-buffer-pre-genesis-ledger-entries.md'
       - Adjudicate Received ParticipantStatus Per Dimension, Not as a Unit: 'adr/0061-per-dimension-partial-accept.md'
       - Normalise Wire to Core at Ingress, and Enforce It Again at the Persistence Boundary: 'adr/0062-normalise-wire-to-core-at-both-ingress-and-persistence.md'
+      - Render Core Objects to Wire JSON Through a Driven Port: 'adr/0063-wire-rendering-port-for-core-objects.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/README.md
+++ b/notes/README.md
@@ -29,7 +29,7 @@ violations, or validating core/wire separation.
 Why core legitimately needs wire-shaped JSON (only for
 `CaseLedgerEntry.payloadSnapshot`), why `alias_generator=to_camel` on core types
 was both an ARCH-12-003 violation and structurally insufficient, and the
-`WireRenderPort` driven seam that replaces it. Lists the four consumers of the
+`WireRenderPort` driven seam that replaces it. Lists the five consumers of the
 old core-side aliasing, the reject-guard that MUST accompany deletion of any
 flat-field shim (SDO-03-005), and why persisted rows are unaffected.
 Normative requirements: `specs/architecture.yaml` ARCH-20,

--- a/notes/README.md
+++ b/notes/README.md
@@ -25,6 +25,19 @@ validate-at-edge / promote-to-core rule (ADR-0032).
 **Load when**: orienting to architecture boundaries, reviewing layering
 violations, or validating core/wire separation.
 
+**`core-wire-rendering-port.md`**
+Why core legitimately needs wire-shaped JSON (only for
+`CaseLedgerEntry.payloadSnapshot`), why `alias_generator=to_camel` on core types
+was both an ARCH-12-003 violation and structurally insufficient, and the
+`WireRenderPort` driven seam that replaces it. Lists the four consumers of the
+old core-side aliasing, the reject-guard that MUST accompany deletion of any
+flat-field shim (SDO-03-005), and why persisted rows are unaffected.
+Normative requirements: `specs/architecture.yaml` ARCH-20,
+`specs/case-ledger-processing.yaml` CLP-07-009/010.
+**Load when**: touching `alias_generator`/`by_alias` anywhere, building or
+reviewing payload snapshots, removing a flat-field migration shim, or adding a
+core→wire projection.
+
 **`domain-validation.md`**
 Strict vs. loose domain object boundary contract: where objects transition from
 loose (wire-deserialized, possibly-None fields) to strict (all required fields

--- a/notes/core-wire-rendering-port.md
+++ b/notes/core-wire-rendering-port.md
@@ -4,7 +4,7 @@ status: active
 description: >
   Why core needs wire-shaped JSON at all, why `alias_generator=to_camel` on core
   types was the wrong way to get it, and the driven-port seam that replaces it.
-  Covers the four consumers of the old core-side aliasing, the reject-guard
+  Covers the five consumers of the old core-side aliasing, the reject-guard
   required before any flat-field shim is deleted, and the failure modes to watch
   for during implementation.
 related_specs:
@@ -106,10 +106,12 @@ CLP-10-005..008 constrain `execute()`. Moving the commit itself into an adapter
 would breach both. If you find yourself designing "a ledger-writing adapter",
 stop and re-read CLP-09.
 
-## The four consumers of the old aliasing
+## The five consumers of the old aliasing
 
-Anyone touching this must account for all four; the first two are in core, the
-last two are outside it and were the surprise.
+Anyone touching this must account for all five. Rows 1, 2 and 5 are in core;
+rows 3 and 4 are outside it and were the surprise. Row 5 depends on the *shim*
+rather than the alias generator, and appeared after the planning baseline — see
+the re-enumeration warning below.
 
 | # | Site | What it did |
 |---|---|---|
@@ -196,6 +198,30 @@ glance like it depends on core-side aliasing. It does not.
 `emConsentState = SIGNATORY` and `embargoAdherence = True`; the *core* dump yields
 `emConsentState = None`. The wire projection is what satisfies the spec, so
 CM-18-006 needs no amendment — and it is evidence for the port, not against it.
+
+## DRPT-02-008 needs no amendment either, and must not be pruned
+
+CONCERN-2260 named DRPT-02-008 alongside CM-18-006 as an interacting
+requirement. It obliges the demo-report extractor to read `pec_state` from
+either the ADR-0036 dimension object (`{"consent": {"state": ...}}`) or any of
+four legacy flat spellings (`emConsentState`, `em_consent_state`,
+`embargoConsentState`, `embargo_consent_state`). Nothing in this work changes
+that, for two reasons:
+
+- The extractor is a **dict reader**, not a model consumer. `_dimension_state`
+  in `vultron/demo/report.py:542-557` walks candidate dicts straight off the
+  `payloadSnapshot`; it never validates through core `ParticipantStatus`. The
+  reject-guards constrain what the *core model* accepts on the way in, so they
+  are invisible to it.
+- The two shapes DRPT-02-008 cares about most both stay reachable. CLP-07-009
+  makes every snapshot wire-shaped, and the wire shape carries the flat
+  `emConsentState` the extractor already handles; the dimension-object form
+  still arrives from core-shaped historical dumps.
+
+So do **not** treat the flat-spelling branches as dead code to delete while
+implementing #2289. Narrowing what the core model accepts is not a licence to
+narrow what a downstream reader tolerates — the extractor parses artefacts of
+unknown vintage, and DRPT-02-008 is still a MUST.
 
 ## Once this lands
 

--- a/notes/core-wire-rendering-port.md
+++ b/notes/core-wire-rendering-port.md
@@ -1,0 +1,215 @@
+---
+title: Core-to-Wire Rendering Port
+status: active
+description: >
+  Why core needs wire-shaped JSON at all, why `alias_generator=to_camel` on core
+  types was the wrong way to get it, and the driven-port seam that replaces it.
+  Covers the four consumers of the old core-side aliasing, the reject-guard
+  required before any flat-field shim is deleted, and the failure modes to watch
+  for during implementation.
+related_specs:
+  - architecture.yaml (ARCH-12-003, ARCH-20)
+  - case-ledger-processing.yaml (CLP-07-001, CLP-07-006, CLP-07-009, CLP-07-010)
+  - status-dimension-objects.yaml (SDO-03-003, SDO-03-005)
+  - datalayer.yaml (DL-05-001)
+related_adrs:
+  - ADR-0017
+  - ADR-0036
+  - ADR-0062
+  - ADR-0063
+---
+
+# Core-to-Wire Rendering Port
+
+Source: CONCERN-2260. Supersedes the known-deviation posture of #1991.
+
+## The legitimate need
+
+Core code needs wire-shaped (AS2 camelCase) JSON in exactly one situation:
+building `CaseLedgerEntry.payloadSnapshot` values.
+
+That is not an accident of implementation. The case ledger wraps *things that
+were received or sent to/from the case manager in the course of managing the
+case*, and those things are by definition wire-shaped. The specs say so
+directly:
+
+- **CLP-07-001** — the snapshot MUST be the verbatim AS2 activity that was
+  asserted, or a deterministic canonical normalization of it.
+- **CLP-01-003 / CLP-01-004** — the ledger is the replication substrate;
+  receivers project entries into their own replica.
+- **CLP-07-006** — nested protocol objects MUST be embedded inline as full
+  objects, not as ID strings requiring an out-of-band lookup.
+
+Put together: a payload snapshot must be valid wire JSON that a receiver can
+reconstitute. camelCase is *correct* there. The mistake was never "core produced
+camelCase"; it was *how*.
+
+## The wrong mechanism, and why it was worse than it looked
+
+Eight `CoreObject` subclasses carried `model_config = ConfigDict(alias_generator=to_camel)`
+so that core could call `model_dump(by_alias=True)`:
+
+`ParticipantStatus`, `CaseStatus`, `VultronPerson`, `VultronOrganization`,
+`VultronService`, `VultronApplication`, `VultronGroup`, `CoreActorCollection`.
+
+This violated ARCH-12-003 (a MUST). Less obviously, **it did not work**. Core and
+wire `ParticipantStatus` differ *structurally*, not just by spelling: core nests
+`consent: PecDimension`, the wire shape carries a flat `emConsentState`. An alias
+generator cannot bridge that, so `build_add_participant_status_snapshot` in
+`vultron/core/behaviors/case/ledger_snapshots.py` hand-patched the dumped dict:
+
+```python
+if "consent" in status_dict and "emConsentState" not in status_dict:
+    pec_state = status_dict.pop("consent", {}).get("state")
+    if pec_state is not None:
+        status_dict["emConsentState"] = pec_state
+```
+
+That is a partial reimplementation of `as_ParticipantStatus.from_core()` living
+in core, covering one field of one type. Every *other* nested type was inlined in
+whatever shape its core class happened to dump — so CLP-07-006 inlining was
+silently unreconstitutable for anything that was not one of the eight aliased
+classes.
+
+The lesson generalises: **when a core-side mechanism needs a per-field patch to
+reach the wire shape, the mechanism is in the wrong layer.** The wire branch
+already owns the authoritative projection (`from_core()`); anything that
+duplicates part of it will drift.
+
+## The seam
+
+A driven port, per ARCH-01-004 and the `SyncActivityPort` precedent.
+
+- **Port**: `vultron/core/ports/wire_render.py`, a `typing.Protocol` with
+  `render(obj) -> dict[str, Any]`.
+- **Adapter**: `vultron/adapters/driven/wire_render/as2.py` — looks the core
+  `type_` up in the wire vocabulary, calls that class's `from_core()`, dumps with
+  `by_alias=True, exclude_none=True`.
+- **Injection**: a `wire_render_port` parameter on `BTBridge.__init__`, published
+  to the blackboard under `wire_render_port`, exactly as `sync_port` is
+  (`vultron/core/behaviors/bridge.py:107,185-190`).
+
+`render()` **raises `VultronValidationError`** when no wire counterpart exists
+(ARCH-20-003). Do not add a core-shaped fallback: a snapshot that is silently
+core-shaped is indistinguishable from a correct one at the call site, and is
+exactly what CLP-07-009 exists to prevent.
+
+The port is deliberately not ledger-specific. Emitters, sync fan-out, and the
+AS2 HTTP routes all need the same rendering.
+
+### What did *not* move
+
+Only *rendering* moves behind the port. The canonical commit stays in the
+role-gated `CommitCaseLedgerEntryNode`: **CLP-09-002** forbids bare canonical
+commits from any production call site outside the guarded composition, and
+CLP-10-005..008 constrain `execute()`. Moving the commit itself into an adapter
+would breach both. If you find yourself designing "a ledger-writing adapter",
+stop and re-read CLP-09.
+
+## The four consumers of the old aliasing
+
+Anyone touching this must account for all four; the first two are in core, the
+last two are outside it and were the surprise.
+
+| # | Site | What it did |
+|---|---|---|
+| 1 | `core/behaviors/case/ledger_snapshots.py` (`obj_to_inline_dict`, `build_add_participant_status_snapshot`) | Dumped core objects `by_alias=True` for CaseActor-synthesized bootstrap snapshots; hand-patched `consent` → `emConsentState`. Only caller is `case_proposal_received_tree.py`. |
+| 2 | `core/use_cases/_helpers.py` (`_inline_snapshot_reference_value`) | Dumped `dl.read()` results `by_alias=True` for CLP-07-006 inlining. `dl.read()` returns **core** objects per DL-05-001, so the alias generator was doing the wire projection here too. |
+| 3 | `adapters/driving/fastapi/routers/actors/_routes.py` (`get_actor`, siblings) | `AS2JSONResponse(cls.model_validate(data).model_dump(mode="json", by_alias=True, exclude_none=True))` where `cls` is a **core** actor class — so core aliases shaped an externally-visible AS2 actor document. Must route through `as_*` classes (ARCH-20-006). |
+| 4 | `vultron/demo/utils.py` | Same pattern, demo-only. |
+| 5 | `core/behaviors/status/nodes/dimension_filter.py` (`_to_core_status`) | **Depends on the shim, not the alias generator.** Dumps a wire status `by_alias=True` and revalidates it through core `ParticipantStatus`, relying on `_migrate_flat_fields` to accept flat `rmState`. Its own docstring says so. Must become `to_core()` (ARCH-20-007). Added by ADR-0061, so it post-dates CONCERN-2260 — re-enumerate before implementing. |
+
+Two further sites hand-write camelCase into snapshot dicts, the same
+anti-pattern as the `consent` → `emConsentState` patch and equally covered by
+CLP-07-010:
+
+- `core/behaviors/status/nodes/dimension_filter.py` `_build_patch` —
+  `patch["caseStatus"] = {"emState": ..., "pxaState": ...}`
+- `core/behaviors/case/nodes/accept_invite.py` `_build_snapshot` — a
+  hand-built `{"type": "Add", ...}` fallback dict in the `else` branch
+
+The pattern replicates: each new snapshot-producing site reinvents a little
+wire spelling. That is the argument for the port, and it is why the fix has to
+land in one pass rather than site by site.
+
+> **Before implementing, re-run the enumeration.** `grep -rn 'by_alias=True'
+> vultron/core/` and check each hit's subject. Sites that dump an
+> *already-wire* object (a received `request.activity`, a reconstituted
+> `create_activity`, `raw_proposal`) are fine and out of scope — ARCH-20-001 is
+> deliberately scoped to core-*branch* objects for exactly this reason. The
+> list above was accurate at ADR-0061; this area is under active change.
+
+Also vestigial: `CoreActor.to_json()` (`core/models/actor.py:76-77`) dumps
+`by_alias=True` and has no callers in `vultron/`. Delete it — an
+always-available bypass of the port seam will be picked up by the next agent who
+needs camelCase (ARCH-20-005).
+
+`build_activity_payload_snapshot` in `core/use_cases/_helpers.py` is **not** in
+this list and should be left alone: it captures a received activity verbatim
+(CLP-07-001) by duck-typing, so core needs no wire import and no rendering. It
+is the model the rest of the snapshot path should converge toward — synthesis is
+only needed where there is no received activity to capture, i.e. case-proposal
+bootstrap.
+
+## Deleting a flat-field shim: the guard is mandatory
+
+`ParticipantStatus._migrate_flat_fields` accepts `rm_state`/`rmState`,
+`vfd_state`/`vfdState`, `em_consent_state`/`emConsentState` and rewrites them
+into the ADR-0036 dimension objects. It violates **SDO-03-003** ("MUST NOT be
+retained as aliases or shim properties") independently of ARCH-12-003, so it has
+to go.
+
+**Do not delete it on its own.** Pydantic v2 defaults to `extra="ignore"`, so a
+flat `rm_state` key would then be *silently discarded* and `rm.state` would
+default to `RM.START` — a whole RM ladder lost with no error. That is the #2232
+defect class and an ARCH-15-001/ARCH-15-002 violation. This is codified as
+**SDO-03-005**.
+
+The guard mechanism already exists: `reject_wire_spelled_keys` in
+`vultron/core/models/_wire_spelling.py`, used by
+`CaseParticipant._reject_wire_spelled_keys`. Extend it to cover the retired flat
+field names, then add a `model_validator(mode="before")` to each de-aliased
+class.
+
+Raising is safe on the read path: `VultronValidationError` is already caught by
+`DataLayer._from_row`, which falls back to `_wire_object_from_row` →
+`_project_wire_row_to_core` → `to_core()` (ADR-0062, commit `b4406b2b`). A
+wire-shaped row still reads back with the correct core shape.
+
+## Persisted rows are not affected
+
+`Record.from_obj` calls `obj.model_dump(mode="json", serialize_as_any=True)` —
+**no `by_alias`** (`vultron/adapters/driven/db_record.py:367-369`). Persisted
+rows are therefore already snake_case. Removing `alias_generator` does not change
+the persisted key shape and implies **no persistence-schema migration**.
+
+CONCERN-2260 was filed on the assumption that it would, and that assumption is
+false. If you are re-deriving this, verify it the same way rather than trusting
+either the issue or this note: dump `Record.from_obj(ParticipantStatus(...)).data_`
+and look at the keys.
+
+## Do not re-read CM-18-006 as requiring the core alias
+
+CM-18-006 constrains the consent/`emConsentState` relationship and looks at first
+glance like it depends on core-side aliasing. It does not.
+`as_ParticipantStatus.from_core(core).model_dump(by_alias=True)` yields
+`emConsentState = SIGNATORY` and `embargoAdherence = True`; the *core* dump yields
+`emConsentState = None`. The wire projection is what satisfies the spec, so
+CM-18-006 needs no amendment — and it is evidence for the port, not against it.
+
+## Once this lands
+
+- The `xfail(strict=False)` on `test_no_core_object_has_to_camel_alias_generator`
+  in `test/architecture/test_hierarchy_invariants.py` becomes a plain passing
+  assertion, and **#1991 closes**.
+- The known-deviation paragraph in `CaseParticipant._reject_wire_spelled_keys`'s
+  docstring must be rewritten. It currently says, correctly for today, "Do not
+  restate ARCH-12-003 as though it held throughout this subtree; it does not
+  yet." After this work it *does*, and the nested `ParticipantStatus` no longer
+  accepts `rmState`.
+- `VultronPerson`'s docstring claim that it is 'Registered in
+  `VOCABULARY["Person"]`' is stale — the six core actor classes are in
+  `CORE_VOCABULARY` only. Fix it while you are in the file.
+- **#2268** (thirteen remaining wire-shadowing types on the write path) stays
+  tracked separately. It is the same family of defect but a different set of
+  types, and `_NORMALIZE_WIRE_TO_CORE` in `db_record.py` is its seam.

--- a/plan/history/2608/learning/CONCERN-2260.md
+++ b/plan/history/2608/learning/CONCERN-2260.md
@@ -8,7 +8,7 @@ type: learning
 
 Docs PR: <https://github.com/CERTCC/Vultron/pull/2285>
 ADR: ADR-0063
-Impl chain: #2286 → #2287 / #2288 → #2289 (Epic #2229)
+Impl chain: #2286 → #2287 / #2288 → #2289 (Epic #2222)
 
 ## What the concern claimed, and what was actually true
 

--- a/plan/history/2608/learning/CONCERN-2260.md
+++ b/plan/history/2608/learning/CONCERN-2260.md
@@ -1,0 +1,110 @@
+---
+source: CONCERN-2260
+timestamp: '2026-08-13T14:17:54.375897+00:00'
+title: 'Core ParticipantStatus wire concerns: rendering belongs behind a port, not
+  on the model'
+type: learning
+---
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2285>
+ADR: ADR-0063
+Impl chain: #2286 → #2287 / #2288 → #2289 (Epic #2229)
+
+## What the concern claimed, and what was actually true
+
+CONCERN-2260 flagged two things on core `ParticipantStatus`: `alias_generator=to_camel`
+(an ARCH-12-003 violation) and a `_migrate_flat_fields` validator accepting flat wire
+spellings. It asked for a migration plan covering the canonical persisted key shape and
+the legacy-row read path.
+
+**The stated blocker was false.** `Record.from_obj` calls
+`model_dump(mode="json", serialize_as_any=True)` with **no** `by_alias`
+(`vultron/adapters/driven/db_record.py:367-369`), so persisted rows are already
+snake_case. Removing `alias_generator` does not change the persisted key shape and
+implies no persistence-schema migration. Verified by dumping
+`Record.from_obj(ParticipantStatus(...)).data_` and inspecting the keys. Combined with
+"no stale data exists — nobody uses this code in prod yet", the entire legacy-row
+question dissolved.
+
+Generalisable: **when an issue states a blocker, check whether the blocker exists before
+planning around it.** Two of this concern's three questions were answered by one
+`model_dump` call. The plan that would have been written from the issue text as given
+(persisted-shape decision + legacy-row migration path) would have been mostly wasted
+work.
+
+## The actual defect was the opposite of the one reported
+
+The concern framed `alias_generator` as an over-permissive core model. The real problem
+is that it is **insufficient**: core and wire `ParticipantStatus` differ *structurally*
+(core nests `consent: PecDimension`, wire carries a flat `emConsentState`), so an alias
+generator cannot bridge them. `build_add_participant_status_snapshot` therefore
+hand-patched the dumped dict — a partial reimplementation of
+`as_ParticipantStatus.from_core()` living in core, covering one field of one type.
+
+The tell was findable by asking what the mechanism was *for* rather than whether it was
+*allowed*: a layering rule cited a violation, but the hand-patch next to it showed the
+mechanism didn't even work. **A workaround that needs per-field special-casing to reach
+its goal is evidence the capability is in the wrong layer, not that the rule is wrong.**
+
+The pattern had also replicated: `dimension_filter._build_patch` writes
+`patch["caseStatus"] = {"emState": ..., "pxaState": ...}` and
+`accept_invite._build_snapshot` hand-builds a wire-spelled fallback dict. Three sites
+independently reinvented a little wire spelling.
+
+## Reframing by asking what the artefact is FOR
+
+The decisive move in the interview was not resolving "may core import wire?" but
+answering "what are case ledger entries FOR?". Grounding in CLP-07-001 (payloadSnapshot
+MUST be the verbatim AS2 activity or a deterministic canonical normalization),
+CLP-01-003/004 (the ledger is the replication substrate) and CLP-07-006 (nested objects
+inline as full objects) established that snapshots are outward-facing wire contracts for
+receiver replay. camelCase is *correct* there — which makes rendering a wire-layer
+responsibility, and the import question a detail rather than the crux.
+
+The candidate design that did *not* survive this reframing was moving ledger **writing**
+behind a port. CLP-09-002 forbids bare canonical commits from any production call site
+outside the guarded composition, and CLP-10-005..008 constrain `execute()`. So only entry
+*rendering* moves; the role-gated commit stays in `CommitCaseLedgerEntryNode`. **Checking
+a proposed seam against the authorization specs before committing to it prevented an ADR
+that would have contradicted CLP-09.**
+
+## Removing a shim without a guard is a silent data-loss bug
+
+Deleting `_migrate_flat_fields` alone would make a flat `rm_state` key *silently
+discarded* (`extra="ignore"` is the Pydantic default) and `rm.state` default to
+`RM.START` — a whole RM ladder lost with no error. Codified as SDO-03-005, and as an
+AGENTS.md pitfall.
+
+A methodological note: the first attempt to test this simulated shim removal by
+subclassing `ParticipantStatus` and assigning the validator to a no-op. It still returned
+`RM.RECEIVED`, because Pydantic registers validators in `__pydantic_decorators__` and
+attribute patching does not disable them. **Patching a Pydantic validator by attribute
+assignment silently does nothing** — the inconclusive result looked like a passing
+result. Testing the underlying mechanism instead (confirm `extra` is `ignore`, confirm a
+bogus key is accepted) gave the real answer.
+
+## Re-enumerate against current main before finalising
+
+`ADR-0061` (per-dimension ParticipantStatus adjudication) landed after the planning
+baseline was taken, and its new `_to_core_status` helper **explicitly depends on the
+shim** — its docstring says "the core model's `_migrate_flat_fields` validator accepts
+that shape, so a dump-and-revalidate normalises both". A fifth consumer appeared mid-plan
+in an area under active change. Caught only by re-running `grep -rn 'by_alias=True'
+vultron/core/` after the branch was freshened, before opening the PR. Captured as
+ARCH-20-007 (no dump-and-revalidate normalisation).
+
+The same re-enumeration corrected a spec entry that was about to ship wrong: the original
+ARCH-20-001 verification said "no module under `vultron/core/` passes `by_alias=True`",
+which is unsatisfiable — core legitimately dumps already-wire objects on the
+verbatim-capture path. **Scoping a MUST to the property you actually mean (core-*branch*
+objects) matters; an unsatisfiable verification criterion gets ratcheted, and this whole
+concern is what a ratchet costs after two years.**
+
+## Scoping decision
+
+The user's instruction was "fix it all in one go. yes it's big, but piecemeal stuff has
+led us into issue propagation hell" — this area generated #1991 → #2232 → #2260 → #2268,
+each fix creating the conditions for the next report. The plan does the comprehensive
+version (all 8 classes, port + adapter, all rendering sites, #1991 closed) decomposed
+into four *ordered, individually-mergeable* steps rather than one giant PR or four
+independent ones. Each step leaves main working; the chain must complete.

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -197,8 +197,19 @@ groups:
     statement: 'The core branch MAY narrow inherited fields via Pydantic validators (e.g., `NonEmptyString | None`, required
       `datetime`). Core-branch types MUST NOT carry wire-specific concerns: `alias_generator=to_camel`, hardcoded AS2 `@context`
       namespace, or VOCABULARY registration are forbidden in core-branch types.'
-    verification: '`CoreObject` and its subclasses do not reference `to_camel` or assign to `VOCABULARY`. Confirmed by the
-      layer-boundary test in `test/architecture/test_layer_boundaries.py`.'
+    verification: 'No `CoreObject` subclass declares `alias_generator` in its `model_config`, references `to_camel`, or assigns
+      to `VOCABULARY`. Confirmed by `test_no_core_object_has_to_camel_alias_generator` in `test/architecture/test_hierarchy_invariants.py`
+      (which MUST NOT be marked `xfail`) and by the layer-boundary test in `test/architecture/test_layer_boundaries.py`.'
+    rationale: 'An `alias_generator` on a core type gives one `type_` two accepted key spellings, so whichever class reads a
+      row decides what the data means (issue #2232). It is also insufficient for its intended purpose: a core `model_dump(by_alias=True)`
+      cannot produce the wire shape for a type whose branches differ structurally, which is why a hand-patched `consent`→`emConsentState`
+      rewrite accumulated in core. Core→wire rendering belongs behind the ARCH-20 driven port.'
+    relationships:
+    - rel_type: depends_on
+      spec_id: ARCH-20-001
+      note: ARCH-20 supplies the driven port that replaces the core-side aliasing this requirement forbids.
+    adr:
+    - ADR-0063
   - id: ARCH-12-004
     priority: MUST
     kind: project
@@ -551,3 +562,121 @@ groups:
       spec_id: ARCH-19-001
     adr:
     - ADR-0019
+- id: ARCH-20
+  title: Core-to-Wire Rendering Port
+  description: Governs how core domain objects are rendered into wire-shaped (AS2 camelCase) JSON. Core legitimately needs
+    a wire representation in one place — the `CaseLedgerEntry.payloadSnapshot`, which CLP-07-001 requires to be receiver-reconstitutable
+    AS2 — but producing it by setting `alias_generator=to_camel` on the core type violates ARCH-12-003 and cannot express
+    structural differences between the two branches. This group establishes a driven port as the single rendering seam.
+  rationale: 'Eight `CoreObject` subclasses carried `alias_generator=to_camel` (issue #1991) solely so that core code could
+    call `model_dump(by_alias=True)` when building ledger payload snapshots. The mechanism was both a layer violation and
+    inadequate: `ParticipantStatus` nests `consent: PecDimension` where the wire shape carries a flat `emConsentState`, so
+    core had to hand-patch the dumped dict — a partial, drifting reimplementation of `as_ParticipantStatus.from_core()`. ARCH-01-004
+    prescribes driven ports as the remediation for core→wire needs. See ADR-0063.'
+  specs:
+  - id: ARCH-20-001
+    priority: MUST
+    kind: architecture
+    statement: Core code that requires a wire-shaped representation of a **core-branch** object MUST obtain it through a driven
+      port declared in `vultron/core/ports/`. Core MUST NOT produce that shape itself, whether by declaring an `alias_generator`
+      on the core class, by calling `model_dump(by_alias=True)` on a core-branch instance, or by rewriting dumped keys into
+      wire spellings. Dumping an already-wire-shaped object that core holds (e.g. a received activity being captured verbatim
+      per CLP-07-001) is unaffected by this requirement.
+    rationale: A single rendering seam keeps every fact about wire spelling (camelCase, flat `emConsentState`, the AS2 `@context`)
+      in the wire layer, where the authoritative `from_core()` projections already live. The requirement is scoped to core-branch
+      objects because core legitimately handles wire objects on the verbatim-capture path; conflating the two would make this
+      requirement unverifiable.
+    verification: No `CoreObject` subclass declares an `alias_generator` (enforced by `test_no_core_object_has_to_camel_alias_generator`),
+      so a `by_alias=True` dump of a core-branch instance can no longer yield wire spelling. Each remaining `by_alias=True`
+      call site under `vultron/core/` is additionally reviewed to confirm its subject is a wire object, and annotated as such.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-01-004
+    adr:
+    - ADR-0063
+  - id: ARCH-20-002
+    priority: MUST
+    kind: project
+    statement: The rendering port's adapter MUST produce its output by locating the core object's wire counterpart in the wire
+      vocabulary and invoking that class's `from_core()` projection, then serialising with `by_alias=True`. The adapter MUST
+      NOT reimplement field-name translation.
+    rationale: '`from_core()` is the authoritative projection and already handles structural differences (nested `PecDimension`
+      → flat `emConsentState`). Any second translation path will drift from it, which is the defect ADR-0063 removes.'
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-20-001
+    adr:
+    - ADR-0063
+  - id: ARCH-20-003
+    priority: MUST
+    kind: project
+    statement: When no wire counterpart exists for the supplied core object, the rendering port MUST raise `VultronValidationError`.
+      It MUST NOT fall back to a core-shaped `model_dump`, return `None`, or emit a partially-rendered object.
+    rationale: A silently core-shaped payload snapshot is unreconstitutable by receivers (CLP-07-001) and is indistinguishable
+      from a correct one at the call site. Failing loudly is required by ARCH-15-002.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-15-002
+    adr:
+    - ADR-0063
+  - id: ARCH-20-004
+    priority: MUST
+    kind: project
+    statement: The rendering port MUST be injected into behavior-tree execution using the established mechanism — a constructor
+      parameter on `BTBridge` published to the blackboard under a named key — in the same manner as `sync_port`. BT nodes and
+      use-case helpers MUST NOT import an adapter directly or instantiate a default renderer.
+    rationale: Consistency with `SyncActivityPort` keeps one injection idiom for driven ports. An import-time default would
+      reintroduce the core→wire import the port exists to prevent (ARCH-01-001).
+    relationships:
+    - rel_type: depends_on
+      spec_id: ARCH-20-001
+    adr:
+    - ADR-0063
+  - id: ARCH-20-005
+    priority: MUST
+    kind: project
+    statement: Core-branch types MUST NOT declare a `to_json()`, `to_wire()`, or similarly-named method that emits wire-shaped
+      output. Rendering is the port's responsibility, not a method on the domain object.
+    rationale: '`CoreActor.to_json()` dumped with `by_alias=True` and had no callers; such a method is an always-available
+      bypass of the port seam and will be picked up by the next agent that needs camelCase.'
+    verification: No class under `vultron/core/models/` defines a method that calls `model_dump`/`model_dump_json` with `by_alias=True`.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-20-001
+    adr:
+    - ADR-0063
+  - id: ARCH-20-006
+    priority: MUST
+    kind: project
+    statement: Driving adapters that serve AS2 documents over HTTP (e.g. `GET /actors/{id}`) MUST render the response from
+      the corresponding `as_*` wire class. They MUST NOT dump a core-branch class with `by_alias=True` to synthesise an AS2
+      document.
+    rationale: The actor routes relied on the core actor classes' `alias_generator` to shape their external AS2 output, which
+      is why removing that generator has an externally-visible blast radius. Routing through `as_*` classes makes the external
+      contract depend on the wire layer that defines it.
+    verification: The actor router constructs responses via wire vocabulary classes; no `by_alias=True` dump of a `CoreObject`
+      subclass appears in `vultron/adapters/driving/`.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-20-001
+    adr:
+    - ADR-0063
+  - id: ARCH-20-007
+    priority: MUST_NOT
+    kind: project
+    statement: Core code MUST NOT normalise a wire object into its core counterpart by dumping it with `by_alias=True` and
+      revalidating through the core class ("dump-and-revalidate"). Wire→core conversion MUST use the wire class's `to_core()`
+      boundary projection, or the object MUST be obtained already-normalised from the DataLayer port (DL-05-001).
+    rationale: 'Dump-and-revalidate only works while the core class tolerates wire spellings — precisely the ARCH-12-003 violation
+      being removed. `FilterParticipantStatusDimensionsNode._to_core_status` documents this dependency explicitly ("The core
+      model''s `_migrate_flat_fields` validator accepts that shape, so a dump-and-revalidate normalises both"), so the shim
+      and this idiom must be retired together. It is also lossy in the general case: a core class that ignores an unknown key
+      silently discards it.'
+    verification: No module under `vultron/core/` constructs a core model via `CoreClass.model_validate(wire_obj.model_dump(by_alias=True, ...))`.
+    relationships:
+    - rel_type: depends_on
+      spec_id: ARCH-20-001
+    - rel_type: refines
+      spec_id: SDO-03-005
+    adr:
+    - ADR-0063

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -198,8 +198,8 @@ groups:
       `datetime`). Core-branch types MUST NOT carry wire-specific concerns: `alias_generator=to_camel`, hardcoded AS2 `@context`
       namespace, or VOCABULARY registration are forbidden in core-branch types.'
     verification: 'No `CoreObject` subclass declares `alias_generator` in its `model_config`, references `to_camel`, or assigns
-      to `VOCABULARY`. Confirmed by `test_no_core_object_has_to_camel_alias_generator` in `test/architecture/test_hierarchy_invariants.py`
-      (which MUST NOT be marked `xfail`) and by the layer-boundary test in `test/architecture/test_layer_boundaries.py`.'
+      to `VOCABULARY`. Confirmed by `test_no_core_object_has_to_camel_alias_generator` in `test/architecture/test_hierarchy_invariants.py`,
+      which MUST NOT be marked `xfail`.'
     rationale: 'An `alias_generator` on a core type gives one `type_` two accepted key spellings, so whichever class reads a
       row decides what the data means (issue #2232). It is also insufficient for its intended purpose: a core `model_dump(by_alias=True)`
       cannot produce the wire shape for a type whose branches differ structurally, which is why a hand-patched `consent`→`emConsentState`

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -219,6 +219,41 @@ groups:
       entry MUST be rejected rather than inlining cross-case data.
     rationale: Blind `dl.read(id)` replacement can leak unrelated local objects into canonical snapshots when inbound activities
       carry attacker-controlled IDs.
+  - id: CLP-07-009
+    priority: MUST
+    kind: project
+    statement: A `payloadSnapshot` — and every object inlined into one under CLP-07-006 — MUST be in the wire (AS2) shape,
+      such that the wire vocabulary class for its `type_` can revalidate it without translation. When the object being captured
+      is a core domain object rather than a received activity, the wire shape MUST be produced through the core→wire rendering
+      port (ARCH-20-001), never by dumping the core object with `by_alias=True` or by rewriting dumped keys in core.
+    rationale: 'CLP-07-001 requires the snapshot to be reconstitutable by receivers, and CLP-01-003/CLP-01-004 make it the
+      replication substrate. Two distinct failure modes existed: core objects with no `alias_generator` were inlined in snake_case
+      (unreconstitutable), and `ParticipantStatus` was dumped with a core `by_alias=True` that cannot produce the wire''s flat
+      `emConsentState`, so core hand-patched the dict afterwards. Both are removed by routing through the rendering port.'
+    verification: For each canonical entry produced by the test suite, `payloadSnapshot` and each inlined nested object revalidate
+      through their wire vocabulary class via `model_validate`, with no key renaming applied first.
+    relationships:
+    - rel_type: refines
+      spec_id: CLP-07-001
+    - rel_type: depends_on
+      spec_id: ARCH-20-001
+    adr:
+    - ADR-0063
+  - id: CLP-07-010
+    priority: MUST_NOT
+    kind: project
+    statement: Core snapshot-construction code MUST NOT special-case individual field names to reach the wire spelling (e.g.
+      moving a nested `consent.state` to a flat `emConsentState`). Structural differences between the core and wire shapes
+      are the responsibility of the wire class's `from_core()` projection.
+    rationale: A per-field patch in core is a partial reimplementation of `from_core()` that drifts as either shape evolves,
+      and it is invisible to the wire layer's own round-trip tests. Each such patch also silently defines the canonical shape
+      for exactly one type, leaving every other nested type unhandled.
+    verification: No module under `vultron/core/` assigns a camelCase key into a snapshot dict.
+    relationships:
+    - rel_type: refines
+      spec_id: CLP-07-009
+    adr:
+    - ADR-0063
 - id: CLP-08
   title: Per-Case Genesis Hash Derivation and Origin Binding
   specs:

--- a/specs/status-dimension-objects.yaml
+++ b/specs/status-dimension-objects.yaml
@@ -134,6 +134,28 @@ groups:
     adr:
     - ADR-0033
     - ADR-0036
+  - id: SDO-03-005
+    priority: MUST
+    kind: project
+    statement: Because unknown keys are ignored by default in Pydantic v2, removing a flat-field migration shim from `CaseStatus`
+      or `ParticipantStatus` MUST be accompanied by a `model_validator(mode="before")` that raises `VultronValidationError`
+      when a retired flat key (`rm_state`/`rmState`, `vfd_state`/`vfdState`, `em_consent_state`/`emConsentState`, `em_state`/`emState`,
+      `pxa_state`/`pxaState`) is present. Deleting the shim without such a guard is prohibited.
+    rationale: 'With `extra="ignore"`, a flat `rm_state` key would be silently discarded and `rm.state` would default to `RM.START`
+      — a whole RM ladder lost with no error, which is the defect class of issue #2232 and a violation of ARCH-15-001/ARCH-15-002.
+      The guard converts the loss into a loud failure that `DataLayer._from_row` already catches and recovers via the wire→core
+      projection path (ADR-0062).'
+    verification: '`ParticipantStatus.model_validate({"rm_state": "RECEIVED"})` and the camelCase equivalent both raise `VultronValidationError`;
+      neither yields a model whose `rm.state` is `RM.START`.'
+    relationships:
+    - rel_type: depends_on
+      spec_id: SDO-03-003
+      note: SDO-03-003 requires the shims to go; this requirement constrains how they are removed safely.
+    - rel_type: refines
+      spec_id: ARCH-15-002
+    adr:
+    - ADR-0062
+    - ADR-0063
 - id: SDO-04
   title: Wire Projection and Migration Scope
   specs:


### PR DESCRIPTION
- Closes #2260

## Summary

Plans the remediation of the ARCH-12-003 violation flagged by CONCERN-2260: eight `CoreObject` subclasses carry `alias_generator=to_camel`, and `ParticipantStatus` additionally carries a `_migrate_flat_fields` shim that accepts flat wire spellings in violation of SDO-03-003. The plan replaces core-side aliasing with a driven core→wire rendering port, and fixes all of it in one pass rather than incrementally.

Two findings during planning reshaped the problem:

- **The concern's stated blocker is false.** `Record.from_obj` calls `model_dump(mode="json", serialize_as_any=True)` with **no** `by_alias`, so persisted rows are already snake_case. Removing `alias_generator` does not change the persisted key shape and implies **no persistence-schema migration**.
- **The core alias never actually produced the wire shape.** Core and wire `ParticipantStatus` differ structurally (nested `consent: PecDimension` vs flat `emConsentState`), so `build_add_participant_status_snapshot` hand-patches the dumped dict — a partial, drifting reimplementation of `as_ParticipantStatus.from_core()`. Two further sites hand-write camelCase the same way. That is why the mechanism is being replaced rather than sanctioned.

Core's need for wire JSON is real but narrow: `CaseLedgerEntry.payloadSnapshot` must be receiver-reconstitutable AS2 (CLP-07-001, CLP-01-003/004). That makes rendering a wire-layer responsibility reached through a port, per ARCH-01-004.

## Changes

- **`docs/adr/0063-wire-rendering-port-for-core-objects.md`** (new): the decision. `WireRenderPort` driven port + AS2 adapter that delegates to `from_core()`; `alias_generator` removed from all eight classes; `_migrate_flat_fields` deleted behind a rejecting guard; actor HTTP routes moved onto `as_*` projections; the `xfail` ratchet retired. Records the three rejected alternatives (amend ARCH-12-003; let core import wire; narrow fix). Notes that the canonical commit does **not** move — CLP-09-002 forbids bare commits, so only entry *rendering* goes behind the port.
- **`specs/architecture.yaml`**: new **ARCH-20** group (7 requirements) governing the rendering port — port location, `from_core()` delegation, fail-loud on missing counterpart, `BTBridge` injection, no `to_json()` on core types, `as_*`-rendered AS2 HTTP responses, and no dump-and-revalidate normalisation. ARCH-12-003's `verification` corrected: it cited `test_layer_boundaries.py`, but the actual check lives in `test_hierarchy_invariants.py`.
- **`specs/case-ledger-processing.yaml`**: **CLP-07-009** (payload snapshots and CLP-07-006-inlined objects MUST be wire-shaped and rendered through the port) and **CLP-07-010** (no per-field camelCase hand-patching in core).
- **`specs/status-dimension-objects.yaml`**: **SDO-03-005** — a flat-field shim MUST NOT be deleted without a rejecting validator. With `extra="ignore"`, removal alone makes `rm_state` *silently dropped* and `rm.state` default to `RM.START`: the #2232 defect class.
- **`notes/core-wire-rendering-port.md`** (new): implementation guidance — the five consumers of the old aliasing, the mandatory reject-guard, why persisted rows are unaffected, why CM-18-006 needs no amendment, and an instruction to re-enumerate `by_alias` sites before starting because this area is under active change.
- **`AGENTS.md`**: two Common Pitfalls entries (never reach for `alias_generator`/`by_alias` in core; deleting a wire-spelling shim without a reject-guard is silent data loss).
- **`docs/adr/index.md`**, **`mkdocs.yml`**, **`notes/README.md`**: index and nav entries.

## Notes for reviewers

- `ADR-0061` landed on `main` after the planning baseline, and its new `_to_core_status` helper **explicitly depends on the shim** ("the core model's `_migrate_flat_fields` validator accepts that shape, so a dump-and-revalidate normalises both"). It is a fifth consumer that must convert to `to_core()` in the same change — captured as ARCH-20-007.
- ARCH-20-001 is deliberately scoped to core-**branch** objects. Core legitimately dumps already-wire objects `by_alias=True` on the verbatim-capture path, so a blanket "no `by_alias` in core" rule would be unsatisfiable for reasons outside this work.
- #1991 tracks the same eight classes and is resolved by this chain, but is **not** closed by this docs PR — it closes when the implementation lands.
- #2268 (thirteen remaining wire-shadowing types on the write path) stays tracked separately.


## Implementation Issues

Ordered chain under Epic #2222 (*Enforce the wire/domain/persistence layer boundary*, `Schedule=Next`), which already tracked #1991 directly. Each step is individually safe to merge, but the chain must complete — stopping partway leaves the ratchet in place and #1991 open, which is the failure mode #2260 was filed about.

1. #2286 — Introduce `WireRenderPort` driven port and AS2 rendering adapter (`size:M`, additive)
2. #2287 — Route all payload-snapshot rendering through the port; delete core camelCase hand-patches (`size:L`, blocked by #2286)
3. #2288 — Remove `alias_generator` from the six core actor classes; render actor AS2 responses from `as_*` types (`size:M`, blocked by #2286; independent of #2289)
4. #2289 — Remove `alias_generator` from `ParticipantStatus`/`CaseStatus`, delete the flat-field shim behind reject-guards, retire the #1991 ratchet (`size:L`, blocked by #2286 and #2287) — **closes #1991**

## Incidental

- **`.agents/skills/archive-history/SKILL.md`**: history entries are **immutable once merged into `main`**, not once pushed. The old wording (`immutable once pushed`, plus `immutable once committed` in the intro) froze an entry the moment it left the machine, so a fact that went stale on an unmerged branch could not be corrected in place — the only sanctioned remedy was a second entry restating the first. That surfaced here: the CONCERN-2260 learning entry named the wrong parent epic and was already pushed. Pre-merge, an entry is ordinary working-branch content; the post-merge rule (correct the record with a new entry, never edit the old one) is unchanged. `.claude/skills` is a symlink to `.agents/skills`, so this is one file.
- **`plan/history/2608/learning/CONCERN-2260.md`**: corrected the epic pointer to #2222 under that clarified rule.

