### PR TITLE
fix(outbox): per-activity abort scope + 4xx terminal classification

### DIFF
--- a/notes/outbox-delivery-reliability.md
+++ b/notes/outbox-delivery-reliability.md
@@ -56,21 +56,27 @@ while dl.outbox_list():
             break
 
 # AFTER
+activity_err_counts: dict[str, int] = {}  # declared OUTSIDE the while loop
 while dl.outbox_list():
     activity_id = dl.outbox_pop()
-    per_activity_err = 0
     ...
     except Exception as e:
         dl.outbox_append(activity_id)
-        per_activity_err += 1
-        if per_activity_err > 3:
+        activity_err_counts[activity_id] = activity_err_counts.get(activity_id, 0) + 1
+        per_err = activity_err_counts[activity_id]
+        if per_err > 3:
+            # Break only when every remaining item is also capped.
+            if all(activity_err_counts.get(i, 0) > 3 for i in dl.outbox_list()):
+                break
             continue  # skip this activity for this pass, process others
-        backoff = (2 ** (per_activity_err - 1)) + random.uniform(0, 0.5)
+        backoff = (2 ** (per_err - 1)) + random.uniform(0, 0.5)
         await asyncio.sleep(backoff)
 ```
 
-The per-pass cap (skip after 4 per-activity failures) is retained as a backstop;
-`continue` replaces `break` so other activities in the queue are unaffected.
+The per-activity dict is declared **outside** the while loop so error counts
+persist across queue iterations within a drain pass. `continue` replaces `break`
+so other activities in the queue are unaffected. Break fires only when every
+remaining item in the queue has also hit its per-pass cap (OX-13-006).
 
 **Spec:** OX-13-006.
 

--- a/plan/incoming/learnings/20260818-outbox-abort-scope-per-activity-dict.md
+++ b/plan/incoming/learnings/20260818-outbox-abort-scope-per-activity-dict.md
@@ -1,0 +1,57 @@
+---
+title: Per-activity outbox error counter requires a dict outside the while loop, not a reset-per-iteration variable
+type: learning
+timestamp: 2026-08-18
+source: ISSUE-2315
+signal: design-question
+---
+
+## Decision
+
+`notes/outbox-delivery-reliability.md` Task AB shows pseudocode with
+`per_activity_err = 0` *inside* the `while dl.outbox_list():` block:
+
+```python
+while dl.outbox_list():
+    activity_id = dl.outbox_pop()
+    per_activity_err = 0        # <-- resets every iteration
+    ...
+    except Exception as e:
+        per_activity_err += 1
+        if per_activity_err > 3:
+            continue
+```
+
+This never fires: `per_activity_err` resets to 0 at the top of each iteration,
+so it can only ever reach 1 per iteration, never exceeding the cap of 3.
+
+## Correct Implementation
+
+Use a dict keyed by activity ID, declared *outside* the while loop:
+
+```python
+activity_err_counts: dict[str, int] = {}
+while dl.outbox_list():
+    activity_id = dl.outbox_pop()
+    try:
+        ...
+    except Exception as e:
+        activity_err_counts[activity_id] = activity_err_counts.get(activity_id, 0) + 1
+        per_err = activity_err_counts[activity_id]
+        if per_err > 3:
+            # Terminate only when ALL remaining queue entries are also capped
+            if all(activity_err_counts.get(i, 0) > 3 for i in dl.outbox_list()):
+                break
+            continue
+        backoff = (2 ** (per_err - 1)) + random.uniform(0, 0.5)
+        await asyncio.sleep(backoff)
+```
+
+The all-capped termination guard is required: without it, a single
+permanently-failing activity is re-queued and re-popped forever, producing an
+infinite loop.
+
+## Implication
+
+The pseudocode in `notes/outbox-delivery-reliability.md` should be updated to
+reflect the correct implementation before the next implementation of Task C/D.

--- a/test/adapters/driven/test_delivery_backoff.py
+++ b/test/adapters/driven/test_delivery_backoff.py
@@ -274,6 +274,63 @@ class TestDeliveryRetry:
                 with pytest.raises(Exception):
                     asyncio.run(adapter.emit(activity, [RECIPIENT_URI]))
 
+    def test_4xx_raises_delivery_error_immediately_without_retry(self):
+        """HTTP 4xx is terminal: DeliveryError raised on first attempt, no retries, no sleep (OX-13-005 AC-2/AC-4)."""
+        import pytest
+
+        adapter = HttpDeliveryAdapter(max_retries=3, initial_delay=0.0)
+        activity = _make_activity()
+        call_count = 0
+
+        async def four_xx(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_resp = MagicMock()
+            mock_resp.status_code = 422
+            mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "422 Unprocessable Entity",
+                request=MagicMock(),
+                response=mock_resp,
+            )
+            return mock_resp
+
+        with patch("httpx2.AsyncClient.post", side_effect=four_xx):
+            with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                with pytest.raises(Exception):
+                    asyncio.run(adapter.emit(activity, [RECIPIENT_URI]))
+
+        assert call_count == 1, "4xx must not consume retry slots"
+        mock_sleep.assert_not_called()
+
+    def test_5xx_retries_up_to_max_retries(self):
+        """HTTP 5xx is retryable: exhausts all retry slots (OX-13-005 AC-4)."""
+        import pytest
+
+        adapter = HttpDeliveryAdapter(
+            max_retries=2, initial_delay=0.0, backoff_multiplier=1.0
+        )
+        activity = _make_activity()
+        call_count = 0
+
+        async def five_xx(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_resp = MagicMock()
+            mock_resp.status_code = 503
+            mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "503 Service Unavailable",
+                request=MagicMock(),
+                response=mock_resp,
+            )
+            return mock_resp
+
+        with patch("httpx2.AsyncClient.post", side_effect=five_xx):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(Exception):
+                    asyncio.run(adapter.emit(activity, [RECIPIENT_URI]))
+
+        assert call_count == 3, "5xx must exhaust max_retries + 1 = 3 attempts"
+
     def test_zero_retries_attempts_once_only(self):
         adapter = HttpDeliveryAdapter(max_retries=0, initial_delay=0.0)
         activity = _make_activity()

--- a/test/adapters/driving/fastapi/test_outbox_handler.py
+++ b/test/adapters/driving/fastapi/test_outbox_handler.py
@@ -184,6 +184,45 @@ def test_outbox_handler_continues_after_one_error(monkeypatch):
     assert "urn:test:good" in processed
 
 
+def test_failing_activity_does_not_block_healthy_activity_in_same_pass(
+    monkeypatch,
+):
+    """Multiple distinct failing activities must not exhaust a shared error counter
+    and block healthy activities that follow in the same drain pass (OX-13-006 AC-3).
+
+    With the old shared err_count, 4 different bad items each fail once and the
+    shared counter hits 4 before the good item is ever reached.  With the fix
+    (per-activity counter), each bad item has its own count; the good item is
+    always delivered.
+    """
+    queue = _make_queue(
+        "urn:test:bad-1",
+        "urn:test:bad-2",
+        "urn:test:bad-3",
+        "urn:test:bad-4",
+        "urn:test:good",
+    )
+    mock_dl = _mock_dl_with_queue(queue)
+
+    processed = []
+
+    async def sometimes_raise(actor_id, activity_id, dl, emitter):
+        if "bad" in activity_id:
+            raise RuntimeError("permanent failure")
+        processed.append(activity_id)
+
+    monkeypatch.setattr(oh, "handle_outbox_item", sometimes_raise)
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(oh.asyncio, "sleep", no_sleep)
+
+    asyncio.run(oh.outbox_handler("actor-xyz", mock_dl))
+
+    assert "urn:test:good" in processed
+
+
 def test_outbox_handler_resolves_actor_by_short_id(monkeypatch):
     """outbox_handler falls back to find_actor_by_short_id when full ID lookup fails."""
     queue: list[str] = []

--- a/vultron/adapters/driven/http_delivery.py
+++ b/vultron/adapters/driven/http_delivery.py
@@ -192,6 +192,7 @@ class HttpDeliveryAdapter:
         delay = self._initial_delay
 
         for attempt in range(self._max_retries + 1):
+            last_exc: Exception
             try:
                 response = await client.post(
                     inbox_url,
@@ -207,29 +208,43 @@ class HttpDeliveryAdapter:
                     response.status_code,
                 )
                 return
-            except Exception as exc:
-                if attempt < self._max_retries:
-                    logger.warning(
-                        "Delivery attempt %d/%d failed for activity %s "
-                        "to %s: %s — retrying in %.1fs",
-                        attempt + 1,
-                        self._max_retries + 1,
-                        activity_id,
-                        inbox_url,
-                        exc,
-                        delay,
-                    )
-                    await asyncio.sleep(delay)
-                    delay = min(
-                        delay * self._backoff_multiplier, self._max_delay
-                    )
-                else:
+            except httpx.HTTPStatusError as exc:
+                if 400 <= exc.response.status_code < 500:
+                    # 4xx is deterministic: the same payload will never succeed.
+                    # Raise immediately without consuming retry slots (OX-13-005).
                     logger.error(
-                        "Failed to deliver activity %s to %s after %d "
-                        "attempt(s): %s",
+                        "Terminal delivery failure (HTTP %d) for activity %s"
+                        " to %s — not retrying (OX-13-005).",
+                        exc.response.status_code,
                         activity_id,
                         inbox_url,
-                        self._max_retries + 1,
-                        exc,
                     )
                     raise DeliveryError([recipient_id], activity_id) from exc
+                last_exc = exc
+            except Exception as exc:
+                last_exc = exc
+
+            # Retryable failure (5xx or network error).
+            if attempt < self._max_retries:
+                logger.warning(
+                    "Delivery attempt %d/%d failed for activity %s "
+                    "to %s: %s — retrying in %.1fs",
+                    attempt + 1,
+                    self._max_retries + 1,
+                    activity_id,
+                    inbox_url,
+                    last_exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * self._backoff_multiplier, self._max_delay)
+            else:
+                logger.error(
+                    "Failed to deliver activity %s to %s after %d "
+                    "attempt(s): %s",
+                    activity_id,
+                    inbox_url,
+                    self._max_retries + 1,
+                    last_exc,
+                )
+                raise DeliveryError([recipient_id], activity_id) from last_exc

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -240,7 +240,7 @@ async def outbox_handler(
         return
 
     logger.debug("Processing outbox for actor %s", actor_id)
-    err_count = 0
+    activity_err_counts: dict[str, int] = {}
     while dl.outbox_list():
         activity_id = dl.outbox_pop()
         if activity_id is None:
@@ -253,14 +253,23 @@ async def outbox_handler(
                 "Error processing outbox item for actor %s: %s", actor_id, e
             )
             dl.outbox_append(activity_id)
-            err_count += 1
-            if err_count > 3:
+            activity_err_counts[activity_id] = (
+                activity_err_counts.get(activity_id, 0) + 1
+            )
+            per_err = activity_err_counts[activity_id]
+            if per_err > 3:
                 logger.error(
-                    "Too many errors processing outbox for actor %s,"
-                    " aborting.",
+                    "Too many errors for outbox item %s (actor %s),"
+                    " skipping for this pass (OX-13-006).",
+                    activity_id,
                     actor_id,
                 )
-                break
+                # Stop when every remaining item has already hit its cap.
+                if all(
+                    activity_err_counts.get(i, 0) > 3 for i in dl.outbox_list()
+                ):
+                    break
+                continue
             # Back off before retrying to avoid hammering a busy recipient.
-            backoff = (2 ** (err_count - 1)) + random.uniform(0, 0.5)
+            backoff = (2 ** (per_err - 1)) + random.uniform(0, 0.5)
             await asyncio.sleep(backoff)


### PR DESCRIPTION
- Closes #2315

## Summary

Fixes two delivery-path defects in the outbox layer: a shared error counter
that let one failing activity abort delivery for all others in the same drain
pass, and a missing 4xx-terminal classification that caused client-error
responses to be retried like transient failures.

## Changes

- **`vultron/adapters/driving/fastapi/outbox_handler.py`**: replace the
  single function-local `err_count` with a per-activity `dict[str, int]`.
  When an activity exceeds the per-pass cap, use `continue` (not `break`)
  so the drain loop processes remaining activities; break only when every
  remaining queue entry is also capped (OX-13-006).
- **`vultron/adapters/driven/http_delivery.py`**: add an
  `except httpx.HTTPStatusError` guard before the bare `except Exception` in
  `_deliver_with_retry`; 4xx responses raise `DeliveryError` immediately
  without consuming retry slots or sleeping; 5xx and network errors continue
  through the existing backoff loop (OX-13-005).
- **`test/adapters/driving/fastapi/test_outbox_handler.py`**: add AC-3
  regression — 4 distinct bad activities do not prevent a healthy activity
  from being delivered in the same drain pass.
- **`test/adapters/driven/test_delivery_backoff.py`**: add AC-4 tests —
  4xx-terminal path (no retries, no sleep) and 5xx-retryable path (exhausts
  all retry slots) exercised separately.

## Verification

- 28 tests pass in the two affected test modules (25 pre-existing + 3 new)
- Full unit suite: 7056 passed, 372 skipped, 4 xfailed
- Integration suite: 1156 passed, 2 xfailed
- Black, flake8, mypy, pyright all clean
- [x] AC-1: `outbox_handler.py` uses per-activity error counter; failure of one activity does not prevent others from being delivered in the same pass
- [x] AC-2: `http_delivery.py` raises `DeliveryError` immediately on HTTP 4xx without sleeping or retrying
- [x] AC-3: test confirms 4 failing activities do not block a healthy activity in the same drain pass
- [x] AC-4: 4xx-terminal and 5xx-retryable paths tested separately