### PR TITLE
fix: all-skip pytest session exits non-zero in invariant harness (DEMOCI-10-005)

### DIFF
--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -50,7 +50,7 @@ but `devlogs/` was empty. The `invariant-harness` job then died on **artifact
 download** — the run that most needed forensics produced none, and the harness
 reported a plumbing error instead of an invariant result (issue #2239).
 
-**Design**: three pieces, spec'd as DEMOCI-10-001 through DEMOCI-10-004.
+**Design**: four pieces, spec'd as DEMOCI-10-001 through DEMOCI-10-005.
 
 1. **A shared harness owns the ordering.**
    `vultron/demo/helpers/harness.py` provides `scenario_harness(demo_name)`.
@@ -88,14 +88,24 @@ reported a plumbing error instead of an invariant result (issue #2239).
    reason — so the harness output explains *why* there are no ledgers rather
    than leaving a reviewer to guess.
 
-**A dump failure must not mask the scenario failure.** Errors raised inside the
-dump are recorded in the manifest's `reason` field and swallowed; the harness
-re-raises the original exception with the accumulated `demo_check` failures
-attached as exception notes (DEMOCI-10-004).
+   A dump failure must not mask the scenario failure. Errors raised inside the
+   dump are recorded in the manifest's `reason` field and swallowed; the harness
+   re-raises the original exception with the accumulated `demo_check` failures
+   attached as exception notes (DEMOCI-10-004).
+
+4. **The harness exits non-zero on an all-skip session.**
+   When `devlogs/` is absent or empty, `load_devlogs()` calls `pytest.skip()` at
+   fixture level and every test skips. pytest exits 0 by default for skip-only
+   sessions, which let CI report green even though no invariant was checked.
+   An `_AllSkipGuard` pytest plugin registered in
+   `test/ci/invariants/conftest.py` forces `session.exitstatus = 1` whenever at
+   least one test was reported and all reported outcomes were `"skipped"`
+   (DEMOCI-10-005). This converts a vacuous pass into a visible red.
 
 Regression coverage: `test/demo/test_issue_2239_ledger_dump_in_finally.py`
-(all nine scenarios), `test/demo/test_scenario_harness.py`, and
-`test/ci/invariants/test_common.py::TestLoadDevlogsManifestHandling`.
+(all nine scenarios), `test/demo/test_scenario_harness.py`,
+`test/ci/invariants/test_common.py::TestLoadDevlogsManifestHandling`, and
+`test/ci/invariants/test_common.py::TestAllSkipGuard`.
 
 ---
 
@@ -207,14 +217,14 @@ deferred to the implementation PR together.
 ## Reading a Red Invariant Harness Job (CONCERN-2243)
 
 **A red `<scenario> Invariant Harness` job is not evidence that any invariant
-was violated — or even evaluated.** The job has three distinct red modes and
-one false-green mode, and they are easy to confuse:
+was violated — or even evaluated.** The job has three distinct red modes, and
+they are easy to confuse:
 
 | Job outcome | What actually happened | What it tells you about invariants |
 |---|---|---|
 | Red at `Download case log JSONL files` | The demo job never uploaded an artifact, so `actions/download-artifact` errored (`Artifact not found for name: <scenario>-case-logs`). **pytest never ran.** | Nothing at all |
 | Red at `Run case-ledger invariant harness` | pytest ran and an assertion failed | A real invariant result |
-| Green with every test skipped | `load_devlogs` called `pytest.skip` because `devlogs/<scenario>/` held no `*-case-ledger.jsonl`; a skip-only run exits 0 | Nothing — this is a **false green** |
+| Red at `Run case-ledger invariant harness` with every test skipped | `load_devlogs` called `pytest.skip` because `devlogs/<scenario>/` held no `*-case-ledger.jsonl`; the `_AllSkipGuard` (DEMOCI-10-005) forces `exitstatus=1` | Nothing — vacuous red; no invariant was checked |
 
 CONCERN-2243 was filed because a permanently-red `fvcv-handoff Invariant
 Harness` was read as proof that its `engage_case` assertion could never pass.

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -932,3 +932,23 @@ groups:
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-10-001
+
+      - id: DEMOCI-10-005
+        priority: MUST
+        kind: project
+        statement: >-
+          The invariant-harness pytest session MUST exit non-zero when every
+          collected test was skipped.  A ``pytest_sessionfinish`` hook registered
+          in ``test/ci/invariants/conftest.py`` MUST set ``session.exitstatus = 1``
+          whenever at least one test was reported and all reported test outcomes
+          were ``"skipped"``.
+        rationale: >-
+          When devlogs are absent or a scenario sub-directory is missing,
+          ``load_devlogs()`` calls ``pytest.skip()`` at fixture level and every
+          test in the file skips.  pytest exits 0 by default for a skip-only
+          session, which lets CI mark the invariant-harness job green even though
+          no invariant was actually checked.  Forcing exit 1 converts a vacuous
+          pass into a visible failure, closing the last gap in DEMOCI-10 coverage.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-10-003

--- a/test/ci/invariants/conftest.py
+++ b/test/ci/invariants/conftest.py
@@ -168,3 +168,36 @@ def full_history_replicas() -> dict[str, list[dict]]:
     """Late actor has the complete chain (no missing entries)."""
     chain = _build_chain("case-actor", _base_events())
     return {"early": chain, "late": list(chain)}
+
+
+# ---------------------------------------------------------------------------
+# DEMOCI-10-005: all-skip guard
+# ---------------------------------------------------------------------------
+
+
+class _AllSkipGuard:
+    """Force exit-code 1 when every collected test was skipped.
+
+    When devlogs are absent, load_devlogs() calls pytest.skip() at fixture
+    level.  A session where all tests skip exits 0 by default, which makes
+    CI report green even though no invariant was actually checked.
+    DEMOCI-10-005 requires the harness to exit non-zero in this case.
+    """
+
+    def __init__(self) -> None:
+        self._outcomes: list[str] = []
+
+    def pytest_runtest_logreport(self, report) -> None:
+        if report.when == "call":
+            self._outcomes.append(report.outcome)
+        elif report.when == "setup" and report.outcome == "skipped":
+            # Fixture-level skip: no "call" phase follows.
+            self._outcomes.append("skipped")
+
+    def pytest_sessionfinish(self, session) -> None:
+        if self._outcomes and all(o == "skipped" for o in self._outcomes):
+            session.exitstatus = 1
+
+
+def pytest_configure(config) -> None:
+    config.pluginmanager.register(_AllSkipGuard(), "_all_skip_guard")

--- a/test/ci/invariants/conftest.py
+++ b/test/ci/invariants/conftest.py
@@ -188,7 +188,7 @@ class _AllSkipGuard:
         self._outcomes: list[str] = []
 
     def pytest_runtest_logreport(self, report) -> None:
-        if report.when == "call":
+        if report.when == "call" and not getattr(report, "wasxfail", None):
             self._outcomes.append(report.outcome)
         elif report.when == "setup" and report.outcome == "skipped":
             # Fixture-level skip: no "call" phase follows.

--- a/test/ci/invariants/test_common.py
+++ b/test/ci/invariants/test_common.py
@@ -749,3 +749,75 @@ class TestLoadDevlogsManifestHandling:
         with pytest.raises(Failed) as excinfo:
             common.load_devlogs()
         assert "no case-ledger" in (excinfo.value.msg or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# _AllSkipGuard (DEMOCI-10-005)
+# ---------------------------------------------------------------------------
+
+import types as _types  # noqa: E402
+
+from test.ci.invariants.conftest import _AllSkipGuard  # noqa: E402
+
+
+def _rpt(when: str, outcome: str):
+    return _types.SimpleNamespace(when=when, outcome=outcome)
+
+
+def _ses(exitstatus: int = 0):
+    return _types.SimpleNamespace(exitstatus=exitstatus)
+
+
+class TestAllSkipGuard:
+    """DEMOCI-10-005: all-skip session must not exit 0."""
+
+    def test_forces_exit_1_on_fixture_level_skips(self):
+        """All tests skipped at setup (fixture skip) → exitstatus forced to 1."""
+        guard = _AllSkipGuard()
+        for _ in range(3):
+            guard.pytest_runtest_logreport(_rpt("setup", "skipped"))
+        session = _ses(0)
+        guard.pytest_sessionfinish(session=session)
+        assert session.exitstatus == 1
+
+    def test_forces_exit_1_on_call_level_skips(self):
+        """All tests skipped in the test body → exitstatus forced to 1."""
+        guard = _AllSkipGuard()
+        for _ in range(2):
+            guard.pytest_runtest_logreport(_rpt("call", "skipped"))
+        session = _ses(0)
+        guard.pytest_sessionfinish(session=session)
+        assert session.exitstatus == 1
+
+    def test_does_not_trigger_when_any_test_passes(self):
+        """One passing test among skips → exitstatus unchanged."""
+        guard = _AllSkipGuard()
+        guard.pytest_runtest_logreport(_rpt("setup", "skipped"))
+        guard.pytest_runtest_logreport(_rpt("call", "passed"))
+        session = _ses(0)
+        guard.pytest_sessionfinish(session=session)
+        assert session.exitstatus == 0
+
+    def test_does_not_trigger_on_empty_session(self):
+        """No tests reported → exitstatus unchanged."""
+        guard = _AllSkipGuard()
+        session = _ses(0)
+        guard.pytest_sessionfinish(session=session)
+        assert session.exitstatus == 0
+
+    def test_does_not_trigger_when_tests_fail(self):
+        """Failed tests → guard does not alter the already-nonzero exitstatus."""
+        guard = _AllSkipGuard()
+        guard.pytest_runtest_logreport(_rpt("call", "failed"))
+        session = _ses(1)
+        guard.pytest_sessionfinish(session=session)
+        assert session.exitstatus == 1
+
+    def test_ignores_teardown_reports(self):
+        """Teardown outcomes are not tracked; a setup skip still triggers."""
+        guard = _AllSkipGuard()
+        guard.pytest_runtest_logreport(_rpt("teardown", "passed"))
+        guard.pytest_runtest_logreport(_rpt("setup", "skipped"))
+        session = _ses(0)
+        guard.pytest_sessionfinish(session=session)
+        assert session.exitstatus == 1

--- a/test/ci/invariants/test_common.py
+++ b/test/ci/invariants/test_common.py
@@ -821,3 +821,14 @@ class TestAllSkipGuard:
         session = _ses(0)
         guard.pytest_sessionfinish(session=session)
         assert session.exitstatus == 1
+
+    def test_does_not_trigger_for_xfail_expected_failures(self):
+        """xfail expected-failure (outcome='skipped', wasxfail set) → not counted."""
+        guard = _AllSkipGuard()
+        rpt = _types.SimpleNamespace(
+            when="call", outcome="skipped", wasxfail="reason"
+        )
+        guard.pytest_runtest_logreport(rpt)
+        session = _ses(0)
+        guard.pytest_sessionfinish(session=session)
+        assert session.exitstatus == 0


### PR DESCRIPTION
- Closes #2242
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Adds an `_AllSkipGuard` pytest plugin to `test/ci/invariants/conftest.py` that forces `session.exitstatus = 1` when every collected test was skipped, closing the last gap in issue #2242 (invariant harness reports green on four confirmed-broken scenarios).

## Changes

- **`test/ci/invariants/conftest.py`**: Add `_AllSkipGuard` plugin class and `pytest_configure` hook. The guard tracks per-test outcomes via `pytest_runtest_logreport` (setup-level skips and call-level outcomes) and in `pytest_sessionfinish` sets `session.exitstatus = 1` when `_outcomes` is non-empty and every entry is `"skipped"`.
- **`test/ci/invariants/test_common.py`**: Add `TestAllSkipGuard` with 6 regression tests covering fixture-level skips, call-level skips, mixed pass+skip, empty session, all-fail, and teardown-report exclusion.
- **`specs/demo-ci.yaml`**: Add DEMOCI-10-005 (MUST, project kind) specifying the non-zero-on-all-skip requirement; refines DEMOCI-10-003.

## Context

Root causes of #2242:
1. **8 of 15 invariants are canonical-only** (`auth_entries()` returns only the case-actor log) — addressed by the `engage_case` universal invariant (commit `fad16e32`).
2. **`engage_case` missing from 8/9 scenario harnesses** — fixed in `fad16e32`; structural ratchet added in `test_universal_event_types.py`.
3. **Skip-only session exits 0** — fixed in this PR.

With this PR all three root causes are resolved. A scenario that produces no devlogs (or whose demo fails before any ledger entries are emitted) now produces a **red** invariant harness rather than a vacuous green.

## Verification

- All 6995 unit tests pass (6 new in `TestAllSkipGuard`); 2 pre-existing fv failures catalogued in #2274
- Integration suite: 1126 passed
- Black, flake8, mypy, pyright all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)