### PR TITLE
docs: plan issue #2261 — post-construction mutation safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,19 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **Case Participant Lookup**: `case_participants` is authoritative; check
   `actor_participant_index` first (fast path), fall back to `case_participants`.
   Fail only on contradictions, not cache misses.
+- **Construction-Time Validation Does Not Cover Assignment or `append`** —
+  Pydantic validates a model when it is built, and not again. `case.field = x`
+  and `case.field.append(x)` both bypass every type guarantee, so a wire-shaped
+  object can occupy a core-typed field and then read as *absent* rather than
+  raising (#2232, #2264). Do not hand-mutate `case_participants`,
+  `case_statuses` or `participant_statuses`; use the canonical mutators
+  (CM-27-001, PRM-03-003). Corollary: **never assign to `self` inside a
+  `mode="after"` model validator** (ARCH-21-004) — once `validate_assignment` is
+  on, the assignment re-runs the validator and it re-enters itself, which
+  presents as a baffling `RecursionError` far from the cause. Derive in
+  `mode="before"` instead. See
+  [notes/domain-validation.md](notes/domain-validation.md)
+  § "Post-Construction Mutation: Three Doors, One Lock".
 - **Orphan Module Cleanup Requires Importer Proof** — verify no live importers
   in `vultron/` and `test/` before deleting.
 - **Worktree Sync Checks Need Ancestry Verification** — use `ensure-synced`

--- a/docs/adr/0064-core-branch-validate-assignment.md
+++ b/docs/adr/0064-core-branch-validate-assignment.md
@@ -1,0 +1,208 @@
+---
+status: accepted
+date: 2026-08-13
+deciders: Vultron maintainers
+consulted: Vultron maintainers
+informed: Vultron contributors
+---
+
+# Enforce Post-Construction Type Safety on the Core Branch Only, in Three Ratcheted Steps
+
+## Context and Problem Statement
+
+Pydantic v2 validates a model at **construction**. `VultronBase.model_config` is
+`ConfigDict(populate_by_name=True)` and does not set `validate_assignment`, so
+validation stops the moment an object exists. The same value the constructor
+rejects is silently accepted through two other doors:
+
+```python
+case = VulnerabilityCase(case_participants=[wire_obj])  # ValidationError
+case.case_participants = [wire_obj]                     # accepted
+case.case_participants.append(wire_obj)                 # accepted
+```
+
+This matters because the core and wire branches (ADR-0017) carry structurally
+incompatible shapes for the same concepts. A wire-shaped object in a core-typed
+field does not raise when read — it reads as *absent*, and readers substitute an
+initial state, silently resetting a participant's RM ladder. That is the failure
+mode of #2232 / #2264, and it is the same class of defect as #2233, which had
+seven Demo Integration scenarios red on `main` at the time of writing.
+
+ADR-0062 already closed the two boundaries where wire data crosses into
+persistence: normalisation at ingress and again at the persistence boundary.
+What remains unenforced is the **in-memory** invariant — nothing stops code
+already inside the core from planting a wrong-shaped object in a typed field.
+
+The obvious remedy is `validate_assignment=True` on `VultronBase`. It was
+measured, and it does not work as-is.
+
+## Decision Drivers
+
+- The invariant should hold whichever door a value arrives through.
+- `VultronBase` is shared by *both* branches (ARCH-12-001), and ARCH-12-002
+  requires it to stay lenient for the wire branch — inbound wire data is
+  legitimately loose.
+- Whatever we adopt must be measurable and reviewable in increments; a change
+  that touches every domain object cannot land as one diff.
+- Progress must be visible and drift-proof across multiple issues and weeks.
+- Re-validation cost on BT tick loops and ledger replay was unquantified.
+
+### What the measurements showed
+
+Against `origin/main` (baseline: 2 pre-existing unrelated failures, #2274):
+
+| Variant | FAILED | ERROR | Failure types |
+|---|---|---|---|
+| `validate_assignment` on `VultronBase` | 747 | 423 | **879 × `RecursionError`, nothing else** |
+| `validate_assignment` on `CoreObject` | 398 | 268 | **403 × `RecursionError`, nothing else** |
+
+Not one type-strictness failure was visible in either variant. The cause is
+uniform: `validate_assignment` re-runs every `mode="after"` model validator on
+each assignment, so a validator that writes to `self` re-enters itself. Twenty
+three core validators do this (plus twelve in the wire branch). Guarded ones
+terminate at depth 2; unguarded ones — `FinderParticipant._set_role`,
+`ReporterParticipant._set_accepted_status`, `as_EmbargoEvent.set_name` and
+others — recurse until the stack is gone. The recursion **masks** the real blast
+radius, which therefore cannot be measured until the validators are fixed.
+
+Two further findings shaped the decision:
+
+- **`validate_assignment` does not close the append door at all.**
+  `list.append` is not an attribute assignment, so Pydantic never observes it.
+  A separate mechanism is required regardless.
+- **Cost is not the obstacle.** Scalar attribute assignment measured
+  475 ns → 1464 ns (3.1×, ~1 µs absolute) — immaterial for BT tick loops. The
+  open question is collection fields, where assigning `case_participants`
+  re-validates all N items.
+
+## Considered Options
+
+Four decisions were made, each with alternatives rejected.
+
+### A — Overall strategy
+
+- Three ordered steps: fix validators, then flip the core branch, then close the
+  append door **(chosen)**
+- Abandon `validate_assignment`; rely on architecture ratchet tests alone
+- One big-bang PR doing all of it
+- Close #2261 as won't-fix, since ADR-0062 covers the concrete defect
+
+### B — Where the flag goes
+
+- A core-only mixin applied to every core model **(chosen)**
+- `CoreObject` only, accepting the gaps
+- Per-class opt-in on the highest-risk types
+- `VultronBase` — everything, core and wire
+
+### C — How validators are made assignment-safe
+
+- Ban self-assignment in `mode="after"`; derive in `mode="before"` **(chosen)**
+- Sanction `self.__dict__["field"] = value` as an escape hatch
+- A re-entry guard flag on the model
+- Case-by-case mix of `mode="before"` and the escape hatch
+
+### D — How the append door is closed
+
+- Spec prohibition + canonical mutators + AST ratchet **(chosen)**
+- Frozen/tuple collection fields
+- A validating sequence wrapper type
+- Ratchet now, wrapper later if it proves insufficient
+
+## Decision Outcome
+
+**A — Three ordered steps**, because the measured recursion wall makes any
+single-PR approach unreviewable, and because the true type-strictness blast
+radius is unknowable until step 1 lands. Each step is independently valuable:
+step 1 is a correctness-neutral refactor, step 3 shares no files with the others
+and runs in parallel.
+
+**B — A core-only mixin**, applied to the ten root classes from which all 103
+core models descend. `VultronBase` is excluded permanently, not deferred: it is
+the shared base and `as_Base` inherits it, so setting the flag there violates
+ARCH-12-002 and produced the worst measured result. `CoreObject`-only was
+rejected because 16 core models sit outside it — including all five dimension
+objects (`RmDimension`, `VfdDimension`, `EmDimension`, `PxaDimension`,
+`PecDimension`), which are precisely the types implicated in #2232. Per-class
+opt-in was rejected because an opt-in list rots: the default stays unsafe and
+every new model is unprotected unless someone remembers.
+
+**C — Derive in `mode="before"`**, because the derived value is then validated
+normally. The `__dict__` escape hatch would trade one silent hole for a smaller
+one — it writes the field unvalidated and does not update `model_fields_set` —
+and a rule of the form "MUST NOT, except where noted" needs its own allowlist,
+which weakens the ratchet. Scope is `vultron/core/` only; the wire branch's
+twelve equivalent validators are **exempt by design**, because the wire branch
+never gets `validate_assignment` and therefore cannot recurse.
+
+**D — Spec prohibition, canonical mutators, and an AST ratchet**, because this
+exact pattern is already proven in-repo: PRM-03-001 plus
+`test_participant_case_roles.py` drove direct `case_roles` mutation in
+`vultron/` to **zero** sites. `add_participant()` and `remove_participant()`
+already exist. Frozen collections would be a breaking change across ~142
+test-side mutation sites; a validating sequence wrapper is a novel type with
+serialization and copy semantics to maintain, and no evidence yet that the
+static scan is insufficient.
+
+### Ratcheting across the steps
+
+Work spanning three issues loses coherence, and this repo has direct evidence of
+how: the `strict=False` xfails for #1991 and #1992 have sat green-and-ignored
+since they were filed. A non-strict xfail keeps passing after the work is done,
+so it never tells anyone to remove it, and it gives no partial-progress signal.
+
+`test/architecture/test_validate_assignment_ratchet.py` therefore lands with
+this decision, before any implementation, carrying three **exact-set backlogs**:
+23 self-assigning validators, 10 mixin targets, 3 collection-mutation modules.
+Each is asserted with `==`, so it fails if the backlog grows **and** if an entry
+is fixed without being ticked off. Each has a companion `xfail(strict=True)`
+goal test: when the last entry goes, the goal test XPASSes, which fails the
+build and forces the marker to be deleted. The #1991 and #1992 markers were
+converted to the same shape in the same change.
+
+### Consequences
+
+- Good, because the invariant becomes enforced rather than documented, and the
+  #2232 class of silent state reset becomes a loud failure.
+- Good, because the plan is encoded in CI from day one; neither drift nor
+  completion can go unnoticed, and partial progress is visible as a shrinking
+  set.
+- Good, because ARCH-12-002 is preserved and asserted by a test, so a future
+  "finish the job" PR cannot quietly move the flag onto the shared base.
+- Bad, because 23 validators must be rewritten before any type safety is gained
+  — real work with no user-visible benefit.
+- Bad, because the type-strictness blast radius remains unknown until step 1
+  lands, so step 2 cannot be sized in advance.
+- Bad, because the append door stays open until step 3, and the static scan
+  cannot see a mutation computed at runtime.
+- Neutral: the wire branch keeps its twelve self-assigning validators. If it
+  ever gains `validate_assignment`, this trap returns; the exemption is recorded
+  here deliberately rather than left implicit.
+
+## Validation
+
+- `test/architecture/test_validate_assignment_ratchet.py` — three exact-set
+  backlogs, three strict goal tests, plus `test_detectors_are_not_vacuous`,
+  `test_shared_base_is_never_a_target` and
+  `test_wire_branch_does_not_enable_validate_assignment`. The heaviest scan runs
+  in 0.55 s.
+- The ratchet was verified in both directions before merge: injecting a new
+  mutation site fails the exact-set test, and neutralising all three backlog-3
+  sites turns the goal test into `[XPASS(strict)]` → FAILED, proving the
+  completion path forces cleanup.
+- Step 2 carries an acceptance criterion to benchmark a BT tick loop and a
+  ledger replay, quantifying the O(N) collection-field cost and stating the
+  threshold above which the placement would be narrowed.
+
+## More Information
+
+Generated spec entries: ARCH-21-001 through ARCH-21-005
+(`specs/architecture.yaml`), CM-27-001 through CM-27-003
+(`specs/case-management.yaml`), PRM-03-003
+(`specs/participant-role-management.yaml`).
+
+Source: issue #2261 (Concern), planned under Epic #2229.
+Related: ADR-0017 (two-branch hierarchy), ADR-0036 (dimension objects),
+ADR-0062 (normalisation at ingress and persistence), issue #2232 (the shape
+duality), issue #2268 (remaining shadowing types), issues #1991 / #1992 (the
+xfail markers repaired here).
+Guidance: `notes/domain-validation.md`.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -133,6 +133,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0061 Adjudicate Received `ParticipantStatus` Per Dimension, Not as a Unit](0061-per-dimension-partial-accept.md)
 - [ADR-0062 Normalise Wire → Core at Ingress, and Enforce It Again at the Persistence Boundary](0062-normalise-wire-to-core-at-both-ingress-and-persistence.md)
 - [ADR-0063 Render Core Objects to Wire JSON Through a Driven Port; Remove `alias_generator` From All Core-Branch Types](0063-wire-rendering-port-for-core-objects.md)
