### PR TITLE
feat(core-models): apply ValidatedAssignmentMixin to 10 core model roots

### DIFF
--- a/notes/domain-validation.md
+++ b/notes/domain-validation.md
@@ -282,9 +282,11 @@ wire branch ever gains `validate_assignment`, this trap returns.
 ### Cost
 
 Scalar attribute assignment measured **475 ns → 1464 ns** (3.1×, ~1 µs
-absolute) — immaterial for BT tick loops. The cost that still needs watching is
-collection fields: assigning `case_participants` re-validates all N items, so it
-is O(N) per assignment.
+absolute) — immaterial for BT tick loops. Collection fields are O(N) per
+assignment: assigning `case_participants` re-validates all N items. Step 2
+(issue #2294, AC-6) benchmarked `list[FakeParticipant]` reassignment and found
+**3.8× overhead at N=100 (~3 µs absolute)** — O(N) confirmed, within the
+acceptable range.
 
 See ADR-0064 for the decision and the three-step rollout, and
 `test/architecture/test_validate_assignment_ratchet.py` for the enumerated

--- a/plan/incoming/learnings/20260819-as-object-validate-assignment-override.md
+++ b/plan/incoming/learnings/20260819-as-object-validate-assignment-override.md
@@ -1,0 +1,42 @@
+---
+title: "as_Object needs explicit validate_assignment=False to block cross-branch MRO contamination"
+type: learning
+timestamp: 2026-08-19
+source: ISSUE-2294
+signal: design-question
+---
+
+## Decision
+
+When applying `ValidatedAssignmentMixin` (which sets `validate_assignment=True`) to
+`VultronObject`, the cross-branch MRO coupling `as_Object(as_Base, VultronObject)`
+propagates the flag to all 65 wire vocabulary classes — violating ARCH-12-002 (wire
+branch must stay lenient for inbound AS2 data).
+
+The chosen fix: add an explicit `model_config = ConfigDict(validate_assignment=False)` to
+`as_Object` in `vultron/wire/as2/vocab/base/objects/base.py`. Pydantic v2 merges
+`model_config` dicts in MRO order with the most-derived class winning, so this override
+cancels the inherited `True` at the wire boundary.
+
+**Alternative rejected**: replacing `VultronObject` in `_VALIDATE_ASSIGNMENT_TARGETS` with
+`CoreObject` + individual classes that cover VultronObject's core-only descendants. This
+would have required more ratchet-test churn and left `VultronObject` itself uncovered by
+any named target, which the coverage test would have flagged.
+
+## Why this matters for future work
+
+Any future `model_config` change on `VultronObject` will propagate across the
+`as_Object` MRO unless explicitly overridden there. The `as_Object` config override
+is load-bearing infrastructure — it must be preserved (or extended, not removed) by
+any change to `VultronObject.model_config`.
+
+The broader fragility (cross-branch MRO coupling at `as_Object`) is tracked by
+issues #2288/#2289 (the `alias_generator=to_camel` contamination, same root cause).
+Full resolution requires completing the ADR-0017 wire→core separation.
+
+## Secondary discovery
+
+`ValidatedAssignmentMixin` itself is picked up by `_core_model_classes()` in the ratchet
+test (it lives in `vultron/core/models/base`, inherits `BaseModel`, and the scanner has no
+mixin-exclusion logic). The fix was to add it to `_VALIDATE_ASSIGNMENT_TARGETS` — it is
+its own covered root, trivially satisfying the coverage invariant.

--- a/test/architecture/test_validate_assignment_ratchet.py
+++ b/test/architecture/test_validate_assignment_ratchet.py
@@ -60,7 +60,6 @@ import pkgutil
 import re
 from pathlib import Path
 
-import pytest
 from pydantic import BaseModel
 
 import vultron.core.models
@@ -111,6 +110,7 @@ _VALIDATE_ASSIGNMENT_TARGETS: frozenset[str] = frozenset(
         "PecDimension",
         "PxaDimension",
         "RmDimension",
+        "ValidatedAssignmentMixin",
         "VfdDimension",
         "VultronEvent",
         "VultronObject",
@@ -338,13 +338,6 @@ def test_wire_branch_does_not_enable_validate_assignment():
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Goal state for issue #2294 (#2261 step 2): every core model carries"
-    " validate_assignment. Blocked on step 1 — flipping the flag first aborts"
-    " 400+ tests with RecursionError. When step 2 lands this test XPASSes and"
-    " fails the build — delete the marker then.",
-)
 def test_every_core_model_has_validate_assignment():
     lacking = sorted(
         name

--- a/vultron/core/models/__init__.py
+++ b/vultron/core/models/__init__.py
@@ -9,7 +9,11 @@ from vultron.core.models.actor import (
     VultronPerson,
     VultronService,
 )
-from vultron.core.models.base import CoreObject, VultronObject
+from vultron.core.models.base import (
+    CoreObject,
+    ValidatedAssignmentMixin,
+    VultronObject,
+)
 from vultron.core.models.registry import (
     CORE_VOCABULARY,
     find_in_core_vocabulary,
@@ -19,6 +23,7 @@ __all__ = [
     "CORE_VOCABULARY",
     "CoreActor",
     "CoreObject",
+    "ValidatedAssignmentMixin",
     "VultronActorMixin",
     "VultronApplication",
     "VultronGroup",

--- a/vultron/core/models/base.py
+++ b/vultron/core/models/base.py
@@ -33,6 +33,20 @@ from vultron.core.models._helpers import _new_urn, _now_utc
 from vultron.core.models.registry import CORE_VOCABULARY
 
 
+class ValidatedAssignmentMixin(BaseModel):
+    """Mixin that enables Pydantic post-construction field validation on core models.
+
+    Apply to core-branch roots only (ARCH-21-001). ``VultronBase`` is permanently
+    excluded because it is the shared base of both branches and ``as_Base``
+    inherits it (ARCH-12-001, ARCH-12-002). Composes correctly with
+    ``VultronBase.model_config`` (``populate_by_name=True``) across the MRO:
+    Pydantic v2 merges ``model_config`` from all BaseModel ancestors, so the
+    result carries both ``validate_assignment=True`` and ``populate_by_name=True``.
+    """
+
+    model_config = ConfigDict(validate_assignment=True)
+
+
 def _non_empty(v: str) -> str:
     if not v.strip():
         raise ValueError("must be a non-empty string")
@@ -70,7 +84,7 @@ class VultronBase(BaseModel):
     media_type: NonEmptyString | None = None
 
 
-class VultronObject(VultronBase):
+class VultronObject(ValidatedAssignmentMixin, VultronBase):
     """Base class for core domain object models.
 
     Captures the common ``id_``, ``type_``, and ``name`` fields shared by

--- a/vultron/core/models/case_actor.py
+++ b/vultron/core/models/case_actor.py
@@ -19,11 +19,11 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from vultron.core.models.base import CoreObject
+from vultron.core.models.base import CoreObject, ValidatedAssignmentMixin
 from vultron.core.models.enums import VultronActorType
 
 
-class VultronOutbox(BaseModel):
+class VultronOutbox(ValidatedAssignmentMixin, BaseModel):
     """Minimal outbox representation for domain actor types."""
 
     items: list[str] = Field(default_factory=list)

--- a/vultron/core/models/case_ledger.py
+++ b/vultron/core/models/case_ledger.py
@@ -64,6 +64,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, model_validator
 
 from vultron.core.models._helpers import _now_utc
+from vultron.core.models.base import ValidatedAssignmentMixin
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +152,7 @@ def _sha256_hex(data: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-class HashChainLedgerRecord(BaseModel):
+class HashChainLedgerRecord(ValidatedAssignmentMixin, BaseModel):
     """A single canonical case ledger entry.
 
     Each entry is created by the CaseActor's single authoritative write path

--- a/vultron/core/models/dead_letter.py
+++ b/vultron/core/models/dead_letter.py
@@ -26,10 +26,14 @@ from typing import Any, Literal
 
 from pydantic import Field
 
-from vultron.core.models.base import NonEmptyString, VultronBase
+from vultron.core.models.base import (
+    NonEmptyString,
+    ValidatedAssignmentMixin,
+    VultronBase,
+)
 
 
-class DeadLetterRecord(VultronBase):
+class DeadLetterRecord(ValidatedAssignmentMixin, VultronBase):
     """Record of an inbox activity whose ``object_`` URI could not be resolved.
 
     Attributes:

--- a/vultron/core/models/dimensions.py
+++ b/vultron/core/models/dimensions.py
@@ -25,6 +25,8 @@ Design: ADR-0036, spec: specs/status-dimension-objects.yaml (SDO-01 to SDO-04).
 
 from pydantic import BaseModel, field_serializer, field_validator
 
+from vultron.core.models.base import ValidatedAssignmentMixin
+
 from vultron.core.states.cs import (
     CS_pxa,
     CS_vfd,
@@ -128,7 +130,7 @@ def _apply_transition(
     )
 
 
-class EmDimension(BaseModel):
+class EmDimension(ValidatedAssignmentMixin, BaseModel):
     """Embargo Management state dimension object.
 
     Holds the case-level EM state and owns immutable transition validation.
@@ -169,7 +171,7 @@ class EmDimension(BaseModel):
         return self.state == EM.NONE
 
 
-class PxaDimension(BaseModel):
+class PxaDimension(ValidatedAssignmentMixin, BaseModel):
     """PXA (public/exploit/attacks) case state dimension object.
 
     Holds the participant-agnostic public state and owns immutable transition
@@ -211,7 +213,7 @@ class PxaDimension(BaseModel):
         return self.state == CS_pxa.pxa
 
 
-class RmDimension(BaseModel):
+class RmDimension(ValidatedAssignmentMixin, BaseModel):
     """Report Management state dimension object.
 
     Holds the per-participant RM state and owns immutable transition validation.
@@ -252,7 +254,7 @@ class RmDimension(BaseModel):
         return self.state == RM.CLOSED
 
 
-class VfdDimension(BaseModel):
+class VfdDimension(ValidatedAssignmentMixin, BaseModel):
     """VFD (vendor/fix/deploy) vendor fix path dimension object.
 
     Holds the per-participant vendor fix path state and owns immutable
@@ -291,7 +293,7 @@ class VfdDimension(BaseModel):
         return self.state in VFD_FIX_DEPLOYED
 
 
-class PecDimension(BaseModel):
+class PecDimension(ValidatedAssignmentMixin, BaseModel):
     """Participant Embargo Consent dimension object.
 
     Holds a single participant's embargo consent state and owns immutable

--- a/vultron/core/models/events/base.py
+++ b/vultron/core/models/events/base.py
@@ -10,7 +10,11 @@ from enum import StrEnum, auto
 from pydantic import BaseModel
 
 from vultron.core.models.activity import VultronActivity
-from vultron.core.models.base import NonEmptyString, VultronObject
+from vultron.core.models.base import (
+    NonEmptyString,
+    ValidatedAssignmentMixin,
+    VultronObject,
+)
 
 
 class MessageSemantics(StrEnum):
@@ -84,7 +88,7 @@ class MessageSemantics(StrEnum):
     REJECT_CASE_PROPOSAL = auto()
 
 
-class VultronEvent(BaseModel):
+class VultronEvent(ValidatedAssignmentMixin, BaseModel):
     """Base domain event produced from an inbound wire-format activity.
 
     ``VultronEvent`` is the semantic event type used for dispatching within

--- a/vultron/wire/as2/vocab/base/objects/base.py
+++ b/vultron/wire/as2/vocab/base/objects/base.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 from typing import Any, TypeAlias, cast
 
 import isodate  # type: ignore[import-untyped]
-from pydantic import field_serializer, field_validator, Field
+from pydantic import ConfigDict, field_serializer, field_validator, Field
 
 from vultron.core.models.base import CoreObject, VultronObject
 from vultron.wire.as2.vocab.base.base import as_Base
@@ -35,6 +35,12 @@ class as_Object(as_Base, VultronObject):
     """Base class for all ActivityPub objects.
     See definition in ActivityStreams Vocabulary <https://www.w3.org/TR/activitystreams-vocabulary/#object>
     """
+
+    # Explicitly opt out of validate_assignment here: the wire branch must
+    # stay lenient for inbound AS2 data (ARCH-12-002).  VultronObject now
+    # carries ValidatedAssignmentMixin, so without this override the flag
+    # propagates here via the cross-branch MRO.
+    model_config = ConfigDict(validate_assignment=False)
 
     replies: Any | None = None
     url: Any | None = None


### PR DESCRIPTION
- Closes #2294

## Summary

Step 2 of 3 for CONCERN-2261 (ADR-0064): introduce `ValidatedAssignmentMixin` and apply it to the ten core model root classes so that all 103+ core domain models now reject wrong-typed attribute assignments via Pydantic's `validate_assignment` mechanism.

## Changes

- **`vultron/core/models/base.py`**: add `ValidatedAssignmentMixin(BaseModel)` with `model_config = ConfigDict(validate_assignment=True)`; apply it to `VultronObject` (AC-1, AC-2)
- **`vultron/core/models/case_actor.py`**: apply mixin to `VultronOutbox` (AC-2)
- **`vultron/core/models/case_ledger.py`**: apply mixin to `HashChainLedgerRecord` (AC-2)
- **`vultron/core/models/dead_letter.py`**: apply mixin to `DeadLetterRecord` (AC-2)
- **`vultron/core/models/dimensions.py`**: apply mixin to all five dimension classes — `EmDimension`, `PecDimension`, `PxaDimension`, `RmDimension`, `VfdDimension` (AC-2)
- **`vultron/core/models/events/base.py`**: apply mixin to `VultronEvent` (AC-2)
- **`vultron/core/models/__init__.py`**: export `ValidatedAssignmentMixin` (AC-1)
- **`vultron/wire/as2/vocab/base/objects/base.py`**: add explicit `model_config = ConfigDict(validate_assignment=False)` to `as_Object` to cancel the flag inherited through the cross-branch MRO `as_Object(as_Base, VultronObject)` — zero wire classes are affected (AC-3, ARCH-12-002)
- **`test/architecture/test_validate_assignment_ratchet.py`**: add `"ValidatedAssignmentMixin"` to `_VALIDATE_ASSIGNMENT_TARGETS`; delete `xfail` marker from `test_every_core_model_has_validate_assignment` (AC-4)

## Wire-branch containment

`as_Object(as_Base, VultronObject)` is the cross-branch coupling point. Without the explicit override, adding the mixin to `VultronObject` would propagate `validate_assignment=True` to all 65 wire vocabulary classes, breaking inbound AS2 parsing (ARCH-12-002). The `model_config = ConfigDict(validate_assignment=False)` on `as_Object` cancels the inherited flag; confirmed with zero `VOCABULARY` entries carrying the flag.

## AC-6 benchmark — collection-field re-validation cost

Measured on `list[FakeParticipant]` reassignment:

| N   | with flag (µs) | without flag (µs) | ratio |
|-----|---------------|-------------------|-------|
| 1   | 1.8           | 0.6               | 2.8×  |
| 10  | 1.9           | 0.7               | 2.6×  |
| 50  | 2.3           | 0.7               | 3.3×  |
| 100 | 3.3           | 0.9               | 3.8×  |

O(N) scaling confirmed; absolute overhead is sub-microsecond to ~3 µs at N=100 — within the acceptable range per ADR-0064.

## Verification

- All 10 ratchet tests pass (including `test_every_core_model_has_validate_assignment` now passing without xfail)
- Full unit suite: **7088 passed, 0 failed**
- Integration suite: **1162 passed, 0 failed**
- black, flake8, mypy, pyright: all clean