### PR TITLE
docs: plan concern #2325 — async race windows in fv-demo (demo_check vs demo_gate)

### DIFF
--- a/notes/demo-ci-diagnostics.md
+++ b/notes/demo-ci-diagnostics.md
@@ -287,6 +287,99 @@ addition to INFO-level delivery/receipt/commit lines.
 
 ---
 
+## Async Race Window Patterns
+
+Demo CI timeouts and out-of-order state failures are usually one of two
+shapes. Recognizing the shape tells you which layer broke and whether the
+fix is in the demo script or the protocol code.
+
+### The BackgroundTasks delivery gap
+
+Every trigger endpoint (`validate-report`, `engage-case`, etc.) returns
+HTTP 202 before its protocol effects are committed. The effect — a
+`ParticipantStatus` write, a `CaseLedgerEntry`, a replica arriving on
+another container — lands later, in a `BackgroundTasks` callback. A demo
+step that depends on that effect must wait for it explicitly. If it does
+not, one of two failure modes appears in CI:
+
+**Shape A — wrong precondition state**: the dependent step runs before the
+effect commits. The BT or use case detects the missing state (e.g.,
+`TransitionParticipantRMtoAccepted` rejects a 422 because RM.VALID has not
+committed yet) and the demo fails with a protocol-level error that looks
+like a bug rather than a timing issue.
+
+**Shape B — inconsistent replica comparison**: the demo reads a replica
+before it has all entries, computes a result (e.g., ledger tail index,
+state diff), and either the assertion passes on wrong data or the timeout
+fires while the replica is mid-delivery. Both produce flaky results across
+CI runs with different container load.
+
+### Recognizing causal vs temporal waits
+
+Ask one question about each `wait_for_*` call: **if this wait times out
+and the next step runs anyway, does the next step operate on state that was
+never established?**
+
+- **Yes** → the wait is a causal precondition. The next step depends on it.
+  Wrap it in `demo_gate`. A `demo_check` wrapper records the miss and
+  continues — the dependent step then runs blind, producing a confusing
+  secondary failure that obscures the root cause.
+
+- **No** → the wait is temporal (service liveness, transport backoff, or a
+  post-hoc verification). `demo_check` is appropriate. Identify it as
+  temporal at the call site per EDF-06-006 so it is not mistaken for a
+  causal gate in a future edit.
+
+Common causal waits (should be `demo_gate`):
+
+| Wait | Precondition for |
+|---|---|
+| `wait_for_participant_rm_state` to RM.VALID | `engage-case` trigger (rejects at 422 if RM.VALID not committed) |
+| `wait_for_case_on_container` (replica present) | `wait_for_contiguous_ledger_coverage` (needs genesis hash to anchor chain) |
+| `wait_for_contiguous_ledger_coverage` | any state comparison across replicas |
+| `wait_for_event_type_in_ledger` (close phase) | reading ledger tail on a complete replica |
+
+Common temporal waits (may stay `demo_check` if they do not gate a
+downstream step):
+
+| Wait | Why temporal |
+|---|---|
+| `wait_for_case_participants` | cross-container delivery budget; timeout is a time-based estimate, not a protocol precondition the system can accelerate |
+
+### Diagnosing a timeout in CI
+
+1. Find the `demo_check`/`demo_gate` failure message in `demo-runner.log`.
+2. Check which `wait_for_*` timed out and note what follows it in the
+   scenario script.
+3. Apply the causal-vs-temporal test above to the timed-out wait.
+4. If causal: the wait should be a `demo_gate`. Look for a `demo_check`
+   wrapper or bare `wait_for_*` call (no wrapper) — bare calls raise
+   `AssertionError` directly, bypassing the failure accumulator entirely.
+5. If temporal: the timeout budget may be under-sized for the CI
+   environment. Check the comment at the `wait_for_*` call site in
+   `vultron/demo/helpers/polling.py` for the EDF-06-006 justification.
+   Raising the budget is a last resort; verify first that the underlying
+   delivery is not silently failing.
+
+### Bare calls are not equivalent to `demo_gate`
+
+A `wait_for_*` call with no wrapper looks like a gate but is not:
+
+- It raises `AssertionError` directly on timeout, bypassing the demo
+  harness's failure accumulator.
+- The scenario may have accumulated earlier `demo_check` failures that are
+  lost when the bare raise propagates to `scenario_harness`.
+- Downstream steps do not get the structured "precondition not met" skip
+  that `demo_gate` provides; they simply never run because the exception
+  terminates the scenario.
+
+Wrap all `wait_for_*` calls in either `demo_gate` (causal) or `demo_check`
+(temporal, non-gating). No bare calls. See `vultron/demo/AGENTS.md`
+§ "Gate Each Step on Its Cause" and § "Never Wrap a Causal Wait in
+`demo_check`" for the enforcement rule and anti-pattern examples.
+
+---
+
 ## Ratchet Workflow Reference
 
 When a fix lands that resolves an xfail invariant, see

