### PR TITLE
fix(devcontainer): bake .devcontainer, drop host mount, reset slots to origin/main

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -33,11 +33,22 @@ The script will:
 
 Every slot container is ephemeral — it is destroyed when you exit the shell.
 The source code lives at `/app` inside the container, baked into the image at
-build time. On every startup, `poststart.sh` runs `git pull` to bring `/app`
-up to date with `origin/main`.
+build time. When the container is created, `poststart.sh` fetches and then
+force-resets `/app` to `origin/main` — so every slot starts from the same known
+state, on `main`, regardless of which branch your Mac's checkout is on. It does
+not run again when you re-attach to a running container.
+
+The image carries `main` and nothing else. The build strips the local branches,
+stashes and reflog copied in from your Mac's `.git`, so there is no stale local
+branch for an agent to check out by mistake. Branches you have not pushed are
+not reachable from inside a slot — push first if you need one there.
 
 Because containers are destroyed on exit, any uncommitted work in `/app` is
 lost. **Push your work before exiting.**
+
+`.devcontainer/` is baked into the image like any other tracked directory. Edits
+you make to it on your Mac do not appear inside a running container; you get them
+on the next `./start-dev.sh <slot>`, which rebuilds because the file changed.
 
 All slots are identical. There is no "main" slot.
 

--- a/.devcontainer/poststart.sh
+++ b/.devcontainer/poststart.sh
@@ -1,12 +1,25 @@
 #!/bin/bash
-# Runs on every container start.
+# Runs once, when start-dev.sh CREATES a container. Re-attaching to a running
+# container does not run this (start-dev.sh execs the shell directly), so the
+# hard reset below can never discard an agent's work in progress.
 set -euo pipefail
 
 CONTAINER_NAME="$(hostname)"
 
-# Refresh /app from origin. The container is ephemeral (destroyed on exit),
-# so there are never local uncommitted changes to protect here.
-git -C /app pull --ff-only --quiet 2>&1 || echo "[warn] git pull failed — running with baked image snapshot"
+# Force /app to origin/main. The baked .git is a copy of the host repo's, so
+# without this a slot starts on whatever branch the host happened to be on at
+# build time, carrying any uncommitted host edits with it.
+#
+# Deliberately NOT `git pull --ff-only`: pull aborts when a tracked file is
+# locally modified and the incoming commits touch it, which left slots silently
+# stuck on a stale snapshot. fetch + `checkout -f` cannot fail that way.
+# The container is destroyed on exit, so there is no local work to protect.
+if git -C /app fetch --prune --quiet origin; then
+    git -C /app checkout -q -f -B main origin/main
+    git -C /app clean -fdq          # no -x: keeps the gitignored CA certs and .venv
+else
+    echo "[error] git fetch failed — /app is the baked image snapshot, NOT origin/main"
+fi
 
 echo ""
 echo "=== $CONTAINER_NAME ==="

--- a/.dockerignore
+++ b/.dockerignore
@@ -68,24 +68,23 @@ wip_notes
 wip_outputs
 graphify-out
 
-# .devcontainer is clobber-mounted at /app/.devcontainer at runtime, so only
-# what the BUILD needs is admitted: certs/, which docker/Dockerfile copies to
-# /usr/local/share/ca-certificates/ and feeds to update-ca-certificates before
-# the gh / Node / AWS CLI / Claude Code installs curl over HTTPS. Those .crt
-# files are host-local (see .git/info/exclude), so they can never arrive via the
-# in-container `git pull` — the build context is their only route in.
-.devcontainer
-!.devcontainer/certs
+# NOTE: .devcontainer is deliberately NOT excluded here. Its files are TRACKED,
+# so rule 1 applies: withholding them left /app/.devcontainer empty, which
+# start-dev.sh had to paper over by bind-mounting the host directory back in.
+# That made one host directory the working tree for every slot container AND the
+# host repo at once, each with its own HEAD — so whichever git wrote last decided
+# the bytes and every other repo reported phantom modifications. Only the secret
+# is withheld now (see below); the rest is baked in.
 
 # Secrets — must not be baked into any image layer, the dev stage included.
 # NOTE: .dockerignore is independent of .gitignore. A git-ignored secret is
 # still part of the build context and still lands in the image unless it is
 # listed HERE. Never rely on .gitignore to keep credentials out of a layer.
 #
