### PR TITLE
fix: update_participant_rm_state reads live DL record via actor_participant_index (#2233)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,9 +268,15 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   all matching functions before commit.
 - **Case-Actor Broadcast Guard Tests Need a Third Participant** — include at
   least one non-sender peer or the assertion is vacuous.
-- **Case Participant Lookup**: `case_participants` is authoritative; check
-  `actor_participant_index` first (fast path), fall back to `case_participants`.
-  Fail only on contradictions, not cache misses.
+- **Case Participant Lookup**: `actor_participant_index` is the authoritative fast
+  path. Two lookup patterns exist — pick by context:
+  - **RM state mutation** (`update_participant_rm_state`): MUST use
+    `actor_participant_index → dl.read()` exclusively (CM-19-003). Never read
+    inline objects from `case_participants`; they may be stale snapshots (#2233).
+  - **BT-level resolution** (`FindParticipantByActorIdNode`): check
+    `actor_participant_index` first; fall back to `case_participants` scan for
+    bootstrap compatibility. Fail only on index↔scan contradictions, not cache
+    misses.
 - **Orphan Module Cleanup Requires Importer Proof** — verify no live importers
   in `vultron/` and `test/` before deleting.
 - **Worktree Sync Checks Need Ancestry Verification** — use `ensure-synced`

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -111,19 +111,13 @@ No open entries.
 |---|---|---|
 | `fvcv-extension` | — | 2026-07-31 |
 | `fccv-extension` | — | 2026-07-31 |
-| `fcvcv Demo Integration` | #2233 (was #2216, closed) | 2026-08-13 |
-| `fvcv-handoff Demo Integration` | #2233 (was #2216, closed) | 2026-08-13 |
-| `fvcv-handoff Invariant Harness` | #2233 (was #2216, closed) | 2026-08-13 |
-| `fcvcv Invariant Harness` | #2233 | 2026-08-13 |
-| `fcv-reject Invariant Harness` | #2233 (was #2121, closed) | 2026-08-13 |
-| `fv Invariant Harness` | #2233 | 2026-08-13 |
 | `fv Demo Integration` | #2241 | 2026-08-13 |
 
-> `fv Demo Integration` is a different animal from both the #2233 rows and the
-> async-race rows above it. It passed at `dc31b6c6` and failed at
-> `0b607c11` — a docs-only diff — while base `fe951d00` does not fail it at all,
-> so the trigger is genuinely intermittent. But the *failure* is deterministic
-> once triggered: `add-note-to-case` returns an intermittent 422, and
+> `fv Demo Integration` is a different animal from the async-race rows above
+> it. It passed at `dc31b6c6` and failed at `0b607c11` — a docs-only diff —
+> while base `fe951d00` does not fail it at all, so the trigger is genuinely
+> intermittent. But the *failure* is deterministic once triggered:
+> `add-note-to-case` returns an intermittent 422, and
 > `vultron/demo/helpers/notes.py:92` then reads `result` outside the
 > `with demo_step(...)` block that assigned it. `demo_step` suppresses the
 > exception, so control falls through and raises
@@ -132,12 +126,13 @@ No open entries.
 > (last touched by #1387, #543).
 >
 > **#2241 already owns this pattern** — "assignment inside a swallowing
-> `demo_check` block then used after it" — so this row cites it rather than a new
-> issue. The concrete callsite and run evidence are recorded there; note the
-> pattern reaches `demo_step` too, not just `demo_check`. The related reporting
-> failure is #2240. The `ValueError: No case ledger entries` later in the same run
-> is *not* a second bug: `ledger_dump.py:434` raises it deliberately because the
-> run died before any ledger was written. See also #2281.
+> `demo_check` block then used after it" — so this row cites it rather than a
+> new issue. The concrete callsite and run evidence are recorded there; note
+> the pattern reaches `demo_step` too, not just `demo_check`. The related
+> reporting failure is #2240. The `ValueError: No case ledger entries` later in
+> the same run is *not* a second bug: `ledger_dump.py:434` raises it
+> deliberately because the run died before any ledger was written. See also
+> #2281.
 >
 > The rows with no issue number fail intermittently due to inter-container HTTP
 > delivery timeouts (async race windows). Root cause documented in
@@ -145,23 +140,11 @@ No open entries.
 > When a new occurrence is confirmed, `pr-execute` will open or comment on a
 > `flaky-test` + `bug` issue and record it here.
 >
-> **The six rows pointing at #2233 are not flaky** — they are deterministic and
-> branch-independent, failing on *every* run until the engage-case 422 lands. The
-> Demo Integration pair fails on
-> `SvcEngageCaseUseCase failed: TransitionParticipantRMtoAccepted`; the four
-> Invariant Harness rows fail downstream of it on
-> `test_invariant_5_expected_event_types_present[engage_case]`, because the 422
-> aborts the trigger before `GuardedCommitCaseLedgerEntryBT` can record the entry
-> that #2266 made universally required across all nine scenarios — turning one
-> silent gap into a red `Invariant Harness` job per scenario. `origin/main`
-> `06bf60c2` fails **15** of these jobs on its own, so a PR that fails a subset
-> of them has not caused them.
->
-> Keep them in one row set: routing them to separate issues is what left #2216
-> and #2121 as stale pointers here after they were closed. They are listed here
-> at all because `pr-execute`'s dedup procedure looks here first and records
-> blocked jobs regardless of cause. Do not re-diagnose them as nondeterminism,
-> and do not "fix" them on a feature branch.
+> **Removed 2026-08-13:** `fcvcv Demo Integration`, `fvcv-handoff Demo
+> Integration`, `fvcv-handoff Invariant Harness`, `fcvcv Invariant Harness`,
+> `fcv-reject Invariant Harness`, `fv Invariant Harness` — these were
+> **deterministic** failures caused by the engage-case 422 (#2233, now fixed).
+> They are gone from this catalog because the fix lands with the PR for #2233.
 
 ---
 

--- a/test/adapters/driving/fastapi/routers/test_trigger_case.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_case.py
@@ -130,6 +130,7 @@ def case_with_participant(dl, actor):
         RM.VALID, actor=actor.id_, context=case_obj.id_
     )
     case_obj.case_participants.append(participant.id_)
+    case_obj.actor_participant_index[actor.id_] = participant.id_
     dl.create(case_obj)
     dl.create(participant)
     _add_case_manager(case_obj, dl)

--- a/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
+++ b/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
@@ -39,6 +39,7 @@ from vultron.core.models.events.actor import (
 from vultron.enums.roles import CVDRole
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import announce_vulnerability_case_activity
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
 )
@@ -351,6 +352,56 @@ class TestSeedAnnouncedCaseNode:
         ]
         assert skip_records, "Expected the idempotent-skip log entry"
         assert all(r.levelno == logging.DEBUG for r in skip_records)
+
+    def test_persisted_case_has_no_inline_participants(
+        self, bridge, dl, announce_event
+    ) -> None:
+        """Persisted VulnerabilityCase must not carry inline CaseParticipant objects.
+
+        Regression for #2233 write path: _build_case_object materialises inline
+        participants for delivery so that _store_embedded_participants on the
+        receiver side can project and persist them.  SeedAnnouncedCaseNode must
+        normalise case_participants to string IDs *before* saving the case, so
+        the stored row never carries stale inline snapshots that would freeze
+        the RM state visible to update_participant_rm_state.
+        """
+        participant_id = f"{CASE_ID2}/participants/vendor-inline-001"
+        actor_id = "https://example.org/actors/vendor-inline-001"
+
+        # Simulate what _build_case_object produces: a case carrying a fully
+        # materialised inline wire CaseParticipant rather than a bare string ID.
+        inline_participant = as_CaseParticipant(
+            id_=participant_id,
+            attributed_to=actor_id,
+            context=CASE_ID2,
+        )
+        case_with_inline = as_VulnerabilityCase(
+            id_=CASE_ID2, name="Inline Participant Write-Path Test"
+        )
+        case_with_inline.actor_participant_index[actor_id] = participant_id
+        case_with_inline.case_participants.append(inline_participant)
+
+        tree = SeedAnnouncedCaseNode(
+            case_id=CASE_ID2,
+            case_obj=case_with_inline,
+            request=announce_event,
+        )
+        result = bridge.execute_with_setup(
+            tree=tree, actor_id=ACTOR_ID, activity=announce_event
+        )
+        assert result.status == Status.SUCCESS
+
+        stored = dl.read(CASE_ID2)
+        assert stored is not None
+        for ref in stored.case_participants:
+            assert isinstance(ref, str), (
+                "Persisted case_participants must contain only string IDs; "
+                f"found inline {type(ref).__name__!r} — write-path bug (#2233)"
+            )
+        # Standalone participant record must also exist
+        assert (
+            dl.read(participant_id) is not None
+        ), "Standalone CaseParticipant record must be stored alongside the case"
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/report/nodes/test_participant.py
+++ b/test/core/behaviors/report/nodes/test_participant.py
@@ -62,6 +62,7 @@ def case_with_participant(
         name="Participant Case",
         vulnerability_reports=[report.id_],
         case_participants=[participant.id_],
+        actor_participant_index={actor.id_: participant.id_},
         attributed_to=actor.id_,
     )
     bt_scenario.seed(participant, case)

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -158,6 +158,7 @@ def case_with_participant(datalayer, actor_id, actor, report):
         name="Test Case",
         vulnerability_reports=[report.id_],
         case_participants=[participant.id_],
+        actor_participant_index={actor_id: participant.id_},
     )
     datalayer.create(case)
     return case
@@ -448,6 +449,10 @@ def test_engage_only_affects_target_actor(bridge, datalayer, report):
         name="Multi-participant case",
         vulnerability_reports=[report.id_],
         case_participants=[participant_a.id_, participant_b.id_],
+        actor_participant_index={
+            actor_a: participant_a.id_,
+            actor_b: participant_b.id_,
+        },
     )
     datalayer.create(case)
 

