### PR TITLE
refactor: rename SYNC-1/2/3/4 to domain-grounded ledger sync concepts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,7 +366,7 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   `test_trignotify.py` is insufficient. See
   [notes/triggers-test-coverage.md](notes/triggers-test-coverage.md).
 - **Hash-Chain Ledger Record vs. Domain Model** — `HashChainLedgerRecord` (in-memory
-  SYNC-1) vs. `CaseLedgerEntry` (wire-serializable). Import by full module path.
+  AppendOnlyLedger) vs. `CaseLedgerEntry` (wire-serializable). Import by full module path.
   See ARCH-12-007.
 - **Case Ledger Is Not a Process Log** — only CaseActor-accepted protocol-significant
   assertions; `payloadSnapshot` MUST NOT be empty. See ADR-0019, CLP-07,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,8 +365,8 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **Trigger Use Cases Need Per-Use-Case Tests** — incidental coverage via
   `test_trignotify.py` is insufficient. See
   [notes/triggers-test-coverage.md](notes/triggers-test-coverage.md).
-- **Hash-Chain Ledger Record vs. Domain Model** — `HashChainLedgerRecord` (in-memory
-  AppendOnlyLedger) vs. `CaseLedgerEntry` (wire-serializable). Import by full module path.
+- **Hash-Chain Ledger Record vs. Domain Model** — `HashChainLedgerRecord` (AppendOnlyLedger
+  phase, in-memory) vs. `CaseLedgerEntry` (wire-serializable). Import by full module path.
   See ARCH-12-007.
 - **Case Ledger Is Not a Process Log** — only CaseActor-accepted protocol-significant
   assertions; `payloadSnapshot` MUST NOT be empty. See ADR-0019, CLP-07,

--- a/docs/howto/demos/fvv-demo.md
+++ b/docs/howto/demos/fvv-demo.md
@@ -5,7 +5,7 @@ The **FVV demo** exercises the three-actor CVD workflow:
 
 Vendor1 creates the case, invites the Finder and Vendor2, and each vendor
 advances through an independent fix path (`CS_vfd`).
-Both Finder and Vendor2 DataLayers are verified as SYNC-2 replicas of the
+Both Finder and Vendor2 DataLayers are verified as LedgerFanout replicas of the
 authoritative Vendor1 state.
 
 ---
@@ -83,9 +83,9 @@ sequenceDiagram
 
     note over F,V2: Phase 2 — Replica Synchronization Verification
 
-    V1-->>F: ledger tail replicated (SYNC-2)
-    V1-->>V2: ledger tail replicated (SYNC-2)
-    note over F,V2: ✓ M2 — Finder and Vendor2 DataLayers synchronized (SYNC-2 verified)
+    V1-->>F: ledger tail replicated (LedgerFanout)
+    V1-->>V2: ledger tail replicated (LedgerFanout)
+    note over F,V2: ✓ M2 — Finder and Vendor2 DataLayers synchronized (LedgerFanout verified)
 
     note over F,V2: Phase 3 — Notes Exchange
 
@@ -136,7 +136,7 @@ and Vendor2 have a local case record.
 ### Phase 2 — Replica synchronization verification (M2)
 
 The demo runner waits for both Finder and Vendor2 to receive the Vendor1
-ledger tail entry (SYNC-2 replication), then calls `verify_replica_state`
+ledger tail entry (LedgerFanout replication), then calls `verify_replica_state`
 for each — asserting that the `actor_participant_index`, active embargo ID,
 and log tail hash all match the authoritative Vendor1 state.
 
@@ -184,7 +184,7 @@ The Case Actor auto-closes when all participants are closed.
 | Marker | What it means |
 |:-------|:--------------|
 | `✅ M1:` | ≥4 participants, EM.ACTIVE, Finder and Vendor2 have replicas |
-| `✓ M2:` | Finder and Vendor2 DataLayers synchronized (SYNC-2 verified) |
+| `✓ M2:` | Finder and Vendor2 DataLayers synchronized (LedgerFanout verified) |
 | `✓ Phase 3:` | Notes exchange complete (question + reply committed to case ledger) |
 | `✅ M4:` | All replicas: both vendors CS includes F (fix ready) |
 | `✅ M5:` | All replicas: both vendors CS includes D (fix deployed) |

--- a/docs/reference/fv-demo-protocol.md
+++ b/docs/reference/fv-demo-protocol.md
@@ -59,8 +59,8 @@ sequenceDiagram
     note over F,CA: Phase 2 — Replica Synchronization Verification
 
     note right of V: trigger: sync-log-entry
-    V->>F: Announce(CaseLedgerEntry)<br/>[SYNC-2 verification]
-    note over F,CA: ✓ M2 — Finder replica synchronized (SYNC-2)
+    V->>F: Announce(CaseLedgerEntry)<br/>[LedgerFanout verification]
+    note over F,CA: ✓ M2 — Finder replica synchronized (LedgerFanout)
 
     note over F,CA: Phase 3 — Notes Exchange
 
@@ -219,7 +219,7 @@ The demo runner calls trigger endpoints on both actors:
 1. **Vendor** commits a demo verification case ledger entry and queues `Announce(CaseLedgerEntry)` in its outbox.
 2. Outbox delivery delivers the `Announce(CaseLedgerEntry)` to the Finder.
 3. **Finder** processes the log entry and updates its local replica.
-4. The demo runner verifies the Finder replica matches the authoritative Vendor state (SYNC-2).
+4. The demo runner verifies the Finder replica matches the authoritative Vendor state (LedgerFanout).
 
 ### Example: Announce(CaseLedgerEntry)
 