+- [ADR-0064 Enforce Post-Construction Type Safety on the Core Branch Only, in Three Ratcheted Steps](0064-core-branch-validate-assignment.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -281,6 +281,7 @@ nav:
       - Adjudicate Received ParticipantStatus Per Dimension, Not as a Unit: 'adr/0061-per-dimension-partial-accept.md'
       - Normalise Wire to Core at Ingress, and Enforce It Again at the Persistence Boundary: 'adr/0062-normalise-wire-to-core-at-both-ingress-and-persistence.md'
       - Render Core Objects to Wire JSON Through a Driven Port: 'adr/0063-wire-rendering-port-for-core-objects.md'
+      - Enforce Post-Construction Type Safety on the Core Branch Only: 'adr/0064-core-branch-validate-assignment.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/domain-validation.md
+++ b/notes/domain-validation.md
@@ -6,7 +6,10 @@ description: >
   None/unresolved fields) to "strict" (all required fields guaranteed),
   and how helpers must fail fast when strict guarantees are violated.
 related_specs:
-  - specs/architecture.yaml (ARCH-10-001, ARCH-15-001 through ARCH-15-004)
+  - specs/architecture.yaml (ARCH-10-001, ARCH-15-001 through ARCH-15-004,
+    ARCH-21-001 through ARCH-21-005)
+  - specs/case-management.yaml (CM-27-001 through CM-27-003)
+  - specs/participant-role-management.yaml (PRM-03-003)
 related_notes:
   - notes/architecture-hexagonal.md
   - notes/bt-integration.md
@@ -173,6 +176,90 @@ wire-spelled (camelCase) payload drops every snake-only key in silence, because
 Pydantic v2 ignores unknown keys. It is computed per exact class, so a
 `CaseParticipant` role subclass that adds a field is covered without any
 registration step.
+
+---
+
+## Post-Construction Mutation: Three Doors, One Lock (#2261)
+
+Pydantic v2 validates a model at **construction**. Nothing else. The same value
+the constructor rejects is silently accepted through two other doors:
+
+```python
+case = VulnerabilityCase(case_participants=[wire_obj])  # ValidationError
+case.case_participants = [wire_obj]                     # accepted
+case.case_participants.append(wire_obj)                 # accepted
+```
+
+Combine that with the shape duality above and you get the #2232 / #2264 failure:
+a wire-shaped object in a core-typed field does not raise when read — it reads as
+*absent*, so the reader substitutes an initial state and the participant's ladder
+silently resets.
+
+**The two remedies are different mechanisms, because they close different
+doors.** `validate_assignment=True` closes the assignment door. It does
+*nothing* for `append` — an in-place list mutation is not an attribute
+assignment, so Pydantic never observes it. That door is closed by prohibition
+plus canonical mutators plus an architecture ratchet (CM-27-001, PRM-03-003),
+the same way PRM-03-001 closed it for `case_roles`.
+
+### Where `validate_assignment` goes — and where it must not
+
+| Layer | `validate_assignment` | Why |
+|---|---|---|
+| Core models (`vultron/core/models/`) | **on** (ARCH-21-001) | Core fields carry a shape guarantee that readers depend on |
+| `VultronBase` | **never** (ARCH-21-002) | Shared base of both branches; `as_Base` inherits it (ARCH-12-001/002) |
+| Wire (`vultron/wire/`) | **never** (ARCH-21-003) | Inbound data is legitimately loose; strictness belongs at the projection |
+
+Setting the flag on `VultronBase` is the one-line fix that looks right and is
+not. It contradicts ARCH-12-002 and, when measured, produced the largest blast
+radius of any variant (747 failed, 423 errors).
+
+### Pitfall: never assign to `self` in a `mode="after"` validator
+
+This is the trap that makes the whole change non-trivial, and it is invisible
+from reading the model:
+
+```python
+# Wrong — with validate_assignment on, this recurses until the stack is gone.
+@model_validator(mode="after")
+def _set_role(self) -> FinderParticipant:
+    self.case_roles = []          # assignment re-runs this validator...
+    self.add_role(CVDRole.FINDER)
+    return self
+
+# Right — derive before validation, so the derived value is itself validated.
+@model_validator(mode="before")
+@classmethod
+def _set_role(cls, data: Any) -> Any:
+    ...
+```
+
+`validate_assignment` re-runs **every** `mode="after"` validator on each
+assignment, so a validator that writes to `self` re-enters itself. A guarded one
+(`if self.name is None: self.name = ...`) terminates at depth 2; an unguarded one
+never terminates. Enabling the flag before this rule holds aborts 400+ tests with
+`RecursionError` **and nothing else** — the recursion masks every real type
+failure, so the actual blast radius cannot be measured until the validators are
+fixed. ARCH-21-004 makes this a MUST NOT for `vultron/core/`.
+
+Writing the field through `self.__dict__["field"]` was considered and rejected:
+it stops the recursion but leaves the derived value unvalidated, trading one
+silent hole for a smaller one.
+
+Wire-layer validators are **exempt by design** — the wire branch never enables
+the flag, so they cannot re-enter. Twelve of them still assign to `self`. If the
+wire branch ever gains `validate_assignment`, this trap returns.
+
+### Cost
+
+Scalar attribute assignment measured **475 ns → 1464 ns** (3.1×, ~1 µs
+absolute) — immaterial for BT tick loops. The cost that still needs watching is
+collection fields: assigning `case_participants` re-validates all N items, so it
+is O(N) per assignment.
+
+See ADR-0064 for the decision and the three-step rollout, and
+`test/architecture/test_validate_assignment_ratchet.py` for the enumerated
+backlogs that track it.
 
 ---
 