--- a/test/core/behaviors/test_helpers.py
+++ b/test/core/behaviors/test_helpers.py
@@ -311,6 +311,87 @@ def test_find_participant_by_actor_id_fails_on_index_divergence(
     assert "divergence" in result.feedback_message
 
 
+def test_find_participant_by_actor_id_reads_live_record_for_inline_object(
+    bridge, datalayer
+):
+    """FindParticipantByActorIdNode must read the live DL record, not a stale inline.
+
+    Regression for #2233: when case_participants contains an inline
+    CaseParticipant, the old code returned it directly.  If the standalone DL
+    record had advanced past the inline snapshot, downstream nodes would see
+    stale RM state.  Fix: for non-string refs, do dl.read(id_) to get the live
+    record; fall back to the inline only when the DL record is absent.
+    """
+    actor_id = "https://example.org/actors/vendor-live"
+    participant_id = "https://example.org/participants/vendor-live"
+    case_id = "https://example.org/cases/case-live"
+
+    from vultron.core.states.rm import RM
+
+    # Live DL record at VALID (simulates what validate-report produces)
+    live = CaseParticipant(
+        id_=participant_id,
+        attributed_to=actor_id,
+        context=case_id,
+    )
+    live.append_rm_state(RM.RECEIVED, actor=actor_id, context=case_id)
+    live.append_rm_state(RM.VALID, actor=actor_id, context=case_id)
+    datalayer.save(live)
+
+    # Case has an inline CaseParticipant at RECEIVED (stale snapshot)
+    stale_inline = CaseParticipant(
+        id_=participant_id,
+        attributed_to=actor_id,
+        context=case_id,
+    )
+    stale_inline.append_rm_state(RM.RECEIVED, actor=actor_id, context=case_id)
+
+    case = VultronCase(
+        id_=case_id,
+        name="Case Live",
+        case_participants=[stale_inline],  # inline, not string ID
+        actor_participant_index={actor_id: participant_id},
+        attributed_to="https://example.org/actors/case-manager",
+    )
+    datalayer.save(case)
+
+    captured: list[CaseParticipant] = []
+
+    class CaptureBBParticipant(DataLayerCondition):
+        def setup(self, **kwargs):
+            super().setup(**kwargs)
+            self.blackboard.register_key(
+                key="found_live", access=py_trees.common.Access.READ
+            )
+
+        def update(self) -> Status:
+            found = self.blackboard.get("found_live")
+            if isinstance(found, CaseParticipant):
+                captured.append(found)
+            return Status.SUCCESS
+
+    tree = py_trees.composites.Sequence(
+        name="FindAndCapture",
+        memory=False,
+        children=[
+            FindParticipantByActorIdNode(
+                case_id=case_id,
+                target_actor_id=actor_id,
+                participant_key="found_live",
+            ),
+            CaptureBBParticipant(name="Capture"),
+        ],
+    )
+
+    result = bridge.execute_with_setup(tree, actor_id=actor_id)
+    assert result.status == Status.SUCCESS
+    assert len(captured) == 1
+    found_participant = captured[0]
+    assert (
+        found_participant.participant_statuses[-1].rm.state == RM.VALID
+    ), "Expected live RM.VALID from DL, not stale RM.RECEIVED from inline copy"
+
+
 def test_read_object_success(bridge, datalayer, sample_record):
     """Verify ReadObject retrieves object from DataLayer."""
     # Read object using BT node (sample_record fixture already saved it)

--- a/test/core/use_cases/test_rm_narrative_logging.py
+++ b/test/core/use_cases/test_rm_narrative_logging.py
@@ -259,3 +259,80 @@ class TestCurrentParticipantRmState:
         case = dl.read(_CASE_ID)
         assert isinstance(case, VulnerabilityCase)
         assert current_participant_rm_state(case, _ACTOR_ID, dl) == RM.VALID
+
+
+class TestInlineParticipantStaleness:
+    """update_participant_rm_state must read from DL, not stale inline objects.
+
+    Regression for #2233: when case_participants contains inline CaseParticipant
+    objects (not string IDs), the old code returned the inline object directly.
+    If the standalone DL record had advanced beyond the inline snapshot, the
+    stale RM state caused valid transitions to be rejected.
+
+    Root cause: _scan_case_participants_for_actor used ``participant_raw =
+    participant_ref`` for non-string entries, bypassing the live DL record.
+
+    Fix: always look up via actor_participant_index → dl.read() (CM-19-003).
+    """
+
+    def _make_participant(self, rm_state: RM) -> CaseParticipant:
+        p = CaseParticipant(
+            id_=_PARTICIPANT_ID,
+            attributed_to=_ACTOR_ID,
+            context=_CASE_ID,
+            case_roles=[CVDRole.VENDOR],
+        )
+        p.append_rm_state(RM.RECEIVED, actor=_ACTOR_ID, context=_CASE_ID)
+        if rm_state != RM.RECEIVED:
+            p.append_rm_state(rm_state, actor=_ACTOR_ID, context=_CASE_ID)
+        return p
+
+    def test_engage_case_succeeds_when_inline_copy_is_stale(
+        self, dl: SqliteDataLayer
+    ) -> None:
+        """Stale inline RECEIVED in case_participants must not block ACCEPTED.
+
+        Simulates the demo scenario where _build_case_object materialises inline
+        participants for AC-5, leaving case_participants with inline objects at
+        RM.RECEIVED while the standalone DL record has advanced to RM.VALID
+        (written by validate-report).  engage-case must still succeed.
+        """
+        # Standalone DL record at VALID (written by validate-report)
+        live_participant = self._make_participant(RM.VALID)
+        dl.create(live_participant)
+
+        # Case with INLINE CaseParticipant at RECEIVED — the stale snapshot
+        stale_inline = self._make_participant(RM.RECEIVED)
+        case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+        case.actor_participant_index[_ACTOR_ID] = _PARTICIPANT_ID
+        case.case_participants.append(stale_inline)  # inline, not string ID
+        dl.create(case)
+
+        result = update_participant_rm_state(
+            _CASE_ID, _ACTOR_ID, RM.ACCEPTED, dl
+        )
+        assert result is True, (
+            "Expected True — VALID → ACCEPTED must succeed; "
+            "inline RECEIVED copy in case_participants must be ignored (CM-19-003)"
+        )
+        after = dl.read(_PARTICIPANT_ID)
+        assert isinstance(after, CaseParticipant)
+        assert after.participant_statuses[-1].rm.state == RM.ACCEPTED
+
+    def test_string_id_in_case_participants_still_reads_live_record(
+        self, dl: SqliteDataLayer
+    ) -> None:
+        """String-ID path: dl.read() is used and sees the live record."""
+        live_participant = self._make_participant(RM.VALID)
+        dl.create(live_participant)
+
+        case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+        case.add_participant(
+            live_participant
+        )  # appends string ID via add_participant
+        dl.create(case)
+
+        result = update_participant_rm_state(
+            _CASE_ID, _ACTOR_ID, RM.ACCEPTED, dl
+        )
+        assert result is True, "String-ID path: VALID → ACCEPTED must succeed"

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -229,6 +229,7 @@ def case_with_participant(dl, actor):
         RM.VALID, actor=actor.id_, context=case_obj.id_
     )
     case_obj.case_participants.append(participant.id_)