@@ -232,7 +232,7 @@ The demo runner calls trigger endpoints on both actors:
   "object": {
     "type": "CaseLedgerEntry",
     "id": "http://vendor:7999/api/v2/datalayer/{entry-uuid}",
-    "content": "SYNC-2 replication verification",
+    "content": "LedgerFanout replication verification",
     "hash": "sha256:..."
   },
   "target": {
@@ -249,7 +249,7 @@ The demo runner calls trigger endpoints on both actors:
 | Finder DataLayer has case ID | ✓ |
 | Matching `actor_participant_index` | ✓ |
 | Matching `active_embargo` | ✓ |
-| Matching log tail hash (SYNC-2) | ✓ |
+| Matching log tail hash (LedgerFanout) | ✓ |
 
 ---
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -132,6 +132,10 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 | **Participant Case Replica** | A local copy of **VulnerabilityCase** state maintained by a **Participant** node; must satisfy PCR safety rules (proper seeding, no out-of-order mutations) and convergence to the **CaseActor**'s authoritative state | Case replica, local case copy |
 | **Trust Bootstrap** | The first-time establishment of trust between the **CaseActor** and a new **Participant** via an **Accept** activity in response to an **Offer**; includes sending a `Create(VulnerabilityCase)` activity to seed the **Participant Case Replica** | Trust handoff, initial trust |
 | **Case Replica Seeding** | The process of initializing a **Participant Case Replica** by receiving an `Announce(VulnerabilityCase)` or `Create(VulnerabilityCase)` activity from the **CaseActor**; must occur before case-context activities can be processed | Replica initialization, case sync |
+| **Append-Only Ledger** | The first ledger synchronization phase: establishes the local append-only case ledger with hash-chain indexing, providing the cryptographic integrity foundation for all subsequent replication phases. Each entry is immutable once committed and uniquely identified by its content hash. | SYNC-1, phase 1 |
+| **Ledger Fanout** | The second ledger synchronization phase: one-way replication from the authoritative **CaseActor** to all **Participant Actors** via `Announce(CaseLedgerEntry)` messages. A participant's replica is considered synchronized when its log tail hash matches the **CaseActor**'s. | SYNC-2, phase 2 |
+| **Ledger Reconciliation** | The third ledger synchronization phase: a full sync loop with retry and backoff that detects and repairs gaps in participant replicas, ensuring eventual convergence even after missed or delayed deliveries. | SYNC-3, phase 3 |
+| **Peer Ledger Sync** | The fourth ledger synchronization phase: multi-peer synchronization enabling actors with equal standing to reconcile their ledgers with each other, supporting federated and ownership-transfer scenarios where no single actor is permanently authoritative. | SYNC-4, phase 4 |
 
 ## Activity & Wire Format
 
@@ -180,6 +184,8 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 | **Retriever** | A **Coordination Agent** subtype that fetches external data needed by the BT (e.g., CVE ID lookup, SSVC scoring) | Fetch agent, lookup agent |
 | **Composer** | A **Coordination Agent** subtype that assembles content from domain state (e.g., drafting advisory text) | Generator agent, authoring agent |
 | **Actuator** | A **Coordination Agent** subtype that invokes an external system to cause a side effect (notification dispatch, state write, queue mutation, API call); returns SUCCESS when the side effect is confirmed, FAILURE otherwise; produces no content artifact | Side-effect agent, executor |
+| **StatusAdoptionGate** | A BT authorization gate that determines whether a received **CaseStatus** update should be adopted by the receiving actor; guards the `add_participant_status_tree` path for received-side status canonicalization (ADR-0046). | Seam 1, StatusUpdateGuard |
+| **EmbargoTeardownAuthorizationGate** | A BT authorization gate that determines whether an incoming status update should trigger **Embargo** teardown; guards the `add_case_status_tree` path alongside `ThreatTerminationBranchNode` for received-side CaseStatus canonicalization (ADR-0046). | Seam 2, SideEffectsGuard |
 
 ## Domain Model — CVD Coordination
 

--- a/docs/tutorials/fv-demo.md
+++ b/docs/tutorials/fv-demo.md
@@ -133,8 +133,8 @@ sequenceDiagram
     V->>F: replies to question
     note over F,V: ✅ M3 — Vendor holds authoritative final case state
 
-    V-->>F: case ledger entry replicated (SYNC-2)
-    note over F,V: ✓ M2 — Finder replica synchronized (SYNC-2 verified)
+    V-->>F: case ledger entry replicated (LedgerFanout)
+    note over F,V: ✓ M2 — Finder replica synchronized (LedgerFanout verified)
 
     note over F,V: Phase 3 — Fix Lifecycle
 
@@ -178,13 +178,13 @@ reply back.
 state after the notes exchange.
 
 Next, the demo runner triggers the Vendor to commit a `CaseLedgerEntry` and
-deliver it to the Finder via the outbox (SYNC-2 replication verification).
+deliver it to the Finder via the outbox (LedgerFanout replication verification).
 The Finder waits for the log entry to appear in its DataLayer.
 
 !!! note "Milestone order in the log output"
 
     M3 appears in the log **before** M2. The notes-exchange phase runs first,
-    then SYNC-2 verification runs immediately after.
+    then LedgerFanout verification runs immediately after.
 
 **M2 verified when:** Finder's DataLayer contains the replicated log entry.
 
@@ -231,7 +231,7 @@ milestone lines as anchor points when reading the output.
 |:-------|:--------------|
 | `✅ M1:` | Case active: required participants and EM.ACTIVE confirmed on both replicas |
 | `✅ M3:` | Vendor container holds the authoritative final case state |
-| `✓ M2:` | Finder DataLayer synchronized (SYNC-2 verified) |
+| `✓ M2:` | Finder DataLayer synchronized (LedgerFanout verified) |
 | `✅ M4:` | Both replicas show CS includes F (fix ready) |
 | `✅ M5:` | Both replicas show CS includes D (fix deployed) |
 | `✅ M6:` | Both replicas: CS.VFDPxa and EM.EXITED confirmed |
@@ -239,7 +239,7 @@ milestone lines as anchor points when reading the output.
 
 !!! note "M3 appears before M2"
 
-    The notes-exchange phase (M3) runs before the SYNC-2 verification phase
+    The notes-exchange phase (M3) runs before the LedgerFanout verification phase
     (M2) in the demo execution order, so `✅ M3:` will appear in the log
     before `✓ M2:`.
 

--- a/notes/README.md
+++ b/notes/README.md
@@ -520,18 +520,18 @@ implementing `payloadSnapshot` parsers.
 
 **`sync-ledger-replication.md`**
 Log-centric architecture overview: hash-chain design rationale, log position
-in activity `context`, implementation phases (SYNC-1–4), system invariants,
+in activity `context`, implementation phases (AppendOnlyLedger–PeerLedgerSync), system invariants,
 open questions for the replicated case event log, SYNC-13 ledger write-ownership
 boundary, and pre-SYNC-13 upgrade path.
 **Load when**: designing multi-actor case synchronization, evaluating the
-hash-chain log approach, scoping the SYNC-1–4 implementation phases, or
+hash-chain log approach, scoping the AppendOnlyLedger–PeerLedgerSync implementation phases, or
 investigating the SYNC-12/SYNC-13 effects-before-persist and write-ownership
 invariants.
 
 **`participant-case-replica.md`**
 Design notes for participant case replicas: per-actor case copies, the
 synchronisation model between `CaseActor` and participant actors, and the
-relationship to SYNC-1/SYNC-2 implementation phases.
+relationship to AppendOnlyLedger/LedgerFanout implementation phases.
 **Load when**: implementing participant-side case replica handling, working on
 `specs/participant-case-replica.yaml` (PCR) requirements, or designing the
 `Announce(CaseLedgerEntry)` inbound handler.

--- a/notes/fv-demo.md
+++ b/notes/fv-demo.md
@@ -270,7 +270,7 @@ scripts for verification — they are read-only assertions, not puppeteering.
 | Milestone | What to verify |
 |-----------|---------------|
 | M1 | Vendor: case exists, 3 participants, EM.ACTIVE, embargo present. Reporter: has case replica, matching `actor_participant_index`, matching `active_embargo`. |
-| M2 | Reporter DataLayer has case ID. Both sides: matching participant index, matching embargo, matching log tail hash (SYNC-2). |
+| M2 | Reporter DataLayer has case ID. Both sides: matching participant index, matching embargo, matching log tail hash (LedgerFanout). |
 | M4 | Both replicas: participant status includes CS.F. |
 | M5 | Both replicas: participant status includes CS.D. |
 | M6 | Both replicas: CS.VFDPxa; EM state terminated/exited. |

--- a/notes/sync-ledger-replication.md
+++ b/notes/sync-ledger-replication.md
@@ -37,7 +37,7 @@ Key properties:
 - **Audit vs replication split**: The CaseActor MAY keep a broader local case
   audit trail including rejected assertion outcomes, but only the recorded
   canonical projection participates in replication and hash chaining.
-- **Single-node Raft framing**: The SYNC-1 through SYNC-4 phases effectively
+- **Single-node Raft framing**: The AppendOnlyLedger through PeerLedgerSync phases effectively
   implement a single-node Raft cluster. The CaseActor is permanently the
   leader (no election needed), and every append is an immediate commit. A
   single-node configuration MUST always be supported as the degenerate case
@@ -47,14 +47,14 @@ Key properties:
   multiple CaseActor instances for high-availability write authority — this
   is the scope of the Raft consensus protocol. (2) *Participant replication*
   delivers the canonical recorded log from the CaseActor cluster leader to
-  Participant Actors for state convergence — this is the scope of SYNC-1–4.
+  Participant Actors for state convergence — this is the scope of AppendOnlyLedger–PeerLedgerSync.
   Both tiers share the same `Announce(CaseLedgerEntry)` wire format, but serve
   different purposes.
 - **Forward compatibility**: The single-writer, single-node design explicitly
   preserves forward compatibility with a multi-node Raft cluster for
   high-availability failover. A future Phase 3 adds N-node CaseActor cluster
   support using standard Raft (static membership, log-completeness election,
-  no priority tiebreaker). Failover semantics are out of scope for SYNC-1–4
+  no priority tiebreaker). Failover semantics are out of scope for AppendOnlyLedger–PeerLedgerSync
   and MUST NOT be implicitly assumed by implementations in those phases.
 
 ---
