### PR TITLE
docs: sweep ephemeral counts from spec cross-references; add MS-16 convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -765,6 +765,15 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   > /tmp/unit.log 2>&1; echo $?`. The spec-lint test
   (`test_real_specs_lint_no_hard_errors`) is particularly load-sensitive at ~3s
   against the 5s budget. *Source: ISSUE-2232*
+- **Never Restate Counts in Cross-References or Long-Lived Docs** — when a
+  spec entry, notes file, or AGENTS.md pitfall cross-references another spec,
+  omit the count: write "the universal types (DEMOMA-16-001)" not "the five
+  universal types (DEMOMA-16-001)". Counts drift silently when the authoritative
+  source is updated — the linter validates that the spec ID resolves, not the
+  prose next to it. The same applies to any long-lived doc: avoid counts like
+  "there are 4 unimplemented nodes" or "15 xfails" — these are stale snapshots.
+  See MS-16-001 and [notes/specs-vs-adrs.md](notes/specs-vs-adrs.md).
+  *Source: CONCERN-2277*
 
 ---
 

--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -202,7 +202,7 @@ scenario-specific phases to regress silently (e.g. `invite_actor_to_case`
 missing from a scenario that requires it).
 
 **Design**: Each scenario defines its own required event-type list that
-extends the five universal types with scenario-specific required phases.
+extends the universal types (DEMOMA-16-001) with scenario-specific required phases.
 The spec requirements in `specs/multi-actor-demo.yaml` DEMOMA-16-001 through
 DEMOMA-16-011 are the normative source; the test constants implement them.
 

--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -154,7 +154,7 @@ the minimum set's event-type and protocol-path coverage. (`fcv-reject` is the
 
 | Scenario | Covered by minimum set | Rationale |
 |---|:---:|---|
-| fv | ✓ (member) | 2-actor baseline; covers all 5 universal event types with no invitation phases |
+| fv | ✓ (member) | 2-actor baseline; covers all universal event types (DEMOMA-16-001) with no invitation phases |
 | fvcv-handoff | ✓ (member) | Adds `invite_actor_to_case` + `accept_invite_actor_to_case` + ownership-transfer protocol path |
 | fcvcv | ✓ (member) | Adds `offer_case_participant` + `accept_actor_recommendation` + ≥3-actor invite/accept chains |
 | fcv-reject | ✓ (member) | Adds `reject_invite_actor_to_case` — the only scenario where the Vendor sends `Reject(Invite(actor, case))` (invitation-layer rejection) |

--- a/notes/demo-ci-scenario-coverage.md
+++ b/notes/demo-ci-scenario-coverage.md
@@ -33,9 +33,7 @@ event types it exercises. Event types are those recorded as `event_type` in
 
 **Notes:**
 
-- The five universal types (`validate_report`, `add_participant_status_to_participant`,
-  `close_case`, `add_note_to_case`, `engage_case`) appear in every scenario
-  (DEMOMA-16-001).
+- The universal types (DEMOMA-16-001) appear in every scenario.
 - `engage_case` is universal because emission lives in the shared demo helper
   layer, not at scenario call sites: `run_direct_path_rm_triage()` calls
   `receiver_engages_case()` for the direct receiver (all eight multi-actor

--- a/notes/specs-vs-adrs.md
+++ b/notes/specs-vs-adrs.md
@@ -159,6 +159,48 @@ Generated spec requirements: `datalayer.yaml` DL-01 through DL-03.
 
 ---
 
+## Never State Ephemeral Counts in Long-Lived Docs
+
+Long-lived documents — specs, notes files, AGENTS.md — **MUST NOT state
+counts that will drift independently of their authoritative source** (MS-16-001).
+
+### The problem
+
+When a spec requirement like DEMOMA-16-001 defines an enumeration ("the five
+universal event types"), sibling requirements and cross-file citations are
+tempted to copy the count: "the five universal types (DEMOMA-16-001)". The
+linter validates that `DEMOMA-16-001` resolves; it has no opinion about the
+prose next to it. When DEMOMA-16-001 is updated (e.g., a sixth type is added),
+every copied count drifts silently — a reader who encounters a stale count first
+gets a false picture of the system. The count adds no normative force.
+
+The same applies to any long-lived doc: writing "there are 4 unimplemented
+nodes" or "15 xfails" is a snapshot virtually guaranteed to be wrong when read
+later.
+
+### The fix
+
+**When cross-referencing another spec**, omit the count and cite the source by
+ID:
+
+| Instead of | Write |
+|---|---|
+| "the five universal types (DEMOMA-16-001)" | "the universal types (DEMOMA-16-001)" |
+| "these four scenarios cover all types" | "these scenarios cover all types" |
+| "the full 9-scenario suite" | "the full scenario suite" |
+
+**Counts are only appropriate in the authoritative source itself** — the spec
+entry that *defines* the enumeration (e.g., DEMOMA-16-001 listing its own
+members is the authority for that count; siblings that cross-reference it are
+not).
+
+**In notes and AGENTS.md**, avoid counting items that can change: replace
+"there are 4 unimplemented nodes" with "the unimplemented nodes are listed in
+[...]"; replace "15 xfails" with "known-flaky tests are tracked in
+`notes/flaky-tests.md`".
+
+---
+
 ## Where the Authoritative Rules Live
 
 | Artifact | Location |

--- a/plan/history/2608/learning/CONCERN-2277.md
+++ b/plan/history/2608/learning/CONCERN-2277.md
@@ -1,0 +1,35 @@
+---
+source: CONCERN-2277
+timestamp: '2026-08-17T20:02:22.878778+00:00'
+title: Restated counts in spec cross-references drift silently
+type: learning
+---
+
+## Concern
+
+Numeric and enumerative prose that is *repeated across sibling requirements*
+drifts silently. The spec registry linter checks structure (ids, kinds,
+priorities, cross-reference targets) but nothing checks that two requirements
+telling the same story tell the same story.
+
+Concrete instance, found while doing ISSUE-2266: DEMOMA-16-001 declared four
+universal event types, and the phrase "the four universal types (DEMOMA-16-001)"
+was copied into **nine** sibling statements (DEMOMA-16-002 … -16-011) plus
+DEMOCI-04-004 and DEMOCI-06-002 in a second spec file. Promoting `engage_case`
+to the fifth universal type therefore required 12 coordinated edits to keep
+MUST-level statements factually true.
+
+The failure mode is spec-vs-spec drift: there is no test that can fail — a
+reader picks whichever statement they read first.
+
+## Resolution
+
+The broader principle: long-lived docs (specs, notes, AGENTS.md) must never
+state ephemeral counts that will drift out of sync. When cross-referencing
+another spec item, omit the count and cite the source by ID.
+
+**Resolved**: 2026-08-17 — implemented in PR #2349.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2349>.
+Spec: `specs/meta-specifications.yaml` (MS-16-001).
+Notes: `notes/specs-vs-adrs.md` (new section "Never State Ephemeral Counts").

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -435,8 +435,8 @@ groups:
           `test/ci/invariants/test_fv_invariants.py`) MUST include a
           per-scenario expected-event-types list that is comprehensive for that
           scenario: it MUST cover all protocol phases that the scenario is
-          designed to exercise, not only the five universal phases shared by
-          all scenarios.
+          designed to exercise, not only the universal phases (DEMOMA-16-001)
+          shared by all scenarios.
         rationale: >-
           A shared minimal list (validate_report,
           add_participant_status_to_participant, close_case, add_note_to_case,
@@ -575,12 +575,12 @@ groups:
         kind: project
         statement: >-
           The minimum PR validation scenario set is `fv`, `fvcv-handoff`,
-          `fcvcv`, and `fcv-reject`. Together these four scenarios cover all
+          `fcvcv`, and `fcv-reject`. Together these scenarios cover all
           distinct protocol event types exercised by the full scenario suite:
-          the five universal types plus `invite_actor_to_case`,
+          the universal types (DEMOMA-16-001) plus `invite_actor_to_case`,
           `offer_case_participant`, `accept_invite_actor_to_case`,
           `accept_actor_recommendation`, and `reject_invite_actor_to_case`.
-          The `demo-integration.yml` workflow MUST use this 4-scenario set as
+          The `demo-integration.yml` workflow MUST use this scenario set as
           the `pull_request` matrix and run only these scenarios on every PR
           commit.
         rationale: >-
@@ -602,11 +602,11 @@ groups:
         priority: MUST
         kind: project
         statement: >-
-          The full 9-scenario suite MUST run on push events to main, regardless
+          The full scenario suite MUST run on push events to main, regardless
           of which subset runs for PR validation, so that all scenario variants
           continue to generate case-log invariant signals on the default branch.
           The `demo-integration.yml` workflow MUST include a `push: branches:
-          ["main"]` trigger that runs all 9 scenarios (`fv`, `fvv`,
+          ["main"]` trigger that runs all scenarios (`fv`, `fvv`,
           `fvcv-extension`, `fvcv-handoff`, `fccv-extension`, `fccv-handoff`,
           `fcvcv`, `fcv`, `fcv-reject`).
         rationale: >-

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -550,7 +550,7 @@ groups:
         kind: project
         statement: >-
           A scenario coverage analysis MUST be performed that maps each of the
-          8 demo scenarios to the distinct Vultron protocol phases and
+          demo scenarios to the distinct Vultron protocol phases and
           message-type milestones it exercises, producing a coverage matrix.
           The analysis MUST inspect the actual milestone sets defined in each
           scenario script (not assume they are complete), and MAY update
@@ -558,7 +558,7 @@ groups:
           left them incomplete. The validated coverage matrix MUST be recorded
           in `notes/demo-ci-scenario-coverage.md`.
         rationale: >-
-          The 8 scenarios share common helper phases but each exercises a
+          The scenarios share common helper phases but each exercises a
           distinct set of protocol phases (e.g. invite_actor_to_case,
           offer_case_participant, accept_invite_actor_to_case). Milestone sets
           were often copied from simpler scenarios and may under-report what a
@@ -653,7 +653,7 @@ groups:
           signal read as noise rather than a real regression.
 
           Deriving both matrices from one JSON file also removes the verbatim
