### PR TITLE
docs: decision-audit -- ADR-0025 stale prose, ADR-0015 dangling spec refs

### DIFF
--- a/docs/adr/0025-call-out-point-abstraction-layer.md
+++ b/docs/adr/0025-call-out-point-abstraction-layer.md
@@ -27,15 +27,6 @@ The design question is: **What mechanism makes each call-out point backend
 swappable while remaining consistent with the existing py_trees Behaviour
 pattern, factory-function conventions, and blackboard contract model?**
 
-> **Design status — formed in sand, not concrete**: This ADR captures the
-> forward-looking intent after one planning session. The design will be
-> exercised in #1151 (one exemplar per agent shape) and is expected to
-> converge after two or three concrete implementations across different
-> domain areas. Implementers working on the shape-based follow-on issues
-> (FUZZ-08d through FUZZ-08g) SHOULD refine this ADR if the pattern proves
-> incorrect or incomplete. The ADR status will advance from `proposed` to
-> `accepted` once the exemplars validate the approach.
-
 ## Decision Drivers
 
 - Must be consistent with the existing BT factory-function pattern

--- a/plan/history/2608/learning/ADR-0015.md
+++ b/plan/history/2608/learning/ADR-0015.md
@@ -1,0 +1,11 @@
+---
+source: ADR-0015
+timestamp: '2026-08-17T18:45:52.854175+00:00'
+title: ADR-0015 dangling refs in LST-02, CM-15 — updated to ADR-0041
+type: learning
+---
+
+ADR-0015 (Create VulnerabilityCase at report receipt) is archived/superseded by ADR-0041. Two active spec groups still cited it as the authoritative reason for their requirements: specs/lifecycle-staged-types.yaml LST-02-002 (rationale credited ADR-0015; updated to credit ADR-0041) and specs/case-management.yaml CM-15-001 (adr edge cited only ADR-0015; ADR-0041 added alongside).
+
+Resolved: 2026-08-17 — spec citation edges updated.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2340>

--- a/plan/history/2608/learning/ADR-0025.md
+++ b/plan/history/2608/learning/ADR-0025.md
@@ -1,0 +1,11 @@
+---
+source: ADR-0025
+timestamp: '2026-08-17T18:45:40.648717+00:00'
+title: ADR-0025 — stale 'formed in sand' prose removed
+type: learning
+---
+
+ADR-0025 (Call-out point abstraction layer) had a 'formed in sand' blockquote in the Context section that said the status would advance from proposed to accepted after exemplar implementations. The exemplars were completed (#1151), the pattern proved sound, and the status was already advanced to accepted. The block was a stale artifact.
+
+Resolved: 2026-08-17 — removed blockquote from ADR-0025 Context section.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2340>

--- a/plan/history/2608/learning/ADR-0058.md
+++ b/plan/history/2608/learning/ADR-0058.md
@@ -1,0 +1,10 @@
+---
+source: ADR-0058
+timestamp: '2026-08-17T18:45:53.111566+00:00'
+title: ADR-0058 — accepted-provisional confirmed correct
+type: learning
+---
+
+ADR-0058 (Gate demo scenario steps on causal preconditions) is accepted-provisional. Audit confirmed: demo_gate exists in docs but not as a Python implementation; no scenario has been migrated. Provisional status is appropriate.
+
+Resolved: 2026-08-17 — confirmed correct; no changes.

--- a/plan/history/2608/learning/ADR-0065.md
+++ b/plan/history/2608/learning/ADR-0065.md
@@ -1,0 +1,10 @@
+---
+source: ADR-0065
+timestamp: '2026-08-17T18:45:53.376239+00:00'
+title: ADR-0065 — accepted-provisional confirmed correct
+type: learning
+---
+
+ADR-0065 (Carry embargo invite RSVP deadline on Invite.end_time) is accepted-provisional. Audit confirmed: end_time field exists on as_Object/as_Invite, but no lapse enforcement or late-Accept logic is implemented. Provisional status is appropriate.
+
+Resolved: 2026-08-17 — confirmed correct; no changes.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -760,6 +760,7 @@ groups:
       spec_id: CM-12-001
     adr:
     - ADR-0015
+    - ADR-0041
 - id: CM-16
   title: Actor Suggestion Routing (Recommend-Actor Flow)
   specs:

--- a/specs/lifecycle-staged-types.yaml
+++ b/specs/lifecycle-staged-types.yaml
@@ -49,12 +49,13 @@ groups:
     kind: protocol
     statement: A `Case` MUST guarantee at least one vulnerability report, the reporter and receiver participants (at least
       two parties), and a seeded `case_statuses` list.
-    rationale: ADR-0015 creates the case at report receipt, so these structural minimums always hold for any case that exists.
+    rationale: ADR-0041 (superseding ADR-0015) requires the CaseActor to author all initialization entries when accepting a
+      CaseProposal, so these structural minimums are guaranteed for any case that exists.
     relationships:
     - rel_type: depends_on
       spec_id: ARCH-10-001
     adr:
-    - ADR-0015
+    - ADR-0041
   - id: LST-02-003
     priority: MUST
     kind: protocol


### PR DESCRIPTION
## Summary

Periodic decision-audit pass. Two actionable findings; two confirmed correct.

## Changes

- **`docs/adr/0025-call-out-point-abstraction-layer.md`**: Remove the stale
  "formed in sand" blockquote from the Context section. The Validation section
  already documents that exemplar PR #1151 validated the approach and advanced
  the ADR status to `accepted`. The block was a misleading artifact.

- **`specs/lifecycle-staged-types.yaml` (LST-02-002)**: Update rationale from
  "ADR-0015 creates the case at report receipt" to credit ADR-0041 (the current
  active decision); replace `adr: [ADR-0015]` with `adr: [ADR-0041]`.

- **`specs/case-management.yaml` (CM-15-001)**: Add `ADR-0041` alongside
  `ADR-0015` in the `adr:` edge so the authoritative active decision is
  visible. Historical prose reference to "ADR-0015 Option 4" preserved for
  context.

## Confirmed correct (no action)

- **ADR-0058** (causal gating in demo scenarios, accepted-provisional):
  `demo_gate` not yet implemented — provisional status is appropriate.
- **ADR-0065** (embargo invite RSVP deadline, accepted-provisional):
  Lapse enforcement not yet implemented — provisional status is appropriate.