### PR TITLE
docs: plan issue #2281 — pre-harness demo CI empty artifact

### DIFF
--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -50,7 +50,12 @@ but `devlogs/` was empty. The `invariant-harness` job then died on **artifact
 download** — the run that most needed forensics produced none, and the harness
 reported a plumbing error instead of an invariant result (issue #2239).
 
-**Design**: four pieces, spec'd as DEMOCI-10-001 through DEMOCI-10-005.
+**Design**: five pieces in two layers, spec'd as DEMOCI-10-001 through
+DEMOCI-10-006.
+
+### Layer 1 — In-harness failures (DEMOCI-10-001 through DEMOCI-10-005)
+
+These cover any failure that happens *inside* `scenario_harness()`.
 
 1. **A shared harness owns the ordering.**
    `vultron/demo/helpers/harness.py` provides `scenario_harness(demo_name)`.
@@ -69,7 +74,11 @@ reported a plumbing error instead of an invariant result (issue #2239).
    and a per-actor list naming each missing actor with the reason it was
    missing. So the artifact is non-empty even when there were no ledgers at all
    to capture — including the "died before any case existed" case, where the
-   manifest records `ledgerFileCount: 0` and the reason why.
+   manifest records `ledgerFileCount: 0` and the reason why. The per-actor
+   `reason` field also distinguishes a network-timeout dump failure from a
+   scenario that never started: a timed-out dump records the actor's exception
+   in `reason` alongside `captured: false`, while a pre-run sentinel records no
+   actors at all (see Layer 2).
 
 3. **`load_devlogs()` fails instead of skipping when a dump happened.**
    Previously a missing/empty `devlogs/` meant "no test data" → `pytest.skip`,
@@ -102,10 +111,40 @@ reported a plumbing error instead of an invariant result (issue #2239).
    least one test was reported and all reported outcomes were `"skipped"`
    (DEMOCI-10-005). This converts a vacuous pass into a visible red.
 
-Regression coverage: `test/demo/test_issue_2239_ledger_dump_in_finally.py`
-(all nine scenarios), `test/demo/test_scenario_harness.py`,
-`test/ci/invariants/test_common.py::TestLoadDevlogsManifestHandling`, and
-`test/ci/invariants/test_common.py::TestAllSkipGuard`.
+### Layer 2 — Pre-harness failures (DEMOCI-10-006)
+
+`scenario_harness()` only runs when the demo-runner container starts and the
+scenario module imports successfully. Three failure modes exit before that
+point — none of which the in-harness pieces above can catch:
+
+- **Health-check gate**: `main()` calls `sys.exit(1)` when a container is
+  unreachable.
+- **Import error**: the scenario module fails to import before `main()` runs.
+- **Docker startup failure**: the demo-runner container never starts at all.
+
+In all three cases `devlogs/<demo>/` is never created. The `upload-artifact`
+step publishes nothing, the `download-artifact` step fails with "Artifact not
+found", and the invariant-harness job dies on a plumbing error instead of
+reporting a protocol result.
+
+1. **A CI sentinel step writes the manifest before the demo-runner starts.**
+   The demo job writes `devlogs/<demo>/dump-manifest.json` (conforming to the
+   DEMOCI-10-002 schema, `ledgerFileCount: 0`, `targetCount: 0`) immediately
+   before `docker compose up`. If the demo-runner then runs normally, the
+   harness overwrites the sentinel. If the runner exits early, the sentinel
+   survives, the artifact is non-empty, the download succeeds, and
+   `load_devlogs()` reports a real failure via the manifest-without-ledgers path
+   (DEMOCI-10-003). Implementation: `write_prerun_sentinel(demo_name)` in
+   `vultron/demo/helpers/ledger_dump.py`; CI step calls it via `python3 -c` so
+   no uv setup is needed in the demo job.
+
+### Regression coverage
+
+- `test/demo/test_issue_2239_ledger_dump_in_finally.py` (all nine scenarios)
+- `test/demo/test_scenario_harness.py`
+- `test/ci/invariants/test_common.py::TestLoadDevlogsManifestHandling`
+- `test/ci/invariants/test_common.py::TestAllSkipGuard`
+- `test/demo/test_ledger_dump.py::TestWritePrerunSentinel` (AC4 for #2281)
 
 ---
 

--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -135,8 +135,10 @@ reporting a protocol result.
    survives, the artifact is non-empty, the download succeeds, and
    `load_devlogs()` reports a real failure via the manifest-without-ledgers path
    (DEMOCI-10-003). Implementation: `write_prerun_sentinel(demo_name)` in
-   `vultron/demo/helpers/ledger_dump.py`; CI step calls it via `python3 -c` so
-   no uv setup is needed in the demo job.
+   `vultron/demo/helpers/ledger_dump.py` provides a testable Python entry point
+   (exercised by `TestWritePrerunSentinel`). The CI step independently writes
+   the same JSON inline via `python3 -c` with no vultron import, so no uv setup
+   is needed in the demo job.
 
 ### Regression coverage
 

--- a/plan/history/2608/learning/CONCERN-2281.md
+++ b/plan/history/2608/learning/CONCERN-2281.md
@@ -1,0 +1,43 @@
+---
+source: CONCERN-2281
+timestamp: '2026-08-14T18:29:07.309709+00:00'
+title: Pre-harness demo CI empty artifact
+type: learning
+---
+
+## Context
+
+Issue #2239 (PR #2279) moved the case-ledger dump into a shared `scenario_harness()`
+so that any phase failure inside a scenario body still dumps the ledgers, then
+asserts. That closes the in-scenario case, which was the reported bug.
+
+It does **not** close the case where the scenario never reaches the harness at
+all.
+
+## Problem
+
+If a demo dies *before* `scenario_harness()` is entered, nothing writes a
+manifest and `devlogs/` stays empty:
+
+- the health-check gate in each `main()` calls `sys.exit(1)`,
+- an import error in the scenario module,
+- a `docker compose` startup failure that never gets as far as the runner.
+
+Downstream, the failure looks exactly like ISSUE-2239 did:
+
+1. `mkdir -p devlogs` creates an empty directory with no files.
+2. `upload-artifact` runs with the default `if-no-files-found: warn` and
+   publishes nothing.
+3. The `invariant-harness` job's download step dies on the missing artifact
+   and reports nothing about the protocol.
+
+This is the residual hole in DEMOCI-10-002's guarantee that "the artifact
+upload then always has something to upload".
+
+## Resolution
+
+**Resolved**: 2026-08-14 — implementation tracked in #2312.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2311>.
+Spec: `specs/demo-ci.yaml` (DEMOCI-10-006).
+Notes: `notes/demo-ci-invariants.md` (Layer 2 — Pre-harness failures).

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -6,7 +6,7 @@ description: >-
   when the demo fails — closing the gap where tests pass while the demo produces
   silent failures. Includes requirements for the invariant harness to run as an
   independent CI gate so failures are visible even when the demo itself also fails.
-version: 1.9.0
+version: 2.0.0
 scope:
   - prototype
   - production
@@ -891,8 +891,8 @@ groups:
           download error. The manifest's per-actor `reason` field also
           distinguishes a network-timeout dump failure from a scenario that never
           started: a timed-out dump records the error in the actor's `reason`
-          alongside `captured: false`, while a pre-run sentinel records no actors
-          at all.
+          alongside `captured: false`, while a pre-run CI sentinel
+          (DEMOCI-10-006) records an empty `actors` array (`actors: []`).
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-10-001
@@ -964,8 +964,9 @@ groups:
           The CI demo job MUST write a pre-run sentinel `dump-manifest.json`
           under `devlogs/<demo-name>/` immediately before launching the
           demo-runner container. The sentinel MUST conform to the DEMOCI-10-002
-          schema with `ledgerFileCount: 0`, `targetCount: 0`, and a `reason`
-          string indicating the demo-runner had not yet started. When the
+          schema with `caseId: null` (no case exists at pre-run time),
+          `ledgerFileCount: 0`, `targetCount: 0`, and a `reason` string
+          indicating the demo-runner had not yet started. When the
           demo-runner subsequently runs and reaches `scenario_harness()`, the
           harness MUST overwrite the sentinel with the real dump manifest. When
           the demo-runner exits before reaching `scenario_harness()` — due to a
@@ -988,3 +989,5 @@ groups:
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-10-002
+          - rel_type: refines
+            spec_id: DEMOCI-10-003

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -888,7 +888,11 @@ groups:
           download succeed unconditionally and turns "nothing was uploaded" into
           a machine-readable statement of which actors were missing and why, so
           the invariant harness can report a real invariant result instead of a
-          download error.
+          download error. The manifest's per-actor `reason` field also
+          distinguishes a network-timeout dump failure from a scenario that never
+          started: a timed-out dump records the error in the actor's `reason`
+          alongside `captured: false`, while a pre-run sentinel records no actors
+          at all.
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-10-001
@@ -952,3 +956,35 @@ groups:
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-10-003
+
+      - id: DEMOCI-10-006
+        priority: MUST
+        kind: project
+        statement: >-
+          The CI demo job MUST write a pre-run sentinel `dump-manifest.json`
+          under `devlogs/<demo-name>/` immediately before launching the
+          demo-runner container. The sentinel MUST conform to the DEMOCI-10-002
+          schema with `ledgerFileCount: 0`, `targetCount: 0`, and a `reason`
+          string indicating the demo-runner had not yet started. When the
+          demo-runner subsequently runs and reaches `scenario_harness()`, the
+          harness MUST overwrite the sentinel with the real dump manifest. When
+          the demo-runner exits before reaching `scenario_harness()` — due to a
+          container startup failure, import error, or health-check gate — the
+          sentinel survives and is uploaded as the artifact, so the
+          invariant-harness job can download it and report a real failure
+          instead of a plumbing error.
+        rationale: >-
+          `scenario_harness()` only runs when the demo-runner container starts
+          and the scenario module imports successfully. Docker startup failures,
+          import errors, and health-check `sys.exit(1)` calls all exit before
+          `scenario_harness()` is entered, leaving `devlogs/<demo>/` empty.
+          The `upload-artifact` step then publishes nothing, the
+          `download-artifact` step fails with "Artifact not found", and the
+          invariant-harness job reports a plumbing error instead of an invariant
+          result. The sentinel step closes this gap: the artifact directory is
+          non-empty regardless of how early the runner exits, so the download
+          succeeds and `load_devlogs()` reports a real failure via the
+          manifest-without-ledgers path (DEMOCI-10-003).
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-10-002


### PR DESCRIPTION
- Closes #2281

## Summary

Plans the pre-harness artifact gap in demo CI: when the demo-runner exits
before `scenario_harness()` is entered (health-check gate, import error,
docker startup failure), `devlogs/<demo>/` is never written and the invariant-harness
job dies on artifact download. Adds DEMOCI-10-006 specifying a CI sentinel step
that writes a pre-run manifest before `docker compose up`, and documents the
two-layer DEMOCI-10 guarantee in notes.

## Changes

- **`specs/demo-ci.yaml`**: add DEMOCI-10-006 (CI MUST write pre-run sentinel
  manifest before demo-runner launch); clarify DEMOCI-10-002 rationale to note
  that per-actor `reason` field distinguishes timeout dumps from never-started
  scenarios
- **`notes/demo-ci-invariants.md`**: restructure DEMOCI-10 section into Layer 1
  (in-harness, 001–005) and Layer 2 (pre-harness, 006); document
  `write_prerun_sentinel()` as the canonical implementation helper; add
  regression coverage pointer to `TestWritePrerunSentinel`

## Implementation Issues

- #2312