### PR TITLE
fix(devcontainer): enable OSC 52 clipboard in tmux

### DIFF
--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -45,6 +45,7 @@ set -s extended-keys on
 set -as terminal-features ',xterm-256color:extkeys'
 set -g history-limit 50000
 set -g mouse on
+set -g set-clipboard on
 set -g default-shell /bin/zsh
 EOF
 


### PR DESCRIPTION
## Summary

- Adds `set -g set-clipboard on` to the tmux config written by `postcreate.sh`

## Problem

`mouse on` causes tmux to intercept all mouse events, so the terminal app can't do its own text selection. Even when text is selected via `Shift`+drag (Terminal.app workaround), tmux copy-mode selections don't reach the macOS clipboard from inside the container — there's no `pbcopy` or `reattach-to-user-namespace` bridge available.

## Fix

`set-clipboard on` makes tmux emit [OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands) escape sequences when copying. Terminal.app (and most modern terminals) translate OSC 52 directly into the host clipboard, which works across the container boundary without any additional tooling.

After this change:
- tmux copy-mode (`prefix [`, select, `Enter`) puts text in the macOS clipboard
- `Shift`+drag still works for quick mouse selections
- All mouse ergonomics (`mouse on`) are preserved

## Test plan

- [ ] Rebuild or re-create a slot container (runs `postcreate.sh`)
- [ ] Verify `~/.tmux.conf` contains `set -g set-clipboard on`
- [ ] In tmux copy mode, select text and confirm it lands in the macOS clipboard via `Cmd+V`

🤖 Generated with [Claude Code](https://claude.com/claude-code)