-# devcontainer.env (AWS credentials, written by .devcontainer/setup.sh) is
-# already covered by the .devcontainer rule above; it is repeated explicitly so
-# that re-including more of .devcontainer later cannot quietly admit it.
-# start-dev.sh supplies it at runtime via `docker run --env-file`.
+# devcontainer.env (AWS credentials, written by .devcontainer/setup.sh) is the
+# ONLY path under .devcontainer/ withheld from the build. It is gitignored, so
+# its absence cannot surface as a phantom deletion. start-dev.sh supplies it at
+# runtime via `docker run --env-file`.
 # .env.example files are intentionally NOT matched by these patterns.
 .env
 **/.env

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -129,9 +129,29 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt \
 #
 # Only two categories are withheld, both via .dockerignore: secrets (.env,
 # .devcontainer/*.env), and gitignored paths that start-dev.sh clobber-mounts
-# over /app at runtime (.devcontainer, wip_notes, wip_outputs, graphify-out).
+# over /app at runtime (wip_notes, wip_outputs, graphify-out).
 # Being gitignored, those cannot surface as phantom deletions.
 COPY . /app/
+
+# Normalize the baked git state. The COPY above brings in the HOST repo's .git
+# verbatim: every local branch, stash, reflog entry and stale worktree record it
+# had at build time. Collapse it to main alone — a stale local branch left lying
+# around is a branch an agent can check out by mistake. poststart.sh re-fetches
+# and force-resets to origin/main when the container is created.
+#
+# This runs BEFORE `uv sync` so the lockfile that gets installed is the one from
+# origin/main, not whatever the host working tree happened to hold.
+RUN git -C /app rev-parse --verify --quiet refs/remotes/origin/main >/dev/null \
+        || { echo "ERROR: origin/main missing from the baked .git — run 'git fetch origin' in your host clone, then rebuild"; exit 1; } \
+    && git -C /app worktree prune \
+    && git -C /app checkout -q -f -B main origin/main \
+    && git -C /app for-each-ref --format='%(refname:short)' refs/heads \
+        | grep -vx main \
+        | xargs -r -n1 git -C /app branch -D \
+    && git -C /app stash clear \
+    && git -C /app reflog expire --expire=all --all \
+    && git -C /app gc --prune=now --quiet
+
 ENV PYTHONPATH=/app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --dev
@@ -145,8 +165,8 @@ RUN groupadd --gid 1000 vscode \
 # Claude Code CLI (installed as vscode user so it lands in ~/.local)
 RUN su - vscode -c "curl -fsSL https://claude.ai/install.sh | bash"
 
-# /app is owned by root from the earlier COPY steps; hand it to vscode so
-# `git pull` in poststart.sh doesn't fail on dubious-ownership checks.
+# /app is owned by root from the earlier COPY and git steps; hand it to vscode so
+# the git reset in poststart.sh doesn't fail on dubious-ownership checks.
 RUN chown -R vscode:vscode /app
 
 WORKDIR /app

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -3,8 +3,8 @@
 # Usage: ./start-dev.sh <slot> [--rebuild]
 #   slot       Name for this dev slot (e.g. inky, pinky, blinky).
 #              Every slot gets its own independent container. /app is baked
-#              into the image and refreshed from origin on every startup via
-#              `git pull` in poststart.sh.
+#              into the image, and poststart.sh force-resets it to origin/main
+#              when the container is created.
 #   --rebuild  Remove the image and rebuild from scratch.
 set -euo pipefail
 