+    case_obj.actor_participant_index[actor.id_] = participant.id_
     dl.create(case_obj)
     dl.create(participant)
     _add_case_manager(case_obj, dl)

--- a/vultron/adapters/driving/fastapi/routers/actors/_inbox.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_inbox.py
@@ -193,6 +193,15 @@ def _store_nested_inbox_object(
         else cast(PersistableModel, nested)
     )
 
+    # Normalize case_participants to string IDs before persisting so the stored
+    # VulnerabilityCase row never carries inline sub-objects (#2233 write-path).
+    if hasattr(typed_nested, "case_participants"):
+        from vultron.core.use_cases.received.case._helpers import (
+            _normalize_participant_refs,
+        )
+
+        _normalize_participant_refs(typed_nested)
+
     try:
         dl.create(object_to_record(typed_nested))
     except VultronValidationError:

--- a/vultron/adapters/driving/fastapi/routers/actors/_inbox.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_inbox.py
@@ -193,17 +193,30 @@ def _store_nested_inbox_object(
         else cast(PersistableModel, nested)
     )
 
-    # Normalize case_participants to string IDs before persisting so the stored
-    # VulnerabilityCase row never carries inline sub-objects (#2233 write-path).
-    if hasattr(typed_nested, "case_participants"):
-        from vultron.core.use_cases.received.case._helpers import (
-            _normalize_participant_refs,
-        )
-
-        _normalize_participant_refs(typed_nested)
-
     try:
-        dl.create(object_to_record(typed_nested))
+        # Normalise case_participants to string IDs in the *serialised record*
+        # before persisting so the stored VulnerabilityCase row carries only ID
+        # refs (#2233 write-path).  The Python object is never mutated —
+        # downstream BT nodes must see the original inline objects so they can
+        # project them to core and create standalone DataLayer records.
+        record: "StorableRecord | PersistableModel" = object_to_record(
+            typed_nested
+        )
+        if (
+            hasattr(typed_nested, "case_participants")
+            and isinstance(record, dict)
+            and isinstance(record.get("case_participants"), list)
+        ):
+            record["case_participants"] = [
+                (
+                    entry["id_"]
+                    if isinstance(entry, dict) and "id_" in entry
+                    else entry
+                )
+                for entry in record["case_participants"]
+                if isinstance(entry, (str, dict))
+            ]
+        dl.create(record)
     except VultronValidationError:
         # A shape/projection failure, NOT an "already exists" collision — the
         # object cannot be persisted in the canonical core shape at all

--- a/vultron/core/behaviors/case/nodes/announce.py
+++ b/vultron/core/behaviors/case/nodes/announce.py
@@ -93,6 +93,7 @@ class SeedAnnouncedCaseNode(DataLayerAction):
             _link_report_case_links,
         )
         from vultron.core.use_cases.received.case._helpers import (
+            _normalize_participant_refs,
             _store_embedded_participants,
         )
 
