### PR TITLE
feat(demo-ci): write pre-run sentinel manifest before demo-runner starts

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -187,6 +187,18 @@ jobs:
       - name: Create devlogs directory
         run: mkdir -p devlogs
 
+      # DEMOCI-10-006: write a sentinel before the demo-runner starts so the
+      # artifact is non-empty even on a pre-harness failure (health-check gate,
+      # import error, Docker startup failure).  Uses plain python3 with no uv
+      # setup so it runs regardless of whether the vultron package is available.
+      # The real harness overwrites this sentinel when it runs; if the runner
+      # exits early the sentinel survives and load_devlogs() reports a failure.
+      - name: Write pre-run sentinel manifest
+        env:
+          DEMO: ${{ matrix.demo }}
+        run: |
+          python3 -c "import json,os,pathlib; d=os.environ['DEMO']; p=pathlib.Path('devlogs')/d; p.mkdir(parents=True,exist_ok=True); (p/'dump-manifest.json').write_text(json.dumps({'demoName':d,'caseId':None,'ledgerFileCount':0,'targetCount':0,'reason':'Pre-run sentinel: demo-runner had not yet started.','actors':[]},indent=2)+'\n',encoding='utf-8')"
+
       - name: Run ${{ matrix.demo }} demo
         env:
           DEMO: ${{ matrix.demo }}

--- a/plan/incoming/learnings/20260817-github-actions-python-c-yaml-indentation.md
+++ b/plan/incoming/learnings/20260817-github-actions-python-c-yaml-indentation.md
@@ -1,0 +1,32 @@
+---
+title: Multi-line python3 -c in GitHub Actions YAML run block causes actionlint YAML parse failure
+type: learning
+timestamp: 2026-08-17
+source: ISSUE-2312
+signal: tooling-issue
+---
+
+When embedding multi-line Python in a GitHub Actions `run: |` block via
+`python3 -c "..."`, the Python code lines must stay within the YAML block
+scalar's indentation level.  If the code starts at column 0 (or any
+indentation less than the block's base), YAML terminates the block early and
+`actionlint` fails with:
+
+```text
+could not parse as YAML: yaml: line N: could not find expected ':'
+```
+
+**Root cause**: YAML literal block scalars auto-detect indentation from the
+first content line.  Any subsequent line at a lower indentation level ends the
+block; the remainder is parsed as bare YAML and fails.
+
+**Fix**: Collapse the Python to a single semicolon-separated line that fits on
+one line of the `run:` block:
+
+```yaml
+        run: |
+          python3 -c "import json,os,pathlib; ..."
+```
+
+For longer scripts, write them to a file in a prior step and execute them, or
+use `jq -n` for pure JSON generation.

--- a/test/demo/test_ledger_dump.py
+++ b/test/demo/test_ledger_dump.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from _pytest.outcomes import Failed
@@ -29,8 +30,7 @@ from vultron.demo.helpers.ledger_dump import (
 )
 
 
-def _read_sentinel(manifest_path: Path) -> dict:
-    """Parse the manifest written at *manifest_path*."""
+def _read_sentinel(manifest_path: Path) -> Any:
     return json.loads(manifest_path.read_text(encoding="utf-8"))
 
 

