### PR TITLE
fix: engage_case never recorded in case-actor ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,9 +492,15 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **FastAPI `dependency_overrides` Key Must Be Re-Exported When Converting a
   Router Module to a Package** — scan tests for `module.dependency_function`
   patterns. Issue #970.
-- **Guarded-Commit Tests Must Use the CASE_MANAGER Actor as `receiving_actor_id`**
-  — `CheckIsCaseManagerNode` checks the participant entry, not the service ID.
-  See BT-17-005.
+- **Guarded-Commit BTs Must Execute Under the CASE_MANAGER Actor's Identity** —
+  `CheckIsCaseManagerNode` compares the *blackboard* `actor_id` against the case's
+  CASE_MANAGER participant. Any code that calls `execute_with_setup` for a BT
+  containing `GuardedCommitCaseLedgerEntryBT` MUST pass the *receiving* actor's
+  ID (e.g. `request.receiving_actor_id`), NOT the sender's (`request.actor_id`).
+  This applies to production received-side use cases and to tests alike. In tests,
+  use `actor_id=case_manager_actor_id`; in received-side use cases, use
+  `actor_id=request.receiving_actor_id if request.receiving_actor_id is not None
+  else request.actor_id`. See BT-17-005. *Source: ISSUE-2300*
 - **Staged-Type `model_validate` Only Works on Core-Constructed Objects** — don't
   use on `dl.read()` results; check pre-conditions directly on returned object.
 - **`freshen-branch.sh` Leaves Temp Branch on Conflict When Abort Silently Fails** —

--- a/plan/incoming/learnings/20260813-received-usecase-must-pass-receiving-actor-id.md
+++ b/plan/incoming/learnings/20260813-received-usecase-must-pass-receiving-actor-id.md
@@ -1,0 +1,29 @@
+---
+title: Received-side use cases must pass receiving_actor_id to execute_with_setup
+type: learning
+timestamp: "2026-08-13"
+source: ISSUE-2300
+signal: spec-gap
+---
+
+BT-17-005 in AGENTS.md says *guarded-commit tests* must use the CASE_MANAGER
+actor as `receiving_actor_id` in `execute_with_setup`. The same rule applies
+to *production received-side use cases*.
+
+`EngageCaseReceivedUseCase` and `DeferCaseReceivedUseCase` were passing
+`request.actor_id` (the sender) instead of `request.receiving_actor_id` (the
+CaseActor). `CheckIsCaseManagerNode` compared the sender against the case's
+CASE_MANAGER, found a mismatch, and skipped the ledger commit via the "not a
+manager" guard. `engage_case` never appeared in the CaseActor's ledger.
+
+Rule to add to specs/BT spec: any received-side use case that executes a BT
+containing `GuardedCommitCaseLedgerEntryBT` MUST call `execute_with_setup`
+with `actor_id=request.receiving_actor_id`. The `actor_id` field in those
+events is the *sender*; `receiving_actor_id` is the *receiver* (CaseActor).
+
+BT nodes that need to target the *sender's* participant (e.g.
+`TransitionParticipantRMtoAccepted`) must store the actor ID in a private
+attribute (e.g. `_target_actor_id`) to prevent `DataLayerAction.setup()`
+from overwriting it with the blackboard's `actor_id`.
+
+Related: BT-17-005, BT-06-006, CLP-10-006, ISSUE-2300.

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -241,9 +241,12 @@ def case_with_manager(
     )
     datalayer.create(cm_participant)
 
