### PR TITLE
fix: raise wait_for_case_participants default and add explicit sync budgets

### DIFF
--- a/test/demo/test_polling_timeout_defaults.py
+++ b/test/demo/test_polling_timeout_defaults.py
@@ -1,0 +1,33 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Regression tests for polling helper timeout defaults (#2305).
+
+``wait_for_case_participants`` shipped with a 5.0 s default that fires before
+cross-container participant-count convergence under CI contention.  The new
+default must be at least 15.0 s.
+"""
+
+import inspect
+
+from vultron.demo.helpers.polling import wait_for_case_participants
+
+
+def test_wait_for_case_participants_default_is_at_least_15s():
+    """Default timeout must survive cross-container CI contention (#2305)."""
+    sig = inspect.signature(wait_for_case_participants)
+    default = sig.parameters["timeout_seconds"].default
+    assert default >= 15.0, (
+        f"wait_for_case_participants default ({default}s) is too short; "
+        "must be >=15 s for cross-container convergence under CI load"
+    )

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -138,7 +138,8 @@ def wait_for_case_participants(
     vendor_client: DataLayerClient,
     case_id: str,
     expected_count: int,
-    timeout_seconds: float = 5.0,
+    # 15 s: conservative cross-container delivery budget (temporal per EDF-06-006).
+    timeout_seconds: float = 15.0,
     poll_interval: float = 0.25,
 ) -> None:
     """Poll until the case on *vendor_client* reflects *expected_count* participants.

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -467,18 +467,26 @@ def _phase_sync_verification(
             with demo_check(
                 f"{label} ledger coverage (sync-verification phase)"
             ):
+                # Temporal (EDF-06-006): Vendor joins Phase 2 so needs extra
+                # ledger catch-up time; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=c1_tail_index,
+                    timeout_seconds=timeout,
                 )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, c2_client, vendor_client):
+        # Temporal (EDF-06-006): Vendor is a late joiner — allow extra time
+        # for participant-index propagation; causal-gate migration in #2202.
+        p_timeout = 30.0 if replica_client is vendor_client else 10.0
         wait_for_case_participants(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_count=5,
+            timeout_seconds=p_timeout,
         )
 
     with demo_check("Finder replica matches authoritative C1 state"):
@@ -804,10 +812,14 @@ def _phase_case_closure(
             (vendor_client, "Vendor"),
         ]:
             with demo_check(f"{label} ledger coverage (close phase)"):
+                # Temporal (EDF-06-006): Vendor joined Phase 2 so may still
+                # lag on final entries; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=c1_tail_index,
+                    timeout_seconds=timeout,
                 )
 
 

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -585,18 +585,26 @@ def _phase_sync_verification(
             with demo_check(
                 f"{label} ledger coverage (sync-verification phase)"
             ):
+                # Temporal (EDF-06-006): Vendor joins Phase 3 so needs extra
+                # ledger catch-up time; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=c1_tail_index,
+                    timeout_seconds=timeout,
                 )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, c2_client, vendor_client):
+        # Temporal (EDF-06-006): Vendor is a late joiner — allow extra time
+        # for participant-index propagation; causal-gate migration in #2202.
+        p_timeout = 30.0 if replica_client is vendor_client else 10.0
         wait_for_case_participants(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_count=5,
+            timeout_seconds=p_timeout,
         )
 
     with demo_check("Finder replica matches authoritative C1 state"):
@@ -923,10 +931,14 @@ def _phase_case_closure(
             (vendor_client, "Vendor"),
         ]:
             with demo_check(f"{label} ledger coverage (close phase)"):
+                # Temporal (EDF-06-006): Vendor joined Phase 3 so may still
+                # lag on final entries; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=c2_tail_index,
+                    timeout_seconds=timeout,
                 )
 
 

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -372,18 +372,26 @@ def _phase_sync_verification(
             with demo_check(
                 f"{label} ledger coverage (sync-verification phase)"
             ):
+                # Temporal (EDF-06-006): Vendor joins Phase 2 so needs extra
+                # ledger catch-up time; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=coord_tail_index,
+                    timeout_seconds=timeout,
                 )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, vendor_client):
+        # Temporal (EDF-06-006): Vendor is a late joiner — allow extra time
+        # for participant-index propagation; causal-gate migration in #2202.
+        p_timeout = 30.0 if replica_client is vendor_client else 10.0
         wait_for_case_participants(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_count=4,
+            timeout_seconds=p_timeout,
         )
 
     with demo_check("Finder replica matches authoritative Coordinator state"):
@@ -669,10 +677,14 @@ def _phase_case_closure(
             (vendor_client, "Vendor"),
         ]:
             with demo_check(f"{label} ledger coverage (close phase)"):
+                # Temporal (EDF-06-006): Vendor joined Phase 2 so may still
+                # lag on final entries; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=coord_tail_index,
+                    timeout_seconds=timeout,
                 )
 
 

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -467,18 +467,26 @@ def _phase_sync_verification(
             with demo_check(
                 f"{label} ledger coverage (sync-verification phase)"
             ):
+                # Temporal (EDF-06-006): Vendor2 joins Phase 2 so needs extra
+                # ledger catch-up time; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor2" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=vendor_tail_index,
+                    timeout_seconds=timeout,
                 )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, coordinator_client, vendor2_client):
+        # Temporal (EDF-06-006): Vendor2 is a late joiner — allow extra time
+        # for participant-index propagation; causal-gate migration in #2202.
+        p_timeout = 30.0 if replica_client is vendor2_client else 10.0
         wait_for_case_participants(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_count=5,
+            timeout_seconds=p_timeout,
         )
 
     with demo_check("Finder replica matches authoritative Vendor1 state"):
@@ -833,10 +841,14 @@ def _phase_case_closure(
             (vendor2_client, "Vendor2"),
         ]:
             with demo_check(f"{label} ledger coverage (close phase)"):
+                # Temporal (EDF-06-006): Vendor2 joined Phase 2 so may still
+                # lag on final entries; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor2" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=vendor_tail_index,
+                    timeout_seconds=timeout,
                 )
 
 

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -585,18 +585,26 @@ def _phase_sync_verification(
             with demo_check(
                 f"{label} ledger coverage (sync-verification phase)"
             ):
+                # Temporal (EDF-06-006): Vendor2 joins Phase 3 so needs extra
+                # ledger catch-up time; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor2" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=vendor_tail_index,
+                    timeout_seconds=timeout,
                 )
             logger.info("  %s ledger synchronized", label)
 
     for replica_client in (finder_client, coordinator_client, vendor2_client):
+        # Temporal (EDF-06-006): Vendor2 is a late joiner — allow extra time
+        # for participant-index propagation; causal-gate migration in #2202.
+        p_timeout = 30.0 if replica_client is vendor2_client else 10.0
         wait_for_case_participants(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_count=5,
+            timeout_seconds=p_timeout,
         )
 
     with demo_check("Finder replica matches authoritative Vendor1 state"):
@@ -958,10 +966,14 @@ def _phase_case_closure(
             (vendor2_client, "Vendor2"),
         ]:
             with demo_check(f"{label} ledger coverage (close phase)"):
+                # Temporal (EDF-06-006): Vendor2 joined Phase 3 so may still
+                # lag; causal-gate migration in #2202.
+                timeout = 45.0 if label == "Vendor2" else 15.0
                 wait_for_contiguous_ledger_coverage(
                     client=replica_client,
                     case_id=case.id_,
                     expected_tail_index=vendor_tail_index,
+                    timeout_seconds=timeout,
                 )
 
 


### PR DESCRIPTION
- Closes #2305
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Raises the `wait_for_case_participants` primitive default from 5.0 s to 15.0 s and adds explicit late-joiner budgets to all five named replica-sync loops, eliminating the nondeterministic timeout that caused `fvcv-handoff Demo Integration` to flake under CI contention.

## Changes

- **`vultron/demo/helpers/polling.py`**: raise `wait_for_case_participants` default from 5.0 → 15.0 s; add EDF-06-006 comment justifying the temporal budget
- **`vultron/demo/scenario/fvcv_handoff_demo.py`**: add explicit 45.0/15.0 budgets to `wait_for_contiguous_ledger_coverage` (sync-verification + close phases) and 30.0/10.0 to `wait_for_case_participants` (Vendor2 is late joiner); EDF-06-006 labels throughout
- **`vultron/demo/scenario/fccv_handoff_demo.py`**: same treatment, Vendor is late joiner
- **`vultron/demo/scenario/fvcv_extension_demo.py`**: same treatment, Vendor2 is late joiner
- **`vultron/demo/scenario/fccv_extension_demo.py`**: same treatment, Vendor is late joiner
- **`vultron/demo/scenario/fcv_demo.py`**: same treatment, Vendor is late joiner
- **`test/demo/test_polling_timeout_defaults.py`**: regression test — asserts `wait_for_case_participants` default >= 15.0 s (fails on 5.0, passes on 15.0)

No causal-gate helpers added or modified; predicate redesign stays in #2202 (AC-6).

## Verification

- 6996 unit tests pass, 1128 integration tests pass (1 new)
- Black, flake8, mypy, pyright clean