--- a/plan/history/2608/learning/CONCERN-2325.md
+++ b/plan/history/2608/learning/CONCERN-2325.md
@@ -1,0 +1,52 @@
+---
+source: CONCERN-2325
+timestamp: '2026-08-19T14:34:34.227166+00:00'
+title: demo_check vs demo_gate — causal precondition gating in fv-demo
+type: learning
+---
+
+## Concern
+
+Async race windows in `fv_demo.py` beyond the genesis ordering guard (ADR-0059).
+Several `wait_for_*` calls that are causal preconditions for subsequent steps were
+wrapped in `demo_check` (records failure and continues) instead of `demo_gate`
+(blocks dependent steps on failure). One call was a bare unwrapped call.
+
+## Investigation findings
+
+- `demo_check` wrapping a causal wait lets the dependent step run on unestablished
+  state, producing confusing secondary failures (422s from triggers, invalid
+  snapshot comparisons) that mask the root cause.
+- A bare `wait_for_*` call raises `AssertionError` directly, bypassing the harness
+  failure accumulator — earlier `demo_check` failures are lost.
+- Investigation of `wait_for_case_participants` (L509) revealed that `fv_demo.py`
+  was bypassing the real CaseProposal round-trip entirely: it called
+  `post_to_trigger(create-case)` and `seed_case_participants_for_demo` directly,
+  making the wait a no-op poll on already-committed state. The real CaseProposal
+  dance (vendor → CaseActor → Accept + Create(VulnerabilityCase)) is exercised by
+  `fvcv_handoff_demo` via `run_direct_path_rm_triage` and the vendor's own
+  case-actor service at port 7999.
+- `LedgerGapBuffer` already handles out-of-order `Announce(CaseLedgerEntry)`
+  deliveries (both pre-genesis and non-genesis), so the concern's first bullet
+  was already mitigated at the actor level.
+
+## Outcome
+
+**Docs PR**: <https://github.com/CERTCC/Vultron/pull/2374> (`Closes #2325`)
+
+New spec entries:
+
+- `EDF-06-008`: temporal wait timeouts MUST be justified at the call site
+- `DEMOMA-22-007`: every `wait_for_*` call MUST be wrapped in `demo_gate` or
+  `demo_check`; bare calls prohibited
+
+New notes section: `notes/demo-ci-diagnostics.md` § "Async Race Window Patterns"
+
+New AGENTS.md pitfall: `vultron/demo/AGENTS.md` § "Never Wrap a Causal Wait in
+`demo_check`" — before/after code examples for all three anti-patterns.
+
+**Implementation issues spawned**:
+
+- #2372: fix fv-demo to use real CaseProposal round-trip (prerequisite)
+- #2375: migrate `demo_check`-wrapped causal waits to `demo_gate` in
+  `fv_demo.py` and `fvcv_handoff_demo.py` (blocked-by #2372)

--- a/specs/event-driven-control-flow.yaml
+++ b/specs/event-driven-control-flow.yaml
@@ -245,3 +245,26 @@ groups:
     tags:
     - demo
     - testing
+  - id: EDF-06-008
+    priority: MUST
+    kind: project
+    statement: >-
+      The timeout value of a temporal wait (EDF-06-006) MUST be accompanied by
+      a comment at the call site that names the delivery chain being bounded and
+      justifies the chosen value relative to worst-case BackgroundTasks delivery
+      across the containers involved.
+    rationale: >-
+      A bare integer timeout (e.g. `timeout_seconds=15.0`) with no explanation
+      is indistinguishable from an arbitrary guess. When the wait starts failing
+      in CI, there is no basis for deciding whether to raise the budget, change
+      the observable, or investigate a deeper delivery failure. The justification
+      comment is the decision record that makes that choice tractable.
+    adr:
+    - ADR-0058
+    relationships:
+    - rel_type: refines
+      spec_id: EDF-06-006
+      note: Adds a justification requirement to the identification requirement; both apply to every temporal wait.
+    tags:
+    - demo
+    - testing

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -2948,6 +2948,41 @@ groups:
     tags:
     - demo
     - documentation
+  - id: DEMOMA-22-007
+    priority: MUST
+    kind: project
+    statement: >-
+      Every `wait_for_*` call in a scenario script MUST be wrapped in either
+      `demo_gate` (when the wait is a causal precondition for a subsequent
+      step) or `demo_check` (when the wait is temporal or a non-gating
+      post-hoc verification). Bare unwrapped `wait_for_*` calls are
+      prohibited.
+    rationale: >-
+      A bare call raises `AssertionError` directly on timeout, bypassing the
+      demo harness's failure accumulator. Earlier `demo_check` failures
+      accumulated in the same run are lost, and downstream steps do not
+      receive the structured skip that `demo_gate` provides — the exception
+      terminates the scenario with no record of what preceded the failure.
+      `demo_gate` and `demo_check` are the two sanctioned wrappers; using
+      them consistently keeps the failure record complete and the control
+      flow explicit.
+    adr:
+    - ADR-0058
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-22-001
+      note: >-
+        DEMOMA-22-001 requires causal gating at every async boundary;
+        this requirement closes the loophole of bare calls that appear to
+        gate but do not integrate with the failure accumulator.
+    - rel_type: refines
+      spec_id: EDF-06-005
+      note: >-
+        EDF-06-005 requires unmet causal gates to prevent dependent steps;
+        this requirement enforces the same principle for the bare-call case.
+    tags:
+    - demo
+    - testing
 - id: DEMOMA-23
   title: Shared Scenario Harness
   specs:

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -265,6 +265,64 @@ DEMOMA-22, ADR-0058, and
 
 ---
 
+### Never Wrap a Causal Wait in `demo_check` (and Never Leave One Bare)
+
+A `wait_for_*` call that is a precondition for the next step MUST be
+wrapped in `demo_gate`, not `demo_check` and not left as a bare call.
+
+**Why `demo_check` is wrong here:** `demo_check` records the timeout as a
+failure and then **continues**. The next step runs on state that was never
+established — producing a confusing secondary failure (a 422 from a
+trigger, a wrong snapshot comparison, a ledger assertion on a partial
+replica) that obscures the root cause.
+
+**Why a bare call is also wrong:** a bare `wait_for_*` call raises
+`AssertionError` directly on timeout, bypassing the harness's failure
+accumulator. Earlier `demo_check` failures are lost. Downstream steps get
+no structured skip — the exception terminates the scenario. Bare calls look
+like gates but are not.
+
+```python
+# ❌ Wrong — demo_check lets the next step run on uncommitted RM.VALID state
+with demo_check(f"{actor.id_} reached RM.VALID before engage-case"):
+    wait_for_participant_rm_state(
+        client=vendor_client, case_id=case.id_,
+        actor_id=actor.id_, expected_states={RM.VALID, RM.ACCEPTED},
+    )
+vendor_engages_case(...)  # may 422 if RM.VALID not yet committed
+
+# ❌ Wrong — bare call raises AssertionError directly, bypasses accumulator
+wait_for_contiguous_ledger_coverage(
+    client=finder_client, case_id=case.id_,
+    expected_tail_index=vendor_tail_index,
+)
+compare_replica_state(...)  # runs on partial replica if wait timed out
+
+# ✅ Correct — demo_gate blocks dependent steps when precondition is unmet
+with demo_gate(f"{actor.id_} reached RM.VALID before engage-case"):
+    wait_for_participant_rm_state(
+        client=vendor_client, case_id=case.id_,
+        actor_id=actor.id_, expected_states={RM.VALID, RM.ACCEPTED},
+    )
+vendor_engages_case(...)  # skipped (not run) if gate failed
+```
+
+**How to decide `demo_gate` vs `demo_check`:** ask whether the next step
+would operate on wrong or incomplete state if this wait timed out.
+
+- **Yes** → `demo_gate`. The wait is a causal precondition.
+- **No** → `demo_check`. The wait is temporal or a post-hoc verification.
+  Label it as temporal at the call site (EDF-06-006) so it is not mistaken
+  for a causal gate in a future edit.
+
+See `notes/demo-ci-diagnostics.md` § "Async Race Window Patterns" for the
+full diagnostic workflow, and `specs/event-driven-control-flow.yaml`
+EDF-06-005 and EDF-06-006 for the normative rules.
+
+<!-- Source: CONCERN-2325 -->
+
+---
+
 ### Event-Phrase Lookups MUST Use `lookup_entry()`, Not a Local Phrase Dict
 
 Any display-layer code that maps a `MessageSemantics` value to a human-readable


### PR DESCRIPTION
- Closes #2325

## Summary

Documents the async race window patterns in demo scenarios — specifically
the difference between `demo_gate` (blocks dependent steps on failure) and
`demo_check` (records and continues), and when each applies to `wait_for_*`
calls. Adds two new spec requirements and a concrete anti-pattern pitfall.

## Changes

- **`notes/demo-ci-diagnostics.md`**: new "Async Race Window Patterns"
  section covering the two failure shapes, causal-vs-temporal wait
  identification, a diagnostic table of causal vs temporal wait examples,
  CI timeout triage workflow, and the bare-call anti-pattern
- **`vultron/demo/AGENTS.md`**: new pitfall "Never Wrap a Causal Wait in
  `demo_check`" with before/after code examples for the three anti-patterns
  (`demo_check` on causal, bare call, correct `demo_gate`)
- **`specs/event-driven-control-flow.yaml`**: EDF-06-008 — temporal wait
  timeout values MUST be justified at the call site with the delivery chain
  and rationale for the chosen value
- **`specs/multi-actor-demo.yaml`**: DEMOMA-22-007 — every `wait_for_*`
  call MUST be wrapped in `demo_gate` or `demo_check`; bare unwrapped calls
  are prohibited

## Implementation Issues

- #2372 (prerequisite: fix fv-demo CaseProposal round-trip)
- #2375 (migrate demo_check-wrapped causal waits to demo_gate)