+    # attributed_to triggers genesis_hash computation (CLP-08-001/002), required
+    # for CommitCaseLedgerEntryNode to succeed in tests that run as CaseManager.
     case = VultronCase(
         id_="https://example.org/cases/case-manager-001",
         name="Test Case With Manager",
+        attributed_to=case_manager_actor_id,
         vulnerability_reports=[report.id_],
         case_participants=[vendor_participant.id_, cm_participant.id_],
         actor_participant_index={
@@ -541,6 +544,47 @@ def test_defer_case_tree_idempotent(
         if s.rm.state == RM.DEFERRED
     ]
     assert len(deferred_entries) == 1
+
+
+# ============================================================================
+# Divergent actor_id tests — verifies _target_actor_id invariant (#2300 fix)
+# ============================================================================
+
+
+def test_engage_case_tree_targets_constructor_actor_when_blackboard_differs(
+    bridge, datalayer, actor_id, case_manager_actor_id, case_with_manager
+):
+    """TransitionParticipantRMtoAccepted uses the constructor actor_id, not the blackboard.
+
+    After the #2300 fix, received-side BTs run under the CaseManager's identity
+    (blackboard actor_id = CaseManager) while the RM transition must still target
+    the engaging actor (constructor actor_id = vendor).  This test exercises the
+    split-identity path: blackboard != constructor.
+    """
+    request = _make_engage_request(case_with_manager, actor_id)
+    tree = create_engage_case_tree(
+        case_id=case_with_manager.id_, actor_id=actor_id
+    )
+    result = bridge.execute_with_setup(
+        tree=tree,
+        actor_id=case_manager_actor_id,
+        activity=request,
+    )
+    assert result.status == Status.SUCCESS
+
+    # Vendor's RM state must be ACCEPTED — not the CaseManager's.
+    vendor_participant_id = case_with_manager.actor_participant_index[actor_id]
+    updated_vendor = datalayer.read(vendor_participant_id)
+    assert updated_vendor.participant_statuses[-1].rm.state == RM.ACCEPTED
+
+    # CaseManager's participant must not have gained an RM entry.
+    cm_participant_id = case_with_manager.actor_participant_index[
+        case_manager_actor_id
+    ]
+    cm_participant = datalayer.read(cm_participant_id)
+    assert not any(
+        s.rm.state == RM.ACCEPTED for s in cm_participant.participant_statuses
+    ), "CaseManager must not have been incorrectly transitioned to ACCEPTED"
 
 
 # ============================================================================

--- a/test/core/use_cases/received/case/test_engage_defer.py
+++ b/test/core/use_cases/received/case/test_engage_defer.py
@@ -340,3 +340,119 @@ class TestEngageCaseLedgerCommit:
         assert isinstance(updated, VultronParticipant)
         latest_status = updated.participant_statuses[-1]
         assert latest_status.rm.state == RM.ACCEPTED
+
+
+class TestDeferCaseLedgerCommit:
+    """DeferCaseReceivedUseCase must commit a defer_case ledger entry.
+
+    Symmetric regression for #2300 on the defer path.
+    """
+
+    _SENDER_ID = "https://example.org/actors/vendor-2300-defer"
+    _CASE_MANAGER_ID = "https://example.org/actors/coordinator-2300-defer"
+    _CASE_ID = "https://example.org/cases/case-2300-defer"
+    _VENDOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor"
+    _CM_PARTICIPANT_ID = f"{_CASE_ID}/participants/coordinator"
+
+    @pytest.fixture
+    def dl(self):
+        return SqliteDataLayer("sqlite:///:memory:")
+
+    @pytest.fixture
+    def seeded_dl(self, dl):
+        from vultron.core.models.vultron_types import VultronCaseActor
+
+        dl.create(VultronCaseActor(id_=self._SENDER_ID, name="Vendor"))
+        vendor_p = VultronParticipant(
+            id_=self._VENDOR_PARTICIPANT_ID,
+            attributed_to=self._SENDER_ID,
+            context=self._CASE_ID,
+            participant_statuses=[
+                ParticipantStatus(
+                    attributed_to=self._SENDER_ID,
+                    context=self._CASE_ID,
+                    rm=RmDimension(state=RM.RECEIVED),
+                ),
+                ParticipantStatus(
+                    attributed_to=self._SENDER_ID,
+                    context=self._CASE_ID,
+                    rm=RmDimension(state=RM.VALID),
+                ),
+            ],
+        )
+        dl.create(vendor_p)
+        dl.create(
+            VultronCaseActor(id_=self._CASE_MANAGER_ID, name="Coordinator")
+        )
+        cm_p = VultronParticipant(
+            id_=self._CM_PARTICIPANT_ID,
+            attributed_to=self._CASE_MANAGER_ID,
+            context=self._CASE_ID,
+            case_roles=[CVDRole.CASE_MANAGER, CVDRole.COORDINATOR],
+        )
+        dl.create(cm_p)
+        case = VultronCase(
+            id_=self._CASE_ID,
+            name="Defer Ledger Commit Regression #2300",
+            attributed_to=self._CASE_MANAGER_ID,
+            case_participants=[
+                self._VENDOR_PARTICIPANT_ID,
+                self._CM_PARTICIPANT_ID,
+            ],
+            actor_participant_index={
+                self._SENDER_ID: self._VENDOR_PARTICIPANT_ID,
+                self._CASE_MANAGER_ID: self._CM_PARTICIPANT_ID,
+            },
+        )
+        dl.create(case)
+        return dl
+
+    def _defer_event(self) -> DeferCaseReceivedEvent:
+        return DeferCaseReceivedEvent(
+            activity_id=f"{self._CASE_ID}/activities/defer-2300",
+            actor_id=self._SENDER_ID,
+            receiving_actor_id=self._CASE_MANAGER_ID,
+            object_=VultronObject(id_=self._CASE_ID),
+            semantic_type=MessageSemantics.DEFER_CASE,
+            activity=VultronActivity(
+                type_="Ignore",
+                actor=self._SENDER_ID,
+                object_=VultronCase(id_=self._CASE_ID),
+                context=self._CASE_ID,
+            ),
+        )
+
+    def test_defer_case_commits_ledger_entry_when_receiving_actor_is_case_manager(
+        self, seeded_dl
+    ):
+        """DeferCaseReceivedUseCase commits a defer_case ledger entry.
+
+        Symmetric regression test to TestEngageCaseLedgerCommit for the
+        defer path. Regression for #2300.
+        """
+        from vultron.core.models.case_ledger_entry import (
+            VultronCaseLedgerEntry,
+        )
+
+        DeferCaseReceivedUseCase(seeded_dl, self._defer_event()).execute()
+
+        entries = seeded_dl.list_objects("CaseLedgerEntry")
+        defer_entries = [
+            e
+            for e in entries
+            if isinstance(e, VultronCaseLedgerEntry)
+            and e.event_type == "defer_case"
+        ]
+        assert len(defer_entries) == 1, (
+            "Expected exactly one 'defer_case' ledger entry when "
+            "receiving_actor_id is the CaseManager — regression for #2300"
+        )
+
+    def test_defer_case_transitions_vendor_rm_to_deferred(self, seeded_dl):
+        """DeferCaseReceivedUseCase still transitions the deferring actor's RM to DEFERRED."""
+        DeferCaseReceivedUseCase(seeded_dl, self._defer_event()).execute()
+
+        updated = seeded_dl.read(self._VENDOR_PARTICIPANT_ID)
+        assert isinstance(updated, VultronParticipant)
+        latest_status = updated.participant_statuses[-1]
+        assert latest_status.rm.state == RM.DEFERRED

--- a/test/core/use_cases/received/case/test_engage_defer.py
+++ b/test/core/use_cases/received/case/test_engage_defer.py
@@ -17,18 +17,23 @@ import logging
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.models.activity import VultronActivity
 from vultron.core.models.base import VultronObject
 from vultron.core.models.case import VultronCase
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.events import MessageSemantics
 from vultron.core.models.events.case import (
     DeferCaseReceivedEvent,
     EngageCaseReceivedEvent,
 )
 from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.states.rm import RM
 from vultron.core.use_cases.received.case.engage_defer import (
     DeferCaseReceivedUseCase,
     EngageCaseReceivedUseCase,
 )
+from vultron.enums.roles import CVDRole
 
 
 class TestEngageDeferCaseBTFailureReason:
@@ -202,3 +207,136 @@ class TestEngageCaseStoresEmbeddedParticipants:
             "refs — no VultronParticipant record should be created for a bare "
             "string"
         )
+
+
+class TestEngageCaseLedgerCommit:
+    """EngageCaseReceivedUseCase must commit an engage_case ledger entry.
+
+    Regression for #2300: the blackboard actor_id was set to the sender's ID
+    (request.actor_id) instead of the receiving CaseActor's ID
+    (request.receiving_actor_id).  CheckIsCaseManagerNode compared the sender
+    against the case's CASE_MANAGER, found a mismatch, and skipped the commit
+    via the "not a case manager" guard path.  No ledger entry was ever written.
+    """
+
+    _SENDER_ID = "https://example.org/actors/vendor-2300"
+    _CASE_MANAGER_ID = "https://example.org/actors/coordinator-2300"
+    _CASE_ID = "https://example.org/cases/case-2300"
+    _VENDOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor"
+    _CM_PARTICIPANT_ID = f"{_CASE_ID}/participants/coordinator"
+
+    @pytest.fixture
+    def dl(self):
+        return SqliteDataLayer("sqlite:///:memory:")
+
+    @pytest.fixture
+    def seeded_dl(self, dl):
+        from vultron.core.models.vultron_types import VultronCaseActor
+
+        dl.create(VultronCaseActor(id_=self._SENDER_ID, name="Vendor"))
+
+        vendor_p = VultronParticipant(
+            id_=self._VENDOR_PARTICIPANT_ID,
+            attributed_to=self._SENDER_ID,
+            context=self._CASE_ID,
+            participant_statuses=[
+                ParticipantStatus(
+                    attributed_to=self._SENDER_ID,
+                    context=self._CASE_ID,
+                    rm=RmDimension(state=RM.RECEIVED),
+                ),
+                ParticipantStatus(
+                    attributed_to=self._SENDER_ID,
+                    context=self._CASE_ID,
+                    rm=RmDimension(state=RM.VALID),
+                ),
+            ],
+        )
+        dl.create(vendor_p)
+
+        dl.create(
+            VultronCaseActor(id_=self._CASE_MANAGER_ID, name="Coordinator")
+        )
+
+        cm_p = VultronParticipant(
+            id_=self._CM_PARTICIPANT_ID,
+            attributed_to=self._CASE_MANAGER_ID,
+            context=self._CASE_ID,
+            case_roles=[CVDRole.CASE_MANAGER, CVDRole.COORDINATOR],
+        )
+        dl.create(cm_p)
+
+        # attributed_to triggers genesis_hash computation (CLP-08-001/002).
+        case = VultronCase(
+            id_=self._CASE_ID,
+            name="Ledger Commit Regression Case #2300",
+            attributed_to=self._CASE_MANAGER_ID,
+            case_participants=[
+                self._VENDOR_PARTICIPANT_ID,
+                self._CM_PARTICIPANT_ID,
+            ],
+            actor_participant_index={
+                self._SENDER_ID: self._VENDOR_PARTICIPANT_ID,
+                self._CASE_MANAGER_ID: self._CM_PARTICIPANT_ID,
+            },
+        )
+        dl.create(case)
+        return dl
+
+    def _engage_event(self) -> EngageCaseReceivedEvent:
+        # object_ must be a VulnerabilityCase so the canonical-entry validator
+        # sees type="VulnerabilityCase" and recognises the ("Join","VulnerabilityCase")
+        # pair as canonical (CLP-canonical-pairs / _CANONICAL_PAIRS check).
+        return EngageCaseReceivedEvent(
+            activity_id=f"{self._CASE_ID}/activities/engage-2300",
+            actor_id=self._SENDER_ID,
+            receiving_actor_id=self._CASE_MANAGER_ID,
+            object_=VultronObject(id_=self._CASE_ID),
+            semantic_type=MessageSemantics.ENGAGE_CASE,
+            activity=VultronActivity(
+                type_="Join",
+                actor=self._SENDER_ID,
+                object_=VultronCase(id_=self._CASE_ID),
+                context=self._CASE_ID,
+            ),
+        )
+
+    def test_engage_case_commits_ledger_entry_when_receiving_actor_is_case_manager(
+        self, seeded_dl
+    ):
+        """EngageCaseReceivedUseCase commits an engage_case ledger entry.
+
+        The receiving actor (CaseManager) must be the executing actor so
+        GuardedCommitCaseLedgerEntryBT commits the entry instead of skipping
+        it via the "not a case manager" guard.  Regression for #2300.
+        """
+        from vultron.core.models.case_ledger_entry import (
+            VultronCaseLedgerEntry,
+        )
+
+        EngageCaseReceivedUseCase(seeded_dl, self._engage_event()).execute()
+
+        entries = seeded_dl.list_objects("CaseLedgerEntry")
+        engage_entries = [
+            e
+            for e in entries
+            if isinstance(e, VultronCaseLedgerEntry)
+            and e.event_type == "engage_case"
+        ]
+        assert len(engage_entries) == 1, (
+            "Expected exactly one 'engage_case' ledger entry when "
+            "receiving_actor_id is the CaseManager — regression for #2300"
+        )
+
+    def test_engage_case_transitions_vendor_rm_to_accepted(self, seeded_dl):
+        """EngageCaseReceivedUseCase still transitions the engaging actor's RM to ACCEPTED.
+
+        Verifies that fixing the receiving_actor_id does not break the RM
+        transition for the sending actor (the actor who engaged the case).
+        """
+        EngageCaseReceivedUseCase(seeded_dl, self._engage_event()).execute()
+
+        updated = seeded_dl.read(self._VENDOR_PARTICIPANT_ID)
+        assert isinstance(updated, VultronParticipant)
+        latest_status = updated.participant_statuses[-1]
+        assert latest_status.rm.state == RM.ACCEPTED

--- a/vultron/core/behaviors/report/nodes/participant.py
+++ b/vultron/core/behaviors/report/nodes/participant.py
@@ -45,7 +45,10 @@ class TransitionParticipantRMtoAccepted(DataLayerAction):
         """
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
-        self.actor_id = actor_id
+        # Store in a private attribute so DataLayerAction.setup() cannot
+        # overwrite it with the blackboard actor_id (which is the receiving
+        # actor, not the engaging actor, after the #2300 fix).
+        self._target_actor_id = actor_id
 
     def update(self) -> Status:
         """
@@ -58,11 +61,14 @@ class TransitionParticipantRMtoAccepted(DataLayerAction):
             return f
         assert self.datalayer is not None
         try:
-            if self.actor_id is None:
+            if self._target_actor_id is None:
                 self.logger.error(f"{self.name}: actor_id not available")
                 return Status.FAILURE
             result = update_participant_rm_state(
-                self.case_id, self.actor_id, RM.ACCEPTED, self.datalayer
+                self.case_id,
+                self._target_actor_id,
+                RM.ACCEPTED,
+                self.datalayer,
             )
             return Status.SUCCESS if result else Status.FAILURE
         except Exception as e:
@@ -93,7 +99,10 @@ class TransitionParticipantRMtoDeferred(DataLayerAction):
         """
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
-        self.actor_id = actor_id
+        # Store in a private attribute so DataLayerAction.setup() cannot
+        # overwrite it with the blackboard actor_id (which is the receiving
+        # actor, not the deferring actor, after the #2300 fix).
+        self._target_actor_id = actor_id
 
     def update(self) -> Status:
         """
@@ -106,11 +115,14 @@ class TransitionParticipantRMtoDeferred(DataLayerAction):
             return f
         assert self.datalayer is not None
         try:
-            if self.actor_id is None:
+            if self._target_actor_id is None:
                 self.logger.error(f"{self.name}: actor_id not available")
                 return Status.FAILURE
             result = update_participant_rm_state(
-                self.case_id, self.actor_id, RM.DEFERRED, self.datalayer
+                self.case_id,
+                self._target_actor_id,
+                RM.DEFERRED,
+                self.datalayer,
             )
             return Status.SUCCESS if result else Status.FAILURE
         except Exception as e:

--- a/vultron/core/use_cases/received/case/engage_defer.py
+++ b/vultron/core/use_cases/received/case/engage_defer.py
@@ -47,6 +47,13 @@ class EngageCaseReceivedUseCase:
             logger.warning("engage_case: missing case_id on request")
             return
 
+        # The BT must execute under the receiving actor's identity so that
+        # CheckIsCaseManagerNode in GuardedCommitCaseLedgerEntryBT can match
+        # the CaseActor and commit the ledger entry (fix for #2300).
+        # Fall back to the sender's ID only when receiving_actor_id is absent
+        # (e.g. in legacy unit tests that do not populate the field).
+        receiving_actor_id = request.receiving_actor_id or actor_id
+
         # Persist any inline participant objects carried in the case snapshot
         # so BT nodes (CheckParticipantExists, AppendParticipantStatusNode) can
         # locate them by UUID.  Mirrors the Create (#564) and Announce (#566)
@@ -68,7 +75,7 @@ class EngageCaseReceivedUseCase:
         )
         tree = create_engage_case_tree(case_id=case_id, actor_id=actor_id)
         result = bridge.execute_with_setup(
-            tree=tree, actor_id=actor_id, activity=request
+            tree=tree, actor_id=receiving_actor_id, activity=request
         )
 
         if result.status != Status.SUCCESS:
@@ -106,6 +113,11 @@ class DeferCaseReceivedUseCase:
             logger.warning("defer_case: missing case_id on request")
             return
 
+        # The BT must execute under the receiving actor's identity so that
+        # CheckIsCaseManagerNode in GuardedCommitCaseLedgerEntryBT can match
+        # the CaseActor and commit the ledger entry (fix for #2300).
+        receiving_actor_id = request.receiving_actor_id or actor_id
+
         logger.info(
             "Actor '%s' defers case '%s' (RM → DEFERRED)",
             actor_id,
@@ -119,7 +131,7 @@ class DeferCaseReceivedUseCase:
         )
         tree = create_defer_case_tree(case_id=case_id, actor_id=actor_id)
         result = bridge.execute_with_setup(
-            tree=tree, actor_id=actor_id, activity=request
+            tree=tree, actor_id=receiving_actor_id, activity=request
         )
 
         if result.status != Status.SUCCESS:

--- a/vultron/core/use_cases/received/case/engage_defer.py
+++ b/vultron/core/use_cases/received/case/engage_defer.py
@@ -52,7 +52,11 @@ class EngageCaseReceivedUseCase:
         # the CaseActor and commit the ledger entry (fix for #2300).
         # Fall back to the sender's ID only when receiving_actor_id is absent
         # (e.g. in legacy unit tests that do not populate the field).