-          9-entry matrix duplication between the `demo` and `invariant-harness`
+          matrix duplication between the `demo` and `invariant-harness`
           jobs, where the two copies could silently drift apart.
 
           Detection is delegated to `actionlint` in CI and pre-commit
@@ -729,7 +729,7 @@ groups:
         statement: >-
           A follow-up coverage analysis SHOULD be performed after `rcv-embargo`
           and `rcvv-embargo` are implemented and passing in CI. The analysis
-          MUST evaluate whether the 3-scenario minimum PR set defined in
+          MUST evaluate whether the minimum PR set defined in
           DEMOCI-06-002 requires expansion to preserve full embargo lifecycle
           protocol coverage, and MUST update `notes/demo-ci-scenario-coverage.md`,
           DEMOCI-06-002, and DEMOCI-06-003 accordingly. If the embargo scenarios
@@ -741,10 +741,9 @@ groups:
           DEMOCI-06-002 defined the minimum PR set before embargo-lifecycle
           scenarios existed. The embargo protocol messages (EP, EA, EV, EJ, ET)
           are not exercised by any scenario in the current minimum set.
-          DEMOCI-06-003 was updated in this PR to list exactly 8 scenarios by
-          name; after #2073 adds rcv-embargo and rcvv-embargo to the CI matrix
-          that count becomes 10, so DEMOCI-06-003 must be updated in the same
-          pass. This SHOULD-priority spec creates an explicit obligation to
+          DEMOCI-06-003 lists the full scenario suite by name; after #2073
+          adds rcv-embargo and rcvv-embargo to the CI matrix, DEMOCI-06-003
+          must be updated in the same pass. This SHOULD-priority spec creates an explicit obligation to
           revisit both coverage specs rather than letting either gap go unnoticed.
         relationships:
           - rel_type: refines

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -571,3 +571,39 @@ groups:
     tags:
     - documentation
     - tooling
