### PR TITLE
docs: plan issue #2268 — wire vocab normalization coverage

### DIFF
--- a/plan/history/2608/learning/CONCERN-2268.md
+++ b/plan/history/2608/learning/CONCERN-2268.md
@@ -1,0 +1,28 @@
+---
+source: CONCERN-2268
+timestamp: '2026-08-19T19:10:55.902818+00:00'
+title: 13 wire vocabulary classes still shadow a CORE_VOCABULARY type on the write
+  path
+type: learning
+---
+
+## Concern
+
+Wire vocabulary `type_` values are *bare* names (`"CaseParticipant"`), not `as_`-prefixed, so the only write-path shape guard in `Record.from_obj` — `if obj.type_.startswith("as_")` — never fires for them. Measured during #2232: **15** wire classes have a `type_` that is also a key in `CORE_VOCABULARY`:
+
+```text
+CaseLedgerEntry, CaseParticipant, CaseReference, CaseStatus, EmbargoEvent,
+EmbargoPolicy, ParticipantStatus, VulnerabilityCase, VulnerabilityRecord,
+VulnerabilityReport, VultronApplication, VultronGroup, VultronOrganization,
+VultronPerson, VultronService
+```
+
+Each can be written into a core-typed DataLayer row in the *wire* field shape, so whichever class reads the row back decides what the data means.
+
+Issue #2232 fixed **2** of them — `CaseParticipant` and `ParticipantStatus` — by normalising via `to_core()` at the persistence boundary (`_NORMALIZE_WIRE_TO_CORE` in `vultron/adapters/driven/db_record.py`). Those two were prioritised because their shapes are *structurally* incompatible: core nests `rm: RmDimension` where wire carries a flat `rm_state`, so a wire-shaped row silently yielded `None` for `status.rm.state`.
+
+The remaining **13** are unfixed. They are lower-severity today only because their wire and core shapes happen to differ by key spelling rather than by nesting — that is a coincidence, not an invariant.
+
+**Resolved**: 2026-08-19 — implementation tracked in #2401, #2402. Structural Idea: #2403.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2400>.
+Spec: `specs/datalayer.yaml` (DL-05-005).

--- a/specs/datalayer.yaml
+++ b/specs/datalayer.yaml
@@ -2,7 +2,7 @@ id: DL
 title: DataLayer Port
 description: Behavioural contract that all DataLayer adapter implementations MUST satisfy. Covers auto-rehydration on read,
   type-safe write operations, and port isolation.
-version: 1.3.0
+version: 1.4.0
 scope:
 - prototype
 - production
@@ -200,6 +200,28 @@ groups:
     - persistence
     - testing
     - wire-format
+  - id: DL-05-005
+    priority: MUST
+    kind: project
+    statement: >-
+      An architecture ratchet test MUST assert that `_NORMALIZE_WIRE_TO_CORE` in
+      `vultron/adapters/driven/db_record.py` covers every wire vocabulary class whose bare `type_`
+      shadows a `CORE_VOCABULARY` entry; the set may only grow (shrinking re-opens the write-path
+      shape duality). When all shadowing types are migrated the companion `_NOT_YET_NORMALIZED`
+      enumeration MUST be empty and the test MUST enforce that no shadowing type is left uncovered.
+    rationale: >-
+      Prevents regression on the write path: a wire-shaped row MUST NOT be persisted in a
+      core-typed DataLayer table. The write-side ratchet is the mirror-image of DL-05-004 and
+      enforces the persistence-boundary backstop described in ADR-0062. Source concern #2268.
+    relationships:
+    - rel_type: implements
+      spec_id: DL-05-001
+    tags:
+    - persistence
+    - testing
+    - wire-format
+    adr:
+    - ADR-0062
 - id: DL-06
   title: Activity Read-Back and the Semantic/Envelope Split
   description: >-


### PR DESCRIPTION
- Closes #2268
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Add DL-05-005 to `specs/datalayer.yaml`: a write-side architecture ratchet test MUST assert that `_NORMALIZE_WIRE_TO_CORE` covers every wire vocabulary class whose bare `type_` shadows a `CORE_VOCABULARY` entry, mirroring the read-side DL-05-004 guard. Bump spec version to 1.4.0.

## Changes

- **`specs/datalayer.yaml`**: Add DL-05-005 requirement specifying the write-side normalization ratchet; bump version 1.3.0 → 1.4.0.

## Implementation Issues

- #2401 (Migrate 8 wire types with existing `to_core()` into `_NORMALIZE_WIRE_TO_CORE`)
- #2402 (Write `to_core()` for 5 actor wire types and migrate into `_NORMALIZE_WIRE_TO_CORE`)
- #2403 (Structural Idea: disjoint type_ namespaces to eliminate wire/core VOCABULARY collision)