### PR TITLE
fix(status-write): validate VFD/RM/PXA transitions on trigger path

### DIFF
--- a/notes/bt-pitfalls.md
+++ b/notes/bt-pitfalls.md
@@ -1187,8 +1187,26 @@ This is a known fragility (GitHub concern #1896): if a guard node is too weak
 an invalid status snapshot can be persisted silently. The same issue applies
 to RM and PXA dimension writes through this node.
 
+**Status (PR #2307, 2026-08-14)**: the fragility is now mitigated for all
+known write paths:
+
+- **Trigger path** (`add_participant_status_trigger_bt`): guarded by
+  `ValidateTriggerTransitionsNode` (new in PR #2307, issues #2081 / #1903).
+  Fail-closed: an invalid RM/VFD/PXA jump raises `VultronValidationError` and
+  no snapshot is written.
+- **Received wire path** (`add_participant_status_tree`): guarded by
+  `FilterParticipantStatusDimensionsNode` + `ValidateRMTransitionNode`
+  (in place since `a17d7649`). Partial-accept: refused dimensions carry forward
+  the current value so other dimensions still land.
+
+`CreateParticipantStatusNode` itself still does not validate inline.
+`test/architecture/test_vfd_rm_pxa_write_sites.py` (the AC-7 ratchet, also
+added in PR #2307) AST-audits every `VfdDimension`/`RmDimension`/`PxaDimension`
+constructor call in `vultron/core/behaviors/` and fails immediately on any new
+unclassified site, forcing an explicit audit before merge.
+
 **When writing or reviewing guard nodes that precede `CreateParticipantStatusNode`**:
 treat the guard as the *only* line of defence for transition validity and verify
 it against the state-machine transitions defined in `vultron/core/states/`.
 
-<!-- Source: ISSUE-1825; GitHub concern #1896 -->
+<!-- Source: ISSUE-1825; GitHub concern #1896; PR #2307 -->

--- a/notes/status-dimension-objects.md
+++ b/notes/status-dimension-objects.md
@@ -227,13 +227,25 @@ Rules:
 - Otherwise → `Status.FAILURE` with a descriptive `feedback_message`
 - `None` target → skip validation (caller is preserving current state)
 
-This makes write nodes fail-closed regardless of whether an upstream guard
-is present, weak, or bypassed. See BTND-10-001, SDO-02-004, CSB-16-001/002.
+The ideal is for write nodes to be fail-closed regardless of whether an upstream
+guard is present, weak, or bypassed. See BTND-10-001, SDO-02-004, CSB-16-001/002.
 
 The primary write boundary is `CreateParticipantStatusNode` in
 `vultron/core/behaviors/case/nodes/participant/status.py` — all VFD/RM/PXA
-state-write paths in the prototype route through it or should follow the same
-pattern.
+state-write paths in the prototype route through it. In practice,
+`CreateParticipantStatusNode` itself does not validate inline (see
+`notes/bt-pitfalls.md` § "State-Validation Bypass"). Instead, each call path
+relies on an upstream guard node:
+
+- **Trigger path**: `ValidateTriggerTransitionsNode` — fail-closed; invalid jump
+  raises `VultronValidationError` before `CreateParticipantStatusNode` runs.
+- **Received wire path**: `FilterParticipantStatusDimensionsNode` +
+  `ValidateRMTransitionNode` — partial-accept; refused dimensions carry the
+  current value forward.
+
+`test/architecture/test_vfd_rm_pxa_write_sites.py` (the AC-7 ratchet) AST-scans
+`vultron/core/behaviors/` for every dimension constructor call and fails on any
+new unclassified site, making it hard to add an unguarded write path silently.
 
 ---
 

--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""AC-7 architecture ratchet: audit VFD/RM/PXA dimension write sites.
+
+AST-scans ``vultron/core/behaviors/`` for every ``VfdDimension``,
+``RmDimension``, and ``PxaDimension`` constructor call and asserts the result
+matches the audited set below.
+
+A new unclassified constructor call fails this test immediately, which forces
+an explicit audit decision:
+
+- If the site is already protected (trigger guard, received-path filter, or a
+  classified bootstrap/predicate use), add it to ``AUDITED_SITES`` with a
+  comment stating why.
+- If it is a new user-driven write outside the protected paths, add transition
+  validation before merging.
+
+Per specs/behavior-tree-node-design.yaml BTND-10-001.
+Closes #2081 AC-7, #1903.
+"""
+
+import ast
+import pathlib
+from collections import Counter
+
+# ---------------------------------------------------------------------------
+# Audited sites — (path_relative_to_behaviors_root, constructor_name)
+# One entry per call-site occurrence (multiplicity matters).
+#
+# Classification key:
+#   PROTECTED  — user-driven write covered by ValidateTriggerTransitionsNode
+#                (trigger path) or FilterParticipantStatusDimensionsNode
+#                (received path)
+#   BOOTSTRAP  — initial / authoritative seeding write; no prior state to
+#                violate; outside the scope of transition validation
+#   PREDICATE  — read-only dimension instantiation (guard / is_*() checks),
+#                no DataLayer write
+#   RM-TRACKED — RM transition nodes documented in rm_transitions.py;
+#                tracked separately per BTND-10-001 / issue #2081
+#   FILTER     — carry-forward writes inside FilterParticipantStatusDimensions-
+#                Node (received path); the filter adjudicates before writing
+#   REPLICATE  — authoritative ledger-replication write with monotonic ratchet
+# ---------------------------------------------------------------------------
+AUDITED_SITES: list[tuple[str, str]] = sorted(
+    [
+        # PROTECTED — CreateParticipantStatusNode (trigger + received paths)
+        ("case/nodes/participant/status.py", "PxaDimension"),
+        ("case/nodes/participant/status.py", "RmDimension"),
+        ("case/nodes/participant/status.py", "VfdDimension"),
+        # BOOTSTRAP — case_proposal_received_tree: seeds RM.RECEIVED/VALID/ACCEPTED
+        ("case/case_proposal_received_tree.py", "RmDimension"),
+        ("case/case_proposal_received_tree.py", "RmDimension"),
+        ("case/case_proposal_received_tree.py", "RmDimension"),
+        # BOOTSTRAP — participant/common.py: initial accepted-status builder
+        ("case/nodes/participant/common.py", "RmDimension"),
+        ("case/nodes/participant/common.py", "RmDimension"),
+        ("case/nodes/participant/common.py", "RmDimension"),
+        ("case/nodes/participant/common.py", "RmDimension"),
+        ("case/nodes/participant/common.py", "VfdDimension"),
+        # BOOTSTRAP — owner.py: initial owner RM state seeding
+        ("case/nodes/participant/owner.py", "RmDimension"),
+        ("case/nodes/participant/owner.py", "RmDimension"),
+        # PREDICATE — deploy_fix.py: VfdDimension.is_fix_deployed() / is_fix_ready()
+        ("report/nodes/deploy_fix.py", "VfdDimension"),
+        ("report/nodes/deploy_fix.py", "VfdDimension"),
+        # PREDICATE — develop_fix.py: VfdDimension.is_fix_ready()
+        ("report/nodes/develop_fix.py", "VfdDimension"),
+        # RM-TRACKED — rm_transitions.py: RM.VALID / RM.INVALID / RM.CLOSED writes
+        ("report/nodes/rm_transitions.py", "RmDimension"),
+        ("report/nodes/rm_transitions.py", "RmDimension"),
+        ("report/nodes/rm_transitions.py", "RmDimension"),
+        # FILTER — FilterParticipantStatusDimensionsNode carry-forward
+        ("status/nodes/dimension_filter.py", "PxaDimension"),
+        ("status/nodes/dimension_filter.py", "RmDimension"),
+        ("status/nodes/dimension_filter.py", "VfdDimension"),
+        # REPLICATE — participant_status_effect.py: monotonic RM ratchet
+        ("sync/nodes/participant_status_effect.py", "RmDimension"),
+    ]
+)
+
+
+def _collect_sites() -> list[tuple[str, str]]:
+    """Return sorted (rel_path, constructor_name) pairs from an AST scan."""
+    target_names = {"VfdDimension", "RmDimension", "PxaDimension"}
+    root = pathlib.Path("vultron/core/behaviors")
+    found: list[tuple[str, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:  # pragma: no cover
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name: str | None = None
+            if isinstance(func, ast.Name):
+                name = func.id
+            elif isinstance(func, ast.Attribute):
+                name = func.attr
+            if name in target_names:
+                rel = str(path.relative_to("vultron/core/behaviors"))
+                # Normalise path separators for cross-platform consistency.
+                found.append((rel.replace("\\", "/"), name))
+    return sorted(found)
+
+
+def test_audited_write_sites_unchanged() -> None:
+    """All VfdDimension/RmDimension/PxaDimension sites match the audited set.
+
+    A NEW site (file or extra call in an existing file) causes this test to
+    fail with a clear diff so the reviewer can decide which classification
+    label applies.  A REMOVED site also fails — the audited list must stay
+    current.
+    """
+    actual = _collect_sites()
+    actual_counts = Counter(actual)
+    expected_counts = Counter(AUDITED_SITES)
+
+    new_sites = actual_counts - expected_counts
+    removed_sites = expected_counts - actual_counts
+
+    messages: list[str] = []
+    if new_sites:
+        messages.append(
+            "NEW unaudited dimension write sites found — classify and add to"
+            " AUDITED_SITES:\n"
+            + "\n".join(
+                f"  + {path!r}  {ctor}" for path, ctor in sorted(new_sites)
+            )
+        )
+    if removed_sites:
+        messages.append(
+            "Sites in AUDITED_SITES no longer present — remove from list:\n"
+            + "\n".join(
+                f"  - {path!r}  {ctor}" for path, ctor in sorted(removed_sites)
+            )
+        )
+    assert not messages, "\n\n".join(messages)

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -323,7 +323,7 @@ class TestSvcAddParticipantStatusExecuteUpdatesSenderRecord:
         request = AddParticipantStatusTriggerRequest(
             actor_id=self.actor.id_,
             case_id=self.case.id_,
-            rm_state=RM.ACCEPTED,
+            rm_state=RM.RECEIVED,
         )
         before = set(self.dl.outbox_list_for_actor(self.actor.id_))
         SvcAddParticipantStatusUseCase(
@@ -363,7 +363,7 @@ class TestSvcAddParticipantStatusExecuteUpdatesSenderRecord:
         request = AddParticipantStatusTriggerRequest(
             actor_id=self.actor.id_,
             case_id=self.case.id_,
-            rm_state=RM.ACCEPTED,
+            rm_state=RM.RECEIVED,
         )
         result = SvcAddParticipantStatusUseCase(
             self.dl,
@@ -403,7 +403,7 @@ class TestSvcAddParticipantStatusExecuteUpdatesSenderRecord:
         request = AddParticipantStatusTriggerRequest(
             actor_id=self.actor.id_,
             case_id=self.case.id_,
-            rm_state=RM.ACCEPTED,
+            rm_state=RM.RECEIVED,
         )
         use_case = SvcAddParticipantStatusUseCase(
             self.dl,
@@ -413,13 +413,13 @@ class TestSvcAddParticipantStatusExecuteUpdatesSenderRecord:
         use_case.execute()
 
         # On a second call, _resolve_current_participant_state must return
-        # RM.ACCEPTED (the state we just emitted), not RM.START.
+        # RM.RECEIVED (the state we just emitted), not RM.START.
         rm, _ = use_case._resolve_current_participant_state(
             self.dl, self.actor_participant.id_
         )
-        assert rm == RM.ACCEPTED, (
-            f"After execute() with rm_state=RM.ACCEPTED, "
-            f"_resolve_current_participant_state must return RM.ACCEPTED; "
+        assert rm == RM.RECEIVED, (
+            f"After execute() with rm_state=RM.RECEIVED, "
+            f"_resolve_current_participant_state must return RM.RECEIVED; "
             f"got {rm!r} (#624)"
         )
 
@@ -765,3 +765,177 @@ class TestCreateParticipantStatusNode:
             self._run_node(rm_state=None, vfd_state=CS_vfd.Vfd, pxa_state=None)
 
         assert not self._rm_narrative_records(caplog)
+
+
+# ---------------------------------------------------------------------------
+# ValidateTriggerTransitionsNode — AC-1 through AC-6 (issues #2081, #1903)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateTriggerTransitions:
+    """Trigger-path transition guard: fail-closed for invalid state jumps.
+
+    AC-1: Invalid VFD jump → VultronValidationError, no record persisted.
+    AC-2: Invalid RM transition → VultronValidationError, no record persisted.
+    AC-3: Backward PXA → VultronValidationError, no record persisted.
+    AC-4: Same-state write → SUCCESS, record persisted.
+    AC-5: None target → SUCCESS, record persisted.
+    AC-6: Trigger path (end-to-end through use case) rejects invalid VFD jump.
+
+    Per BTND-10-001, SDO-02-004, CSB-16-001, CSB-16-002.
+    Closes #2081, #1903.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from vultron.adapters.driven.datalayer_sqlite import (
+            SqliteDataLayer,
+            reset_datalayer,
+        )
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+        from vultron.enums.roles import CVDRole
+        from vultron.wire.as2.vocab.base.objects.actors import as_Service
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            as_CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        self.actor = as_Service(name="Finder")
+        actor_id = self.actor.id_
+        reset_datalayer(actor_id)
+        self.dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
+        self.dl.clear_all()
+        self.dl.create(self.actor)
+
+        self.case_actor = as_Service(name="Case Actor")
+        reset_datalayer(self.case_actor.id_)
+        self.dl.create(self.case_actor)
+
+        self.case = as_VulnerabilityCase(name="Test Case AC-1..6")
+        self.actor_participant = as_CaseParticipant(
+            attributed_to=actor_id,
+            context=self.case.id_,
+            case_roles=[CVDRole.FINDER],
+        )
+        self.case_manager_participant = as_CaseParticipant(
+            attributed_to=self.case_actor.id_,
+            context=self.case.id_,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        self.case.actor_participant_index[actor_id] = (
+            self.actor_participant.id_
+        )
+        self.case.actor_participant_index[self.case_actor.id_] = (
+            self.case_manager_participant.id_
+        )
+        self.dl.create(self.case)
+        self.dl.create(self.actor_participant)
+        self.dl.create(self.case_manager_participant)
+        self.trigger_activity = TriggerActivityAdapter(self.dl)
+        yield
+        try:
+            self.dl.clear_all()
+        finally:
+            self.dl.close()
+            reset_datalayer(actor_id)
+            reset_datalayer(self.case_actor.id_)
+
+    def _execute(self, rm_state=None, vfd_state=None, pxa_state=None):
+        from vultron.core.use_cases.triggers.case import (
+            SvcAddParticipantStatusUseCase,
+        )
+        from vultron.core.use_cases.triggers.requests import (
+            AddParticipantStatusTriggerRequest,
+        )
+
+        request = AddParticipantStatusTriggerRequest(
+            actor_id=self.actor.id_,
+            case_id=self.case.id_,
+            rm_state=rm_state,
+            vfd_state=vfd_state,
+            pxa_state=pxa_state,
+        )
+        return SvcAddParticipantStatusUseCase(
+            self.dl, request, trigger_activity=self.trigger_activity
+        ).execute()
+
+    def _status_count(self):
+        participant = self.dl.read(self.actor_participant.id_)
+        return len(getattr(participant, "participant_statuses", []))
+
+    def test_ac1_invalid_vfd_jump_raises_and_persists_nothing(self):
+        """AC-1: vfd → VFD (skips Vfd) raises VultronValidationError; no record written."""
+        from vultron.errors import VultronValidationError
+
+        before = self._status_count()
+        with pytest.raises(VultronValidationError):
+            self._execute(vfd_state=CS_vfd.VFD)
+        assert self._status_count() == before
+
+    def test_ac2_invalid_rm_transition_raises_and_persists_nothing(self):
+        """AC-2: START → CLOSED (non-adjacent) raises VultronValidationError; no record written."""
+        from vultron.errors import VultronValidationError
+
+        before = self._status_count()
+        with pytest.raises(VultronValidationError):
+            self._execute(rm_state=RM.CLOSED)
+        assert self._status_count() == before
+
+    def test_ac3_backward_pxa_raises_and_persists_nothing(self):
+        """AC-3: Pxa → pxa (backward) raises VultronValidationError; no record written.
+
+        First advances to Pxa via a valid write, then attempts a backward
+        move to pxa to confirm the guard rejects it.
+        """
+        from vultron.core.states.cs import CS_pxa
+        from vultron.errors import VultronValidationError
+
+        # Valid forward step: pxa → Pxa.
+        self._execute(pxa_state=CS_pxa.Pxa)
+        before = self._status_count()
+
+        # Backward step: Pxa → pxa must be rejected.
+        with pytest.raises(VultronValidationError):
+            self._execute(pxa_state=CS_pxa.pxa)
+        assert self._status_count() == before
+
+    def test_ac4_same_state_write_succeeds(self):
+        """AC-4: Same-state write (target == current) is a valid confirmation; record persisted."""
+        before = self._status_count()
+        # START → START is a same-state write (initial RM state).
+        self._execute(rm_state=RM.START)
+        assert self._status_count() == before + 1
+
+    def test_ac5_none_target_skips_validation_and_succeeds(self):
+        """AC-5: All-None request skips all validation and persists a snapshot."""
+        before = self._status_count()
+        self._execute(rm_state=None, vfd_state=None, pxa_state=None)
+        assert self._status_count() == before + 1
+
+    def test_ac6_trigger_path_rejects_invalid_vfd_end_to_end(self):
+        """AC-6: The add-participant-status trigger path rejects invalid VFD via use case.
+
+        Confirms the guard is wired into add_participant_status_trigger_bt
+        and therefore fires for every HTTP-trigger invocation.
+        """
+        from vultron.errors import VultronValidationError
+
+        # Participant starts at vfd (initial). Jumping to VFD skips Vfd.
+        with pytest.raises(VultronValidationError, match="VFD"):
+            self._execute(vfd_state=CS_vfd.VFD)
+
+    def test_valid_adjacent_vfd_step_succeeds(self):
+        """Valid adjacent VFD step (vfd → Vfd) is accepted and record persisted."""
+        before = self._status_count()
+        self._execute(vfd_state=CS_vfd.Vfd)
+        assert self._status_count() == before + 1
+
+    def test_valid_adjacent_rm_step_succeeds(self):
+        """Valid adjacent RM step (START → RECEIVED) is accepted and record persisted."""
+        before = self._status_count()
+        self._execute(rm_state=RM.RECEIVED)
+        assert self._status_count() == before + 1

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -153,6 +153,14 @@ def demo_notify_fix_ready(
     from vultron.core.states.cs import CS_vfd
 
     with domain_error_translation():
+        # VFD hypercube: vfd → Vfd is the only valid first hop from the
+        # initial state; Vfd → VFd is the second hop. Both must be emitted
+        # in order so ValidateTriggerTransitionsNode passes each step.
+        svc.add_participant_status(
+            actor_id=actor_id,
+            case_id=body.case_id,
+            vfd_state=CS_vfd.Vfd,
+        )
         result = svc.add_participant_status(
             actor_id=actor_id,
             case_id=body.case_id,

--- a/vultron/core/behaviors/case/add_participant_status_trigger_tree.py
+++ b/vultron/core/behaviors/case/add_participant_status_trigger_tree.py
@@ -37,6 +37,7 @@ import py_trees
 
 from vultron.core.behaviors.case.nodes.participant import (
     CreateParticipantStatusNode,
+    ValidateTriggerTransitionsNode,
 )
 from vultron.core.behaviors.case.nodes.vfd_role_guards import (
     CheckDeployerRoleNode,
@@ -103,6 +104,13 @@ def add_participant_status_trigger_bt(
 
     children.extend(
         [
+            ValidateTriggerTransitionsNode(
+                case_id=case_id,
+                actor_id=actor_id,
+                rm_state=rm_state,
+                vfd_state=vfd_state,
+                pxa_state=pxa_state,
+            ),
             CreateParticipantStatusNode(
                 case_id=case_id,
                 actor_id=actor_id,

--- a/vultron/core/behaviors/case/nodes/participant/__init__.py
+++ b/vultron/core/behaviors/case/nodes/participant/__init__.py
@@ -62,6 +62,9 @@ from vultron.core.behaviors.case.nodes.participant.participant_add import (
 from vultron.core.behaviors.case.nodes.participant.status import (
     CreateParticipantStatusNode,
 )
+from vultron.core.behaviors.case.nodes.participant.trigger_validation import (
+    ValidateTriggerTransitionsNode,
+)
 
 __all__ = [
     "_create_and_attach_participant",
@@ -93,6 +96,7 @@ __all__ = [
     # composite subtrees — lazy via __getattr__
     "CreateCaseParticipantNode",
     "CreateParticipantStatusNode",
+    "ValidateTriggerTransitionsNode",
     "EnsureReporterParticipantAtAcceptedNode",
 ]
 

--- a/vultron/core/behaviors/case/nodes/participant/trigger_validation.py
+++ b/vultron/core/behaviors/case/nodes/participant/trigger_validation.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Fail-closed transition guard for the add-participant-status trigger path.
+
+When an actor self-reports a new RM/VFD/PXA state via an HTTP trigger, the
+requested state must be a valid adjacent step from the actor's current state.
+:class:`ValidateTriggerTransitionsNode` enforces this before
+:class:`~vultron.core.behaviors.case.nodes.participant.status\
+.CreateParticipantStatusNode` writes anything to the DataLayer.
+
+This is the trigger-path counterpart of
+:class:`~vultron.core.behaviors.status.nodes.dimension_filter\
+.FilterParticipantStatusDimensionsNode` (received wire path).  The two differ
+in disposition: the received path uses per-dimension partial-accept (a refused
+dimension carries the current value forward so other dimensions still land);
+the trigger path is fail-closed (a self-reported invalid jump is rejected
+outright — the actor controls its own state machine and must request valid
+steps).
+
+Per specs/behavior-tree-node-design.yaml BTND-10-001,
+specs/status-dimension-objects.yaml SDO-02-004,
+specs/cs-behavior.yaml CSB-16-001, CSB-16-002.
+Closes #2081 (AC-1, AC-2, AC-3, AC-6), #1903 (AC-1, AC-2, AC-3).
+"""
+
+import logging
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.case.nodes.participant.common import (
+    resolve_participant_state_from_dl,
+)
+from vultron.core.behaviors.helpers import DataLayerCondition
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.states.cs import (
+    CS_pxa,
+    CS_vfd,
+    is_valid_pxa_transition,
+    is_valid_vfd_transition,
+)
+from vultron.core.states.rm import RM, is_valid_rm_transition
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_current_pxa(case: object, participant: object) -> CS_pxa:
+    """Return the participant's current PXA state before a new snapshot lands.
+
+    Reads the participant's own status history first (authoritative for PXA
+    because this node records PXA on the participant snapshot, not on
+    ``case.case_statuses``).  Falls back to case-level PXA then ``CS_pxa.pxa``
+    when the participant has no PXA-bearing snapshot yet.
+    """
+    statuses = getattr(participant, "participant_statuses", None) or []
+    for status in reversed(statuses):
+        pxa_dim = getattr(getattr(status, "case_status", None), "pxa", None)
+        pxa_state = getattr(pxa_dim, "state", None)
+        if isinstance(pxa_state, CS_pxa):
+            return pxa_state
+    # Fall back to case-level PXA.
+    try:
+        current_status = case.current_status  # type: ignore[attr-defined]
+    except (AttributeError, ValueError):
+        return CS_pxa.pxa
+    pxa_dim = getattr(getattr(current_status, "pxa", None), "state", None)
+    return pxa_dim if isinstance(pxa_dim, CS_pxa) else CS_pxa.pxa
+
+
+class ValidateTriggerTransitionsNode(DataLayerCondition):
+    """Fail-closed transition guard for the add-participant-status trigger path.
+
+    Validates each non-``None`` requested dimension against the participant's
+    current state using strict-adjacency checks.  Returns ``FAILURE`` with a
+    descriptive ``feedback_message`` when any dimension would be an illegal
+    jump; returns ``SUCCESS`` otherwise.
+
+    Rules (per BTND-10-001):
+
+    - ``None`` target → skip that dimension (AC-5).
+    - ``target == current`` → same-state confirmation, always valid (AC-4).
+    - ``target != current`` and invalid adjacent step → ``FAILURE`` (AC-1/2/3).
+
+    When the participant has no current status (first write) the initial states
+    ``RM.START``, ``CS_vfd.vfd``, ``CS_pxa.pxa`` are used as the baseline, so
+    the first valid transition from each initial state always passes.
+
+    Returns ``SUCCESS`` without validation when the participant or case cannot
+    be read from the DataLayer — ``CreateParticipantStatusNode`` downstream
+    handles missing-entity failures with its own error returns.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id: str,
+        rm_state: "RM | None",
+        vfd_state: "CS_vfd | None",
+        pxa_state: "CS_pxa | None",
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._actor_id = actor_id
+        self._rm_state = rm_state
+        self._vfd_state = vfd_state
+        self._pxa_state = pxa_state
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+        dl = self.datalayer
+
+        case = dl.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            # CreateParticipantStatusNode will report this; pass through.
+            return Status.SUCCESS
+
+        participant_id = case.actor_participant_index.get(self._actor_id)
+        if participant_id is None:
+            # CreateParticipantStatusNode will report this; pass through.
+            return Status.SUCCESS
+
+        current_rm, current_vfd = resolve_participant_state_from_dl(
+            dl, participant_id
+        )
+        participant_obj = dl.read(participant_id)
+
+        # --- RM dimension ---
+        if (
+            self._rm_state is not None
+            and self._rm_state != current_rm
+            and not is_valid_rm_transition(current_rm, self._rm_state)
+        ):
+            self.feedback_message = (
+                f"Invalid RM transition {current_rm!r} → {self._rm_state!r}"
+            )
+            self.logger.info("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        # --- VFD dimension ---
+        if (
+            self._vfd_state is not None
+            and self._vfd_state != current_vfd
+            and not is_valid_vfd_transition(current_vfd, self._vfd_state)
+        ):
+            self.feedback_message = (
+                f"Invalid VFD transition"
+                f" {current_vfd!r} → {self._vfd_state!r}"
+            )
+            self.logger.info("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        # --- PXA dimension ---
+        if self._pxa_state is not None and isinstance(
+            participant_obj, CaseParticipant
+        ):
+            current_pxa = _resolve_current_pxa(case, participant_obj)
+            if self._pxa_state != current_pxa and not is_valid_pxa_transition(
+                current_pxa, self._pxa_state
+            ):
+                self.feedback_message = (
+                    f"Invalid PXA transition"
+                    f" {current_pxa!r} → {self._pxa_state!r}"
+                )
+                self.logger.info("%s: %s", self.name, self.feedback_message)
+                return Status.FAILURE
+
+        return Status.SUCCESS


### PR DESCRIPTION
- Closes #2081
- Closes #1903

## Summary

The add-participant-status **trigger path** was fail-open: `add_participant_status_trigger_bt` called `CreateParticipantStatusNode` directly with no transition checks, so an HTTP trigger submitting e.g. `vfd → VFD` (skipping `Vfd`) would silently write an illegal state jump to the DataLayer.

The **received path** (`add_participant_status_tree`) already has `FilterParticipantStatusDimensionsNode` + `ValidateRMTransitionNode` since `a17d7649` — but those only fire when a status arrives over the wire.

## Changes

- **`vultron/core/behaviors/case/nodes/participant/trigger_validation.py`** (new): `ValidateTriggerTransitionsNode` — fail-closed pre-flight guard. Validates each non-`None` RM/VFD/PXA dimension against the participant's current state using strict-adjacency checks (`is_valid_rm_transition`, `is_valid_vfd_transition`, `is_valid_pxa_transition`). Returns `FAILURE` on any illegal jump; `SUCCESS` otherwise. Same-state writes and `None` targets always pass.

- **`add_participant_status_trigger_tree.py`**: Wire `ValidateTriggerTransitionsNode` as the first node in `AddParticipantStatusTriggerBT`, before `CreateParticipantStatusNode`.

- **`participant/__init__.py`**: Export `ValidateTriggerTransitionsNode`.

- **`test/architecture/test_vfd_rm_pxa_write_sites.py`** (new, AC-7 ratchet): AST-scans `vultron/core/behaviors/` for every `VfdDimension`/`RmDimension`/`PxaDimension` constructor call and asserts the exact audited set. New unclassified sites fail immediately, forcing an explicit audit before merge.

- **`test/core/use_cases/triggers/case/test_add_participant_status.py`**: 8 new tests (`TestValidateTriggerTransitions`) covering AC-1 through AC-6 end-to-end through `SvcAddParticipantStatusUseCase`. Three pre-existing tests corrected: `START → ACCEPTED` (non-adjacent) → `START → RECEIVED`.

## Design contrast with the received path

| Path | Disposition | Node |
|---|---|---|
| Trigger (this PR) | Fail-closed — invalid jump rejected outright | `ValidateTriggerTransitionsNode` |
| Received wire | Per-dimension partial-accept — refused dim carries current value forward | `FilterParticipantStatusDimensionsNode` |

The trigger path is fail-closed because a self-reported status is actor-authoritative: the actor controls its own state machine and must request valid adjacent steps.

## Verification

- All 8 new AC tests pass
- All 32 tests in `test_add_participant_status.py` pass
- AC-7 ratchet passes against current codebase
- `test/core/` + `test/architecture/`: 0 failures, 5 pre-existing xfails
- black, flake8, mypy, pyright: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)