### PR TITLE
fix: received-side use cases pass receiving_actor_id to execute_with_setup (BT-17-006)

### DIFF
--- a/test/architecture/test_received_side_actor_id.py
+++ b/test/architecture/test_received_side_actor_id.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Architecture invariant: received-side execute_with_setup must use receiving_actor_id.
+
+Spec BT-17-006 (MUST): any received-side use case that calls
+``execute_with_setup`` MUST pass ``actor_id=request.receiving_actor_id``
+(or a local variable derived from it), never ``actor_id=request.actor_id``
+(the sender).  Passing the sender ID scopes the DataLayer and GuardedCommit
+to the wrong actor, silently attributing ledger entries and state transitions
+to the remote peer.
+
+Issue: #2338
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]
+_RECEIVED_ROOT = REPO_ROOT / "vultron" / "core" / "use_cases" / "received"
+
+
+def _is_execute_with_setup_call(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute) and func.attr == "execute_with_setup"
+    ) or (isinstance(func, ast.Name) and func.id == "execute_with_setup")
+
+
+def _walk_own_scope(node: ast.AST):
+    yield node
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        yield from _walk_own_scope(child)
+
+
+def _is_request_actor_id(node: ast.expr) -> bool:
+    """Return True for the AST node ``request.actor_id``."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "actor_id"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "request"
+    )
+
+
+def _label(source_path: Path) -> str:
+    try:
+        return source_path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(source_path)
+
+
+def _violations_in_execute(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    label: str,
+) -> list[str]:
+    """Return 'label:lineno' for every execute_with_setup that passes request.actor_id."""
+    results: list[str] = []
+    for child in _walk_own_scope(func):
+        if not _is_execute_with_setup_call(child):
+            continue
+        assert isinstance(child, ast.Call)
+        for kw in child.keywords:
+            if kw.arg == "actor_id" and _is_request_actor_id(kw.value):
+                results.append(f"{label}:{child.lineno}")
+    return results
+
+
+def _collect_violations(source_path: Path) -> list[str]:
+    """Return 'file:lineno' entries where execute_with_setup passes request.actor_id."""
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+
+    label = _label(source_path)
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != "execute":
+            continue
+        violations.extend(_violations_in_execute(node, label))
+    return violations
+
+
+def test_received_side_execute_with_setup_never_passes_request_actor_id():
+    """No received-side execute() may pass actor_id=request.actor_id to execute_with_setup.
+
+    Spec BT-17-006. Issue #2338.
+    """
+    all_violations: list[str] = []
+    for py_file in _RECEIVED_ROOT.rglob("*.py"):
+        if "__pycache__" in py_file.parts:
+            continue
+        all_violations.extend(_collect_violations(py_file))
+
+    assert not all_violations, (
+        "received-side execute() calls pass actor_id=request.actor_id"
+        " (should use request.receiving_actor_id — BT-17-006, issue #2338):\n"
+        + "\n".join(f"  {v}" for v in sorted(all_violations))
+    )
+
+
+def test_detector_catches_synthetic_violation(tmp_path: Path) -> None:
+    """Confirm the detector flags a synthetic request.actor_id violation."""
+    violation_file = tmp_path / "synthetic_bad.py"
+    violation_file.write_text(
+        "class FakeUseCase:\n"
+        "    def execute(self):\n"
+        "        bridge.execute_with_setup(tree=t, actor_id=request.actor_id)\n",
+        encoding="utf-8",
+    )
+    violations = _collect_violations(violation_file)
+    assert violations, "Detector did not flag the synthetic violation"
+
+    ok_file = tmp_path / "synthetic_ok.py"
+    ok_file.write_text(
+        "class FakeUseCase:\n"
+        "    def execute(self):\n"
+        "        receiving_actor_id = request.receiving_actor_id\n"
+        "        bridge.execute_with_setup(tree=t, actor_id=receiving_actor_id)\n",
+        encoding="utf-8",
+    )
+    assert not _collect_violations(
+        ok_file
+    ), "Detector produced a false positive for receiving_actor_id usage"
+
+    ok_inline_file = tmp_path / "synthetic_ok_inline.py"
+    ok_inline_file.write_text(
+        "class FakeUseCase:\n"
+        "    def execute(self):\n"
+        "        bridge.execute_with_setup(\n"
+        "            tree=t,\n"
+        "            actor_id=request.receiving_actor_id\n"
+        "                if request.receiving_actor_id is not None\n"
+        "                else request.actor_id,\n"
+        "        )\n",
+        encoding="utf-8",
+    )
+    assert not _collect_violations(
+        ok_inline_file
+    ), "Detector produced a false positive for defensive inline form"

--- a/test/core/use_cases/received/test_embargo_ledger_cascade.py
+++ b/test/core/use_cases/received/test_embargo_ledger_cascade.py
@@ -120,7 +120,7 @@ class TestEmbargoLogEntryCascade:
         author_id = "https://example.org/users/coord"
         case_id = "https://example.org/cases/em_cas_add"
         dl, case_actor, case, embargo = _make_embargo_case_with_actor(
-            case_id, author_id, case_manager_actor_id=author_id
+            case_id, author_id
         )
         case_read = cast(VulnerabilityCase, dl.read(case.id_))
         assert case_read is not None
@@ -329,7 +329,7 @@ class TestEmbargoLogEntryCascade:
         coordinator_id = "https://example.org/users/coordinator"
         case_id = "https://example.org/cases/em_cas_reject"
         dl, case_actor, case, embargo = _make_embargo_case_with_actor(
-            case_id, coordinator_id, case_manager_actor_id=coordinator_id
+            case_id, coordinator_id
         )
 
         proposal = em_propose_embargo_activity(

--- a/test/core/use_cases/received/test_report_routing_guard.py
+++ b/test/core/use_cases/received/test_report_routing_guard.py
@@ -1,0 +1,303 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for InvalidateReportReceivedUseCase and CloseReportReceivedUseCase
+BT execution under the receiving actor's identity (BT-17-006).
+
+Pins the BT-17-006 requirement: ``execute_with_setup`` MUST be called with
+``actor_id=request.receiving_actor_id`` so the RM-transition BT updates the
+RECEIVING actor's participant, not the sender's.  Before the fix both use cases
+passed ``request.actor_id`` (the sender) instead.
+
+The trees for these use cases do NOT contain ``GuardedCommitCaseLedgerEntryBT``
+(unlike the AckReport and CloseCase trees), so the routing assertion is on RM
+state rather than ledger entry presence.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.models.activity import VultronActivity
+from vultron.core.models.dimensions import RmDimension
+from vultron.core.models.events import MessageSemantics
+from vultron.core.models.events.report import (
+    CloseReportReceivedEvent,
+    InvalidateReportReceivedEvent,
+)
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.report import VultronReport
+from vultron.core.states.rm import RM
+from vultron.core.use_cases.received.report import (
+    CloseReportReceivedUseCase,
+    InvalidateReportReceivedUseCase,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    as_VulnerabilityReport,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+RECEIVING_ACTOR_ID = "https://example.org/actors/receiving-report-guard"
+SENDER_ACTOR_ID = "https://example.org/actors/sender-report-guard"
+REPORT_ID = "https://example.org/reports/r-routing-guard-test"
+CASE_ID = "https://example.org/cases/c-routing-guard-test"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_blackboard():
+    import py_trees
+
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+def _make_dl(
+    receiving_rm: RM = RM.RECEIVED,
+    sender_rm: RM = RM.RECEIVED,
+) -> SqliteDataLayer:
+    """DataLayer with a case linked to a report and two participants.
+
+    Both RECEIVING_ACTOR_ID and SENDER_ACTOR_ID have participants in the case
+    so tests can verify which participant's RM state is transitioned.
+    """
+    dl = SqliteDataLayer("sqlite:///:memory:")
+
+    report = as_VulnerabilityReport(id_=REPORT_ID, name="Routing Guard Report")
+    dl.save(report)
+
+    receiving_participant = VultronParticipant(
+        id_="https://example.org/participants/p-receiving-guard",
+        attributed_to=RECEIVING_ACTOR_ID,
+        context=CASE_ID,
+        participant_statuses=[
+            ParticipantStatus(
+                rm=RmDimension(state=receiving_rm),
+                context=CASE_ID,
+                attributed_to=RECEIVING_ACTOR_ID,
+            )
+        ],
+    )
+    sender_participant = VultronParticipant(
+        id_="https://example.org/participants/p-sender-guard",
+        attributed_to=SENDER_ACTOR_ID,
+        context=CASE_ID,
+        participant_statuses=[
+            ParticipantStatus(
+                rm=RmDimension(state=sender_rm),
+                context=CASE_ID,
+                attributed_to=SENDER_ACTOR_ID,
+            )
+        ],
+    )
+
+    case = as_VulnerabilityCase(
+        id_=CASE_ID,
+        name="Report Routing Guard Test Case",
+    )
+    case.vulnerability_reports.append(REPORT_ID)
+    case.case_participants.append(receiving_participant.id_)
+    case.case_participants.append(sender_participant.id_)
+    case.actor_participant_index[RECEIVING_ACTOR_ID] = (
+        receiving_participant.id_
+    )
+    case.actor_participant_index[SENDER_ACTOR_ID] = sender_participant.id_
+
+    dl.save(receiving_participant)
+    dl.save(sender_participant)
+    dl.save(case)
+
+    return dl
+
+
+def _rm_state(dl: SqliteDataLayer, actor_id: str) -> RM | None:
+    """Return the current RM state for actor_id's participant in the test case."""
+    case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
+    participant_id = case.actor_participant_index.get(actor_id)
+    if not participant_id:
+        return None
+    participant = cast(VultronParticipant, dl.read(participant_id))
+    if not participant.participant_statuses:
+        return None
+    return participant.participant_statuses[-1].rm.state
+
+
+def _make_invalidate_event(
+    receiving_actor_id: str | None = RECEIVING_ACTOR_ID,
+) -> InvalidateReportReceivedEvent:
+    activity = VultronActivity(
+        id_="https://example.org/activities/invalidate-guard",
+        type_="TentativeReject",
+        actor=SENDER_ACTOR_ID,
+        object_=REPORT_ID,
+    )
+    return InvalidateReportReceivedEvent(
+        semantic_type=MessageSemantics.INVALIDATE_REPORT,
+        activity_id=activity.id_,
+        actor_id=SENDER_ACTOR_ID,
+        object_=VultronReport(id_=REPORT_ID),
+        inner_object=VultronReport(id_=REPORT_ID),
+        activity=activity,
+        receiving_actor_id=receiving_actor_id,
+    )
+
+
+def _make_close_report_event(
+    receiving_actor_id: str | None = RECEIVING_ACTOR_ID,
+) -> CloseReportReceivedEvent:
+    activity = VultronActivity(
+        id_="https://example.org/activities/close-report-guard",
+        type_="Reject",
+        actor=SENDER_ACTOR_ID,
+        object_=REPORT_ID,
+    )
+    return CloseReportReceivedEvent(
+        semantic_type=MessageSemantics.CLOSE_REPORT,
+        activity_id=activity.id_,
+        actor_id=SENDER_ACTOR_ID,
+        object_=VultronReport(id_=REPORT_ID),
+        inner_object=VultronReport(id_=REPORT_ID),
+        activity=activity,
+        receiving_actor_id=receiving_actor_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — InvalidateReportReceivedUseCase
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidateReportReceivedActorId:
+    """BT-17-006: execute_with_setup runs under receiving_actor_id, not actor_id.
+
+    The RM-INVALID transition targets the RECEIVING actor's CaseParticipant.
+    Before the fix, actor_id (sender) was passed instead.
+    """
+
+    def test_receiving_actor_participant_transitions_to_invalid(self):
+        """RM.INVALID transition targets the receiving actor's participant."""
+        dl = _make_dl(receiving_rm=RM.RECEIVED, sender_rm=RM.RECEIVED)
+
+        InvalidateReportReceivedUseCase(
+            dl=dl,
+            request=_make_invalidate_event(
+                receiving_actor_id=RECEIVING_ACTOR_ID
+            ),
+        ).execute()
+
+        assert (
+            _rm_state(dl, RECEIVING_ACTOR_ID) == RM.INVALID
+        ), "Receiving actor's participant must transition to RM.INVALID"
+
+    def test_sender_participant_unchanged_when_receiving_actor_differs(self):
+        """Sender's participant RM state is not touched (BT-17-006 regression)."""
+        dl = _make_dl(receiving_rm=RM.RECEIVED, sender_rm=RM.RECEIVED)
+
+        InvalidateReportReceivedUseCase(
+            dl=dl,
+            request=_make_invalidate_event(
+                receiving_actor_id=RECEIVING_ACTOR_ID
+            ),
+        ).execute()
+
+        assert _rm_state(dl, SENDER_ACTOR_ID) == RM.RECEIVED, (
+            "Sender's participant must remain RM.RECEIVED; only the receiving"
+            " actor's participant should be transitioned (BT-17-006)"
+        )
+
+    def test_fallback_to_actor_id_when_receiving_actor_id_is_none(self):
+        """Falls back to actor_id (sender) when receiving_actor_id is None."""
+        dl = _make_dl(receiving_rm=RM.RECEIVED, sender_rm=RM.RECEIVED)
+
+        InvalidateReportReceivedUseCase(
+            dl=dl,
+            request=_make_invalidate_event(receiving_actor_id=None),
+        ).execute()
+
+        assert _rm_state(dl, SENDER_ACTOR_ID) == RM.INVALID, (
+            "Fallback: sender's participant must transition when"
+            " receiving_actor_id is None and actor_id is the fallback"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests — CloseReportReceivedUseCase
+# ---------------------------------------------------------------------------
+
+
+class TestCloseReportReceivedActorId:
+    """BT-17-006: execute_with_setup runs under receiving_actor_id, not actor_id.
+
+    The RM-CLOSED transition targets the RECEIVING actor's CaseParticipant.
+    Before the fix, actor_id (sender) was passed instead.
+    """
+
+    def test_receiving_actor_participant_transitions_to_closed(self):
+        """RM.CLOSED transition targets the receiving actor's participant."""
+        # RM.CLOSED is only reachable from RM.INVALID, ACCEPTED, or DEFERRED
+        dl = _make_dl(receiving_rm=RM.INVALID, sender_rm=RM.RECEIVED)
+
+        CloseReportReceivedUseCase(
+            dl=dl,
+            request=_make_close_report_event(
+                receiving_actor_id=RECEIVING_ACTOR_ID
+            ),
+        ).execute()
+
+        assert (
+            _rm_state(dl, RECEIVING_ACTOR_ID) == RM.CLOSED
+        ), "Receiving actor's participant must transition to RM.CLOSED"
+
+    def test_sender_participant_unchanged_when_receiving_actor_differs(self):
+        """Sender's participant RM state is not touched (BT-17-006 regression)."""
+        dl = _make_dl(receiving_rm=RM.INVALID, sender_rm=RM.RECEIVED)
+
+        CloseReportReceivedUseCase(
+            dl=dl,
+            request=_make_close_report_event(
+                receiving_actor_id=RECEIVING_ACTOR_ID
+            ),
+        ).execute()
+
+        assert _rm_state(dl, SENDER_ACTOR_ID) == RM.RECEIVED, (
+            "Sender's participant must remain RM.RECEIVED; only the receiving"
+            " actor's participant should be transitioned (BT-17-006)"
+        )
+
+    def test_fallback_to_actor_id_when_receiving_actor_id_is_none(self):
+        """Falls back to actor_id (sender) when receiving_actor_id is None."""
+        # Sender needs RM.INVALID so RM.CLOSED transition is valid
+        dl = _make_dl(receiving_rm=RM.RECEIVED, sender_rm=RM.INVALID)
+
+        CloseReportReceivedUseCase(
+            dl=dl,
+            request=_make_close_report_event(receiving_actor_id=None),
+        ).execute()
+
+        assert _rm_state(dl, SENDER_ACTOR_ID) == RM.CLOSED, (
+            "Fallback: sender's participant must transition when"
+            " receiving_actor_id is None and actor_id is the fallback"
+        )

--- a/vultron/core/use_cases/received/actor/announce.py
+++ b/vultron/core/use_cases/received/actor/announce.py
@@ -130,7 +130,11 @@ class AnnounceVulnerabilityCaseReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
         )
         if result.status != Status.SUCCESS:

--- a/vultron/core/use_cases/received/case_participant.py
+++ b/vultron/core/use_cases/received/case_participant.py
@@ -65,7 +65,11 @@ class AddCaseParticipantToCaseReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
         )
         if result.status != Status.SUCCESS:
@@ -108,7 +112,11 @@ class RemoveCaseParticipantFromCaseReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
         )
         if result.status != Status.SUCCESS:

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -136,7 +136,11 @@ class AddEmbargoEventToCaseReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
             sync_port=self._sync_port,
         )
@@ -486,7 +490,11 @@ class RejectInviteToEmbargoOnCaseReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
         )
 

--- a/vultron/core/use_cases/received/report.py
+++ b/vultron/core/use_cases/received/report.py
@@ -190,7 +190,11 @@ class CreateReportReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
         )
         if result.status != Status.SUCCESS:
@@ -371,7 +375,11 @@ class InvalidateReportReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
         )
         if result.status != Status.SUCCESS:
@@ -459,7 +467,11 @@ class CloseReportReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
         )
         if result.status != Status.SUCCESS:

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -79,7 +79,11 @@ class AddCaseStatusToCaseReceivedUseCase:
         )
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
         )
 

--- a/vultron/core/use_cases/received/unknown.py
+++ b/vultron/core/use_cases/received/unknown.py
@@ -61,7 +61,11 @@ class UnresolvableObjectUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=(
+                request.receiving_actor_id
+                if request.receiving_actor_id is not None
+                else request.actor_id
+            ),
             activity=request,
         )
         if result.status != Status.SUCCESS:


### PR DESCRIPTION
- Closes #2338

## Summary

Fix 10 received-side use cases that passed \`request.actor_id\` (the sender)
instead of \`request.receiving_actor_id\` (the local actor) to
\`execute_with_setup\`, causing ledger entries and DataLayer operations to be
scoped to the remote peer rather than the receiving actor (BT-17-006).

## Changes

- **\`received/report.py\`**: fix \`CreateReportReceivedUseCase\`,
  \`InvalidateReportReceivedUseCase\`, \`CloseReportReceivedUseCase\` (3 sites)
- **\`received/embargo.py\`**: fix \`AddEmbargoEventToCaseReceivedUseCase\`,
  \`RejectInviteToEmbargoOnCaseReceivedUseCase\` (2 sites)
- **\`received/case_participant.py\`**: fix
  \`AddCaseParticipantToCaseReceivedUseCase\`,
  \`RemoveCaseParticipantFromCaseReceivedUseCase\` (2 sites)
- **\`received/status.py\`**: fix \`AddCaseStatusToCaseReceivedUseCase\` (1 site)
- **\`received/unknown.py\`**: fix \`UnresolvableObjectUseCase\` (1 site)
- **\`received/actor/announce.py\`**: fix
  \`AnnounceVulnerabilityCaseReceivedUseCase\` (1 site)
- **\`test/architecture/test_received_side_actor_id.py\`**: new architecture
  ratchet — AST-based; asserts that no received-side \`execute()\` passes
  \`actor_id=request.actor_id\` to \`execute_with_setup\`
- **\`test/core/use_cases/received/test_embargo_ledger_cascade.py\`**: fix two
  test setups that had \`case_manager_actor_id\` set to the sender instead of
  the case actor; the tests only passed before because the bug was using the
  sender's ID as the BT actor
- **\`test/core/use_cases/received/test_report_routing_guard.py\`**: new
  behavioral routing-guard tests for \`InvalidateReportReceivedUseCase\` and
  \`CloseReportReceivedUseCase\` — verify the RM-transition BT runs under the
  receiving actor's identity, not the sender's (BT-17-006)

All call sites use the defensive form:
\`request.receiving_actor_id if request.receiving_actor_id is not None else request.actor_id\`

## Verification

- [x] AC-1: all 10 received-side \`execute()\` sites pass \`receiving_actor_id\` (defensive form)
- [x] AC-2: architecture ratchet (\`test_received_side_actor_id.py\`) prevents regression
- [x] AC-3: per-use-case behavioral routing-guard tests for all GuardedCommit and RM-transition paths

---

- 7046 unit tests pass (216 lines added, new ratchet + routing-guard tests)
- 1135 integration tests pass
- Black, flake8, mypy, pyright all clean