@@ -85,7 +85,7 @@ synchronization state reporting because:
 ## Canonical Serialization
 
 **Critical constraint**: Before cryptographic signatures are added to log
-entries (SYNC-1 "PROD_ONLY" requirement), a **canonical serialization form**
+entries (AppendOnlyLedger "PROD_ONLY" requirement), a **canonical serialization form**
 MUST be established. Changing the serialization after entries are signed will
 invalidate existing hash chains.
 
@@ -134,15 +134,15 @@ a slightly-behind participant.
 
 | Phase  | Description                                               |
 |--------|-----------------------------------------------------------|
-| SYNC-1 | Local append-only log with hash-chain indexing            |
-| SYNC-2 | One-way replication from CaseActor to Participant Actors  |
-| SYNC-3 | Full sync loop with retry/backoff                         |
-| SYNC-4 | Multi-peer synchronization (completes single-node CaseActor participant replication) |
+| AppendOnlyLedger | Local append-only log with hash-chain indexing            |
+| LedgerFanout | One-way replication from CaseActor to Participant Actors  |
+| LedgerReconciliation | Full sync loop with retry/backoff                         |
+| PeerLedgerSync | Multi-peer synchronization (completes single-node CaseActor participant replication) |
 
-### SYNC-1 Scope
+### AppendOnlyLedger Scope
 
 The canonical `CaseLedgerEntry` model (see `notes/case-ledger-authority.md`)
-provides the foundation. SYNC-1 extended it toward a true canonical recorded
+provides the foundation. AppendOnlyLedger extended it toward a true canonical recorded
 log with hash-chain indexing; the richer long-term content model is described
 in `notes/case-ledger-authority.md`.
 
@@ -155,12 +155,12 @@ Core domain classes (transport-agnostic):
 - `CaseLedger` — append-only log; enforces immutability and hash-chain
 - `ReplicationState` — per-peer last-acknowledged hash
 
-`CaseLedgerEntry` fields for SYNC-1:
+`CaseLedgerEntry` fields for AppendOnlyLedger:
 
 - `log_index` — monotonically increasing integer scoped to the case (MUST;
-  see SYNC-01-002). Added in SYNC-1 so downstream code and wire format are
+  see SYNC-01-002). Added in AppendOnlyLedger so downstream code and wire format are
   index-aware from the start.
-- `term` — Raft term number (OPTIONAL in SYNC-1; defaults to `null` or `0`
+- `term` — Raft term number (OPTIONAL in AppendOnlyLedger; defaults to `null` or `0`
   in single-node deployments; becomes required when multi-node CaseActor
   cluster is introduced in Phase 3).
 
@@ -170,7 +170,7 @@ Adapter responsibilities:
 - Inbound handler for `Announce` (participant receiving a log entry)
 - File/database log storage
 
-### SYNC-2 Scope
+### LedgerFanout Scope
 
 One-way replication from CaseActor to each Participant Actor:
 
@@ -178,7 +178,7 @@ One-way replication from CaseActor to each Participant Actor:
   with last-accepted hash
 - Sender retries from the entry following the reported last-accepted hash
 
-Design Decision (blocks SYNC-2): Reconcile "replication leadership" with
+Design Decision (blocks LedgerFanout): Reconcile "replication leadership" with
 "Case Ownership". Case Ownership governs who controls the case lifecycle
 (e.g., closing the case, transferring ownership). Replication leadership
 governs which node currently accepts writes to the log. These are distinct:
@@ -194,7 +194,7 @@ A log entry is **committed** when it has been durably appended to the
 authoritative log and is safe to apply to the case state machine and emit
 externally.
 
-- In a **single-node** CaseActor (SYNC-1–4): every append is an immediate
+- In a **single-node** CaseActor (AppendOnlyLedger–PeerLedgerSync): every append is an immediate
   commit. There is no replication quorum to wait for.
 - In a **multi-node CaseActor cluster** (Phase 3 Raft): an entry is committed
   once the leader has received acknowledgement from a majority of cluster
@@ -303,10 +303,10 @@ Design approach:
 - Add a **leadership role-check port** to the BT bridge
   (`vultron/core/behaviors/bridge.py`). The port is a simple callable or
   Protocol that returns `True` if the calling node is the current leader.
-- In SYNC-1–4 (single-node): the port implementation always returns `True`.
+- In AppendOnlyLedger–PeerLedgerSync (single-node): the port implementation always returns `True`.
 - In Phase 3 (multi-node): the port queries the Raft state machine.
 
-This port SHOULD be added during SYNC-1 so that the seam already exists in
+This port SHOULD be added during AppendOnlyLedger so that the seam already exists in
 the BT bridge and Phase 3 only needs to provide a real implementation. The
 port being permanently `True` in single-node imposes zero runtime cost.
 
@@ -323,7 +323,7 @@ port being permanently `True` in single-node imposes zero runtime cost.
   MUST eventually possess a cryptographic identity. The specification must
   define how keys are generated, distributed, rotated, and revoked, and
   how trust anchors are established (e.g., pinned keys vs. PKI). This is
-  `PROD_ONLY` scope but SHOULD be designed before SYNC-3 to avoid
+  `PROD_ONLY` scope but SHOULD be designed before LedgerReconciliation to avoid
   retrofitting later.
 
 ---
@@ -582,7 +582,7 @@ Three properties are load-bearing, and each has a regression test:
   by SYNC-15-001/002, which seed the case and rely on the *following* replay to
   deliver history; a full-length cooldown there starved the bootstrap (caught by
   `fccv-handoff` in CI: 34 suppressions against a Finder stuck at genesis, ending in
-  "SYNC-2 replication did not complete"). Exempting genesis outright would re-admit
+  "LedgerFanout replication did not complete"). Exempting genesis outright would re-admit
   the storm, since a peer that cannot anchor reports genesis on every Reject — 43 of
   51 suppressions in the fixed `fcvcv` run were at genesis. So: 2s, not 0s and not
   30s.

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -636,7 +636,7 @@ groups:
     statement: >-
       The FVV scenario MUST run deterministically end-to-end via a single
       `docker compose` command using the existing multi-actor Compose stack; the