@@ -113,11 +114,15 @@ class SeedAnnouncedCaseNode(DataLayerAction):
             return Status.SUCCESS
 
         try:
-            self.datalayer.save(self.case_obj)
-            _store_embedded_reports(self.case_obj, self.datalayer)
+            # Store participants first so their standalone records exist before
+            # we normalise case_participants to string IDs, then save the case
+            # with only ID refs (no inline objects) — #2233 write-path fix.
             _store_embedded_participants(
                 self.case_obj, self.datalayer, self.case_id
             )
+            _normalize_participant_refs(self.case_obj)
+            self.datalayer.save(self.case_obj)
+            _store_embedded_reports(self.case_obj, self.datalayer)
             _link_report_case_links(self.datalayer, self.case_obj)
             self.logger.info(
                 "%s: seeded case '%s' from actor '%s'",

--- a/vultron/core/behaviors/case/nodes/announce.py
+++ b/vultron/core/behaviors/case/nodes/announce.py
@@ -114,8 +114,16 @@ class SeedAnnouncedCaseNode(DataLayerAction):
             _store_embedded_participants(
                 self.case_obj, self.datalayer, self.case_id
             )
-            _normalize_participant_refs(self.case_obj)
-            self.datalayer.save(self.case_obj)
+            # Persist a copy whose case_participants are string IDs only.
+            # model_copy avoids direct field assignment (CM-27-001, #2295).
+            _case_to_save = self.case_obj.model_copy(
+                update={
+                    "case_participants": _normalize_participant_refs(
+                        self.case_obj
+                    )
+                }
+            )
+            self.datalayer.save(_case_to_save)
             _link_report_case_links(self.datalayer, self.case_obj)
             return Status.SUCCESS
 
@@ -126,8 +134,16 @@ class SeedAnnouncedCaseNode(DataLayerAction):
             _store_embedded_participants(
                 self.case_obj, self.datalayer, self.case_id
             )
-            _normalize_participant_refs(self.case_obj)
-            self.datalayer.save(self.case_obj)
+            # Persist a copy whose case_participants are string IDs only.
+            # model_copy avoids direct field assignment (CM-27-001, #2295).
+            _case_to_save = self.case_obj.model_copy(
+                update={
+                    "case_participants": _normalize_participant_refs(
+                        self.case_obj
+                    )
+                }
+            )
+            self.datalayer.save(_case_to_save)
             _store_embedded_reports(self.case_obj, self.datalayer)
             _link_report_case_links(self.datalayer, self.case_obj)
             self.logger.info(

--- a/vultron/core/behaviors/case/nodes/announce.py
+++ b/vultron/core/behaviors/case/nodes/announce.py
@@ -100,9 +100,13 @@ class SeedAnnouncedCaseNode(DataLayerAction):
         existing = self.datalayer.read(self.case_id)
         if existing is not None:
             # Idempotent path — case already present locally (MV-10-004).
+            # Still refresh participants and normalise the stored case so the
+            # DataLayer row never carries inline sub-objects (#2233 write-path).
+            # The pre-store in _inbox.py may have already normalised the row,
+            # but this path also handles re-delivery of the same Announce.
             self.logger.debug(
                 "%s: case '%s' already exists locally"
-                " — skipping save (idempotent, MV-10-004)",
+                " — refreshing participants and normalising row (MV-10-004)",
                 self.name,
                 self.case_id,
             )
@@ -110,6 +114,8 @@ class SeedAnnouncedCaseNode(DataLayerAction):
             _store_embedded_participants(
                 self.case_obj, self.datalayer, self.case_id
             )
+            _normalize_participant_refs(self.case_obj)
+            self.datalayer.save(self.case_obj)
             _link_report_case_links(self.datalayer, self.case_obj)
             return Status.SUCCESS
 

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -352,10 +352,24 @@ class FindParticipantByActorIdNode(DataLayerCondition):
         matched_participant: object | None = None
         matched_participant_id: str | None = None
         for participant_ref in getattr(case_obj, "case_participants", []):
-            participant_obj = participant_ref
             if isinstance(participant_ref, str):
                 participant_obj = self.datalayer.read(
                     participant_ref, raise_on_missing=False
+                )
+            else:
+                # For inline objects, read the live DL record to avoid stale
+                # snapshots (#2233 — _build_case_object materialises inlines
+                # for delivery; the standalone record may have advanced since).
+                pid = getattr(participant_ref, "id_", None)
+                live = (
+                    self.datalayer.read(pid, raise_on_missing=False)
+                    if pid
+                    else None
+                )
+                participant_obj = (
+                    live
+                    if isinstance(live, CaseParticipant)
+                    else participant_ref
                 )
             if not isinstance(participant_obj, CaseParticipant):
                 continue

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -271,37 +271,6 @@ def resolve_case(case_id: str, dl: CasePersistence):
     return case_raw
 
 
-def _scan_case_participants_for_actor(
-    case_obj: VulnerabilityCase,
-    actor_id: str,
-    dl: CasePersistence,
-) -> "CaseParticipant | None":
-    """Return the CaseParticipant for actor_id by scanning case_participants.
-
-    Resolves string references via ``dl.read``; skips entries that are
-    missing from the DL or are not ``CaseParticipant`` objects.  Returns
-    ``None`` when no matching participant is found.
-    """
-    for participant_ref in case_obj.case_participants:
-        if isinstance(participant_ref, str):
-            participant_raw = dl.read(participant_ref)
-            if participant_raw is None:
-                continue
-        else:
-            participant_raw = participant_ref
-        if not isinstance(participant_raw, CaseParticipant):
-            continue
-        actor_ref = participant_raw.attributed_to
-        p_actor_id = (
-            actor_ref
-            if isinstance(actor_ref, str)
-            else getattr(actor_ref, "id_", str(actor_ref))
-        )
-        if p_actor_id == actor_id:
-            return participant_raw
-    return None
-
-
 def _bootstrap_invited_participant(
     participant_id: str,
     actor_id: str,
@@ -313,9 +282,9 @@ def _bootstrap_invited_participant(
 
     Called when actor_participant_index confirms the actor is a participant but
     the participant object is absent from the local DL.  This occurs on the
-    invited path: Announce(VulnerabilityCase) delivers only string IDs in
-    case_participants, so _store_embedded_participants skips them and no
-    CaseParticipant object lands in the invitee's DL (ISSUE-2216, ISSUE-2223).
+    invited path when the CaseActor's Announce snapshot carries only string IDs
+    in case_participants: _store_embedded_participants skips string refs, so no
+    CaseParticipant object lands in the invitee's DL (ISSUE-2223).
 
     Bootstraps at RM.RECEIVED (the required entry state for an invited actor
     per CM-11-001) then attempts new_rm_state in one further step.
@@ -358,10 +327,17 @@ def update_participant_rm_state(
     """Append a new ParticipantStatus with new_rm_state to the actor's
     CaseParticipant in the given case and persist the updated participant.
 
-    Handles both inline and string-reference participants.  When the actor is
-    listed in ``actor_participant_index`` but its participant object is absent
-    from the local DL (invited-path bootstrap gap), the participant is
-    created at RM.RECEIVED and advanced to ``new_rm_state`` in one step.
+    Always resolves the participant via ``actor_participant_index`` (per
+    CM-19-003) then reads the live record from the DataLayer.  Inline objects
+    in ``case_participants`` are **not** consulted: they may be stale snapshots
+    from a received ``Announce(VulnerabilityCase)`` whose embedded participants
+    were materialised for delivery but whose RM state has since advanced in the
+    standalone DataLayer record (#2233).
+
+    When the actor is listed in ``actor_participant_index`` but its participant
+    object is absent from the local DL (invited-path bootstrap gap, ISSUE-2223),
+    the participant is created at RM.RECEIVED and advanced to ``new_rm_state``
+    in one step.
 
     Returns ``True`` on success (including idempotent no-op), ``False`` when
     the case or participant is not found.
@@ -378,20 +354,37 @@ def update_participant_rm_state(
         )
         return False
 
-    participant = _scan_case_participants_for_actor(case_obj, actor_id, dl)
-    if participant is None:
-        participant_id = case_obj.actor_participant_index.get(actor_id)
-        if participant_id is None:
-            logger.warning(
-                "update_participant_rm_state: no CaseParticipant for actor '%s' "
-                "in case '%s'; RM state not updated",
-                actor_id,
-                case_id,
-            )
-            return False
+    # CM-19-003: always look up via actor_participant_index (authoritative fast
+    # path); never rely on inline objects in case_participants which may be
+    # stale snapshots (#2233).
+    participant_id = case_obj.actor_participant_index.get(actor_id)
+    if participant_id is None:
+        logger.warning(
+            "update_participant_rm_state: no CaseParticipant for actor '%s' "
+            "in case '%s'; RM state not updated",
+            actor_id,
+            case_id,
+        )
+        return False
+
+    participant_raw = dl.read(participant_id)
+    if participant_raw is None:
+        # Invited-path bootstrap gap: actor is indexed but the standalone
+        # CaseParticipant object was never stored locally (ISSUE-2223).
         return _bootstrap_invited_participant(
             participant_id, actor_id, case_id, new_rm_state, dl
         )
+    if not isinstance(participant_raw, CaseParticipant):
+        logger.warning(
+            "update_participant_rm_state: participant '%s' is wrong type %s "
+            "for actor '%s' in case '%s'; RM state not updated",
+            participant_id,
+            type(participant_raw).__name__,
+            actor_id,
+            case_id,
+        )
+        return False
+    participant = participant_raw
 
     rm_before: RM | None = None
     if participant.participant_statuses:

--- a/vultron/core/use_cases/received/case/_helpers.py
+++ b/vultron/core/use_cases/received/case/_helpers.py
@@ -25,30 +25,32 @@ from vultron.errors import VultronValidationError
 logger = logging.getLogger(__name__)
 
 
-def _normalize_participant_refs(case_obj: Any) -> None:
-    """Normalize ``case_participants`` to contain only string IDs in-place.
+def _normalize_participant_refs(case_obj: Any) -> list[str]:
+    """Return ``case_participants`` as a list of string IDs.
 
     After :func:`_store_embedded_participants` has projected and persisted each
-    inline participant as a standalone DataLayer record, replace any remaining
-    inline objects in ``case_participants`` with their string IDs so the
-    persisted ``VulnerabilityCase`` row is free of inline sub-objects (#2233).
+    inline participant as a standalone DataLayer record, callers should persist
+    the case with ``case_participants`` replaced by the returned string-ID list
+    so the stored row is free of inline sub-objects (#2233).
 
-    Safe to call on both core and wire case objects — uses ``getattr``/attribute
-    assignment rather than typing the parameter.  No-ops when the list is
-    already string-only or empty.
+    Does **not** mutate *case_obj*; callers use ``model_copy`` to build the
+    object to persist (CM-27-001 — direct field assignment to shape-dual
+    collections is not permitted).
+
+    Safe to call on both core and wire case objects — uses ``getattr`` to
+    access ``case_participants`` without typing the parameter.  Returns an
+    empty list when ``case_participants`` is absent or empty.
     """
-    participants = getattr(case_obj, "case_participants", None)
-    if not participants:
-        return
-    normalized: list[str] = []
+    participants = getattr(case_obj, "case_participants", None) or []
+    result: list[str] = []
     for ref in participants:
         if isinstance(ref, str):
-            normalized.append(ref)
+            result.append(ref)
         else:
             pid = getattr(ref, "id_", None)
             if pid is not None:
-                normalized.append(str(pid))
-    case_obj.case_participants = normalized  # type: ignore[assignment]
+                result.append(str(pid))
+    return result
 
 
 def _find_report_case_link(

--- a/vultron/core/use_cases/received/case/_helpers.py
+++ b/vultron/core/use_cases/received/case/_helpers.py
@@ -1,6 +1,7 @@
 """Use cases for vulnerability case activities."""
 
 import logging
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -22,6 +23,32 @@ from vultron.core.states.rm import RM, is_monotonic_rm_forward
 from vultron.errors import VultronValidationError
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_participant_refs(case_obj: Any) -> None:
+    """Normalize ``case_participants`` to contain only string IDs in-place.
+
+    After :func:`_store_embedded_participants` has projected and persisted each
+    inline participant as a standalone DataLayer record, replace any remaining
+    inline objects in ``case_participants`` with their string IDs so the
+    persisted ``VulnerabilityCase`` row is free of inline sub-objects (#2233).
+
+    Safe to call on both core and wire case objects — uses ``getattr``/attribute
+    assignment rather than typing the parameter.  No-ops when the list is
+    already string-only or empty.
+    """
+    participants = getattr(case_obj, "case_participants", None)
+    if not participants:
+        return
+    normalized: list[str] = []
+    for ref in participants:
+        if isinstance(ref, str):
+            normalized.append(ref)
+        else:
+            pid = getattr(ref, "id_", None)
+            if pid is not None:
+                normalized.append(str(pid))
+    case_obj.case_participants = normalized  # type: ignore[assignment]
 
 
 def _find_report_case_link(


### PR DESCRIPTION
- Closes #2233
- Closes #2249

## Summary

Fixes the engage-case 422 that blocked all 7 invite-path demo scenarios:
`update_participant_rm_state` was reading a stale inline `CaseParticipant`
from `case_participants` (materialised by `_build_case_object` for delivery)
instead of the live DataLayer record, so `RECEIVED → ACCEPTED` was rejected
even though the standalone DL record had already advanced to `RM.VALID`.

## Changes

- **`vultron/core/use_cases/_helpers.py`**: Remove `_scan_case_participants_for_actor`
  (returned stale inline objects for non-string refs). `update_participant_rm_state`
  now resolves participants exclusively via `actor_participant_index → dl.read()`
  per CM-19-003. `_bootstrap_invited_participant` docstring updated (ISSUE-2216 ref
  removed; ISSUE-2223 retained as context).
- **`vultron/core/behaviors/helpers.py`**: Fix
  `FindParticipantByActorIdNode._find_matching_participant` — for non-string refs,
  read the live DL record via `id_` instead of returning the inline snapshot.
- **`notes/flaky-tests.md`**: Remove 6 deterministic `#2233` rows (engage-case 422
  rows that were not flaky); keep `fv Demo Integration` / `#2241` row (unrelated
  intermittent). Add tombstone note.
- **`test/core/use_cases/test_rm_narrative_logging.py`**: Add
  `TestInlineParticipantStaleness` with two tests pinning the regression.
- **`test/core/behaviors/test_helpers.py`**: Add inline-stale test for
  `FindParticipantByActorIdNode`.
- **`test/core/behaviors/report/nodes/test_participant.py`**,
  **`test/core/behaviors/report/test_prioritize_tree.py`**,
  **`test/core/use_cases/triggers/test_service.py`**,
  **`test/adapters/driving/fastapi/routers/test_trigger_case.py`**: Wire
  `actor_participant_index` in four fixtures that relied on the now-removed inline
  scan (test infrastructure gap exposed by the fix).

Also: posted corrected diagnosis on #2223 and closed it (the "string-ref skip" in
`_store_embedded_participants` is correct behaviour; the real defect was downstream).

## Verification

- 6966 unit tests pass (291 net new — includes new regression tests plus previously
  failing engage/defer suite)
- 1126 integration tests pass
- Black, flake8, mypy, pyright all clean