### PR TITLE
fix(freshen-branch): disable hooks during cherry-pick; guard cleanup checkout

### DIFF
--- a/.agents/skills/shared/freshen-branch.sh
+++ b/.agents/skills/shared/freshen-branch.sh
@@ -39,7 +39,10 @@ fi
 TEMP="temp-freshen-$$"
 git checkout -b "$TEMP" origin/main
 
-if git cherry-pick $COMMITS; then
+# Disable hooks during cherry-pick: pre-commit formatters (e.g. black) modify
+# staged files mid-operation, causing git to abort with "local changes would be
+# overwritten by merge". Hooks run at commit time when the PR is created.
+if git -c core.hooksPath=/dev/null cherry-pick $COMMITS; then
   git branch -f "$TASK_BRANCH" HEAD
   git checkout "$TASK_BRANCH"
   git branch -D "$TEMP"
@@ -48,7 +51,7 @@ if git cherry-pick $COMMITS; then
 else
   # Cherry-pick stopped on a conflict — clean up and signal the caller.
   git cherry-pick --abort 2>/dev/null || true
-  git checkout "$TASK_BRANCH"
+  git checkout "$TASK_BRANCH" 2>/dev/null || git checkout -
   git branch -D "$TEMP"
   echo "⚠ Cherry-pick conflict — push un-rebased branch and open a draft PR with needs-rebase label." >&2
   exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,13 +504,14 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **Staged-Type `model_validate` Only Works on Core-Constructed Objects** — don't
   use on `dl.read()` results; check pre-conditions directly on returned object.
 - **`freshen-branch.sh` Leaves Temp Branch on Conflict When Abort Silently Fails** —
-  If `git cherry-pick --abort` fails (partially-written cherry-pick state),
-  the `|| true` swallows the error but the following `git checkout "$TASK_BRANCH"`
-  fails with "you need to resolve your current index first" and the script exits,
-  leaving the repo on a `temp-freshen-*` branch with conflict markers.
-  Recovery: `git branch --show-current` (confirm `temp-freshen-*`), resolve
-  conflict markers, `git add <file>`, `git cherry-pick --continue --no-edit`,
-  then `git branch -f "$TASK_BRANCH" HEAD && git checkout "$TASK_BRANCH"`.
+  *Fixed in #1784.* The script now runs cherry-pick with `core.hooksPath=/dev/null`
+  (preventing pre-commit hook interference) and guards the cleanup checkout with
+  `|| git checkout -` (preventing silent exit when `cherry-pick --abort` leaves
+  conflict markers). If both checkout attempts still fail (rare: genuine conflict
+  marker blocking every branch switch), manual recovery is required:
+  `git branch --show-current` (confirm `temp-freshen-*`), resolve conflict
+  markers, `git add <file>`, `git cherry-pick --continue --no-edit`, then
+  `git branch -f "$TASK_BRANCH" HEAD && git checkout "$TASK_BRANCH" && git branch -D "$TEMP"`.
   Use `manage_worktree.sh ensure-synced` in preference to the raw script.
 - **A Red CI Job Is Not Evidence That Its Assertions Ran** — a job that dies in
   an earlier step (artifact download, dependency setup, container build) never
@@ -541,7 +542,8 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   uncommitted work. See also: single large-commit branches with 70+ files trigger a
   sequencer duplicate-pick bug; the cherry-pick workaround resolves both variants.
   If `freshen-branch.sh` took this path and then hit a conflict, it can leave the
-  temp branch behind — delete it by hand (ISSUE-1784).
+  temp branch behind — delete it by hand. *Fixed in #1784: the script now guards
+  the cleanup checkout.*
   *Sources: ISSUE-1518, ISSUE-1504, ISSUE-1784*
 - **Verify Issue ACs Against Current Code Before Starting** — an issue may already
   be fully implemented by a prior PR that did not include a `Closes #N` footer.


### PR DESCRIPTION
- Closes #1784

## Summary

Fixes two failure modes in `freshen-branch.sh` that leave the repo stranded on a `temp-freshen-*` branch. Both were hit repeatedly in July 2026 across four sessions (ISSUE-1499, ISSUE-1503-b, ISSUE-1504, ISSUE-1619).

## Changes

- **`.agents/skills/shared/freshen-branch.sh`**: Add `-c core.hooksPath=/dev/null` to the `cherry-pick` invocation (Mode A: prevents pre-commit formatters such as black from aborting the pick by modifying staged files mid-operation); guard the cleanup checkout with `|| git checkout -` (Mode B: prevents the script from hard-exiting under `set -euo pipefail` when `cherry-pick --abort` leaves conflict markers that block `git checkout`).
- **`AGENTS.md`**: Update both related pitfall entries to note the fixes and narrow the manual-recovery instructions to the remaining edge case (both checkout attempts fail).

## Verification

- 7058 unit tests pass (0 new — shell-only fix; regression test tracked in #2332, no shell test framework in repo)
- Black, flake8, mypy, pyright clean
- 2 failures are pre-existing known-flaky tests tracked in #2274