+
+- id: MS-16
+  title: Long-Lived Docs Must Not State Ephemeral Counts
+  specs:
+  - id: MS-16-001
+    priority: MUST
+    kind: process
+    statement: >-
+      A spec statement, notes file, or AGENTS.md entry MUST NOT restate a
+      count that will drift independently of the authoritative source.
+      When cross-referencing another spec item, omit the count and cite the
+      source by ID: write "the universal types (DEMOMA-16-001)" not "the five
+      universal types (DEMOMA-16-001)". Counts in enumerations that are the
+      authoritative source (e.g. DEMOMA-16-001 itself listing its own members)
+      are not subject to this rule.
+    rationale: >-
+      Counts restated in cross-references drift silently: when the authoritative
+      requirement is updated, its sibling references and cross-file citations
+      are not. The linter validates that a referenced spec ID resolves; it
+      has no opinion about the prose next to it. A reader who encounters the
+      stale count first gets a false picture of the system. The count adds no
+      normative force — "the universal types (DEMOMA-16-001)" is equally
+      specific because the ID is the authoritative pointer. This class of
+      drift required 12 coordinated edits when `engage_case` was promoted
+      to a fifth universal event type in ISSUE-2266 (CONCERN-2277).
+      The same principle extends beyond spec cross-references to any
+      long-lived document: notes files, AGENTS.md pitfall entries, and
+      architecture docs MUST NOT state counts such as "there are 4
+      unimplemented nodes" or "15 xfails" — these are snapshots guaranteed
+      to be wrong when read in the future.
+    relationships:
+    - rel_type: derives_from
+      spec_id: MS-04-001
+      note: extends spec-authoring rules with a count-drift prohibition
+    tags:
+    - documentation

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1857,7 +1857,7 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      In addition to the five universal types (DEMOMA-16-001), the FV scenario
+      In addition to the universal types (DEMOMA-16-001), the FV scenario
       MUST verify that its expected-event-types list is restricted to types that
       the FV scenario actually produces. FV does not include an
       `invite_actor_to_case` phase; the Finder joins by submitting a report,
@@ -1874,7 +1874,7 @@ groups:
     statement: >-
       The FVV scenario expected-event-types list MUST include
       `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
-      to the five universal types (DEMOMA-16-001), because Vendor1 invites
+      to the universal types (DEMOMA-16-001), because Vendor1 invites
       Vendor2 into the case and Vendor2 explicitly accepts via the
       `accept-case-invite` trigger.
     relationships:
@@ -1890,7 +1890,7 @@ groups:
       The FVCV-extension scenario expected-event-types list MUST include
       `invite_actor_to_case`, `offer_case_participant`,
       `accept_invite_actor_to_case`, and `accept_actor_recommendation` in
-      addition to the five universal types (DEMOMA-16-001), because Vendor1
+      addition to the universal types (DEMOMA-16-001), because Vendor1
       invites Coordinator, Coordinator uses the ADR-0026 suggest-actor flow
       (`offer_case_participant`) to propose Vendor2, Vendor1 approves the
       recommendation (`accept_actor_recommendation`), CaseActor converts the
@@ -1908,7 +1908,7 @@ groups:
     statement: >-
       The FVCV-handoff scenario expected-event-types list MUST include
       `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
-      to the five universal types (DEMOMA-16-001), because Vendor1 invites
+      to the universal types (DEMOMA-16-001), because Vendor1 invites
       Coordinator, the Coordinator accepts and becomes the new CASE_OWNER,
       and Coordinator then invites Vendor2 who also accepts.
     rationale: >-
@@ -1933,7 +1933,7 @@ groups:
     statement: >-
       The FCCV-handoff scenario expected-event-types list MUST include
       `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
-      to the five universal types (DEMOMA-16-001), because C1 invites C2,
+      to the universal types (DEMOMA-16-001), because C1 invites C2,
       C2 accepts and becomes the new CASE_OWNER, and C2 then invites the
       Vendor who also accepts.
     relationships:
@@ -1948,7 +1948,7 @@ groups:
     statement: >-
       The FCV scenario expected-event-types list MUST include
       `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