@@ -105,11 +105,10 @@ DOCKER_ARGS=(
     -e WIP_NOTES=/app/wip_notes
     -e WIP_OUTPUTS=/app/wip_outputs
     -v "${MAIN_NAME}-data:/home/vscode/.data"
-    # .devcontainer is excluded from the build context except certs/ (see
-    # .dockerignore), so mount it here. Without this the tracked files under it
-    # are missing from /app and `git status` reports them as deleted. Writable so
-    # that the `git pull` in poststart.sh can fast-forward them.
-    -v "$SCRIPT_DIR/.devcontainer:/app/.devcontainer"
+    # NOTE: .devcontainer is NOT mounted. It is baked into the image and belongs
+    # to the container's own working tree. Mounting the host copy over it made
+    # one host directory the working tree for every slot plus the host repo, so
+    # any git operation in one slot dirtied all the others.
     -v "$MAIN_DIR/wip_notes:/app/wip_notes:ro"
     -v "$WIP_OUTPUTS_SLOT:/app/wip_outputs"
     -v "$GRAPHIFY_HOST:/app/graphify-out"


### PR DESCRIPTION
## Summary

Every slot container reported `.devcontainer/README.md` and `.devcontainer/postcreate.sh`
as uncommitted modifications at startup, and syncing with `main` cleared it only until
the next time. The cause is that `/app/.devcontainer` was one host directory serving as
the working tree for several independent git repos at once. This bakes the directory
into the image instead, and makes each slot force-reset to `origin/main` on creation.

## Diagnosis

`.dockerignore` withheld the **tracked** `.devcontainer/` directory from the build
context, so `start-dev.sh` bind-mounted the host copy back over `/app/.devcontainer`
to stop git reporting phantom deletions. Because the `dev` stage's `COPY . /app/` takes
no `--exclude=.git`, every slot also has its own complete copy of the host repo's `.git`
— its own HEAD and index.

So the host repo plus every slot container shared one writable directory. Whichever git
wrote last decided the bytes, and every other repo reported those files as modified.
Confirmed on a live slot: the two files on disk were byte-identical to a commit three
devcontainer commits behind that container's HEAD, with mtimes minutes old and no
matching entry in that container's reflog.

The failure was self-sustaining. `git pull --ff-only` aborts when a tracked file is
locally modified and the incoming commits touch it:

```
error: Your local changes to the following files would be overwritten by merge:
	.devcontainer/README.md
Aborting
```

`poststart.sh` reduced that to a one-line `[warn]`, so a slot that started dirty never
fast-forwarded, stayed on a stale snapshot, and kept re-stamping old content into the
shared directory.

A second, independent defect surfaced while tracing this: since the baked `.git` is the
host repo's verbatim, a slot started on whatever branch the host happened to be on at
build time — carrying its 228 local branches, 3 stashes and reflog back to June — not on
`origin/main`.

## Changes

- **`.dockerignore`**: stop excluding `.devcontainer`. Only `*.env` (the AWS credentials)
  is withheld now; it is gitignored, so its absence cannot surface as a phantom deletion.
- **`start-dev.sh`**: drop the `/app/.devcontainer` bind mount.
- **`docker/Dockerfile`**: normalize the baked `.git` after `COPY` — collapse it to `main`
  alone, dropping the local branches, stashes, reflog and stale worktree records copied in
  from the host, so no stale local branch is left for an agent to check out by mistake.
  Runs before `uv sync` so the installed lockfile is `origin/main`'s. Fails the build with
  an actionable message if `origin/main` is missing from the baked `.git`.
- **`.devcontainer/poststart.sh`**: replace `git pull --ff-only` with `fetch` +
  `checkout -f -B main origin/main` + `clean -fd`, which cannot abort on a dirty tree.
  `clean` omits `-x` so the gitignored CA certs and `.venv` survive. A failed fetch now
  states plainly that `/app` is **not** `origin/main`.
- **`.devcontainer/README.md`**: correct the startup description and document that
  `.devcontainer` edits now require a rebuild to appear in a container.

## Verification

- Simulated a messy host repo (33 branches, a stash, a worktree, dirty `uv.lock`,
  untracked files, checked out on a `plan/` branch), then ran the `COPY`-equivalent plus
  the new `RUN`. Result: branch `main`, exactly at `origin/main`, upstream set, 1 branch,
  0 stashes, 0 reflog entries, and `uv.lock` holding `origin/main`'s content rather than
  the dirty host version.
- Reproduced the `pull --ff-only` abort in a throwaway repo to confirm the trap the new
  sequence avoids.
- `bash -n` clean on both shell scripts; markdownlint clean on the README.
- Black, flake8, mypy and pyright clean. (flake8's 3 findings in `scripts/` are
  pre-existing on `origin/main`; this PR changes no Python.)
- Confirmed `start-dev.sh` is the only builder of the `dev` target, so the new
  `origin/main` guard cannot break CI.

## Notes for review

- Rebased onto `a88f9a40` ("update devcontainer setup"). That commit's `README.md` and
  `postcreate.sh` content is kept as-is, including the `~/.claude` bind-mount row; this PR
  only adds the startup-behaviour paragraphs on top of it.
- `a88f9a40` leaves `README.md` describing a `~/.claude` bind mount that `start-dev.sh`
  does not create, while `start-dev.sh` still mounts the `<repo>-data` named volume at
  `~/.data` that `postcreate.sh` no longer populates. That mismatch is left alone here
  rather than guessed at — it looks like an in-flight design change.
- #1460 tracks the older worktree-overlay concern. This PR does not resolve it.