--- a/test/demo/test_ledger_dump.py
+++ b/test/demo/test_ledger_dump.py
@@ -1,0 +1,119 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for vultron.demo.helpers.ledger_dump."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from _pytest.outcomes import Failed
+
+from test.ci.invariants import common
+from vultron.demo.helpers.ledger_dump import (
+    DUMP_MANIFEST_FILENAME,
+    _PRERUN_SENTINEL_REASON,
+    write_prerun_sentinel,
+)
+
+
+def _read_sentinel(manifest_path: Path) -> dict:
+    """Parse the manifest written at *manifest_path*."""
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+class TestWritePrerunSentinel:
+    """``write_prerun_sentinel`` writes a valid DEMOCI-10-002 manifest.
+
+    Verifies AC-1, AC-3, and AC-4 of ISSUE-2312:
+
+    - The sentinel manifest is created at the expected path.
+    - Its JSON conforms to the DEMOCI-10-002 schema.
+    - ``load_devlogs()`` reports a failure — not a skip — when the sentinel is
+      the only artifact present (manifest-without-ledgers path, DEMOCI-10-003).
+    """
+
+    DEMO_NAME = "fv"
+
+    def test_creates_manifest_file(self, tmp_path):
+        manifest_path = write_prerun_sentinel(
+            self.DEMO_NAME, output_root=tmp_path
+        )
+        assert (
+            manifest_path.is_file()
+        ), f"Expected sentinel manifest at {manifest_path}"
+        assert (
+            manifest_path == tmp_path / self.DEMO_NAME / DUMP_MANIFEST_FILENAME
+        )
+
+    def test_manifest_conforms_to_democi_10_002_schema(self, tmp_path):
+        """Manifest has all required DEMOCI-10-002 fields with correct values."""
+        manifest_path = write_prerun_sentinel(
+            self.DEMO_NAME, output_root=tmp_path
+        )
+        data = _read_sentinel(manifest_path)
+        assert data["demoName"] == self.DEMO_NAME
+        assert data["caseId"] is None
+        assert data["ledgerFileCount"] == 0
+        assert data["targetCount"] == 0
+        assert isinstance(data["reason"], str) and data["reason"]
+        assert data["actors"] == []
+
+    def test_sentinel_reason_string_matches_spec(self, tmp_path):
+        """Reason string indicates the demo-runner had not yet started."""
+        manifest_path = write_prerun_sentinel(
+            self.DEMO_NAME, output_root=tmp_path
+        )
+        data = _read_sentinel(manifest_path)
+        assert data["reason"] == _PRERUN_SENTINEL_REASON
+        assert "sentinel" in data["reason"].lower()
+        assert "not yet started" in data["reason"].lower()
+
+    def test_overwrites_existing_manifest(self, tmp_path):
+        """Sentinel overwrites any manifest already present at the path."""
+        demo_dir = tmp_path / self.DEMO_NAME
+        demo_dir.mkdir(parents=True, exist_ok=True)
+        existing = demo_dir / DUMP_MANIFEST_FILENAME
+        existing.write_text('{"old": true}', encoding="utf-8")
+
+        manifest_path = write_prerun_sentinel(
+            self.DEMO_NAME, output_root=tmp_path
+        )
+
+        data = _read_sentinel(manifest_path)
+        assert "demoName" in data, "Sentinel must overwrite the prior manifest"
+        assert "old" not in data
+
+    def test_load_devlogs_fails_not_skips_on_sentinel(
+        self, tmp_path, monkeypatch
+    ):
+        """load_devlogs() reports failure — not skip — when sentinel is present.
+
+        Verifies the DEMOCI-10-003 fail-vs-skip rule for the pre-harness path
+        (AC-4 of ISSUE-2312): when the sentinel is the only artifact, the
+        invariant-harness job reports a real failure instead of silently
+        skipping.
+        """
+        write_prerun_sentinel(self.DEMO_NAME, output_root=tmp_path)
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
+
+        with pytest.raises(Failed) as excinfo:
+            common.load_devlogs(self.DEMO_NAME)
+
+        message = excinfo.value.msg or ""
+        assert "no case-ledger" in message.lower(), (
+            f"Expected failure message to mention missing ledger files; "
+            f"got: {message!r}"
+        )

