### PR TITLE
fix(devcontainer): wire ~/.agents/skills into Claude Code skill discovery

### DIFF
--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -49,8 +49,13 @@ set -g set-clipboard on
 set -g default-shell /bin/zsh
 EOF
 
-# ~/.claude is a bind-mount of the host's ~/.claude — the host manages its own
-# skills symlink. Nothing to do here.
+# Wire user-level skills into Claude Code's discovery path.
+# start-dev.sh mounts the host's ~/.agents/skills into the container at
+# ~/.agents/skills. Claude Code looks for skills under ~/.claude/skills, so
+# create the symlink if the mount landed and the link doesn't already exist.
+if [ -d "$HOME/.agents/skills" ] && [ ! -e "$HOME/.claude/skills" ]; then
+    ln -s "$HOME/.agents/skills" "$HOME/.claude/skills"
+fi
 
 echo ""
 echo "Post-create complete. Run 'claude' to start Claude Code."


### PR DESCRIPTION
## Summary

Restores user-level skill visibility (e.g. `graphify`) that was lost when commit `95a95867` replaced the host `~/.claude` bind-mount with a named Docker volume.

## Changes

- **`.devcontainer/postcreate.sh`**: Replace the stale "bind-mount" comment with a `ln -s` that wires `~/.claude/skills → ~/.agents/skills` on first container creation. The host skills directory is already mounted at `~/.agents/skills` by `start-dev.sh`; this one-liner closes the gap so Claude Code's skill discovery finds it.

## Root cause

`start-dev.sh` mounts `$HOME/.agents/skills` into the container at `/home/vscode/.agents/skills`. Claude Code discovers skills under `~/.claude/skills`. When the host `~/.claude` was bind-mounted (the old design), the host's own `skills → ~/.agents/skills` symlink came along for free. After the switch to a named volume (`~/.data`), `~/.claude` became a plain container directory with no `skills` entry, and user-level skills silently disappeared.

## Verification

- Applied the symlink live in the running container and confirmed `~/.claude/skills/graphify/` is reachable.
- `postcreate.sh` guard (`[ ! -e "$HOME/.claude/skills" ]`) makes the step idempotent on subsequent runs.
- Black, flake8, mypy clean.