### PR TITLE
ci(label-to-type): add task label → type:Task conversion

### DIFF
--- a/.github/workflows/label-to-issue-type.yml
+++ b/.github/workflows/label-to-issue-type.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   convert:
-    if: contains(fromJson('["idea","concern","bug","feature"]'), github.event.label.name)
+    if: contains(fromJson('["idea","concern","bug","feature","task"]'), github.event.label.name)
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -22,6 +22,7 @@ jobs:
             concern) echo "type_id=IT_kwDOAjf0s84B_2VT" >> "$GITHUB_OUTPUT" ;;
             bug)     echo "type_id=IT_kwDOAjf0s84AcFLq" >> "$GITHUB_OUTPUT" ;;
             feature) echo "type_id=IT_kwDOAjf0s84AcFLs" >> "$GITHUB_OUTPUT" ;;
+            task)    echo "type_id=IT_kwDOAjf0s84AcFLo" >> "$GITHUB_OUTPUT" ;;
           esac
 
       - name: Set issue type (if not already typed)


### PR DESCRIPTION
Adds `task` label → `type:Task` conversion for parity with `bug`, `feature`, `idea`, and `concern`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)