--- a/plan/history/2608/learning/CONCERN-2261.md
+++ b/plan/history/2608/learning/CONCERN-2261.md
@@ -1,0 +1,112 @@
+---
+source: CONCERN-2261
+timestamp: '2026-08-13T16:44:22.446427+00:00'
+title: Post-construction mutation safety — three doors, one lock
+type: learning
+---
+
+CONCERN-2261 asked whether `VultronBase` should set `validate_assignment`.
+Planned as three ratcheted steps in PR <https://github.com/CERTCC/Vultron/pull/2292>,
+codified in ADR-0064, and tracked in CI by
+`test/architecture/test_validate_assignment_ratchet.py`.
+
+## What was learned
+
+**The one-line fix is a measured dead end, not a judgement call.** Setting
+`validate_assignment=True` on `VultronBase` produces 747 FAILED + 423 ERROR;
+on `CoreObject`, 398 + 268 (baseline: 2 pre-existing, #2274). **Every single
+failure is a `RecursionError`** — 879 and 403 of them respectively. Not one
+type-strictness failure is visible in either variant.
+
+The mechanism: `validate_assignment` re-runs every `mode="after"` model
+validator on each attribute assignment, so a validator that writes to `self`
+re-enters itself. 23 core validators do this (plus 12 in the wire branch).
+Guarded ones (`if self.name is None: ...`) terminate at depth 2; unguarded ones
+never terminate. **The recursion masks the real blast radius**, which is why
+step 2 cannot be sized until step 1 lands — the prerequisite is empirical, not
+stylistic.
+
+**There are three doors, and one mechanism cannot close them all.**
+
+```python
+case = VulnerabilityCase(case_participants=[wire_obj])  # ValidationError
+case.case_participants = [wire_obj]                     # accepted
+case.case_participants.append(wire_obj)                 # accepted
+```
+
+`validate_assignment` closes the middle door only. `list.append` is not an
+attribute assignment, so Pydantic never observes it — that door needs
+prohibition + canonical mutators + a static scan, which is exactly what
+PRM-03-001 already did for `case_roles` (driving direct mutation in `vultron/`
+to zero sites).
+
+**Cost was never the obstacle.** Scalar assignment measured 475 ns → 1464 ns
+(3.1×, ~1 µs absolute). The unquantified risk is O(N) collection-field
+re-validation, now an explicit AC in #2294 rather than an assumption.
+
+**Placement mattered more than expected.** `CoreObject`-only leaves 16 core
+models uncovered, *including all five dimension classes* — precisely the types
+implicated in #2232. A core-only mixin on 10 roots covers all 103 core models.
+`VultronBase` is excluded **permanently** per ARCH-12-002, not deferred.
+
+## The transferable lesson: non-strict xfail is a silent ratchet failure
+
+The user's concern was "losing the plot over multiple issues." This repo
+already had the evidence: the `strict=False` xfails for #1991 and #1992 had sat
+green-and-ignored since they were filed. **A non-strict xfail keeps passing
+after the work is done, so it never tells anyone to remove it, and it gives no
+partial-progress signal.**
+
+The shape that fixes this, adopted here and retrofitted onto #1991/#1992 in the
+same PR:
+
+1. An **exact-set backlog** asserted with `==`, so it fails when the set
+   **grows** *and* when an entry is fixed but left listed. One-directional
+   assertions (`<=`) let the enumeration go stale silently.
+2. A companion **`xfail(strict=True)`** goal test. When the last entry goes, the
+   goal test XPASSes, which *fails the build* and forces the marker's deletion.
+3. Dedup against **everything seen**, and verify the ratchet **in both
+   directions** before merge — inject a violation (must fail), then neutralise
+   the backlog (must `[XPASS(strict)]` → FAILED).
+
+The ratchet earned its keep within the same PR: the rebase onto `main` picked up
+the BTND-07 decomposition (`c19b9997`), which split two of the three backlog
+modules. The exact-set assertion failed on the renames and named both new paths
+precisely — a one-directional assertion would have passed in silence.
+
+## Process notes
+
+- **Plain language before options.** The first grill-me question was rejected
+  with "what is the problem we are trying to solve. assume i have not read the
+  issue. use simple language." Lead with the problem statement, then offer
+  choices.
+- **Concurrent planning collides on IDs.** ADR-0063 and spec group ARCH-20 were
+  both claimed by the #2260 plan (PR #2285) while this was in flight; both had
+  to be renumbered to ADR-0064 / ARCH-21 during the rebase. Check the *tip of
+  main*, not the branch base, before assigning an ADR number or a spec group.
+- **Correct measurement errors out loud.** An intermediate claim of "2 wire-layer
+  sites" was wrong — there are 12 (the 2 was the unguarded subset). It changed
+  the scope of step 1, so it was flagged explicitly and re-asked.
+
+## Outcome
+
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/2292>
+- ADR-0064 (core-branch `validate_assignment`, three ratcheted steps)
+- Specs: ARCH-21-001..005, CM-27-001..003, PRM-03-003
+- Notes: `notes/domain-validation.md` § "Post-Construction Mutation: Three
+  Doors, One Lock"; AGENTS.md pitfall covering both traps
+- Impl issues under Epic #2229, `Schedule=Focus`:
+  - #2293 — step 1: 23 core validators to `mode="before"` (`size:M`)
+  - #2294 — step 2: core-only mixin on 10 roots (`size:L`, blocked by #2293)
+  - #2295 — step 3: append door via canonical mutators (`size:M`, parallel)
+- Repaired the #1991 / #1992 `strict=False` xfails
+- Cross-referenced onto #2268 (the 13 remaining shadowing types)
+
+**Explicitly out of scope:** the wire branch stays lenient (ARCH-12-002; its 12
+self-assigning validators are exempt by design), #2268's 13 shadowing types,
+`frozen=True` / immutable core models, and scanning `test/` for direct mutation.
+
+**Honest framing:** #2261 is *preventive hardening* for the #2233 class of
+defect, not the fix for it. Seven Demo Integration scenarios were red on `main`
+at planning time (`422 ValidationError: TransitionParticipantRMtoAccepted`) —
+that is #2233's own work.

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -680,3 +680,99 @@ groups:
       spec_id: SDO-03-005
     adr:
     - ADR-0063
+- id: ARCH-21
+  title: Post-Construction Mutation Safety
+  description: >-
+    Requirements governing validation of core domain objects after construction.
+    Pydantic v2 validates at construction only, so attribute assignment and
+    in-place collection mutation bypassed every type guarantee, allowing a
+    wire-shaped object to occupy a core-typed field and be silently misread as
+    absent (#2232, #2264). Codified by ADR-0064. Source: CONCERN-2261.
+  specs:
+  - id: ARCH-21-001
+    priority: MUST
+    kind: architecture
+    statement: >-
+      Every core domain model (a `pydantic.BaseModel` subclass defined under
+      `vultron/core/models/`) MUST have `validate_assignment=True` in effect,
+      whether set directly or inherited, so that attribute assignment is
+      validated to the same standard as construction.
+    rationale: >-
+      Construction-time-only validation means the same value the constructor
+      rejects is accepted by assignment. A wire-shaped object in a core-typed
+      field does not raise when read — it reads as absent, and readers substitute
+      an initial state, silently resetting a participant's ladder (#2232, #2264).
+    adr:
+    - ADR-0064
+  - id: ARCH-21-002
+    priority: MUST_NOT
+    kind: architecture
+    statement: >-
+      `VultronBase` MUST NOT set `validate_assignment`. It is the shared base of
+      both branches (ARCH-12-001) and `as_Base` inherits it, so the wire branch
+      MUST remain lenient (ARCH-12-002). Enforcement belongs on the core branch
+      only, applied below `VultronBase`.
+    rationale: >-
+      Setting the flag on the shared base is the one-line fix that looks correct
+      and is not: it contradicts ARCH-12-002 and produced the largest measured
+      blast radius (747 failed, 423 errors) because inbound wire data is
+      legitimately loose.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-12-002
+    adr:
+    - ADR-0064
+  - id: ARCH-21-003
+    priority: MUST_NOT
+    kind: architecture
+    statement: >-
+      No wire-layer class (under `vultron/wire/`) MUST have
+      `validate_assignment` enabled. Strictness belongs at the wire-to-core
+      projection, not on the wire types themselves.
+    rationale: >-
+      Inbound wire data is loose by contract. Enforcing strictness on the wire
+      types would reject legitimate inbound payloads instead of projecting them
+      (ADR-0062, ARCH-12-002).
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-12-002
+    adr:
+    - ADR-0064
+  - id: ARCH-21-004
+    priority: MUST_NOT
+    kind: project
+    statement: >-
+      A `mode="after"` model validator on a core model (under `vultron/core/`)
+      MUST NOT assign to `self`. Values derived from other fields MUST be derived
+      in a `mode="before"` validator, where the derived value is itself
+      validated. Wire-layer validators are exempt, because the wire branch never
+      enables `validate_assignment` (ARCH-21-003) and therefore cannot re-enter.
+    rationale: >-
+      `validate_assignment` re-runs every `mode="after"` validator on each
+      assignment, so a validator that writes to `self` re-enters itself. Guarded
+      validators terminate at depth 2; unguarded ones recurse until the stack is
+      exhausted. Measured: enabling the flag before this rule holds aborts 400+
+      tests with `RecursionError` and nothing else, masking every real type
+      failure. Writing the field through `self.__dict__` was rejected as a remedy
+      because it leaves the derived value unvalidated.
+    adr:
+    - ADR-0064
+  - id: ARCH-21-005
+    priority: SHOULD
+    kind: project
+    statement: >-
+      An architecture test SHOULD enforce ARCH-21-001, ARCH-21-003 and
+      ARCH-21-004, and SHOULD enumerate any remaining known violations as an
+      exact set so that the set fails both when it grows and when a listed
+      violation is fixed without being removed. Each such backlog SHOULD have a
+      companion `xfail(strict=True)` goal test, so that emptying the backlog
+      fails the build and forces the marker to be deleted. The test MUST complete
+      within one second per scan.
+    rationale: >-
+      A `strict=False` xfail keeps passing after the work is done, so it never
+      signals that it should be removed, and it gives no partial-progress signal
+      — the failure mode observed on the long-dormant #1991 and #1992 markers. An
+      exact set plus a strict goal test makes both drift and completion
+      impossible to miss.
+    adr:
+    - ADR-0064

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -1776,3 +1776,70 @@ groups:
       spec_id: CM-25-005
     adr:
     - ADR-0057
+
+- id: CM-27
+  title: Case Collection Mutation Discipline
+  description: >-
+    Requirements governing post-construction mutation of the case collections
+    whose items exist in incompatible wire and core shapes. `validate_assignment`
+    does not cover in-place mutation — `list.append` is not an attribute
+    assignment, so Pydantic never observes it — so these collections need a
+    separate prohibition. Codified by ADR-0064. Source: CONCERN-2261.
+  specs:
+  - id: CM-27-001
+    priority: MUST_NOT
+    kind: protocol
+    statement: >-
+      Core code under `vultron/core/` MUST NOT mutate `case_participants` or
+      `case_statuses` directly on a `VulnerabilityCase` instance after
+      construction (e.g. `case.case_participants.append(...)`,
+      `case.case_statuses = [...]`). The canonical mutators on
+      `VulnerabilityCase` MUST be used for all post-construction changes. The
+      mutator methods themselves, in `vultron/core/models/case.py`, are exempt.
+    rationale: >-
+      A wire-shaped participant or status appended to a core-typed list does not
+      raise when read — it reads as absent, and readers substitute an initial
+      state, silently resetting the case's ladder (#2232, #2264).
+      `validate_assignment` cannot close this door because `append` is not an
+      assignment. This mirrors PRM-03-001, whose identical prohibition drove
+      direct `case_roles` mutation in `vultron/` to zero sites.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-21-001
+    adr:
+    - ADR-0064
+  - id: CM-27-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      Passing `case_participants=[...]` or `case_statuses=[...]` as a constructor
+      argument when creating a `VulnerabilityCase` is permitted and does not
+      violate CM-27-001; the prohibition applies only to post-construction
+      mutation.
+    rationale: >-
+      Constructor arguments are validated, which is precisely the guarantee
+      CM-27-001 exists to restore. This clarification prevents over-application
+      of the rule, mirroring PRM-03-002.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-27-001
+    adr:
+    - ADR-0064
+  - id: CM-27-003
+    priority: MUST
+    kind: project
+    statement: >-
+      `VulnerabilityCase` MUST expose a canonical mutator for appending a case
+      status, so that CM-27-001 can be satisfied without direct list mutation.
+      `add_participant()` and `remove_participant()` already provide this for
+      `case_participants`.
+    rationale: >-
+      A prohibition with no sanctioned alternative is unimplementable. At the
+      time of writing `case_statuses` had no mutator at all — only the
+      `current_status` and `case_status` readers — so the rule requires one to be
+      added.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-27-001
+    adr:
+    - ADR-0064

--- a/specs/participant-role-management.yaml
+++ b/specs/participant-role-management.yaml
@@ -119,6 +119,28 @@ groups:
       over-application of the rule.'
     tags:
     - protocol
+  - id: PRM-03-003
+    priority: MUST_NOT
+    kind: protocol
+    statement: >-
+      Core code under `vultron/core/` MUST NOT mutate `participant_statuses`
+      directly on a CaseParticipant instance after construction (e.g.
+      `participant.participant_statuses.append(...)`). The canonical mutators on
+      `CaseParticipant` MUST be used. The mutator methods themselves, in
+      `vultron/core/models/case_participant.py`, are exempt.
+    rationale: >-
+      `ParticipantStatus` exists in two incompatible shapes (SDO-03-002,
+      ADR-0036). A wire-shaped status appended to a core-typed list reads as
+      absent, so readers substitute an initial state — the #2232 / #2264 silent
+      reset. `validate_assignment` cannot close this door because `append` is not
+      an attribute assignment. Extends PRM-03-001 to `participant_statuses`.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-21-001
+    adr:
+    - ADR-0064
+    tags:
+    - protocol
 - id: PRM-04
   title: Wire Layer Interface Parity
   specs:

--- a/test/architecture/test_hierarchy_invariants.py
+++ b/test/architecture/test_hierarchy_invariants.py
@@ -138,15 +138,16 @@ class TestCoreVocabularyHierarchy:
             f"  newly violating: {sorted(has_to_camel - _TO_CAMEL_BACKLOG_1991)}\n"
             f"  fixed but still listed: {sorted(_TO_CAMEL_BACKLOG_1991 - has_to_camel)}\n"
             "to_camel is an AS2 serialization concern and belongs only in the"
-            " wire layer (ARCH-12-004, issue #1991)."
+            " wire layer (ARCH-12-004, #2288 / #2289)."
         )
 
     @pytest.mark.xfail(
         strict=True,
-        reason="Goal state for issue #1991: no CoreObject subclass inherits "
-        "alias_generator=to_camel from as_Base. 8 known classes remain, "
-        "enumerated in _TO_CAMEL_BACKLOG_1991. When the last is fixed this test "
-        "XPASSes and fails the build — delete the marker and the backlog then.",
+        reason="Goal state tracked in #2288 and #2289 (supersedes closed #1991): "
+        "no CoreObject subclass inherits alias_generator=to_camel from as_Base. "
+        "8 known classes remain, enumerated in _TO_CAMEL_BACKLOG_1991. "
+        "When the last is fixed this test XPASSes and fails the build — "
+        "delete the marker and the backlog then.",
     )
     def test_no_core_object_has_to_camel_alias_generator(self) -> None:
         """No CoreObject subclass may use alias_generator=to_camel.

--- a/test/architecture/test_hierarchy_invariants.py
+++ b/test/architecture/test_hierarchy_invariants.py
@@ -26,6 +26,18 @@ between the core (domain) and wire (ActivityStreams) layers:
 
 These invariants are specified in ARCH-12-003 and ARCH-12-004.
 
+Invariants 2 and 3 are not met yet. Their known violations are **enumerated** in
+the two backlog sets below and asserted with ``==``, so the sets fail if a new
+violation appears *and* if a listed one is fixed without being ticked off. Each
+has a companion ``xfail(strict=True)`` goal test, so emptying its backlog makes
+the goal test XPASS and fail the build — forcing the marker to be deleted.
+
+Both backlogs previously sat behind bare ``strict=False`` xfails, which is a
+pattern worth naming: a non-strict xfail keeps passing forever after the work is
+done, so nobody is ever told to clean it up, and it gives no partial-progress
+signal along the way. See ``test_validate_assignment_ratchet.py``, which uses the
+same three-part shape (exact backlog + strict goal + guard-the-guard).
+
 Spec: `specs/architecture.yaml` ARCH-12-003, ARCH-12-004, ARCH-12-007
 Reference: `docs/adr/0017-domain-wire-object-separation.md`
 """
@@ -39,6 +51,39 @@ from vultron.wire.as2.vocab.base.registry import VOCABULARY
 
 # AS2 namespace constant from wire layer
 ACTIVITY_STREAMS_NS = "https://www.w3.org/ns/activitystreams"
+
+# ---------------------------------------------------------------------------
+# Backlog: core classes inheriting alias_generator=to_camel from as_Base,
+# violating ARCH-12-004 (issue #1991). This set may only SHRINK.
+# ---------------------------------------------------------------------------
+_TO_CAMEL_BACKLOG_1991: frozenset[str] = frozenset(
+    {
+        "CaseStatus",
+        "CoreActorCollection",
+        "ParticipantStatus",
+        "VultronApplication",
+        "VultronGroup",
+        "VultronOrganization",
+        "VultronPerson",
+        "VultronService",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Backlog: core-layer classes registered in the wire VOCABULARY registry,
+# violating ARCH-12-003 (issue #1992). This set may only SHRINK.
+# ---------------------------------------------------------------------------
+_NON_AS_BASE_BACKLOG_1992: frozenset[str] = frozenset(
+    {
+        "Actor",
+        "CoreActor",
+        "OfferRecord",
+        "PendingCaseInbox",
+        "PendingCreateCaseActivity",
+        "ReplicationState",
+        "ReportCaseLink",
+    }
+)
 
 
 class TestCoreVocabularyHierarchy:
@@ -74,13 +119,34 @@ class TestCoreVocabularyHierarchy:
                 cls, as_Base
             ), f"{name} inherits from as_Base (wire layer)"
 
+    def test_to_camel_backlog_is_exact(self) -> None:
+        """The #1991 violation set must match reality, in both directions.
+
+        Replaces a bare ``strict=False`` xfail. A non-strict xfail keeps passing
+        after the work is done, so it never tells anyone to remove it, and it
+        gives no signal for partial progress. An exact set does both: it fails if
+        a *new* core class inherits ``alias_generator``, and it fails if one is
+        fixed without being ticked off here.
+        """
+        has_to_camel = {
+            name
+            for name, cls in CORE_VOCABULARY.items()
+            if "alias_generator" in getattr(cls, "model_config", {})
+        }
+        assert has_to_camel == set(_TO_CAMEL_BACKLOG_1991), (
+            "the set of core classes inheriting alias_generator changed.\n"
+            f"  newly violating: {sorted(has_to_camel - _TO_CAMEL_BACKLOG_1991)}\n"
+            f"  fixed but still listed: {sorted(_TO_CAMEL_BACKLOG_1991 - has_to_camel)}\n"
+            "to_camel is an AS2 serialization concern and belongs only in the"
+            " wire layer (ARCH-12-004, issue #1991)."
+        )
+
     @pytest.mark.xfail(
-        strict=False,
-        reason="Known pre-existing violation tracked in #1991. "
-        "CoreObject subclasses VultronPerson, VultronOrganization, VultronService, "
-        "VultronApplication, VultronGroup, CoreActorCollection, CaseStatus, and "
-        "ParticipantStatus inherit alias_generator=to_camel from as_Base (wire layer). "
-        "Tracked in #1991; xfail removed once those classes are refactored.",
+        strict=True,
+        reason="Goal state for issue #1991: no CoreObject subclass inherits "
+        "alias_generator=to_camel from as_Base. 8 known classes remain, "
+        "enumerated in _TO_CAMEL_BACKLOG_1991. When the last is fixed this test "
+        "XPASSes and fails the build — delete the marker and the backlog then.",
     )
     def test_no_core_object_has_to_camel_alias_generator(self) -> None:
         """No CoreObject subclass may use alias_generator=to_camel.
@@ -107,12 +173,36 @@ class TestCoreVocabularyHierarchy:
 class TestWireVocabularyHierarchy:
     """Tests for VOCABULARY (wire) hierarchy invariants."""
 
+    def test_non_as_base_vocabulary_backlog_is_exact(self) -> None:
+        """The #1992 violation set must match reality, in both directions.
+
+        See ``test_to_camel_backlog_is_exact`` for why this replaces a
+        ``strict=False`` xfail.
+        """
+        if not VOCABULARY:
+            pytest.skip(
+                "VOCABULARY is empty; wire objects may not be imported yet"
+            )
+
+        non_as_base = {
+            name
+            for name, cls in VOCABULARY.items()
+            if not issubclass(cls, as_Base)
+        }
+        assert non_as_base == set(_NON_AS_BASE_BACKLOG_1992), (
+            "the set of non-as_Base entries in the wire VOCABULARY changed.\n"
+            f"  newly violating: {sorted(non_as_base - _NON_AS_BASE_BACKLOG_1992)}\n"
+            f"  fixed but still listed: {sorted(_NON_AS_BASE_BACKLOG_1992 - non_as_base)}\n"
+            "VOCABULARY must contain only wire-layer ActivityStreams classes"
+            " (ARCH-12-003, issue #1992)."
+        )
+
     @pytest.mark.xfail(
-        strict=False,
-        reason="Known pre-existing violation tracked in #1992. "
-        "Core-layer classes (CoreActor, VultronOfferRecord, PendingCaseInbox, etc.) "
-        "are registered in the wire VOCABULARY registry. "
-        "Tracked in #1992; xfail removed once core-layer vocabulary is kept separate.",
+        strict=True,
+        reason="Goal state for issue #1992: the wire VOCABULARY contains only "
+        "as_Base subclasses. 7 known core-layer entries remain, enumerated in "
+        "_NON_AS_BASE_BACKLOG_1992. When the last is removed this test XPASSes "
+        "and fails the build — delete the marker and the backlog then.",
     )
     def test_all_vocabulary_are_as_base_subclasses(self) -> None:
         """All VOCABULARY classes must be subclasses of as_Base.

--- a/test/architecture/test_validate_assignment_ratchet.py
+++ b/test/architecture/test_validate_assignment_ratchet.py
@@ -27,7 +27,8 @@ A wire-shaped object sitting in a core-shaped field does not raise when read —
 reads as absent, and the reader substitutes an initial state, silently resetting
 the participant's ladder.  That is the #2232 / #2264 failure mode.
 
-This module ratchets the three-step remediation planned in issue #2261 and
+This module ratchets the three-step remediation planned in issue #2261 (steps:
+#2293, #2294, #2295) and
 decided in ADR-0064.  Each step owns one **backlog**: an exact set, asserted with
 ``==`` so it fails in *both* directions.
 
@@ -68,8 +69,8 @@ _CORE_ROOT = Path("vultron/core")
 _MODELS_PACKAGE = "vultron.core.models"
 
 # ---------------------------------------------------------------------------
-# Backlog 1 — ``mode="after"`` validators that assign to ``self`` (issue #2261,
-# step 1).  ``validate_assignment`` re-runs every ``mode="after"`` validator on
+# Backlog 1 — ``mode="after"`` validators that assign to ``self`` (issue #2293,
+# step 1 of #2261).  ``validate_assignment`` re-runs every ``mode="after"`` validator on
 # each assignment, so a validator that writes to ``self`` re-enters itself.  A
 # guarded one terminates at depth 2; an unguarded one recurses forever.  Turning
 # the flag on before these are fixed aborts 400+ tests with ``RecursionError``
@@ -115,7 +116,7 @@ _SELF_ASSIGNING_AFTER_VALIDATORS: frozenset[str] = frozenset(
 
 # ---------------------------------------------------------------------------
 # Backlog 2 — the classes that must carry ``validate_assignment`` directly
-# (issue #2261, step 2).  Every other core model inherits it from one of these,
+# (issue #2294, step 2 of #2261).  Every other core model inherits it from one of these,
 # so the enumeration stays at ten entries rather than listing all 103 classes.
 #
 # ``VultronBase`` is **permanently excluded**, not a backlog item: it is the
@@ -147,8 +148,8 @@ _VALIDATE_ASSIGNMENT_TARGETS: frozenset[str] = frozenset(
 _LENIENT_SHARED_BASE = "VultronBase"
 
 # ---------------------------------------------------------------------------
-# Backlog 3 — modules that mutate a shape-dual collection in place (issue #2261,
-# step 3).  ``validate_assignment`` does **not** close this door: ``.append()``
+# Backlog 3 — modules that mutate a shape-dual collection in place (issue #2295,
+# step 3 of #2261).  ``validate_assignment`` does **not** close this door: ``.append()``
 # is not an assignment, so Pydantic never sees it.  The remedy is the pattern
 # PRM-03-001/PRM-05-004 already used for ``case_roles``, which drove direct
 # ``case_roles`` mutation in ``vultron/`` to zero: a MUST-NOT spec entry,
@@ -298,13 +299,13 @@ def test_self_assigning_after_validator_backlog_is_exact():
         f"  fixed but still listed: {sorted(_SELF_ASSIGNING_AFTER_VALIDATORS - found)}\n"
         "A validator that writes to `self` re-enters itself once"
         ' `validate_assignment` is on. Derive in `mode="before"` instead'
-        " (ADR-0064, issue #2261)."
+        " (ADR-0064, issue #2293)."
     )
 
 
 @pytest.mark.xfail(
     strict=True,
-    reason='Goal state for issue #2261 step 1: no core `mode="after"` validator'
+    reason='Goal state for issue #2293 (#2261 step 1): no core `mode="after"` validator'
     " assigns to `self`. 23 known sites remain, enumerated in"
     " _SELF_ASSIGNING_AFTER_VALIDATORS. When the last one is fixed this test"
     " XPASSes and fails the build — delete the marker and the backlog then.",
@@ -375,7 +376,7 @@ def test_wire_branch_does_not_enable_validate_assignment():
 
 @pytest.mark.xfail(
     strict=True,
-    reason="Goal state for issue #2261 step 2: every core model carries"
+    reason="Goal state for issue #2294 (#2261 step 2): every core model carries"
     " validate_assignment. Blocked on step 1 — flipping the flag first aborts"
     " 400+ tests with RecursionError. When step 2 lands this test XPASSes and"
     " fails the build — delete the marker then.",
@@ -404,13 +405,13 @@ def test_collection_mutation_backlog_is_exact():
         f"  fixed but still listed: {sorted(_COLLECTION_MUTATION_BACKLOG - found)}\n"
         f"Collections covered: {', '.join(_SHAPE_DUAL_COLLECTIONS)}. Route writes"
         " through the canonical mutators on VulnerabilityCase / CaseParticipant"
-        " (issue #2261, ADR-0064)."
+        " (issue #2295, ADR-0064)."
     )
 
 
 @pytest.mark.xfail(
     strict=True,
-    reason="Goal state for issue #2261 step 3: no module outside the canonical"
+    reason="Goal state for issue #2295 (#2261 step 3): no module outside the canonical"
     " mutators mutates case_participants, case_statuses or participant_statuses"
     " in place. 3 known modules remain. When the last is fixed this test XPASSes"
     " and fails the build — delete the marker and the backlog then.",

--- a/test/architecture/test_validate_assignment_ratchet.py
+++ b/test/architecture/test_validate_assignment_ratchet.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Architecture ratchet: post-construction mutation safety for core models.
+
+Pydantic v2 validates a model at **construction** only.  Because
+``VultronBase.model_config`` does not set ``validate_assignment``, the same value
+that is correctly rejected by the constructor is silently accepted by both
+attribute assignment and in-place list mutation::
+
+    case = VulnerabilityCase(case_participants=[wire_obj])  # ValidationError
+    case.case_participants = [wire_obj]                     # accepted
+    case.case_participants.append(wire_obj)                 # accepted
+
+A wire-shaped object sitting in a core-shaped field does not raise when read — it
+reads as absent, and the reader substitutes an initial state, silently resetting
+the participant's ladder.  That is the #2232 / #2264 failure mode.
+
+This module ratchets the three-step remediation planned in issue #2261 and
+decided in ADR-0064.  Each step owns one **backlog**: an exact set, asserted with
+``==`` so it fails in *both* directions.
+
+- The backlog **grows** → a new violation was introduced; triage it.
+- An entry is **fixed but not removed** → the enumeration is stale; tick it off.
+
+Neither direction can drift unnoticed, and each backlog has a companion
+``xfail(strict=True)`` goal test.  ``strict=True`` is deliberate: when the last
+entry is removed the goal test XPASSes, which **fails** the build and forces the
+marker to be deleted.  The pre-existing ``strict=False`` markers for #1991/#1992
+are what this pattern is correcting — a non-strict xfail keeps passing forever
+after the work is done, so nobody is ever told to clean it up.
+
+Spec: `specs/architecture.yaml` ARCH-21-001 through ARCH-21-005;
+`specs/case-management.yaml` CM-27-001 through CM-27-003;
+`specs/participant-role-management.yaml` PRM-03-003.
+Reference: `docs/adr/0064-core-branch-validate-assignment.md`,
+`notes/domain-validation.md`.
+
+Related: issue #2261 (this ratchet), issue #2232 (the shape duality it protects
+against), ADR-0062 (normalisation at ingress and persistence).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import pkgutil
+import re
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+import vultron.core.models
+
+_CORE_ROOT = Path("vultron/core")
+_MODELS_PACKAGE = "vultron.core.models"
+
+# ---------------------------------------------------------------------------
+# Backlog 1 — ``mode="after"`` validators that assign to ``self`` (issue #2261,
+# step 1).  ``validate_assignment`` re-runs every ``mode="after"`` validator on
+# each assignment, so a validator that writes to ``self`` re-enters itself.  A
+# guarded one terminates at depth 2; an unguarded one recurses forever.  Turning
+# the flag on before these are fixed aborts 400+ tests with ``RecursionError``
+# and nothing else — the recursion masks every real type failure.
+#
+# The remedy (ADR-0064) is to derive in ``mode="before"``, where the derived
+# value is still validated normally, rather than to reach for an escape hatch
+# that writes the field unvalidated.
+#
+# Scope is ``vultron/core/`` only.  The wire branch has twelve validators of the
+# same shape, and they are deliberately exempt: the wire branch never gets
+# ``validate_assignment`` (ARCH-12-002), so they cannot recurse.
+#
+# This set may only SHRINK.
+# ---------------------------------------------------------------------------
+_SELF_ASSIGNING_AFTER_VALIDATORS: frozenset[str] = frozenset(
+    {
+        "vultron/core/models/base.py::CoreObject._set_type_from_class_name",
+        "vultron/core/models/case.py::VulnerabilityCase._compute_genesis_hash_if_missing",
+        "vultron/core/models/case.py::VulnerabilityCase._init_case_statuses",
+        "vultron/core/models/case_ledger.py::HashChainLedgerRecord._compute_entry_hash",
+        "vultron/core/models/case_ledger_entry.py::CaseLedgerEntry._set_id_from_case",
+        "vultron/core/models/case_participant.py::CaseActorParticipant._set_role",
+        "vultron/core/models/case_participant.py::CaseParticipant._init_participant_status_if_empty",
+        "vultron/core/models/case_participant.py::CaseParticipant._set_name_if_empty",
+        "vultron/core/models/case_participant.py::CoordinatorParticipant._set_role",
+        "vultron/core/models/case_participant.py::DeployerParticipant._set_role",
+        "vultron/core/models/case_participant.py::FinderParticipant._set_role",
+        "vultron/core/models/case_participant.py::FinderReporterParticipant._set_accepted_status",
+        "vultron/core/models/case_participant.py::FinderReporterParticipant._set_roles",
+        "vultron/core/models/case_participant.py::OtherParticipant._set_role",
+        "vultron/core/models/case_participant.py::ReporterParticipant._set_accepted_status",
+        "vultron/core/models/case_participant.py::ReporterParticipant._set_role",
+        "vultron/core/models/case_participant.py::VendorParticipant._set_role",
+        "vultron/core/models/offer_record.py::VultronOfferRecord._set_id",
+        "vultron/core/models/ownership_transfer_offer_record.py::VultronOwnershipTransferOfferRecord._set_id",
+        "vultron/core/models/pending_case_inbox.py::VultronPendingCaseInbox._set_id",
+        "vultron/core/models/pending_create_case_activity.py::PendingCreateCaseActivity._set_id",
+        "vultron/core/models/replication_state.py::VultronReplicationState._set_id",
+        "vultron/core/models/report_case_link.py::VultronReportCaseLink._set_id",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Backlog 2 — the classes that must carry ``validate_assignment`` directly
+# (issue #2261, step 2).  Every other core model inherits it from one of these,
+# so the enumeration stays at ten entries rather than listing all 103 classes.
+#
+# ``VultronBase`` is **permanently excluded**, not a backlog item: it is the
+# shared base of both branches (ARCH-12-001) and ARCH-12-002 requires it to stay
+# lenient for the wire branch, since ``as_Base`` inherits it.  Setting the flag
+# there is the one-line fix that looks right and is not — it produced the worst
+# measured blast radius (747 failed + 423 errors) and breaks the wire contract.
+#
+# This set is a PLAN, verified against the live hierarchy by
+# ``test_mixin_targets_cover_every_core_model``: adding a core model outside all
+# ten subtrees fails that test rather than silently escaping coverage.
+# ---------------------------------------------------------------------------
+_VALIDATE_ASSIGNMENT_TARGETS: frozenset[str] = frozenset(
+    {
+        "DeadLetterRecord",
+        "EmDimension",
+        "HashChainLedgerRecord",
+        "PecDimension",
+        "PxaDimension",
+        "RmDimension",
+        "VfdDimension",
+        "VultronEvent",
+        "VultronObject",
+        "VultronOutbox",
+    }
+)
+
+# The ARCH-12-002 boundary: shared base, must stay lenient. Never a target.
+_LENIENT_SHARED_BASE = "VultronBase"
+
+# ---------------------------------------------------------------------------
+# Backlog 3 — modules that mutate a shape-dual collection in place (issue #2261,
+# step 3).  ``validate_assignment`` does **not** close this door: ``.append()``
+# is not an assignment, so Pydantic never sees it.  The remedy is the pattern
+# PRM-03-001/PRM-05-004 already used for ``case_roles``, which drove direct
+# ``case_roles`` mutation in ``vultron/`` to zero: a MUST-NOT spec entry,
+# canonical mutators, and this scan.
+#
+# This set may only SHRINK.
+# ---------------------------------------------------------------------------
+_COLLECTION_MUTATION_BACKLOG: frozenset[str] = frozenset(
+    {
+        "vultron/core/behaviors/status/nodes/append/actions.py",
+        "vultron/core/behaviors/status/nodes/case_status.py",
+        "vultron/core/behaviors/sync/nodes/participant_status_effect.py",
+    }
+)
+
+# Canonical mutator homes — permanently permitted, exactly as PRM-03-001 permits
+# ``vultron/core/models/participant.py`` to mutate ``case_roles``.  The mutators
+# themselves have to write the field; that is their job.
+_CANONICAL_MUTATOR_MODULES: frozenset[str] = frozenset(
+    {
+        "vultron/core/models/case.py",
+        "vultron/core/models/case_participant.py",
+    }
+)
+
+# Collections whose items exist in incompatible wire and core shapes, so a
+# wrong-shaped item is silently misread rather than loudly rejected (ADR-0036,
+# SDO-03-002).
+_SHAPE_DUAL_COLLECTIONS = (
+    "case_participants",
+    "case_statuses",
+    "participant_statuses",
+)
+
+_MUTATION_RE = {
+    field: re.compile(
+        rf"\.{field}\s*(?:=(?!=)|\.\s*(?:append|extend|insert|remove|pop|clear))"
+    )
+    for field in _SHAPE_DUAL_COLLECTIONS
+}
+
+
+# ---------------------------------------------------------------------------
+# Detectors
+# ---------------------------------------------------------------------------
+def _is_after_validator(fn: ast.FunctionDef) -> bool:
+    for decorator in fn.decorator_list:
+        text = ast.unparse(decorator).replace("'", '"')
+        if "model_validator" in text and '"after"' in text:
+            return True
+    return False
+
+
+def _assigns_to_self(fn: ast.FunctionDef) -> bool:
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+            targets = [node.target]
+        else:
+            continue
+        for target in targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+            ):
+                return True
+    return False
+
+
+def _find_self_assigning_after_validators() -> set[str]:
+    """Return ``path::Class.method`` for each core after-validator writing to self."""
+    found: set[str] = set()
+    for path in sorted(_CORE_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (
+            SyntaxError
+        ):  # pragma: no cover - unparseable file is a build error
+            continue
+        for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+            for fn in (n for n in cls.body if isinstance(n, ast.FunctionDef)):
+                if _is_after_validator(fn) and _assigns_to_self(fn):
+                    found.add(f"{path.as_posix()}::{cls.name}.{fn.name}")
+    return found
+
+
+def _find_collection_mutation_modules() -> set[str]:
+    """Return modules under ``vultron/core/`` that mutate a shape-dual collection."""
+    found: set[str] = set()
+    for path in sorted(_CORE_ROOT.rglob("*.py")):
+        posix = path.as_posix()
+        if posix in _CANONICAL_MUTATOR_MODULES:
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            if any(pattern.search(line) for pattern in _MUTATION_RE.values()):
+                found.add(posix)
+                break
+    return found
+
+
+def _core_model_classes() -> dict[str, type[BaseModel]]:
+    """Every ``BaseModel`` subclass defined in ``vultron.core.models``.
+
+    Walks the package so a newly added module is covered without registration.
+    """
+    classes: dict[str, type[BaseModel]] = {}
+    for info in pkgutil.walk_packages(
+        vultron.core.models.__path__, prefix=f"{_MODELS_PACKAGE}."
+    ):
+        module = importlib.import_module(info.name)
+        for obj in vars(module).values():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, BaseModel)
+                and obj is not BaseModel
+                and obj.__module__.startswith(_MODELS_PACKAGE)
+            ):
+                classes[obj.__qualname__] = obj
+    return classes
+
+
+def _lacks_validate_assignment(cls: type[BaseModel]) -> bool:
+    return not cls.model_config.get("validate_assignment", False)
+
+
+# ---------------------------------------------------------------------------
+# Guard the guards — a detector that finds nothing makes every assertion vacuous
+# ---------------------------------------------------------------------------
+def test_detectors_are_not_vacuous():
+    assert len(list(_CORE_ROOT.rglob("*.py"))) > 100, "core tree not found"
+    assert len(_core_model_classes()) > 50, "core models did not import"
+
+
+# ---------------------------------------------------------------------------
+# Backlog 1 — after-validator self-assignment
+# ---------------------------------------------------------------------------
+def test_self_assigning_after_validator_backlog_is_exact():
+    """The enumerated set must match reality, in both directions."""
+    found = _find_self_assigning_after_validators()
+    assert found == set(_SELF_ASSIGNING_AFTER_VALIDATORS), (
+        'the set of core `mode="after"` validators that assign to `self` changed.\n'
+        f"  newly violating: {sorted(found - _SELF_ASSIGNING_AFTER_VALIDATORS)}\n"
+        f"  fixed but still listed: {sorted(_SELF_ASSIGNING_AFTER_VALIDATORS - found)}\n"
+        "A validator that writes to `self` re-enters itself once"
+        ' `validate_assignment` is on. Derive in `mode="before"` instead'
+        " (ADR-0064, issue #2261)."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='Goal state for issue #2261 step 1: no core `mode="after"` validator'
+    " assigns to `self`. 23 known sites remain, enumerated in"
+    " _SELF_ASSIGNING_AFTER_VALIDATORS. When the last one is fixed this test"
+    " XPASSes and fails the build — delete the marker and the backlog then.",
+)
+def test_no_core_after_validator_assigns_to_self():
+    found = _find_self_assigning_after_validators()
+    assert not found, (
+        f'{len(found)} core `mode="after"` validators still assign to `self`:'
+        f" {sorted(found)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backlog 2 — validate_assignment coverage on the core branch
+# ---------------------------------------------------------------------------
+def test_mixin_targets_cover_every_core_model():
+    """Every core model must inherit from one of the ten enumerated targets.
+
+    This is what keeps the plan honest as the hierarchy evolves: a new core
+    model added outside all ten subtrees fails here rather than silently
+    escaping ``validate_assignment`` coverage once step 2 lands.
+    """
+    classes = _core_model_classes()
+    uncovered = sorted(
+        name
+        for name, cls in classes.items()
+        if name != _LENIENT_SHARED_BASE
+        and name not in _VALIDATE_ASSIGNMENT_TARGETS
+        and not any(
+            ancestor.__qualname__ in _VALIDATE_ASSIGNMENT_TARGETS
+            for ancestor in cls.__mro__[1:]
+        )
+    )
+    assert not uncovered, (
+        f"core models outside every _VALIDATE_ASSIGNMENT_TARGETS subtree: {uncovered}.\n"
+        "Either give them a target ancestor or add them to the target set —"
+        " otherwise they escape validate_assignment coverage (issue #2261)."
+    )
+
+
+def test_shared_base_is_never_a_target():
+    """ARCH-12-002: ``VultronBase`` must stay lenient for the wire branch."""
+    assert _LENIENT_SHARED_BASE not in _VALIDATE_ASSIGNMENT_TARGETS, (
+        f"{_LENIENT_SHARED_BASE} is the shared base of both branches"
+        " (ARCH-12-001); `as_Base` inherits it. Setting validate_assignment"
+        " there violates ARCH-12-002 and breaks inbound wire parsing."
+    )
+
+
+def test_wire_branch_does_not_enable_validate_assignment():
+    """ARCH-12-002: the wire branch stays lenient. Must hold now and after step 2."""
+    from vultron.wire.as2.vocab.base.registry import VOCABULARY
+
+    offenders = sorted(
+        name
+        for name, cls in VOCABULARY.items()
+        if isinstance(cls, type)
+        and issubclass(cls, BaseModel)
+        and cls.__module__.startswith("vultron.wire")
+        and cls.model_config.get("validate_assignment", False)
+    )
+    assert not offenders, (
+        f"wire classes with validate_assignment enabled: {offenders}."
+        " Inbound wire data is legitimately loose (ARCH-12-002); strictness"
+        " belongs at the wire→core projection, not on the wire types."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Goal state for issue #2261 step 2: every core model carries"
+    " validate_assignment. Blocked on step 1 — flipping the flag first aborts"
+    " 400+ tests with RecursionError. When step 2 lands this test XPASSes and"
+    " fails the build — delete the marker then.",
+)
+def test_every_core_model_has_validate_assignment():
+    lacking = sorted(
+        name
+        for name, cls in _core_model_classes().items()
+        if name != _LENIENT_SHARED_BASE and _lacks_validate_assignment(cls)
+    )
+    assert not lacking, (
+        f"{len(lacking)} core models accept unvalidated attribute assignment:"
+        f" {lacking}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backlog 3 — in-place mutation of shape-dual collections
+# ---------------------------------------------------------------------------
+def test_collection_mutation_backlog_is_exact():
+    """The enumerated set must match reality, in both directions."""
+    found = _find_collection_mutation_modules()
+    assert found == set(_COLLECTION_MUTATION_BACKLOG), (
+        "the set of core modules mutating a shape-dual collection changed.\n"
+        f"  newly violating: {sorted(found - _COLLECTION_MUTATION_BACKLOG)}\n"
+        f"  fixed but still listed: {sorted(_COLLECTION_MUTATION_BACKLOG - found)}\n"
+        f"Collections covered: {', '.join(_SHAPE_DUAL_COLLECTIONS)}. Route writes"
+        " through the canonical mutators on VulnerabilityCase / CaseParticipant"
+        " (issue #2261, ADR-0064)."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Goal state for issue #2261 step 3: no module outside the canonical"
+    " mutators mutates case_participants, case_statuses or participant_statuses"
+    " in place. 3 known modules remain. When the last is fixed this test XPASSes"
+    " and fails the build — delete the marker and the backlog then.",
+)
+def test_no_direct_shape_dual_collection_mutation_in_core():
+    found = _find_collection_mutation_modules()
+    assert not found, (
+        f"{len(found)} core modules mutate a shape-dual collection directly:"
+        f" {sorted(found)}"
+    )
+
+
+def test_canonical_mutator_modules_still_exist():
+    """A stale allowlist entry silently widens the exemption."""
+    missing = sorted(
+        m for m in _CANONICAL_MUTATOR_MODULES if not Path(m).is_file()
+    )
+    assert not missing, (
+        f"_CANONICAL_MUTATOR_MODULES names files that no longer exist: {missing}."
+        " Remove them so the exemption does not outlive its reason."
+    )


### PR DESCRIPTION
- Closes #2261

## Summary

Plans CONCERN-2261 (`VultronBase` lacks `validate_assignment`) as three
ratcheted steps, and lands the CI ratchet that tracks them *before* any
implementation, so progress cannot drift across the three follow-on issues.

Pydantic v2 validates a model at **construction** only. The same value the
constructor rejects is silently accepted through two other doors:

```python
case = VulnerabilityCase(case_participants=[wire_obj])  # ValidationError
case.case_participants = [wire_obj]                     # accepted
case.case_participants.append(wire_obj)                 # accepted
```

Because core and wire carry structurally incompatible shapes for the same
concepts, a wire-shaped object in a core-typed field does not raise when read —
it reads as *absent*, so readers substitute an initial state and a participant's
RM ladder silently resets. That is the #2232 / #2264 mechanism.

### The one-line fix does not work — measured, not assumed

| Variant | FAILED | ERROR | Failure types |
|---|---|---|---|
| `validate_assignment` on `VultronBase` | 747 | 423 | **879 × `RecursionError`, nothing else** |
| `validate_assignment` on `CoreObject` | 398 | 268 | **403 × `RecursionError`, nothing else** |

Baseline was 2 pre-existing unrelated failures (#2274). Not one
type-strictness failure was visible in either variant: the flag re-runs every
`mode="after"` validator on each assignment, and 23 core validators assign to
`self`, so they re-enter themselves. The recursion **masks** the real blast
radius, which makes the validator refactor a hard prerequisite rather than a
nicety.

Two further findings shaped the plan:

- **`validate_assignment` cannot close the `append` door at all** — an in-place
  list mutation is not an attribute assignment, so Pydantic never observes it.
  That door needs prohibition + canonical mutators + a static ratchet, the same
  way PRM-03-001 drove direct `case_roles` mutation in `vultron/` to zero.
- **Cost is not the obstacle** — scalar assignment measured 475 ns → 1464 ns
  (3.1×, ~1 µs). The open question is O(N) collection-field re-validation, which
  becomes an acceptance criterion in step 2.

## Changes

- **`docs/adr/0064-core-branch-validate-assignment.md`** (new): the decision —
  three ordered steps; a **core-only mixin** on the 10 root classes covering all
  103 core models (not `CoreObject`, which leaves 16 models uncovered including
  all five dimension types — precisely the #2232 types); `VultronBase` excluded
  **permanently** per ARCH-12-002, since `as_Base` inherits it and the wire
  branch is legitimately lenient. Four decision groups with rejected
  alternatives.
- **`specs/architecture.yaml`**: new group `ARCH-21` "Post-Construction Mutation
  Safety" (ARCH-21-001..005).
- **`specs/case-management.yaml`**: new group `CM-27` (CM-27-001..003) — no
  post-construction mutation of `case_participants` / `case_statuses`; a
  canonical `add_case_status()` mutator is required.
- **`specs/participant-role-management.yaml`**: `PRM-03-003` extends PRM-03-001
  to `participant_statuses`.
- **`notes/domain-validation.md`**: "Three Doors, One Lock" — placement table,
  the `self`-assignment pitfall with wrong/right code, and why the
  `self.__dict__` escape hatch was rejected (it leaves the derived value
  unvalidated).
- **`AGENTS.md`**: one Common Pitfalls entry covering both traps.
- **`test/architecture/test_validate_assignment_ratchet.py`** (new): three
  **exact-set** backlogs — 23 self-assigning validators, 10 mixin targets, 3
  mutating modules — asserted with `==`, so each fails if the backlog **grows**
  *and* if an entry is fixed without being ticked off. Each has a companion
  `xfail(strict=True)` goal test. Heaviest scan runs in 0.55 s.
- **`test/architecture/test_hierarchy_invariants.py`**: repairs the
  pre-existing #1991 / #1992 `strict=False` xfails, which is where the ratchet
  design came from — a non-strict xfail keeps passing after the work is done, so
  it never tells anyone to remove it, and it gives no partial-progress signal.
  Both are now `strict=True` with enumerated backlogs (8 and 7 entries).

## Verification

- `test/architecture/`: 61 passed, 5 XFAIL, exit 0.
- **The ratchet was verified in both directions before merge**: injecting a
  mutation site fails the exact-set test, and neutralising all three backlog-3
  sites turns the goal test into `[XPASS(strict)]` → FAILED, proving the
  completion path forces cleanup.
- It also *earned its keep during this PR*: the rebase onto `main` picked up the
  BTND-07 decomposition (`c19b9997`), which split two of the three backlog
  modules. The exact-set assertion failed on the renames and named them
  precisely; the paths were updated.
- `spec-lint`: **zero** new warnings versus `origin/main` (63 before, 63 after).
- `black`, `flake8 vultron/ test/`, `mypy` (678 files), `pyright` (0 errors),
  `markdownlint-cli2`, ADR index/nav sync: all clean.

## Notes for reviewers

- ADR renumbered **0063 → 0064** and the spec group **ARCH-20 → ARCH-21** during
  the rebase: the #2260 plan (PR #2285) claimed both while this was in flight.
- The wire branch keeps its **twelve** self-assigning validators and is exempt
  by design — it never gets `validate_assignment`. Recorded explicitly in the
  ADR rather than left implicit.
- #2261 is **preventive hardening** for the #2233 class of defect, not the fix
  for it. Seven Demo Integration scenarios were red on `main` at the time of
  writing (`422 ValidationError: TransitionParticipantRMtoAccepted`); that is
  #2233's own work.
- The #1991 backlog here and ADR-0063's `alias_generator` removal converge: as
  #2260's issues land, `_TO_CAMEL_BACKLOG_1991` shrinks and eventually XPASSes,
  which fails the build and forces the marker's deletion. That is intended.

## Implementation Issues

- #2293 — step 1: remove `self`-assignment from 23 core `mode="after"` validators (`size:M`, blocked by #2261)
- #2294 — step 2: core-only `validate_assignment` mixin on the 10 core model roots (`size:L`, blocked by #2261 **and #2293** — flipping the flag first aborts 400+ tests with `RecursionError`)
- #2295 — step 3: close the `append` door via canonical mutators (`size:M`, blocked by #2261 only; shares no files with 1 or 2 and runs in **parallel**)

All three are Tasks under Epic #2229 at `Schedule=Focus`.