-      to the five universal types (DEMOMA-16-001), because the Coordinator
+      to the universal types (DEMOMA-16-001), because the Coordinator
       invites both the Finder and the Vendor into the case, and both Finder
       and Vendor explicitly accept via the `accept-case-invite` trigger.
     relationships:
@@ -1981,7 +1981,7 @@ groups:
       The FCVCV scenario expected-event-types list MUST include
       `invite_actor_to_case`, `offer_case_participant`,
       `accept_invite_actor_to_case`, and `accept_actor_recommendation` in
-      addition to the five universal types (DEMOMA-16-001).
+      addition to the universal types (DEMOMA-16-001).
       `invite_actor_to_case` appears at least three times (C1 invites V1, C1
       invites C2, and CaseActor invites V2 via the ADR-0026 path);
       `offer_case_participant` appears at least once (C2 suggests V2 to C1
@@ -2020,7 +2020,7 @@ groups:
       The FCCV-extension scenario expected-event-types list MUST include
       `invite_actor_to_case`, `offer_case_participant`,
       `accept_invite_actor_to_case`, and `accept_actor_recommendation` in
-      addition to the five universal types (DEMOMA-16-001), because
+      addition to the universal types (DEMOMA-16-001), because
       Coordinator1 invites Coordinator2, Coordinator2 uses the ADR-0026
       suggest-actor flow (`offer_case_participant`) to propose the Vendor,
       Coordinator1 approves the recommendation (`accept_actor_recommendation`),
@@ -2038,7 +2038,7 @@ groups:
     statement: >-
       The FCV-reject scenario expected-event-types list MUST include
       `invite_actor_to_case` and `reject_invite_actor_to_case` in addition to
-      the five universal types (DEMOMA-16-001), because the Coordinator invites
+      the universal types (DEMOMA-16-001), because the Coordinator invites
       the Vendor and the Vendor sends `Reject(Invite(actor, case))` (an
       invitation-layer rejection), which triggers
       `RejectInviteActorToCaseReceivedUseCase` on the CaseActor and produces


### PR DESCRIPTION
- Closes #2277
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Restated counts in spec cross-references drift silently when the authoritative
source is updated — promoting `engage_case` to a fifth universal event type
required 12 coordinated edits (ISSUE-2266). This PR removes the restated counts
and codifies the no-ephemeral-counts convention in MS-16-001.

## Changes

- **`specs/multi-actor-demo.yaml`**: Remove "five" from all 9 DEMOMA-16-xxx
  sibling statements (`"the five universal types (DEMOMA-16-001)"` →
  `"the universal types (DEMOMA-16-001)"`)
- **`specs/demo-ci.yaml`**: Remove ephemeral counts from DEMOCI-04-004
  (`"five universal phases"` → `"universal phases (DEMOMA-16-001)"`),
  DEMOCI-06-002 (`"four scenarios"` → `"these scenarios"`, `"4-scenario set"`
  → `"scenario set"`, `"five universal types"` → `"universal types
  (DEMOMA-16-001)"`), and DEMOCI-06-003 (`"9-scenario suite"` →
  `"scenario suite"`, `"all 9 scenarios"` → `"all scenarios"`)
- **`specs/meta-specifications.yaml`**: Add MS-16 group with MS-16-001 MUST
  rule prohibiting ephemeral counts in all long-lived docs (specs, notes,
  AGENTS.md)
- **`notes/specs-vs-adrs.md`**: Add "Never State Ephemeral Counts" section
  with before/after examples and rationale
- **`notes/demo-ci-scenario-coverage.md`**: Replace `"The five universal
  types (...)"` note with `"The universal types (DEMOMA-16-001)"`
- **`AGENTS.md`**: Add pitfall entry citing MS-16-001 and CONCERN-2277