--- a/vultron/demo/helpers/ledger_dump.py
+++ b/vultron/demo/helpers/ledger_dump.py
@@ -399,6 +399,46 @@ def dump_case_ledgers(
     return report
 
 
+_PRERUN_SENTINEL_REASON = "Pre-run sentinel: demo-runner had not yet started."
+"""Reason string written by :func:`write_prerun_sentinel`.
+
+Kept as a module constant so tests and the CI sentinel step can replicate the
+exact value without importing this module (DEMOCI-10-006).
+"""
+
+
+def write_prerun_sentinel(
+    demo_name: str,
+    output_root: pathlib.Path | None = None,
+) -> pathlib.Path:
+    """Write a pre-run sentinel manifest for *demo_name*.
+
+    Called immediately before the demo-runner container starts so the case-log
+    artifact is non-empty even when the runner exits before
+    ``scenario_harness()`` is entered (DEMOCI-10-006).
+
+    When the demo-runner subsequently reaches ``scenario_harness()``, the
+    harness overwrites this sentinel with the real dump manifest.  When the
+    runner exits early — container startup failure, import error, or
+    health-check gate — the sentinel survives and ``load_devlogs()`` reports a
+    real failure instead of a plumbing error.
+
+    Args:
+        demo_name: Scenario name; the devlogs sub-directory to create.
+        output_root: Devlogs root; defaults to ``DEVLOGS_DIR``.
+
+    Returns:
+        Path to the sentinel manifest written.
+    """
+    return write_dump_manifest(
+        LedgerDumpReport(
+            demo_name=demo_name,
+            reason=_PRERUN_SENTINEL_REASON,
+        ),
+        output_root=output_root,
+    )
+
+
 def _dump_one_target(
     target: LedgerDumpTarget,
     record: ActorLedgerRecord,


### PR DESCRIPTION
- Closes #2312
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Closes the pre-harness artifact gap (CONCERN-2281, DEMOCI-10-006): when the demo-runner exits before `scenario_harness()` is entered, the CI artifact is now always non-empty, so the invariant-harness job reports a real invariant failure instead of dying on artifact download.

## Changes

- **`vultron/demo/helpers/ledger_dump.py`**: Add `_PRERUN_SENTINEL_REASON` module constant and `write_prerun_sentinel()` helper. The helper calls `write_dump_manifest()` with a zero-count `LedgerDumpReport` and always overwrites (unlike `ensure_dump_manifest()`, which is write-if-absent). The constant is exposed so tests and the CI step can replicate the exact reason string without importing the module.
- **`.github/workflows/demo-integration.yml`**: Add "Write pre-run sentinel manifest" step immediately before the "Run demo" step in the `demo` job. Uses a stdlib-only `python3 -c` one-liner (no uv setup, no vultron import) so it runs regardless of whether the vultron package is available. The real harness overwrites this sentinel when it runs; if the runner exits early (container startup failure, import error, health-check gate) the sentinel survives and `load_devlogs()` reports a failure.
- **`test/demo/test_ledger_dump.py`**: New `TestWritePrerunSentinel` class (5 tests) covering AC-1, AC-3, and AC-4 of the issue. Uses `monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)` to verify `load_devlogs()` fails (not skips) when the sentinel is the only artifact (DEMOCI-10-003 manifest-without-ledgers path).

## Verification

- 7038 unit tests pass (5 new)
- Black, flake8, mypy, pyright clean
- actionlint clean on the workflow file
- [x] AC-1: `write_prerun_sentinel()` added to `vultron/demo/helpers/ledger_dump.py`; writes DEMOCI-10-002 manifest with `ledgerFileCount: 0`, `targetCount: 0`, and sentinel reason string; always overwrites.
- [x] AC-2: `demo-integration.yml` gets "Write pre-run sentinel manifest" step immediately before "Run demo"; uses stdlib-only `python3 -c` with matching reason string.
- [x] AC-3: `TestWritePrerunSentinel` class (5 tests) in `test/demo/test_ledger_dump.py`; exercises `write_prerun_sentinel()` with `tmp_path`; verifies manifest creation, DEMOCI-10-002 schema, and `load_devlogs()` fails on sentinel-only state.
- [x] AC-4: Invariant-harness jobs pass in CI with the sentinel present (fv, fvcv-handoff, fcvcv, fcv-reject scenarios all green).