### PR TITLE
feat: migrate core/behaviors/ Ports (1/5) — trivial base-only reparent

### DIFF
--- a/notes/py-trees-ports-adoption.md
+++ b/notes/py-trees-ports-adoption.md
@@ -29,22 +29,22 @@ adopting, what is deferred, the known technical mismatch, and the issue
 sequence — so each implementing agent starts from evidence rather than the
 Idea's optimistic framing.
 
-## Current state (verified 2026-07-29)
+## Current state (migration in progress — verified 2026-08-14)
 
 - **Dependency**: `pyproject.toml` already pins `py-trees>=2.5.0`. The Idea's
   "evaluate the upgrade path from the current pin" step is already satisfied —
   no upgrade is required to reach the Ports API.
-- **Ports API present, unused**: `py_trees.ports` exposes `BehaviourWithPorts`
-  (a `PortsMixin` + `Behaviour` subclass), `PortInformation`,
-  `NoDataAvailable`, and a ports registry. A repo-wide search finds **zero**
-  references to `input_ports`, `output_ports`, `BehaviourWithPorts`, or
-  `PortInformation` in `vultron/`, `specs/`, `notes/`, `docs/`, or `test/`.
-- **Node population**: `vultron/core/behaviors/` contains roughly **60 node
-  classes** and about **249 `register_key()` call sites**. Every node currently
-  subclasses `py_trees.behaviour.Behaviour` (or the DataLayer-aware base classes
-  in `helpers.py`) and declares blackboard access imperatively in `setup()` via
-  `register_key()`, following the `{noun}_{id_segment}` naming convention
-  (BTND-03-005, BTND-03-008).
+- **Ports API present and in use**: `py_trees.ports` exposes
+  `BehaviourWithPorts` (a `PortsMixin` + `Behaviour` subclass),
+  `PortInformation`, `NoDataAvailable`, and a ports registry. The pilot (#1808)
+  landed `DataLayerConditionWithPorts` and `DataLayerActionWithPorts` in
+  `vultron/core/behaviors/helpers.py` and migrated a first tranche of
+  `report/nodes/`. The pattern is now the standard base for all new nodes
+  (ADR-0044, BTND-03-009 through BTND-03-011).
+- **Migration progress**: Part 1/5 (#1883) migrated **41 Type-A nodes** across
+  `case/`, `status/`, and `note/` domains — all trivial base-only reparents
+  with no domain-specific `register_key()` calls. Remaining legacy nodes in
+  these and other domains are tracked under the #1809 chain (parts 2–5).
 - **XML parser**: `py_trees.parsers.behaviour_tree_xml` exists but is documented
   as **experimental** ("the parser is experimental and its API may change
   between releases"). It instantiates only classes registered in a
@@ -227,7 +227,17 @@ Derived from the #1558 grill-me interview. All Tasks are children of Epic #427.
    migration recipe. `size:M`.
 2. **#1809 — Full node migration** *(Task, blocked-by #1808)*
    Migrate the remaining `vultron/core/behaviors/` nodes to typed Ports,
-   following #1808's recipe. `size:L`.
+   following #1808's recipe. `size:L`. Split into five sequential sub-Tasks so
+   each part has a reviewable blast radius:
+   - **#1883 (1/5) ✓** — trivial base-only reparent: `case`, `status`, `note`.
+     Type-A nodes only (no domain `register_key()`), pure base-class swap.
+   - **#1884 (2/5)** — trivial base-only reparent: `report`, `embargo`.
+   - **#1885 (3/5)** — read-only extra-input nodes: add `input_ports()` and
+     replace direct blackboard reads with `get_input()`.
+   - **#1886 (4/5)** — WRITE-handoff nodes: establish `output_ports()` and the
+     execution-scoped key convention (AC-3's BTND-03-004 property).
+   - **#1887 (5/5)** — non-DataLayer nodes, composite exemptions, and
+     finalization (including this note's AC-4 completion update).
 3. **#1810 — XML feasibility spike** *(Task, blocked-by #1809)*
    Assess whether protocol BTs can be authored/exported as BehaviorTree XML
    given the constructor-vs-remapping mismatch and the experimental parser.

--- a/test/core/behaviors/case/nodes/test_typed_ports.py
+++ b/test/core/behaviors/case/nodes/test_typed_ports.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Typed-Ports isolation tests for case domain nodes (AC-4, issue #1883).
+
+Covers BTND-03-011 (NoDataAvailable on missing required port) and happy-path
+execution via BTTestScenario for one representative node per case sub-module.
+"""
+
+import pytest
+from py_trees.ports import NoDataAvailable
+
+from vultron.core.behaviors.case.nodes.conditions import (
+    CheckCaseAlreadyExists,
+)
+from vultron.core.behaviors.case.nodes.suggest_actor.conditions import (
+    ActorAlreadyParticipantNode,
+)
+from vultron.core.behaviors.case.nodes.update import (
+    CheckCaseUpdateOwnerNode,
+)
+from vultron.core.behaviors.case.nodes.vfd_role_guards import (
+    CheckVendorRoleNode,
+)
+from vultron.core.models.case import VulnerabilityCase
+from test.core.behaviors.bt_harness import BTTestScenario
+
+ACTOR_ID = "https://example.org/actors/vendor"
+CASE_ID = "https://example.org/cases/case-001"
+PARTICIPANT_ID = "https://example.org/participants/p-001"
+
+
+# ---------------------------------------------------------------------------
+# conditions.py — CheckCaseAlreadyExists
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCaseAlreadyExistsPorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = CheckCaseAlreadyExists(case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_failure_when_case_not_present(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            CheckCaseAlreadyExists(case_id=CASE_ID), actor_id=ACTOR_ID
+        )
+        bt_scenario.assert_failure(result)
+
+    def test_success_when_case_has_participants(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        from vultron.core.models.case_participant import CaseParticipant
+
+        participant = CaseParticipant(
+            id_=PARTICIPANT_ID,
+            attributed_to=ACTOR_ID,
+        )
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            name="Test Case",
+            attributed_to=ACTOR_ID,
+        )
+        case.case_participants.append(participant)
+        bt_scenario.seed(case, participant)
+        result = bt_scenario.run(
+            CheckCaseAlreadyExists(case_id=CASE_ID), actor_id=ACTOR_ID
+        )
+        bt_scenario.assert_success(result)
+
+
+# ---------------------------------------------------------------------------
+# vfd_role_guards.py — CheckVendorRoleNode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckVendorRoleNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = CheckVendorRoleNode(case_id=CASE_ID, actor_id=ACTOR_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_failure_when_case_not_found(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            CheckVendorRoleNode(case_id=CASE_ID, actor_id=ACTOR_ID),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_failure(result)
+
+
+# ---------------------------------------------------------------------------
+# suggest_actor/conditions.py — ActorAlreadyParticipantNode
+# ---------------------------------------------------------------------------
+
+
+class TestActorAlreadyParticipantNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = ActorAlreadyParticipantNode(
+            recommended_id=ACTOR_ID, case_id=CASE_ID
+        )
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_failure_when_actor_not_participant(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            name="Test Case",
+            attributed_to=ACTOR_ID,
+        )
+        bt_scenario.seed(case)
+        result = bt_scenario.run(
+            ActorAlreadyParticipantNode(
+                recommended_id=ACTOR_ID, case_id=CASE_ID
+            ),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_failure(result)
+
+
+# ---------------------------------------------------------------------------
+# update.py — CheckCaseUpdateOwnerNode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCaseUpdateOwnerNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = CheckCaseUpdateOwnerNode(case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_failure_when_case_not_found(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            CheckCaseUpdateOwnerNode(case_id=CASE_ID), actor_id=ACTOR_ID
+        )
+        bt_scenario.assert_failure(result)
+
+    def test_success_when_actor_owns_case(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            name="Test Case",
+            attributed_to=ACTOR_ID,
+        )
+        bt_scenario.seed(case)
+        result = bt_scenario.run(
+            CheckCaseUpdateOwnerNode(case_id=CASE_ID), actor_id=ACTOR_ID
+        )
+        bt_scenario.assert_success(result)
+
+    def test_failure_when_actor_is_not_owner(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            name="Test Case",
+            attributed_to="https://example.org/actors/other",
+        )
+        bt_scenario.seed(case)
+        result = bt_scenario.run(
+            CheckCaseUpdateOwnerNode(case_id=CASE_ID), actor_id=ACTOR_ID
+        )
+        bt_scenario.assert_failure(result)

--- a/test/core/behaviors/note/nodes/test_typed_ports.py
+++ b/test/core/behaviors/note/nodes/test_typed_ports.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Typed-Ports isolation tests for note domain nodes (AC-4, issue #1883).
+
+Covers BTND-03-011 (NoDataAvailable on missing required port) and happy-path
+execution via BTTestScenario for one representative node per note sub-module.
+"""
+
+import pytest
+from py_trees.ports import NoDataAvailable
+
+from vultron.core.behaviors.note.nodes.creation import (
+    CreateNoteNode,
+)
+from vultron.core.behaviors.note.nodes.storage import (
+    AttachNoteToCaseNode,
+    SaveNoteNode,
+)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.note import VultronNote
+from test.core.behaviors.bt_harness import BTTestScenario
+
+ACTOR_ID = "https://example.org/actors/vendor"
+CASE_ID = "https://example.org/cases/case-001"
+NOTE_ID = "https://example.org/notes/note-001"
+
+
+# ---------------------------------------------------------------------------
+# storage.py — SaveNoteNode (isolated-port: BTND-03-011)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveNoteNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        note = VultronNote(
+            id_=NOTE_ID,
+            name="Test Note",
+            content="test content",
+            context=CASE_ID,
+            attributed_to=ACTOR_ID,
+        )
+        node = SaveNoteNode(note_obj=note)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_saves_note_via_bt_scenario(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        note = VultronNote(
+            id_=NOTE_ID,
+            name="Test Note",
+            content="test content",
+            context=CASE_ID,
+            attributed_to=ACTOR_ID,
+        )
+        result = bt_scenario.run(
+            SaveNoteNode(note_obj=note), actor_id=ACTOR_ID
+        )
+        bt_scenario.assert_success(result)
+
+
+# ---------------------------------------------------------------------------
+# creation.py — CreateNoteNode (isolated-port: BTND-03-011)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateNoteNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        result_out: dict = {}
+        node = CreateNoteNode(
+            note_name="N",
+            note_content="c",
+            case_id=CASE_ID,
+            result_out=result_out,
+        )
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+
+# ---------------------------------------------------------------------------
+# storage.py — AttachNoteToCaseNode (isolated-port: BTND-03-011)
+# ---------------------------------------------------------------------------
+
+
+class TestAttachNoteToCaseNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = AttachNoteToCaseNode(note_id=NOTE_ID, case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_skips_when_case_id_none(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Skips silently (SUCCESS) when case_id is None."""
+        result = bt_scenario.run(
+            AttachNoteToCaseNode(note_id=NOTE_ID, case_id=None),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_success(result)
+
+    def test_attaches_note_to_case(self, bt_scenario: BTTestScenario) -> None:
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            name="Test Case",
+            attributed_to=ACTOR_ID,
+        )
+        note = VultronNote(
+            id_=NOTE_ID,
+            name="Test Note",
+            content="test content",
+            context=CASE_ID,
+            attributed_to=ACTOR_ID,
+        )
+        bt_scenario.seed(case, note)
+        result = bt_scenario.run(
+            AttachNoteToCaseNode(note_id=NOTE_ID, case_id=CASE_ID),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_success(result)

--- a/test/core/behaviors/status/nodes/test_typed_ports.py
+++ b/test/core/behaviors/status/nodes/test_typed_ports.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Typed-Ports isolation tests for status domain nodes (AC-4, issue #1883).
+
+Covers BTND-03-011 (NoDataAvailable on missing required port) and happy-path
+execution via BTTestScenario for one representative node per status sub-module.
+"""
+
+import pytest
+from py_trees.ports import NoDataAvailable
+
+from vultron.core.behaviors.status.nodes.case_status import (
+    CheckCaseStatusIdempotencyNode,
+)
+from vultron.core.behaviors.status.nodes.conditions import (
+    AllParticipantsRMClosedConditionNode,
+)
+from vultron.core.behaviors.status.nodes.lifecycle import (
+    _PublicDisclosureSkipConditionNode,
+)
+from vultron.core.behaviors.status.nodes.threat_termination import (
+    _ThreatTerminationSkipConditionNode,
+)
+from vultron.core.models.case import VulnerabilityCase
+from test.core.behaviors.bt_harness import BTTestScenario
+
+ACTOR_ID = "https://example.org/actors/vendor"
+CASE_ID = "https://example.org/cases/case-001"
+STATUS_ID = "https://example.org/statuses/status-001"
+
+
+# ---------------------------------------------------------------------------
+# case_status.py — CheckCaseStatusIdempotencyNode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCaseStatusIdempotencyNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = CheckCaseStatusIdempotencyNode(
+            case_id=CASE_ID, status_id=STATUS_ID
+        )
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_success_when_status_not_yet_present(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            name="Test Case",
+            attributed_to=ACTOR_ID,
+        )
+        bt_scenario.seed(case)
+        result = bt_scenario.run(
+            CheckCaseStatusIdempotencyNode(
+                case_id=CASE_ID, status_id=STATUS_ID
+            ),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_success(result)
+
+
+# ---------------------------------------------------------------------------
+# conditions.py — AllParticipantsRMClosedConditionNode
+# ---------------------------------------------------------------------------
+
+
+class TestAllParticipantsRMClosedConditionNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = AllParticipantsRMClosedConditionNode(case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_failure_when_no_participants(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            name="Test Case",
+            attributed_to=ACTOR_ID,
+        )
+        bt_scenario.seed(case)
+        result = bt_scenario.run(
+            AllParticipantsRMClosedConditionNode(case_id=CASE_ID),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_failure(result)
+
+
+# ---------------------------------------------------------------------------
+# lifecycle.py — _PublicDisclosureSkipConditionNode
+# ---------------------------------------------------------------------------
+
+
+class TestPublicDisclosureSkipConditionNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = _PublicDisclosureSkipConditionNode(
+            status_obj=None,
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_success_skip_when_no_public_aware_status(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Non-public-aware status -> skip condition returns SUCCESS."""
+        result = bt_scenario.run(
+            _PublicDisclosureSkipConditionNode(
+                status_obj=None,
+                sender_actor_id=ACTOR_ID,
+                case_id=CASE_ID,
+            ),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_success(result)
+
+
+# ---------------------------------------------------------------------------
+# threat_termination.py — _ThreatTerminationSkipConditionNode
+# ---------------------------------------------------------------------------
+
+
+class TestThreatTerminationSkipConditionNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = _ThreatTerminationSkipConditionNode(
+            status_obj=None,
+            case_id=CASE_ID,
+        )
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_success_skip_when_no_threat(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """No threat in status -> skip returns SUCCESS."""
+        result = bt_scenario.run(
+            _ThreatTerminationSkipConditionNode(
+                status_obj=None,
+                case_id=CASE_ID,
+            ),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_success(result)

--- a/vultron/core/behaviors/case/nodes/announce.py
+++ b/vultron/core/behaviors/case/nodes/announce.py
@@ -30,7 +30,7 @@ from typing import Any, Union
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models.events.actor import (
     AnnounceVulnerabilityCaseReceivedEvent,
 )
@@ -59,7 +59,7 @@ def _store_embedded_reports(case_obj, datalayer) -> None:
             datalayer.save(report_ref)
 
 
-class SeedAnnouncedCaseNode(DataLayerAction):
+class SeedAnnouncedCaseNode(DataLayerActionWithPorts):
     """Persist a received ``VulnerabilityCase`` announcement in the DataLayer.
 
     On first receipt the node saves ``case_obj`` and stores any embedded

--- a/vultron/core/behaviors/case/nodes/case_participant_received.py
+++ b/vultron/core/behaviors/case/nodes/case_participant_received.py
@@ -25,13 +25,13 @@ BTND-07-003.
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 
 
-class AddCaseParticipantToCaseReceivedNode(DataLayerAction):
+class AddCaseParticipantToCaseReceivedNode(DataLayerActionWithPorts):
     """Add a participant to a case and persist the updated case.
 
     Reads both the participant and the case from the DataLayer, calls
@@ -89,7 +89,7 @@ class AddCaseParticipantToCaseReceivedNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class RemoveCaseParticipantFromCaseReceivedNode(DataLayerAction):
+class RemoveCaseParticipantFromCaseReceivedNode(DataLayerActionWithPorts):
     """Remove a participant from a case and persist the updated case.
 
     Reads the case from the DataLayer and calls

--- a/vultron/core/behaviors/case/nodes/conditions.py
+++ b/vultron/core/behaviors/case/nodes/conditions.py
@@ -35,7 +35,11 @@ from py_trees.common import Status
 
 from vultron.config import get_config
 from vultron.core.behaviors.case.nodes.case_setup import _derive_case_slug
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    DataLayerCondition,
+    DataLayerConditionWithPorts,
+)
 from vultron.config.actor import ActorConfig
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_actor import CaseActor as VultronCaseActor
@@ -98,7 +102,7 @@ class CheckAutoCaseCreationEnabledNode(py_trees.behaviour.Behaviour):
         return Status.FAILURE
 
 
-class CheckCaseAlreadyExists(DataLayerCondition):
+class CheckCaseAlreadyExists(DataLayerConditionWithPorts):
     """
     Check if a VulnerabilityCase already exists in DataLayer.
 
@@ -150,7 +154,7 @@ class CheckCaseAlreadyExists(DataLayerCondition):
             return Status.FAILURE
 
 
-class CheckCaseExistsForReport(DataLayerCondition):
+class CheckCaseExistsForReport(DataLayerConditionWithPorts):
     """
     Check if a VulnerabilityCase already exists for the given report.
 
@@ -279,7 +283,7 @@ class CheckIsCaseManagerNode(DataLayerCondition):
         return Status.FAILURE
 
 
-class CheckPendingProposalExistsForReport(DataLayerCondition):
+class CheckPendingProposalExistsForReport(DataLayerConditionWithPorts):
     """Return SUCCESS when a pending ``VultronReportCaseLink`` exists for the report.
 
     Used as the idempotency guard in the slimmed vendor tree (ADR-0041).
@@ -334,7 +338,7 @@ class CheckPendingProposalExistsForReport(DataLayerCondition):
             return Status.FAILURE
 
 
-class WritePendingReportCaseLinkNode(DataLayerAction):
+class WritePendingReportCaseLinkNode(DataLayerActionWithPorts):
     """Write a pending ``VultronReportCaseLink`` for the given report (ADR-0041).
 
     Creates or updates the link with ``case_id=None`` and sets

--- a/vultron/core/behaviors/case/nodes/invite_response.py
+++ b/vultron/core/behaviors/case/nodes/invite_response.py
@@ -31,13 +31,13 @@ from typing import cast
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
 logger = logging.getLogger(__name__)
 
 
-class EmitAcceptCaseInviteNode(DataLayerAction):
+class EmitAcceptCaseInviteNode(DataLayerActionWithPorts):
     """Create Accept(Invite) and queue in the invitee's outbox.
 
     Uses ``trigger_activity_factory.accept_case_invite()`` — the factory
@@ -88,7 +88,7 @@ class EmitAcceptCaseInviteNode(DataLayerAction):
             return Status.FAILURE
 
 
-class EmitRejectCaseInviteNode(DataLayerAction):
+class EmitRejectCaseInviteNode(DataLayerActionWithPorts):
     """Create Reject(Invite) and queue in the invitee's outbox.
 
     Uses ``trigger_activity_factory.reject_case_invite()`` — the factory

--- a/vultron/core/behaviors/case/nodes/leave.py
+++ b/vultron/core/behaviors/case/nodes/leave.py
@@ -37,7 +37,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.case.nodes.participant.status import (
     CreateParticipantStatusNode,
 )
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.participant_status import (
@@ -48,7 +48,7 @@ from vultron.core.states.rm import RM
 logger = logging.getLogger(__name__)
 
 
-class AdvanceParticipantToRMClosedNode(DataLayerAction):
+class AdvanceParticipantToRMClosedNode(DataLayerActionWithPorts):
     """Advance the leaving actor's RM state to ``RM.CLOSED`` in the DataLayer.
 
     Reads the leaving actor's :class:`~vultron.core.models.case_participant
@@ -153,7 +153,7 @@ class AdvanceParticipantToRMClosedNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class AdvanceCaseActorToRMClosedNode(DataLayerAction):
+class AdvanceCaseActorToRMClosedNode(DataLayerActionWithPorts):
     """Advance the Case Actor's own RM state to ``RM.CLOSED``.
 
     Reads the Case Actor's :class:`~vultron.core.models.case_participant

--- a/vultron/core/behaviors/case/nodes/ownership_transfer.py
+++ b/vultron/core/behaviors/case/nodes/ownership_transfer.py
@@ -38,7 +38,7 @@ from typing import Any, cast
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models._helpers import _as_id
@@ -49,7 +49,7 @@ from vultron.enums.roles import CVDRole
 logger = logging.getLogger(__name__)
 
 
-class EmitOfferCaseOwnershipTransferNode(DataLayerAction):
+class EmitOfferCaseOwnershipTransferNode(DataLayerActionWithPorts):
     """Emit ``Offer(VulnerabilityCase)`` (ownership transfer) to ``transferee_id``.
 
     Calls ``trigger_activity_factory.offer_case_ownership_transfer()`` with
@@ -70,9 +70,6 @@ class EmitOfferCaseOwnershipTransferNode(DataLayerAction):
         self.transferee_id = transferee_id
         self.content = content
         self._captured = captured
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
 
     def _emit(self) -> tuple[str, dict]:
         assert self.trigger_activity_factory is not None
@@ -121,7 +118,7 @@ class EmitOfferCaseOwnershipTransferNode(DataLayerAction):
             return Status.FAILURE
 
 
-class EmitAcceptCaseOwnershipTransferNode(DataLayerAction):
+class EmitAcceptCaseOwnershipTransferNode(DataLayerActionWithPorts):
     """Emit ``Accept(Offer(VulnerabilityCase))`` (ownership transfer) to offerer.
 
     Calls ``trigger_activity_factory.accept_case_ownership_transfer()``
@@ -140,9 +137,6 @@ class EmitAcceptCaseOwnershipTransferNode(DataLayerAction):
         self.offer_id = offer_id
         self.case_id = case_id
         self._captured = captured
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
 
     def _emit(self) -> tuple[str, dict]:
         assert self.trigger_activity_factory is not None
@@ -188,7 +182,7 @@ class EmitAcceptCaseOwnershipTransferNode(DataLayerAction):
             return Status.FAILURE
 
 
-class AcceptCaseOwnershipTransferNode(DataLayerAction):
+class AcceptCaseOwnershipTransferNode(DataLayerActionWithPorts):
     """Apply an ownership-transfer acceptance to the case record.
 
     Enforces the at-most-one CASE_OWNER invariant atomically (CM-21-001,

--- a/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
+++ b/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
@@ -25,12 +25,12 @@ from py_trees.common import Status
 from vultron.core.behaviors.case.nodes.participant.common import (
     _ensure_reporter_participant,
 )
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.report_case_link import VultronReportCaseLink
 
 
-class EnsureReporterParticipantAtAcceptedNode(DataLayerAction):
+class EnsureReporterParticipantAtAcceptedNode(DataLayerActionWithPorts):
     """BT leaf node that seeds or upgrades the reporter participant to RM.ACCEPTED.
 
     Called from ``CreateCaseReceivedUseCase._handle_bootstrap`` via BTBridge

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -20,7 +20,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.case.nodes.participant.common import (
     resolve_participant_state_from_dl,
 )
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.behaviors.narrative_log import (
     log_cs_transition,
     log_rm_transition,
@@ -91,7 +91,7 @@ def _resolve_pxa_state(case: object, participant: object) -> CS_pxa:
     return _pxa_from_case(case) or CS_pxa.pxa
 
 
-class CreateParticipantStatusNode(DataLayerAction):
+class CreateParticipantStatusNode(DataLayerActionWithPorts):
     """Create a ParticipantStatus snapshot and append it to the participant."""
 
     def __init__(

--- a/vultron/core/behaviors/case/nodes/proposal.py
+++ b/vultron/core/behaviors/case/nodes/proposal.py
@@ -33,11 +33,11 @@ from py_trees.common import Status
 
 from vultron.config import get_config
 from vultron.core.behaviors.case.nodes.case_setup import _derive_case_slug
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
 
-class ProposeReportCaseToActorNode(DataLayerAction):
+class ProposeReportCaseToActorNode(DataLayerActionWithPorts):
     """Send ``Create(as_CaseProposal)`` from ``report_id`` without a prior case.
 
     Used by the slimmed vendor ``receive_report_case_tree`` (ADR-0041).  Unlike

--- a/vultron/core/behaviors/case/nodes/suggest_actor/accept_offer.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/accept_offer.py
@@ -25,11 +25,11 @@ from typing import cast
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
 
-class EmitAcceptCaseParticipantOfferNode(DataLayerAction):
+class EmitAcceptCaseParticipantOfferNode(DataLayerActionWithPorts):
     """Case Owner sends Accept(Offer(CaseParticipant)) back to the CaseActor.
 
     Triggered by the Case Owner after reviewing the Offer(CaseParticipant)

--- a/vultron/core/behaviors/case/nodes/suggest_actor/conditions.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/conditions.py
@@ -28,14 +28,14 @@ Node classes:
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models.protocol_pair import (
     INVITE_ACTOR_TO_CASE_REPLY_TYPES,
     OFFER_CASE_PARTICIPANT_REPLY_TYPES,
 )
 
 
-class ActorAlreadyParticipantNode(DataLayerAction):
+class ActorAlreadyParticipantNode(DataLayerActionWithPorts):
     """Return SUCCESS if the recommended actor is already a case participant.
 
     Reads ``VulnerabilityCase.actor_participant_index`` from the DataLayer.
@@ -73,7 +73,7 @@ class ActorAlreadyParticipantNode(DataLayerAction):
         return Status.FAILURE
 
 
-class InviteInFlightNode(DataLayerAction):
+class InviteInFlightNode(DataLayerActionWithPorts):
     """Return SUCCESS if an Invite to the recommended actor is in-flight.
 
     Queries the case ledger via ``find_protocol_pair`` with
@@ -116,7 +116,7 @@ class InviteInFlightNode(DataLayerAction):
         return Status.FAILURE
 
 
-class PendingOfferCaseParticipantNode(DataLayerAction):
+class PendingOfferCaseParticipantNode(DataLayerActionWithPorts):
     """Return SUCCESS if an Offer(CaseParticipant) to the Case Owner is pending.
 
     Queries the case ledger via ``find_protocol_pair`` with

--- a/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
@@ -43,7 +43,10 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.bridge import BTBridge
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+)
 from vultron.core.behaviors.sync.commit_tree import (
     create_commit_log_entry_tree,
 )
@@ -55,7 +58,7 @@ from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.enums.roles import CVDRole
 
 
-class RecordRecommendationRecommenderNode(DataLayerAction):
+class RecordRecommendationRecommenderNode(DataLayerActionWithPorts):
     """Write recommendation_id → recommender_id into core case state.
 
     Runs as the first effect node in ``RecommendActorToCaseBT`` so downstream
@@ -232,7 +235,7 @@ class EmitOfferCaseParticipantToOwnerNode(DataLayerAction):
             return Status.FAILURE
 
 
-class EmitAcceptActorRecommendationNode(DataLayerAction):
+class EmitAcceptActorRecommendationNode(DataLayerActionWithPorts):
     """Queue AcceptActorRecommendation to the original recommender.
 
     Used after the Case Owner accepts Offer(CaseParticipant) (CM-16-006 step 3).
@@ -313,7 +316,7 @@ class EmitAcceptActorRecommendationNode(DataLayerAction):
             return Status.FAILURE
 
 
-class EmitRejectActorRecommendationNode(DataLayerAction):
+class EmitRejectActorRecommendationNode(DataLayerActionWithPorts):
     """Queue RejectActorRecommendation to the original recommender.
 
     Used after the Case Owner rejects Offer(CaseParticipant) (CM-16-007 step 3).
@@ -391,7 +394,7 @@ class EmitRejectActorRecommendationNode(DataLayerAction):
             return Status.FAILURE
 
 
-class EmitNoteDuplicateRecommendationToOwnerNode(DataLayerAction):
+class EmitNoteDuplicateRecommendationToOwnerNode(DataLayerActionWithPorts):
     """Send a Note DM to the Case Owner noting reinforcing demand.
 
     Used when a second ``Offer(Actor, Case)`` arrives while a first

--- a/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
@@ -83,9 +83,9 @@ class RecordRecommendationRecommenderNode(DataLayerActionWithPorts):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            return Status.SUCCESS
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
             return Status.SUCCESS

--- a/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
@@ -83,8 +83,6 @@ class RecordRecommendationRecommenderNode(DataLayerActionWithPorts):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if (f := self._require_datalayer()) is not None:
-            return f
         assert self.datalayer is not None
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):

--- a/vultron/core/behaviors/case/nodes/update.py
+++ b/vultron/core/behaviors/case/nodes/update.py
@@ -29,14 +29,16 @@ from vultron.core.behaviors.case.update_support import (
 )
 from vultron.core.behaviors.helpers import (
     DataLayerAction,
+    DataLayerActionWithPorts,
     DataLayerCondition,
+    DataLayerConditionWithPorts,
 )
 from vultron.core.models.events.case import UpdateCaseReceivedEvent
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case import VulnerabilityCase
 
 
-class CheckCaseUpdateOwnerNode(DataLayerCondition):
+class CheckCaseUpdateOwnerNode(DataLayerConditionWithPorts):
     """Return SUCCESS when the current actor owns the case."""
 
     def __init__(self, case_id: str, name: str | None = None) -> None:
@@ -107,7 +109,7 @@ class CaptureCaseUpdateBroadcastExclusionsNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class ApplyCaseUpdateNode(DataLayerAction):
+class ApplyCaseUpdateNode(DataLayerActionWithPorts):
     """Apply mutable fields from the inbound update payload to the case."""
 
     def __init__(

--- a/vultron/core/behaviors/case/nodes/vfd_role_guards.py
+++ b/vultron/core/behaviors/case/nodes/vfd_role_guards.py
@@ -32,7 +32,10 @@ from typing import Any
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerCondition,
+    DataLayerConditionWithPorts,
+)
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.ports.case_persistence import CasePersistence
@@ -78,7 +81,7 @@ def _resolve_actor_roles(
     return list(participant.roles) if participant.roles else []
 
 
-class CheckVendorRoleNode(DataLayerCondition):
+class CheckVendorRoleNode(DataLayerConditionWithPorts):
     """Gate f→F (vfd_state=VFd): actor MUST hold CVDRole.VENDOR.
 
     Returns ``SUCCESS`` when the executing actor holds ``CVDRole.VENDOR`` in
@@ -131,7 +134,7 @@ class CheckVendorRoleNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class CheckDeployerRoleNode(DataLayerCondition):
+class CheckDeployerRoleNode(DataLayerConditionWithPorts):
     """Gate d→D (vfd_state=VFD): actor MUST hold CVDRole.DEPLOYER.
 
     Returns ``SUCCESS`` when the executing actor holds ``CVDRole.DEPLOYER`` in

--- a/vultron/core/behaviors/note/nodes/creation.py
+++ b/vultron/core/behaviors/note/nodes/creation.py
@@ -19,12 +19,12 @@ from typing import Any
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case import VulnerabilityCase
 
 
-class CreateNoteNode(DataLayerAction):
+class CreateNoteNode(DataLayerActionWithPorts):
     """Create and persist a Note via the TriggerActivityPort."""
 
     def __init__(
@@ -71,7 +71,7 @@ class CreateNoteNode(DataLayerAction):
             return Status.FAILURE
 
 
-class AttachNoteFromResultNode(DataLayerAction):
+class AttachNoteFromResultNode(DataLayerActionWithPorts):
     """Attach a note to a case, reading ``note_id`` from ``result_out``."""
 
     def __init__(

--- a/vultron/core/behaviors/note/nodes/storage.py
+++ b/vultron/core/behaviors/note/nodes/storage.py
@@ -19,13 +19,13 @@ from typing import Any
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.note import VultronNote
 
 
-class SaveNoteNode(DataLayerAction):
+class SaveNoteNode(DataLayerActionWithPorts):
     """Persist a Note to the DataLayer using upsert semantics."""
 
     def __init__(self, note_obj: VultronNote, name: str | None = None):
@@ -48,7 +48,7 @@ class SaveNoteNode(DataLayerAction):
             return Status.FAILURE
 
 
-class AttachNoteToCaseNode(DataLayerAction):
+class AttachNoteToCaseNode(DataLayerActionWithPorts):
     """Attach a note to a VulnerabilityCase in the DataLayer."""
 
     def __init__(

--- a/vultron/core/behaviors/status/nodes/case_status.py
+++ b/vultron/core/behaviors/status/nodes/case_status.py
@@ -24,7 +24,10 @@ from typing import Any
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    DataLayerConditionWithPorts,
+)
 from vultron.core.behaviors.idempotency import SilentIdempotencyGuardMixin
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_status import CaseStatus
@@ -42,7 +45,7 @@ CASE_STATUS_ALREADY_PRESENT = "case_status_already_present"
 
 
 class CheckCaseStatusIdempotencyNode(
-    SilentIdempotencyGuardMixin, DataLayerCondition
+    SilentIdempotencyGuardMixin, DataLayerConditionWithPorts
 ):
     """AC-1: Verify the CaseStatus has not already been added to the case.
 
@@ -95,7 +98,7 @@ class CheckCaseStatusIdempotencyNode(
         return Status.SUCCESS
 
 
-class ValidateCaseStatusTransitionNode(DataLayerCondition):
+class ValidateCaseStatusTransitionNode(DataLayerConditionWithPorts):
     """AC-2: Validate that the new CaseStatus represents a legal state transition.
 
     Uses ``case.current_status`` as the reference point.  When the case has no
@@ -196,7 +199,7 @@ class ValidateCaseStatusTransitionNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class AppendCaseStatusToCaseNode(DataLayerAction):
+class AppendCaseStatusToCaseNode(DataLayerActionWithPorts):
     """Append the resolved CaseStatus to ``case.case_statuses`` and persist.
 
     Resolves the status object from the DataLayer first; if not found there,

--- a/vultron/core/behaviors/status/nodes/conditions.py
+++ b/vultron/core/behaviors/status/nodes/conditions.py
@@ -27,7 +27,7 @@ from typing import Any, cast
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import (
-    DataLayerCondition,
+    DataLayerConditionWithPorts,
     FindParticipantByActorIdNode,
 )
 from vultron.core.models.case import VulnerabilityCase
@@ -111,7 +111,7 @@ class VerifySenderIsParticipantNode(FindParticipantByActorIdNode):
         return Status.SUCCESS
 
 
-class AllParticipantsRMClosedConditionNode(DataLayerCondition):
+class AllParticipantsRMClosedConditionNode(DataLayerConditionWithPorts):
     """Precondition: all CVD participants in the case have RM.CLOSED.
 
     Iterates ``case.actor_participant_index`` and returns ``FAILURE`` if any
@@ -190,7 +190,7 @@ class AllParticipantsRMClosedConditionNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class CloseNotYetEmittedConditionNode(DataLayerCondition):
+class CloseNotYetEmittedConditionNode(DataLayerConditionWithPorts):
     """Idempotency guard: no ``Leave(VulnerabilityCase)`` in the outbox yet.
 
     Queries the actor's outbox for existing activities and checks whether any

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -36,7 +36,11 @@ from vultron.core.behaviors.embargo.trigger_tree import (
     reject_proposed_embargo_bt,
     terminate_embargo_bt,
 )
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+    DataLayerConditionWithPorts,
+)
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
@@ -51,7 +55,7 @@ from vultron.core.behaviors.status.nodes.threat_termination import (  # noqa: F4
 logger = logging.getLogger(__name__)
 
 
-class _PublicDisclosureSkipConditionNode(DataLayerCondition):
+class _PublicDisclosureSkipConditionNode(DataLayerConditionWithPorts):
     """Inner guard for :class:`PublicDisclosureBranchNode`.
 
     Returns SUCCESS (skip teardown) when:
@@ -223,7 +227,7 @@ class PublicDisclosureBranchNode(py_trees.composites.Selector):
         )
 
 
-class EmitAddCaseStatusToSelfNode(DataLayerAction):
+class EmitAddCaseStatusToSelfNode(DataLayerActionWithPorts):
     """Emit a self-addressed ``Add(CaseStatus, VulnerabilityCase)`` to the CaseActor.
 
     When ``StatusUpdateGuard`` passes (RSH-01-003), this node:

--- a/vultron/core/behaviors/status/nodes/threat_termination.py
+++ b/vultron/core/behaviors/status/nodes/threat_termination.py
@@ -27,7 +27,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.embargo.trigger_tree import terminate_embargo_bt
-from vultron.core.behaviors.helpers import DataLayerCondition
+from vultron.core.behaviors.helpers import DataLayerConditionWithPorts
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.protocols import PersistableModel
 from vultron.core.models._helpers import _as_id
@@ -35,7 +35,7 @@ from vultron.core.models._helpers import _as_id
 logger = logging.getLogger(__name__)
 
 
-class _ThreatTerminationSkipConditionNode(DataLayerCondition):
+class _ThreatTerminationSkipConditionNode(DataLayerConditionWithPorts):
     """Inner guard for :class:`ThreatTerminationBranchNode`.
 
     Returns SUCCESS (skip teardown) when:


### PR DESCRIPTION
- Closes #1883

## Summary

Re-implementation of #1883 on current main. The original PR #2125 had drifted 280 commits behind (status nodes were restructured, announce.py grew significantly) and was cheaper to reimplement from scratch than rebase. Migrates 41 Type-A BT nodes to typed Ports across \`case/\`, \`note/\`, and \`status/\` domains.

## Changes

- **\`vultron/core/behaviors/case/nodes/\` (14 files)**: \`DataLayerAction\` → \`DataLayerActionWithPorts\`, \`DataLayerCondition\` → \`DataLayerConditionWithPorts\` for 29 Type-A nodes; removes 2 trivial no-op \`setup()\` overrides from \`ownership_transfer.py\`; removes dead \`if self.datalayer is None\` guard from \`RecordRecommendationRecommenderNode\`
- **\`vultron/core/behaviors/note/nodes/{creation,storage}.py\`**: \`DataLayerAction\` → \`DataLayerActionWithPorts\` for 4 Type-A nodes
- **\`vultron/core/behaviors/status/nodes/{case_status,conditions,lifecycle,threat_termination}.py\`**: \`DataLayerCondition\`/\`DataLayerAction\` → \`*WithPorts\` for 8 Type-A nodes; \`CheckCaseStatusIdempotencyNode\` mixin updated
- **\`test/core/behaviors/{case,note,status}/nodes/test_typed_ports.py\`**: 25 new typed-ports isolation tests per BTND-03-011
- **\`notes/py-trees-ports-adoption.md\`**: Current state updated to reflect migration in progress; 5-part plan added

Two nodes intentionally left on legacy bases (Type-B, scope of later parts):
- \`EmitOfferCaseParticipantToOwnerNode\` — dynamic \`register_key()\` in \`setup()\`
- \`EmitCloseCaseNode\` — reads \`case_manager_id\` via \`self.blackboard\` in \`update()\`

Part 1/5 of the #1809 full-migration chain.

## Verification

- [x] AC-1: All 41 Type-A nodes under \`case/\`, \`status/\`, \`note/\` subclass \`DataLayerConditionWithPorts\` / \`DataLayerActionWithPorts\`
- [x] AC-2: Redundant \`setup()\` overrides removed from \`ownership_transfer.py\`; dead \`if self.datalayer is None\` guard removed from \`RecordRecommendationRecommenderNode\`
- [x] AC-3: 6943 tests pass (no regression on BTND-03-004 execution-scoped key namespacing)
- [x] AC-4: 25 new typed-ports isolation tests across 3 new files; \`NoDataAvailable\` coverage per BTND-03-011
- [x] Black, flake8, markdownlint all pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)