-        receiving_actor_id = request.receiving_actor_id or actor_id
+        receiving_actor_id = (
+            request.receiving_actor_id
+            if request.receiving_actor_id is not None
+            else actor_id
+        )
 
         # Persist any inline participant objects carried in the case snapshot
         # so BT nodes (CheckParticipantExists, AppendParticipantStatusNode) can
@@ -116,7 +120,11 @@ class DeferCaseReceivedUseCase:
         # The BT must execute under the receiving actor's identity so that
         # CheckIsCaseManagerNode in GuardedCommitCaseLedgerEntryBT can match
         # the CaseActor and commit the ledger entry (fix for #2300).
-        receiving_actor_id = request.receiving_actor_id or actor_id
+        receiving_actor_id = (
+            request.receiving_actor_id
+            if request.receiving_actor_id is not None
+            else actor_id
+        )
 
         logger.info(
             "Actor '%s' defers case '%s' (RM → DEFERRED)",

--- a/vultron/demo/helpers/seeding.py
+++ b/vultron/demo/helpers/seeding.py
@@ -1109,11 +1109,9 @@ def seed_case_participants_for_demo(
     """Seed vendor, reporter, and CaseActor participants on an ADR-0041 case.
 
     Under ADR-0041, the CaseActor normally creates participants via
-    ``case_proposal_received_tree`` when it accepts a ``CaseProposal``.  In
-    single-server demo/test environments the nested ASGI delivery is blocked
-    (depth > 0 guard prevents deadlocks), so the CaseProposal round-trip never
-    completes.  This helper compensates by seeding participants directly in the
-    DataLayer and setting ``EM.ACTIVE`` so the demo milestone checks pass.
+    ``case_proposal_received_tree`` when it accepts a ``CaseProposal``.
+    This helper compensates by seeding participants directly in the DataLayer
+    and setting ``EM.ACTIVE`` so the demo milestone checks pass.
 
     It is safe to call this multiple times for the same case — idempotency
     guards on ``actor_participant_index`` prevent duplicate records.

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -468,8 +468,6 @@ def _phase_report_submission(
             )
         logger.info("Case created: %s", case.id_)
 
-    # ADR-0041: CaseActor normally seeds participants via case_proposal_received_tree,
-    # but nested ASGI delivery is blocked in single-server mode.  Seed directly.
     # Participants are seeded without pre-populated RM state so that the protocol
     # drives every RM transition (RECEIVED → VALID → ACCEPTED) through triggers.
     seed_case_participants_for_demo(


### PR DESCRIPTION
- Closes #2300
- Closes #2297

## Summary

`EngageCaseReceivedUseCase` (and `DeferCaseReceivedUseCase`) passed the
sender's actor_id to `execute_with_setup`, so `CheckIsCaseManagerNode` always
compared the engaging actor against the case's CASE_MANAGER, found a mismatch,
and skipped the ledger commit via the "not a manager" guard. No `engage_case`
entry ever landed in the CaseActor's canonical ledger, failing all nine
Invariant Harness jobs on `test_invariant_5_expected_event_types_present[engage_case]`.

## Changes

- **`vultron/core/use_cases/received/case/engage_defer.py`**: Pass
  `request.receiving_actor_id` (the CaseActor) as `actor_id` to
  `execute_with_setup` in both `EngageCaseReceivedUseCase` and
  `DeferCaseReceivedUseCase`. Falls back to `request.actor_id` only when
  `receiving_actor_id` is absent (legacy unit tests that predate the field).

- **`vultron/core/behaviors/report/nodes/participant.py`**: Store the
  target actor in `_target_actor_id` (private) in
  `TransitionParticipantRMtoAccepted` and `TransitionParticipantRMtoDeferred`.
  `DataLayerAction.setup()` overwrites `self.actor_id` from the blackboard; the
  private attribute is immune, so the RM transition still targets the engaging
  actor even though the BT now runs under the receiving actor's identity.

- **`vultron/demo/helpers/seeding.py`** and
  **`vultron/demo/scenario/fv_demo.py`**: Delete two stale comments that
  described the long-deleted ASGIEmitter depth guard as if it were live
  (issue #2300 notes these caused at least one misdiagnosis of this bug).

- **`test/core/use_cases/received/case/test_engage_defer.py`**: Add
  `TestEngageCaseLedgerCommit` with two regression tests — one confirming
  the `engage_case` ledger entry is committed when `receiving_actor_id` is
  the CaseManager, one confirming the engaging actor's RM still transitions
  to ACCEPTED.

## Verification

- 6986 tests pass (2 new), 0 failures
- Black, flake8, mypy, pyright all clean
- Pre-commit hooks passed on commit