### PR TITLE
fix(devcontainer): remove tmux auto-start and clipboard bridge

### DIFF
--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -29,15 +29,6 @@ if ! grep -q 'local/bin' "$HOME/.zshrc" 2>/dev/null; then
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zshrc"
 fi
 
-# Auto-start tmux on login if not already inside a tmux session
-if ! grep -q 'TMUX' "$HOME/.zshrc" 2>/dev/null; then
-    cat >> "$HOME/.zshrc" <<'EOF'
-
-# Auto-start tmux on login
-if [ -z "$TMUX" ]; then exec tmux new-session -s main; fi
-EOF
-fi
-
 # --- tmux configuration ---
 cat > "$HOME/.tmux.conf" <<'EOF'
 set -g default-terminal "tmux-256color"
@@ -45,34 +36,9 @@ set -s extended-keys on
 set -as terminal-features ',xterm-256color:extkeys'
 set -g history-limit 50000
 set -g mouse on
+set -g set-clipboard on
 set -g default-shell /bin/zsh
-
-# OSC 52 doesn't pass through docker exec, so we use a clipboard bridge socket
-# mounted from the host (see start-dev.sh — bridge starts automatically).
-# pbcopy (~/.local/bin/pbcopy) writes to /tmp/clipboard.sock when present.
-set -g set-clipboard off
-bind-key -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
 EOF
-
-# --- clipboard bridge client ---
-# Writes tmux selections to the Unix socket mounted from the Mac host.
-mkdir -p "$HOME/.local/bin"
-cat > "$HOME/.local/bin/pbcopy" <<'EOF'
-#!/usr/bin/env python3
-import sys, socket, os
-sock = '/tmp/clipboard.sock'
-if not os.path.exists(sock):
-    sys.exit(0)
-data = sys.stdin.buffer.read()
-try:
-    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
-        s.connect(sock)
-        s.sendall(data)
-except OSError:
-    sys.exit(0)
-EOF
-chmod +x "$HOME/.local/bin/pbcopy"
 
 # Wire user-level skills into Claude Code's discovery path.
 # start-dev.sh mounts the host's ~/.agents/skills into the container at

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -61,17 +61,6 @@ WIP_OUTPUTS_SLOT="$MAIN_DIR/wip_outputs/$SLOT"
 GRAPHIFY_HOST="$HOME/dev/graphify-out/$SLOT"
 mkdir -p "$GRAPHIFY_HOST"
 
-# Start clipboard bridge in the background if not already running.
-# OSC 52 doesn't pass through docker exec, so tmux pipes selections to a Unix
-# socket that this listener forwards to pbcopy on the Mac host.
-CLIPBOARD_SOCK=/tmp/docker-clipboard.sock
-if ! [ -S "$CLIPBOARD_SOCK" ]; then
-    rm -f "$CLIPBOARD_SOCK"
-    (while true; do nc -lU "$CLIPBOARD_SOCK" 2>/dev/null | pbcopy; done) &
-    disown $!
-    for _i in $(seq 1 10); do [ -S "$CLIPBOARD_SOCK" ] && break; sleep 0.1; done
-fi
-
 # --rebuild: remove container and image
 if [ "$REBUILD" = true ]; then
     if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
@@ -125,11 +114,6 @@ DOCKER_ARGS=(
     -v "$GRAPHIFY_HOST:/app/graphify-out"
     -w "$WORKSPACE"
 )
-
-# Mount clipboard bridge socket if the host listener is running (see scripts/clipboard-bridge.sh)
-if [ -S "/tmp/docker-clipboard.sock" ]; then
-    DOCKER_ARGS+=(-v /tmp/docker-clipboard.sock:/tmp/clipboard.sock)
-fi
 
 # Mount user-level skills read-only if present on the host
 if [ -d "$HOME/.agents/skills" ]; then


### PR DESCRIPTION
## Summary

Removes the forced tmux session on container login so the shell prompt is presented directly. Also reverts the clipboard bridge socket machinery that was added to work around copy-paste issues in docker exec environments.

## Changes

- **`.devcontainer/postcreate.sh`**: Removed the `~/.zshrc` block that auto-started tmux on login. Restored the simple `.tmux.conf` (`set-clipboard on`). Removed the `pbcopy` Unix-socket script.
- **`start-dev.sh`**: Reverted to `origin/main` — no clipboard bridge `nc` listener, no `/tmp/docker-clipboard.sock` volume mount.

Containers now drop directly to a zsh prompt where the user can run `claude` or `tmux` manually. tmux remains fully installed and configured.