-      scenario script MUST verify SYNC-2 replica convergence (both Finder and Vendor2
+      scenario script MUST verify LedgerFanout replica convergence (both Finder and Vendor2
       replicas match the authoritative Vendor1 state) after each major protocol event
   - id: DEMOMA-09-005
     priority: MUST
@@ -786,7 +786,7 @@ groups:
     kind: project
     statement: >-
       The FVCV-extension scenario MUST run deterministically end-to-end; the scenario
-      script MUST verify SYNC-2 replica convergence for Finder, Coordinator, and Vendor2
+      script MUST verify LedgerFanout replica convergence for Finder, Coordinator, and Vendor2
       replicas against the authoritative Vendor1 state after each major protocol event.
     relationships:
     - rel_type: refines
@@ -952,7 +952,7 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The FVCV-handoff scenario MUST run deterministically and MUST verify SYNC-2
+      The FVCV-handoff scenario MUST run deterministically and MUST verify LedgerFanout
       replica convergence for all non-owning participants after each major protocol
       event, as required by DEMOMA-10-007.
     relationships:
@@ -1225,7 +1225,7 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The FCV scenario MUST run deterministically end-to-end and MUST verify SYNC-2
+      The FCV scenario MUST run deterministically end-to-end and MUST verify LedgerFanout
       replica convergence for Finder and Vendor replicas against the authoritative
       Coordinator/CaseActor state after each major protocol event.
     relationships:
@@ -1516,7 +1516,7 @@ groups:
     kind: project
     statement: >-
       The FCCV-extension scenario MUST run deterministically end-to-end and MUST
-      verify SYNC-2 replica convergence for Finder, C2, and Vendor replicas against
+      verify LedgerFanout replica convergence for Finder, C2, and Vendor replicas against
       the authoritative C1/CaseActor state after each major protocol event.
     relationships:
     - rel_type: refines
@@ -1721,12 +1721,12 @@ groups:
     kind: project
     statement: >-
       After Vendor joins, all four actor containers (Finder, C1, C2, Vendor)
-      MUST converge to the same case ledger state (SYNC-2 invariant).  Vendor
+      MUST converge to the same case ledger state (LedgerFanout invariant).  Vendor
       MUST receive the complete ledger backfill from genesis.
     rationale: >-
       Late-joiner backfill is a shared invariant across FVCV-extension,
       FVCV-handoff, and FCCV-handoff.  Verifying it here ensures the
-      ownership-transfer workflow does not break SYNC-2 convergence.
+      ownership-transfer workflow does not break LedgerFanout convergence.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-10-007

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -12,6 +12,41 @@ tags:
 - protocol
 - persistence
 groups:
+- id: SYNC-00
+  title: Ledger Sync Phase Concepts
+  specs:
+  - id: SYNC-00-001
+    priority: MUST
+    kind: architecture
+    statement: >-
+      The **AppendOnlyLedger** phase establishes the local append-only case ledger with
+      hash-chain indexing. Each entry is immutable once committed and cryptographically
+      linked to its predecessor, providing the integrity foundation for all subsequent
+      replication phases.
+  - id: SYNC-00-002
+    priority: MUST
+    kind: architecture
+    statement: >-
+      The **LedgerFanout** phase implements one-way replication from the authoritative
+      CaseActor to all Participant Actors via `Announce(CaseLedgerEntry)` messages.
+      A participant replica is considered synchronized when its log tail hash matches
+      the CaseActor's authoritative tail.
+  - id: SYNC-00-003
+    priority: MUST
+    kind: architecture
+    statement: >-
+      The **LedgerReconciliation** phase extends LedgerFanout with a full sync loop,
+      retry, and backoff. When a participant's replica falls behind, reconciliation
+      detects the gap and retries delivery until convergence is achieved.
+      LedgerReconciliation is how the system recovers; LedgerFanout is how it stays current.
+  - id: SYNC-00-004
+    priority: SHOULD
+    kind: architecture
+    statement: >-
+      The **PeerLedgerSync** phase enables multi-peer synchronization between actors
+      with equal standing. Where LedgerFanout assumes one CaseActor holds authority,
+      PeerLedgerSync allows two or more actors to reconcile their ledgers with each
+      other, supporting federated and ownership-transfer scenarios.
 - id: SYNC-01
   title: Append-Only Log
   specs:
@@ -147,7 +182,7 @@ groups:
   - id: SYNC-06-003
     priority: MUST
     kind: protocol
-    statement: The SYNC-1 through SYNC-4 phases implement a **single-node CaseActor configuration** — a degenerate Raft cluster
+    statement: The AppendOnlyLedger through PeerLedgerSync phases implement a **single-node CaseActor configuration** — a degenerate Raft cluster
       of one. A single-node CaseActor is always the leader and always has write authority; no election is needed.
   - id: SYNC-06-004
     priority: SHOULD
@@ -155,7 +190,7 @@ groups:
     statement: >-
       A future multi-node CaseActor cluster (Phase 3) provides high-availability write authority
       via Raft consensus. This is a distinct replication tier from participant replication:
-      participant replication (SYNC-2) is pull-based fan-out via `Announce(CaseLedgerEntry)`,
+      participant replication (LedgerFanout) is pull-based fan-out via `Announce(CaseLedgerEntry)`,
       whereas the multi-node CaseActor cluster uses Raft consensus to elect a single write
       authority among the CaseActor nodes. The two tiers operate independently and SHOULD NOT
       be conflated.

--- a/test/ci/invariants/test_fccv_extension_invariants.py
+++ b/test/ci/invariants/test_fccv_extension_invariants.py
@@ -19,7 +19,7 @@ FCCV-extension-specific invariants:
 - ``offer_case_participant`` appears at least once (C2 suggests Vendor via
   ADR-0026).
 - Vendor (``vendor2``) is a late joiner — its replica holds the complete log
-  from genesis (SYNC-2 backfill).
+  from genesis (LedgerFanout backfill).
 - CS transitions VFd and VFD observed in Vendor actor-status entries.
 - CS transition P (public-aware) observed in C1 (``vendor``) actor-status
   entries (C1 triggers CS.P as CASE_OWNER).
@@ -355,8 +355,8 @@ def test_fccv_extension_vendor_late_joiner_has_full_history(
     """Vendor (vendor2) replica contains all logIndex values present in C1 (vendor) replica.
 
     Vendor is a late joiner and must receive the full ledger backfill from
-    CaseActor (SYNC-2).
-    Spec: DEMOMA-13-007 (SYNC-2 convergence).
+    CaseActor (LedgerFanout).
+    Spec: DEMOMA-13-007 (LedgerFanout convergence).
     """
     if not fccv_extension_replicas.get(
         "vendor"
@@ -379,7 +379,7 @@ def test_fccv_extension_c2_late_joiner_has_full_history(
 
     C2 joins after initial case creation when C1 invites them; CaseActor must
     backfill all prior entries to C2.
-    Spec: DEMOMA-13-007 (SYNC-2 convergence).
+    Spec: DEMOMA-13-007 (LedgerFanout convergence).
     """
     if not fccv_extension_replicas.get(
         "vendor"

--- a/test/ci/invariants/test_fccv_handoff_invariants.py
+++ b/test/ci/invariants/test_fccv_handoff_invariants.py
@@ -397,7 +397,7 @@ def test_fccv_handoff_vendor_late_joiner_has_full_history(
     """Vendor (vendor2) replica contains all logIndex values present in C1 (vendor) replica.
 
     Vendor is the last actor to join (after the ownership handoff) and must
-    receive the full ledger backfill (SYNC-2 convergence, DEMOMA-14-006).
+    receive the full ledger backfill (LedgerFanout convergence, DEMOMA-14-006).
     """
     if not fccv_handoff_replicas.get(
         "vendor"

--- a/test/ci/invariants/test_fcv_invariants.py
+++ b/test/ci/invariants/test_fcv_invariants.py
@@ -334,7 +334,7 @@ def test_fcv_vendor_late_joiner_has_full_history(
     """Vendor replica contains all logIndex values present in coordinator replica.
 
     Vendor is a late joiner (invited after case creation) and must receive the
-    full ledger backfill.  Spec: DEMOMA-12-004 (SYNC-2 convergence).
+    full ledger backfill.  Spec: DEMOMA-12-004 (LedgerFanout convergence).
     """
     if not fcv_replicas.get("coordinator") or not fcv_replicas.get("vendor"):
         pytest.skip(

--- a/test/ci/invariants/test_fcvcv_invariants.py
+++ b/test/ci/invariants/test_fcvcv_invariants.py
@@ -20,7 +20,7 @@ FCVCV-specific invariants:
 - ``offer_case_participant`` appears at least once (C2 suggests V2 via
   ADR-0026).
 - ``accept_invite_actor_to_case`` appears at least three times.
-- V2 (late joiner via ADR-0026) holds the full ledger from genesis (SYNC-2).
+- V2 (late joiner via ADR-0026) holds the full ledger from genesis (LedgerFanout).
 - C1, V1, C2 are also late joiners whose replicas start from genesis.
 - CS transition VFd observed for both V1 and V2.
 - CS transition VFD observed for V2 only (V1 stops at VFd — DEMOMA-19-004).
@@ -359,9 +359,9 @@ def test_fcvcv_v2_late_joiner_has_full_history(
     """V2 replica holds every logIndex present in C1 (the authoritative actor).
 
     V2 joins via the ADR-0026 path (C2 suggests → C1 approves → CaseActor
-    invites) and must receive the full ledger backfill from CaseActor (SYNC-2).
+    invites) and must receive the full ledger backfill from CaseActor (LedgerFanout).
 
-    Spec: DEMOMA-19-009, SYNC-2.
+    Spec: DEMOMA-19-009, LedgerFanout.
     """
     if not fcvcv_replicas.get("c1") or not fcvcv_replicas.get("v2"):
         pytest.skip(
@@ -380,9 +380,9 @@ def test_fcvcv_c2_late_joiner_has_full_history(
     """C2 replica holds every logIndex present in C1 (the authoritative actor).
 
     C2 joins when C1 invites them; CaseActor must backfill all prior entries
-    (SYNC-2).
+    (LedgerFanout).
 
-    Spec: DEMOMA-19-003, SYNC-2.
+    Spec: DEMOMA-19-003, LedgerFanout.
     """
     if not fcvcv_replicas.get("c1") or not fcvcv_replicas.get("c2"):
         pytest.skip(
@@ -401,9 +401,9 @@ def test_fcvcv_v1_late_joiner_has_full_history(
     """V1 replica holds every logIndex present in C1 (the authoritative actor).
 
     V1 joins when C1 invites them (direct invite, not ADR-0026 path); CaseActor
-    still backfills all prior entries (SYNC-2).
+    still backfills all prior entries (LedgerFanout).
 
-    Spec: DEMOMA-19-003, SYNC-2.
+    Spec: DEMOMA-19-003, LedgerFanout.
     """
     if not fcvcv_replicas.get("c1") or not fcvcv_replicas.get("v1"):
         pytest.skip(

--- a/test/ci/invariants/test_fvcv_extension_invariants.py
+++ b/test/ci/invariants/test_fvcv_extension_invariants.py
@@ -344,7 +344,7 @@ def test_fvcv_extension_vendor2_late_joiner_has_full_history(
     """Vendor2 replica contains all logIndex values present in vendor replica.
 
     Vendor2 is a late joiner and must receive the full ledger backfill.
-    Spec: DEMOMA-10-007 (SYNC-2 convergence).
+    Spec: DEMOMA-10-007 (LedgerFanout convergence).
     """
     if not fvcv_extension_replicas.get(
         "vendor"
@@ -366,7 +366,7 @@ def test_fvcv_extension_finder_late_joiner_has_full_history(
 
     Finder is seeded by the CaseActor's trust-bootstrap Announce; the
     CaseActor must backfill all prior entries to Finder.
-    Spec: DEMOMA-10-007 (SYNC-2 convergence).
+    Spec: DEMOMA-10-007 (LedgerFanout convergence).
     """
     if not fvcv_extension_replicas.get(
         "vendor"
@@ -388,7 +388,7 @@ def test_fvcv_extension_coordinator_late_joiner_has_full_history(
 
     Coordinator joins after case creation when Vendor1 invites them; the
     CaseActor must backfill all prior entries to Coordinator.
-    Spec: DEMOMA-10-007 (SYNC-2 convergence).
+    Spec: DEMOMA-10-007 (LedgerFanout convergence).
     """
     if not fvcv_extension_replicas.get(
         "vendor"

--- a/test/ci/invariants/test_fvcv_handoff_invariants.py
+++ b/test/ci/invariants/test_fvcv_handoff_invariants.py
@@ -367,7 +367,7 @@ def test_fvcv_handoff_vendor2_late_joiner_has_full_history(
     """Vendor2 replica contains all logIndex values present in vendor replica.
 
     Vendor2 is the last actor to join (after the ownership handoff) and must
-    receive the full ledger backfill (SYNC-2 convergence).
+    receive the full ledger backfill (LedgerFanout convergence).
     """
     if not fvcv_handoff_replicas.get(
         "vendor"

--- a/test/ci/invariants/test_fvv_invariants.py
+++ b/test/ci/invariants/test_fvv_invariants.py
@@ -307,7 +307,7 @@ def test_fvv_vendor2_late_joiner_has_full_history(
     """Vendor2 replica contains all logIndex values present in vendor replica.
 
     Vendor2 is a late joiner and must receive the full ledger backfill.
-    Spec: DEMOMA-09-004 (SYNC-2 convergence).
+    Spec: DEMOMA-09-004 (LedgerFanout convergence).
     """
     if not fvv_replicas.get("vendor") or not fvv_replicas.get("vendor2"):
         pytest.skip(
@@ -328,7 +328,7 @@ def test_fvv_finder_late_joiner_has_full_history(
     Finder is seeded by the CaseActor's trust-bootstrap Announce after
     Vendor1 validates the report; the CaseActor must backfill all prior
     entries to Finder.
-    Spec: DEMOMA-09-004 (SYNC-2 convergence).
+    Spec: DEMOMA-09-004 (LedgerFanout convergence).
     """
     if not fvv_replicas.get("vendor") or not fvv_replicas.get("finder"):
         pytest.skip(

--- a/test/core/behaviors/sync/nodes/test_replay_guard.py
+++ b/test/core/behaviors/sync/nodes/test_replay_guard.py
@@ -150,7 +150,7 @@ class TestClaimReplayPosition:
 
         Regression guard: a full-length cooldown at genesis suppressed the
         replay that ``AnnounceCaseOnGenesisRejectNode`` depends on, leaving the
-        peer with an empty replica ("SYNC-2 replication did not complete").
+        peer with an empty replica ("LedgerFanout replication did not complete").
         Genesis still gets *a* cooldown, so the storm stays bounded.
         """
         assert GENESIS_REPLAY_COOLDOWN_SECONDS < REPLAY_COOLDOWN_SECONDS

--- a/test/core/use_cases/received/test_reject_sync.py
+++ b/test/core/use_cases/received/test_reject_sync.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Tests for SYNC-3: RejectLedgerEntryReceivedUseCase and replay trigger.
+"""Tests for LedgerReconciliation: RejectLedgerEntryReceivedUseCase and replay trigger.
 
 Spec: SYNC-03-001, SYNC-03-002, SYNC-04-001, SYNC-04-002.
 """

--- a/test/core/use_cases/received/test_sync.py
+++ b/test/core/use_cases/received/test_sync.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Tests for SYNC-2/SYNC-3 received use cases."""
+"""Tests for LedgerFanout/LedgerReconciliation received use cases."""
 
 import pytest
 from unittest.mock import MagicMock

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -620,7 +620,7 @@ class TestWaitForFinderCase:
 
 
 # ---------------------------------------------------------------------------
-# SYNC-2 log replication helper tests
+# LedgerFanout log replication helper tests
 # ---------------------------------------------------------------------------
 
 
@@ -1171,7 +1171,7 @@ class TestRunTwoActorDemo:
         monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
 
         # After issue #2273 (validate-report ordering fix), the in-process
-        # SYNC-2 gap (#2267) is also resolved: case-actor ledger entries now
+        # LedgerFanout gap (#2267) is also resolved: case-actor ledger entries now
         # exist (validate_report + engage_case are properly recorded), enabling
         # Finder replica replication to complete.  The demo should succeed
         # with no failures.

--- a/vultron/core/behaviors/bridge.py
+++ b/vultron/core/behaviors/bridge.py
@@ -119,7 +119,7 @@ class BTBridge:
                 placed on the py_trees blackboard under the key
                 ``trigger_activity_factory`` so that BT nodes can call it
                 without importing from the wire layer.
-            sync_port: Optional port for SYNC-2 replication fan-out
+            sync_port: Optional port for LedgerFanout replication fan-out
                 (SYNC-02-002).  When provided it is placed on the py_trees
                 blackboard under the key ``sync_port`` so that
                 ``CommitCaseLedgerEntryNode`` can fan out

--- a/vultron/core/behaviors/sync/__init__.py
+++ b/vultron/core/behaviors/sync/__init__.py
@@ -15,7 +15,7 @@
 
 """Sync protocol behavior trees.
 
-Provides BT nodes and tree factories for SYNC-2/SYNC-3 log-entry
+Provides BT nodes and tree factories for LedgerFanout/LedgerReconciliation log-entry
 replication flows:
 
 - :func:`~vultron.core.behaviors.sync.announce_tree.create_announce_log_entry_tree`

--- a/vultron/core/models/case_ledger.py
+++ b/vultron/core/models/case_ledger.py
@@ -12,7 +12,7 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Append-only canonical case ledger for SYNC-1.
+"""Append-only canonical case ledger for AppendOnlyLedger.
 
 This module provides:
 

--- a/vultron/core/models/case_ledger_entry.py
+++ b/vultron/core/models/case_ledger_entry.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Core domain model for a canonical case ledger entry (SYNC-2).
+"""Core domain model for a canonical case ledger entry (LedgerFanout).
 
 :class:`CaseLedgerEntry` is the authoritative domain representation of a
 single hash-chained log entry used for replication via

--- a/vultron/core/models/events/sync.py
+++ b/vultron/core/models/events/sync.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Per-semantic inbound domain event types for SYNC-2/SYNC-3 log replication."""
+"""Per-semantic inbound domain event types for LedgerFanout/LedgerReconciliation log replication."""
 
 from typing import Literal, cast
 

--- a/vultron/core/models/replication_state.py
+++ b/vultron/core/models/replication_state.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Persistable per-peer replication state for SYNC-3/4.
+"""Persistable per-peer replication state for LedgerReconciliation/PeerLedgerSync.
 
 Spec: SYNC-04-001, SYNC-04-002.
 """

--- a/vultron/core/use_cases/README.md
+++ b/vultron/core/use_cases/README.md
@@ -36,7 +36,7 @@ triggers/           (outbound message sent)
    validate a report). This emits an outbound ActivityStreams activity.
 2. **Received** (`received/`): Remote actors receive the inbound activity
    and update their local state to reflect the sender's assertion.
-3. **Sync** (future, `SYNC-1`/`SYNC-2`): The CaseActor replicates the
+3. **Sync** (future, `AppendOnlyLedger`/`LedgerFanout`): The CaseActor replicates the
    resulting case event log to all participants via AS2 Announce activities.
 
 ## Package Root

--- a/vultron/core/use_cases/received/sync.py
+++ b/vultron/core/use_cases/received/sync.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Received use cases for SYNC-2/SYNC-3: accept or reject inbound log-entry
+"""Received use cases for LedgerFanout/LedgerReconciliation: accept or reject inbound log-entry
 announcements, and handle hash-chain rejection replies.
 
 Spec: SYNC-02-003, SYNC-03-001 through SYNC-03-003, SYNC-04-001, SYNC-04-002.

--- a/vultron/core/use_cases/triggers/sync.py
+++ b/vultron/core/use_cases/triggers/sync.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Trigger helper for SYNC-3: replay missing log entries on hash-chain rejection.
+"""Trigger helper for LedgerReconciliation: replay missing log entries on hash-chain rejection.
 
 Public entry point:
 

--- a/vultron/demo/cli.py
+++ b/vultron/demo/cli.py
@@ -424,7 +424,7 @@ def fvv(
       2. Finder submits a vulnerability report to Vendor1's inbox.
       3. Vendor1 validates the report and engages the case.
       4. Vendor1 invites Vendor2; Vendor2 accepts.
-      5. Verify SYNC-2 replication on Finder and Vendor2.
+      5. Verify LedgerFanout replication on Finder and Vendor2.
       6. Both vendors independently advance through fix-ready → fix-deployed.
       7. All participants report publication; embargo terminates.
       8. All participants close the case.
@@ -532,7 +532,7 @@ def fvcv_extension(
       5. Coordinator accepts; Coordinator suggests Vendor2 (ADR-0026).
       6. Vendor1 approves the actor recommendation.
       7. CaseActor invites Vendor2; Vendor2 accepts.
-      8. Verify SYNC-2 replication on all replicas.
+      8. Verify LedgerFanout replication on all replicas.
       9. Both vendors independently advance through fix-ready → fix-deployed.
      10. All participants report publication; embargo terminates.
      11. All participants close the case.
@@ -657,7 +657,7 @@ def fvcv_handoff(
       6. Coordinator accepts the ownership transfer (TRIG-11-002).
       7. Verify case attributed_to updated to Coordinator.
       8. Coordinator invites Vendor2; Vendor2 accepts and Accept routed to CaseActor.
-      9. Verify SYNC-2 replication on all replicas.
+      9. Verify LedgerFanout replication on all replicas.
      10. Both vendors independently advance through fix-ready → fix-deployed.
      11. All participants report publication; embargo terminates.
      12. All participants close the case.
@@ -768,7 +768,7 @@ def fccv_extension(
       4. C2 accepts; C2 suggests Vendor (ADR-0026 suggest-actor flow).
       5. C1 approves the actor recommendation.
       6. CaseActor invites Vendor; Vendor accepts.
-      7. Verify SYNC-2 replication on all replicas.
+      7. Verify LedgerFanout replication on all replicas.
       8. Vendor advances through fix-ready → fix-deployed.
       9. C1 (CASE_OWNER) triggers publication; embargo terminates.
      10. All participants report publication; all participants close the case.
@@ -893,7 +893,7 @@ def fccv_handoff(
       6. C2 accepts the ownership transfer (TRIG-11-002).
       7. Verify case attributed_to updated to C2 on both C1 and C2 replicas.
       8. C2 invites Vendor; Vendor accepts and Accept routed to CaseActor.
-      9. Verify SYNC-2 replication on all replicas.
+      9. Verify LedgerFanout replication on all replicas.
      10. Vendor advances through fix-ready → fix-deployed.
      11. All participants report publication; embargo terminates.
      12. All participants close the case.
@@ -1015,7 +1015,7 @@ def fcvcv(
       2. Finder submits a report to C1; C1 validates and engages.
       3. C1 invites V1 (VENDOR) and C2 (COORDINATOR).
       4. C2 suggests V2 via ADR-0026; C1 approves; V2 joins via CaseActor.
-      5. Verify SYNC-2 replication across all six participants.
+      5. Verify LedgerFanout replication across all six participants.
       6. All five actors exchange notes.
       7. Fix lifecycle: V1 → VFd (no deploy); V2 → VFD (fix-deployed).
       8. Publication: V1 publishes first → embargo terminates; all publish.
@@ -1111,7 +1111,7 @@ def fcv(
     Coordinator receives the Finder's report, creates the authoritative case
     (holding CASE_OWNER), and the CaseActor service manages the case ledger.
     Coordinator invites Finder, then directly invites Vendor.  Vendor accepts
-    as a late joiner and receives the full ledger backfill (SYNC-2).  All
+    as a late joiner and receives the full ledger backfill (LedgerFanout).  All
     participants advance through the full VFDPxa fix lifecycle to closure.
 
     \b
@@ -1120,7 +1120,7 @@ def fcv(
       2. Finder submits a vulnerability report to Coordinator's inbox.
       3. Coordinator validates the report and engages the case (CASE_OWNER).
       4. Coordinator invites Vendor directly (invite-actor-to-case).
-      5. Vendor accepts the case invitation; case replica seeded (SYNC-2).
+      5. Vendor accepts the case invitation; case replica seeded (LedgerFanout).
       6. Verify all replica ledgers synchronized.
       7. Three-way notes exchange among all participants.
       8. Vendor advances: VF (fix ready) → VFD (fix deployed).

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -31,7 +31,7 @@ Sub-modules
   ``seed_containers``, ``seed_containers_fvv``, ``seed_containers_fccv``,
   ``seed_containers_fcv``, ``seed_containers_fcvcv``, and
   ``reset_containers``.
-- :mod:`~vultron.demo.helpers.sync` — SYNC-2 ``trigger_log_commit`` and
+- :mod:`~vultron.demo.helpers.sync` — LedgerFanout ``trigger_log_commit`` and
   ``verify_replica_state``.
 - :mod:`~vultron.demo.helpers.verification` — lower-level participant and
   case-state assertion primitives, plus ``verify_activity_in_inbox``,

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -224,7 +224,7 @@ def wait_for_finder_log_entry(
 
     Proves that the vendor's ``Announce(CaseLedgerEntry)`` outbox activity was
     delivered to the finder's inbox and processed by
-    ``AnnounceLedgerEntryReceivedUseCase`` (SYNC-2 receive side).
+    ``AnnounceLedgerEntryReceivedUseCase`` (LedgerFanout receive side).
 
     Args:
         finder_client: DataLayerClient connected to the Finder container.

--- a/vultron/demo/helpers/sync.py
+++ b/vultron/demo/helpers/sync.py
@@ -11,7 +11,7 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""SYNC-2 log-replication helpers for demo workflows.
+"""LedgerFanout log-replication helpers for demo workflows.
 
 Provides :func:`trigger_log_commit` to commit a log entry and fan it out to
 all case participants, and :func:`verify_replica_state` to assert that a
@@ -73,7 +73,7 @@ def _get_log_entries_for_case(
 
 
 # ---------------------------------------------------------------------------
-# Public SYNC-2 helpers
+# Public LedgerFanout helpers
 # ---------------------------------------------------------------------------
 
 
@@ -201,7 +201,7 @@ def verify_replica_state(
     replica_entries = _get_log_entries_for_case(replica_client, case_id)
     assert len(replica_entries) > 0, (
         "Replica has no CaseLedgerEntry records for the case — "
-        "SYNC-2 replication did not complete"
+        "LedgerFanout replication did not complete"
     )
     auth_tail = max(auth_entries, key=lambda e: e["log_index"])
     replica_tail = max(replica_entries, key=lambda e: e["log_index"])

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -444,7 +444,7 @@ def _phase_sync_verification(
     finder: as_Actor,
     case: as_VulnerabilityCase,
 ) -> None:
-    """Verify SYNC-2 replication for Finder, C2, and Vendor replicas."""
+    """Verify LedgerFanout replication for Finder, C2, and Vendor replicas."""
     logger.info("─" * 80)
     logger.info("Phase 3: Replica synchronization verification")
     logger.info("─" * 80)
@@ -507,7 +507,7 @@ def _phase_sync_verification(
             reporter_actor_id=finder.id_,
         )
 
-    logger.info("✓ M4: All replicas synchronized (SYNC-2 verified)")
+    logger.info("✓ M4: All replicas synchronized (LedgerFanout verified)")
 
 
 def _phase_notes_exchange(

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -348,7 +348,7 @@ def _phase_sync_verification(
     coordinator: as_Actor,
     case: as_VulnerabilityCase,
 ) -> None:
-    """Verify SYNC-2 replication for Finder and Vendor replicas."""
+    """Verify LedgerFanout replication for Finder and Vendor replicas."""
     logger.info("─" * 80)
     logger.info("Phase 3: Replica synchronization verification")
     logger.info("─" * 80)
@@ -412,7 +412,7 @@ def _phase_sync_verification(
             reporter_actor_id=finder.id_,
         )
 
-    logger.info("✓ M3: All replicas synchronized (SYNC-2 verified)")
+    logger.info("✓ M3: All replicas synchronized (LedgerFanout verified)")
 
 
 def _phase_notes_exchange(

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -515,7 +515,7 @@ def _phase_sync_verification(
     finder: as_Actor,
     case: as_VulnerabilityCase,
 ) -> None:
-    """Verify SYNC-2 replication for all participant replicas."""
+    """Verify LedgerFanout replication for all participant replicas."""
     logger.info("─" * 80)
     logger.info("Phase 3: Replica synchronization verification (M1)")
     logger.info("─" * 80)
@@ -535,7 +535,7 @@ def _phase_sync_verification(
             (v1_client, "V1"),
             (c2_client, "C2"),
             # V2 is a late joiner that must catch up from genesis; allow extra
-            # time for the full history to be delivered (SYNC-2 late-joiner).
+            # time for the full history to be delivered (LedgerFanout late-joiner).
             (v2_client, "V2"),
         ]:
             # V2 joins after Phase 1 completes, so it has more entries to sync.
@@ -579,7 +579,7 @@ def _phase_sync_verification(
             reporter_actor_id=finder.id_,
         )
 
-    logger.info("✓ M1: All five replicas synchronized (SYNC-2 verified)")
+    logger.info("✓ M1: All five replicas synchronized (LedgerFanout verified)")
 
 
 def _phase_notes_exchange(

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -597,7 +597,7 @@ def _phase_sync_verification(
     case: as_VulnerabilityCase,
     case_actor_client: DataLayerClient | None,
 ) -> None:
-    """Verify SYNC-2 replication and confirm the dedicated case actor is unused."""
+    """Verify LedgerFanout replication and confirm the dedicated case actor is unused."""
     logger.info("─" * 80)
     logger.info("Phase 2: Replica synchronization verification")
     logger.info("─" * 80)
@@ -648,7 +648,7 @@ def _phase_sync_verification(
             )
 
     logger.info(
-        "Verifying SYNC-2 replication by comparing vendor ↔ finder replica"
+        "Verifying LedgerFanout replication by comparing vendor ↔ finder replica"
         " state (ADR-0019: synthetic entries omitted from canonical ledger)"
     )
 
@@ -664,7 +664,7 @@ def _phase_sync_verification(
     with demo_check("Dedicated CaseActor container remains unused for D5-2"):
         verify_case_actor_unused(case_actor_client, case.id_)
 
-    logger.info("✓ M2: Finder DataLayer synchronized (SYNC-2 verified)")
+    logger.info("✓ M2: Finder DataLayer synchronized (LedgerFanout verified)")
 
 
 def _phase_fix_lifecycle(

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -444,7 +444,7 @@ def _phase_sync_verification(
     vendor2: as_Actor,
     case: as_VulnerabilityCase,
 ) -> None:
-    """Verify SYNC-2 replication for Finder, Coordinator, and Vendor2 replicas."""
+    """Verify LedgerFanout replication for Finder, Coordinator, and Vendor2 replicas."""
     logger.info("─" * 80)
     logger.info("Phase 3: Replica synchronization verification")
     logger.info("─" * 80)
@@ -507,7 +507,7 @@ def _phase_sync_verification(
             reporter_actor_id=finder.id_,
         )
 
-    logger.info("✓ M4: All replicas synchronized (SYNC-2 verified)")
+    logger.info("✓ M4: All replicas synchronized (LedgerFanout verified)")
 
 
 def _phase_notes_exchange(

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -18,7 +18,7 @@
 Orchestrates the full VFDPxa lifecycle across separate Finder, Vendor1,
 and Vendor2 containers with no coordinator.  Vendor1 creates the case and
 invites both Finder and Vendor2; each vendor has an independent fix path
-(CS_vfd).  Vendor2's DataLayer is verified as a SYNC-2 replica of the
+(CS_vfd).  Vendor2's DataLayer is verified as a LedgerFanout replica of the
 authoritative Vendor1 state.
 
 Spec: D5-5 (GitHub issue #1265).
@@ -300,7 +300,7 @@ def _phase_sync_verification(
     vendor2: as_Actor,
     case: as_VulnerabilityCase,
 ) -> None:
-    """Verify SYNC-2 replication for both Finder and Vendor2 replicas."""
+    """Verify LedgerFanout replication for both Finder and Vendor2 replicas."""
     logger.info("─" * 80)
     logger.info("Phase 2: Replica synchronization verification")
     logger.info("─" * 80)
@@ -367,7 +367,7 @@ def _phase_sync_verification(
         )
 
     logger.info(
-        "✓ M2: Finder and Vendor2 DataLayers synchronized (SYNC-2 verified)"
+        "✓ M2: Finder and Vendor2 DataLayers synchronized (LedgerFanout verified)"
     )
 
 

--- a/vultron/wire/as2/factories/sync.py
+++ b/vultron/wire/as2/factories/sync.py
@@ -15,7 +15,7 @@
 """
 Factory functions for outbound Vultron case-ledger synchronization activities.
 
-These are the sole public construction API for SYNC-2/SYNC-3 log
+These are the sole public construction API for LedgerFanout/LedgerReconciliation log
 replication activities. Internal activity subclasses are imported here
 and MUST NOT be imported by callers.
 

--- a/vultron/wire/as2/vocab/activities/sync.py
+++ b/vultron/wire/as2/vocab/activities/sync.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Wire-layer AS2 activity classes for SYNC-2/SYNC-3 log replication.
+"""Wire-layer AS2 activity classes for LedgerFanout/LedgerReconciliation log replication.
 
 Provides :class:`_AnnounceLogEntryActivity` used by the CaseActor to fan
 out canonical log entries to participant actors, and


### PR DESCRIPTION
- Closes #2339

## Summary

Replaces positional phase labels (`SYNC-1` through `SYNC-4`) with descriptive,
domain-grounded names that communicate what each concept represents:

| Old | New |
|-----|-----|
| SYNC-1 | `AppendOnlyLedger` |
| SYNC-2 | `LedgerFanout` |
| SYNC-3 | `LedgerReconciliation` |
| SYNC-4 | `PeerLedgerSync` |

All changes are in comments, docstrings, prose, and YAML statements — no
logic or spec entry IDs (`SYNC-01-xxx`) were altered.

## Changes

- **41 active files** updated (notes, specs, docs, source modules, demo
  scenarios, test files) — all bare phase labels replaced
- **`docs/reference/glossary.md`** — four new entries in the
  "Sync, Authority & Replication" section defining each phase concept;
  two entries in "Behavior Trees" for `StatusAdoptionGate` and
  `EmbargoTeardownAuthorizationGate` (from #2331, previously undocumented
  in the glossary)
- **`specs/sync-ledger-replication.yaml`** — new `SYNC-00` group with four
  `SYNC-00-00x` architecture entries that formally define each phase concept
  by its new name, closing the spec gap where phase names existed only in prose

## Verification

- All 7038 unit tests pass
- All 1130 integration tests pass
- Black, flake8, mypy, pyright clean
- spec-lint clean (pre-existing warnings only)
- No bare `SYNC-1/2/3/4` references remain outside `plan/history/` or `archived_notes/`