### PR TITLE
fix(fv-demo): migrate demo_check causal waits to demo_gate (#2375)

### DIFF
--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -2263,6 +2263,49 @@ class TestFvCausalGates:
 
         coverage_wait_called.assert_not_called()
 
+    def test_sync_verification_skips_replica_check_when_ledger_coverage_times_out(
+        self,
+    ):
+        """Inner demo_gate skips verify_finder_replica_state when ledger coverage times out."""
+        finder_client = self._client()
+        vendor_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        finder = self._actor("urn:test:finder")
+        case = self._case()
+
+        replica_check_called = MagicMock()
+
+        with (
+            patch.object(demo, "wait_for_case_on_container"),
+            patch.object(
+                demo,
+                "_get_log_entries_for_case",
+                return_value=[{"log_index": 0}],
+            ),
+            patch.object(
+                demo,
+                "wait_for_contiguous_ledger_coverage",
+                side_effect=AssertionError(
+                    "timed out waiting for ledger coverage"
+                ),
+            ),
+            patch.object(
+                demo,
+                "verify_finder_replica_state",
+                side_effect=replica_check_called,
+            ),
+        ):
+            demo._phase_sync_verification(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                vendor=vendor,
+                finder=finder,
+                case=case,
+                case_actor_client=None,
+            )
+
+        replica_check_called.assert_not_called()
+
     def test_case_closure_skips_coverage_wait_when_close_case_entry_absent(
         self,
     ):

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -2139,3 +2139,176 @@ class TestFvMilestoneAssertions:
                 case=case,
             )
         mock_m7.assert_called()
+
+
+class TestFvCausalGates:
+    """Verify that causal demo_gate sites skip dependent steps on timeout.
+
+    Each test simulates an async-commit timeout (AssertionError) at the
+    precondition and confirms the dependent step is never called.
+    """
+
+    import contextlib
+
+    def _actor(self, id_: str = "urn:test:actor"):
+        a = MagicMock()
+        a.id_ = id_
+        return a
+
+    def _case(self, id_: str = "urn:test:case"):
+        c = MagicMock()
+        c.id_ = id_
+        return c
+
+    def _client(self):
+        c = MagicMock()
+        c.get.return_value = {}
+        return c
+
+    def test_report_submission_skips_verify_case_active_when_participants_never_ready(
+        self,
+    ):
+        """demo_gate skips verify_case_active when wait_for_case_participants times out."""
+        import contextlib
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        finder = self._actor("urn:test:finder")
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        case = self._case()
+
+        verify_case_active_called = MagicMock()
+
+        with (
+            patch.object(demo, "reset_containers"),
+            patch.object(
+                demo,
+                "seed_containers",
+                return_value=(finder, vendor),
+            ),
+            patch.object(
+                demo, "get_actor_by_id", return_value=vendor_in_vendor
+            ),
+            patch.object(
+                demo,
+                "reporter_submits_report",
+                return_value=(MagicMock(), MagicMock()),
+            ),
+            patch.object(demo, "run_direct_path_rm_triage", return_value=case),
+            patch.object(
+                demo,
+                "wait_for_case_participants",
+                side_effect=AssertionError(
+                    "timed out waiting for participants"
+                ),
+            ),
+            patch.object(
+                demo,
+                "verify_case_active",
+                side_effect=verify_case_active_called,
+            ),
+            patch.object(demo, "as_VulnerabilityCase") as mock_vc,
+            patch.object(
+                demo,
+                "demo_step",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            mock_vc.model_validate.return_value = case
+            demo._phase_report_submission(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                case_actor_client=None,
+                finder_id=None,
+                vendor_id=None,
+            )
+
+        verify_case_active_called.assert_not_called()
+
+    def test_sync_verification_skips_coverage_wait_when_finder_case_not_seeded(
+        self,
+    ):
+        """demo_gate skips ledger coverage wait when wait_for_case_on_container times out."""
+        finder_client = self._client()
+        vendor_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        finder = self._actor("urn:test:finder")
+        case = self._case()
+
+        coverage_wait_called = MagicMock()
+
+        with (
+            patch.object(
+                demo,
+                "wait_for_case_on_container",
+                side_effect=AssertionError(
+                    "timed out waiting for case on container"
+                ),
+            ),
+            patch.object(
+                demo,
+                "wait_for_contiguous_ledger_coverage",
+                side_effect=coverage_wait_called,
+            ),
+        ):
+            demo._phase_sync_verification(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                vendor=vendor,
+                finder=finder,
+                case=case,
+                case_actor_client=None,
+            )
+
+        coverage_wait_called.assert_not_called()
+
+    def test_case_closure_skips_coverage_wait_when_close_case_entry_absent(
+        self,
+    ):
+        """demo_gate skips ledger coverage wait when wait_for_event_type_in_ledger times out."""
+        import contextlib
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        finder = self._actor("urn:test:finder")
+        finder_in_finder = self._actor("urn:test:finder")
+        case = self._case()
+
+        coverage_wait_called = MagicMock()
+
+        with (
+            patch.object(demo, "actor_closes_case"),
+            patch.object(demo, "wait_for_all_participants_rm_closed"),
+            patch.object(demo, "verify_case_closed"),
+            patch.object(
+                demo,
+                "wait_for_event_type_in_ledger",
+                side_effect=AssertionError(
+                    "timed out waiting for close_case entry"
+                ),
+            ),
+            patch.object(
+                demo,
+                "wait_for_contiguous_ledger_coverage",
+                side_effect=coverage_wait_called,
+            ),
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            demo._phase_case_closure(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                finder=finder,
+                finder_in_finder=finder_in_finder,
+                case=case,
+            )
+
+        coverage_wait_called.assert_not_called()

--- a/test/demo/test_fvcv_handoff_demo.py
+++ b/test/demo/test_fvcv_handoff_demo.py
@@ -1307,3 +1307,99 @@ class TestPhaseOwnershipHandoffForwardedOfferId:
             f"got {body.get('offer_id')!r} — Bug #2178: original offer ID "
             f"{original_offer_id!r} is never stored in Coordinator's DataLayer"
         )
+
+
+class TestFvcvHandoffCausalGates:
+    """Verify causal demo_gate sites skip dependent steps on timeout.
+
+    Each test simulates an async-commit timeout at the precondition and
+    confirms the dependent step is never reached.
+    """
+
+    def _actor(self, id_: str = "urn:test:actor"):
+        a = MagicMock()
+        a.id_ = id_
+        return a
+
+    def _case(self, id_: str = "urn:test:case"):
+        c = MagicMock()
+        c.id_ = id_
+        return c
+
+    def _client(self):
+        c = MagicMock()
+        c.get.return_value = {}
+        return c
+
+    def test_report_submission_skips_case_on_container_when_participants_never_ready(
+        self,
+    ):
+        """demo_gate skips wait_for_case_on_container when wait_for_case_participants times out."""
+        import contextlib
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        coordinator_client = self._client()
+        case_actor_client = self._client()
+        vendor2_client = self._client()
+        finder = self._actor("urn:test:finder")
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        coordinator = self._actor("urn:test:coordinator")
+        coordinator_in_coordinator = self._actor("urn:test:coordinator")
+        vendor2 = self._actor("urn:test:vendor2")
+        case = self._case()
+
+        case_on_container_called = MagicMock()
+
+        with (
+            patch.object(demo, "reset_containers"),
+            patch.object(
+                demo,
+                "seed_containers_fvcv",
+                return_value=(finder, vendor, coordinator, vendor2),
+            ),
+            patch.object(
+                demo,
+                "get_actor_by_id",
+                side_effect=[vendor_in_vendor, coordinator_in_coordinator],
+            ),
+            patch.object(
+                demo,
+                "reporter_submits_report",
+                return_value=(MagicMock(), MagicMock()),
+            ),
+            patch.object(demo, "run_direct_path_rm_triage", return_value=case),
+            patch.object(
+                demo,
+                "wait_for_case_participants",
+                side_effect=AssertionError(
+                    "timed out waiting for participants"
+                ),
+            ),
+            patch.object(
+                demo,
+                "wait_for_case_on_container",
+                side_effect=case_on_container_called,
+            ),
+            patch.object(demo, "as_VulnerabilityCase") as mock_vc,
+            patch.object(
+                demo,
+                "demo_step",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            mock_vc.model_validate.return_value = case
+            demo._phase_report_submission(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                coordinator_client=coordinator_client,
+                case_actor_client=case_actor_client,
+                vendor2_client=vendor2_client,
+                finder_id=None,
+                vendor_id=None,
+                coordinator_id=None,
+                vendor2_id=None,
+            )
+
+        case_on_container_called.assert_not_called()

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -588,7 +588,7 @@ class TestEventPhraseBehavioural:
     @pytest.mark.xfail(
         reason=(
             "SE-07-006: submit_report {target} slot not yet populated by runtime"
-            " — tracked in #1898, implementation in #2150"
+            " — tracked in #2150"
         ),
         strict=True,
     )

--- a/test/demo/test_workflow_rm_triage.py
+++ b/test/demo/test_workflow_rm_triage.py
@@ -24,7 +24,6 @@ These tests assert causal ordering (x happens THEREFORE y happens), not mere
 sequence, so the fix cannot silently regress to a case-object-presence proxy.
 """
 
-import contextlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -44,18 +43,6 @@ def actors():
     case = MagicMock()
     case.id_ = "urn:uuid:case-1"
     return receiver, receiver_client, offer, case
-
-
-def _nullcontext(_msg):
-    # Patched in place of demo_check: these tests verify call ordering and
-    # argument shapes using mocks, not context-manager control flow.
-    # demo_gate/demo_check behaviour is covered by test_demo_context_managers.py.
-    # Note: test_engage_not_called_when_rm_valid_never_commits additionally needs
-    # nullcontext because real demo_check suppresses the AssertionError that
-    # pytest.raises expects to catch.  This patch becomes removable once
-    # run_direct_path_rm_triage is migrated to demo_gate (dependent steps inside
-    # the gate block) — see blocking issues #2202/#2203/#2204.
-    return contextlib.nullcontext()
 
 
 def test_engage_gated_on_receivers_own_rm_valid(actors):
@@ -91,7 +78,6 @@ def test_engage_gated_on_receivers_own_rm_valid(actors):
             workflow, "wait_for_participant_rm_state", side_effect=_wait_rm
         ),
         patch.object(workflow, "receiver_engages_case", side_effect=_engage),
-        patch.object(workflow, "demo_check", side_effect=_nullcontext),
     ):
         result = workflow.run_direct_path_rm_triage(
             receiver_client=receiver_client,
@@ -126,13 +112,11 @@ def test_engage_not_called_when_rm_valid_never_commits(actors):
         patch.object(
             workflow, "receiver_engages_case", side_effect=engage_called
         ),
-        patch.object(workflow, "demo_check", side_effect=_nullcontext),
     ):
-        with pytest.raises(AssertionError, match="RM.VALID"):
-            workflow.run_direct_path_rm_triage(
-                receiver_client=receiver_client,
-                receiver=receiver,
-                offer=offer,
-            )
+        workflow.run_direct_path_rm_triage(
+            receiver_client=receiver_client,
+            receiver=receiver,
+            offer=offer,
+        )
 
     engage_called.assert_not_called()

--- a/vultron/demo/helpers/workflow.py
+++ b/vultron/demo/helpers/workflow.py
@@ -32,6 +32,7 @@ from vultron.demo.helpers.polling import (
 from vultron.demo.utils import (
     DataLayerClient,
     demo_check,
+    demo_gate,
     demo_step,
     get_offer_from_datalayer,
     log_case_state,
@@ -449,7 +450,7 @@ def run_direct_path_rm_triage(
     # case-object-presence alone races the async commit (TransitionParticipant
     # RMtoAccepted 422).  RM.ACCEPTED is accepted too in case the state has
     # already advanced by the time we poll.
-    with demo_check(f"{receiver.id_} reached RM.VALID before engage-case"):
+    with demo_gate(f"{receiver.id_} reached RM.VALID before engage-case"):
         wait_for_participant_rm_state(
             client=receiver_client,
             case_id=case.id_,
@@ -457,23 +458,23 @@ def run_direct_path_rm_triage(
             expected_states={RM.VALID, RM.ACCEPTED},
             timeout_seconds=timeout_seconds,
         )
-    logger.info("✓ %s RM state reached VALID", receiver.id_)
+        logger.info("✓ %s RM state reached VALID", receiver.id_)
 
-    receiver_engages_case(
-        receiver_client=receiver_client,
-        receiver=receiver,
-        case_id=case.id_,
-    )
-
-    with demo_check(f"{receiver.id_} reached RM.ACCEPTED"):
-        wait_for_participant_rm_state(
-            client=receiver_client,
+        receiver_engages_case(
+            receiver_client=receiver_client,
+            receiver=receiver,
             case_id=case.id_,
-            actor_id=receiver.id_,
-            expected_states={RM.ACCEPTED},
-            timeout_seconds=timeout_seconds,
         )
-    logger.info("✓ %s RM state reached ACCEPTED", receiver.id_)
+
+        with demo_check(f"{receiver.id_} reached RM.ACCEPTED"):
+            wait_for_participant_rm_state(
+                client=receiver_client,
+                case_id=case.id_,
+                actor_id=receiver.id_,
+                expected_states={RM.ACCEPTED},
+                timeout_seconds=timeout_seconds,
+            )
+        logger.info("✓ %s RM state reached ACCEPTED", receiver.id_)
 
     return case
 

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -448,35 +448,36 @@ def _phase_report_submission(
         offer=offer,
     )
 
-    wait_for_case_participants(
-        vendor_client=vendor_client,
-        case_id=case.id_,
-        expected_count=3,
-    )
-
-    with demo_check(
-        "Finder's DataLayer received case via Vendor outbox delivery"
-    ):
-        wait_for_finder_case(
-            finder_client=finder_client,
+    with demo_gate("participant count ≥3 before M1 verify_case_active"):
+        wait_for_case_participants(
+            vendor_client=vendor_client,
             case_id=case.id_,
-        )
-        logger.info(
-            "Case %s confirmed in Finder's DataLayer (outbox delivery verified)",
-            case.id_,
+            expected_count=3,
         )
 
-    with demo_check(
-        "M1: required participants (vendor + finder + case-actor, ≥3), "
-        "EM.ACTIVE, finder has case replica"
-    ):
-        verify_case_active(
-            receiver_client=vendor_client,
-            reporter_client=finder_client,
-            case_id=case.id_,
-            receiver_actor_id=vendor.id_,
-            reporter_actor_id=finder.id_,
-        )
+        with demo_check(
+            "Finder's DataLayer received case via Vendor outbox delivery"
+        ):
+            wait_for_finder_case(
+                finder_client=finder_client,
+                case_id=case.id_,
+            )
+            logger.info(
+                "Case %s confirmed in Finder's DataLayer (outbox delivery verified)",
+                case.id_,
+            )
+
+        with demo_check(
+            "M1: required participants (vendor + finder + case-actor, ≥3), "
+            "EM.ACTIVE, finder has case replica"
+        ):
+            verify_case_active(
+                receiver_client=vendor_client,
+                reporter_client=finder_client,
+                case_id=case.id_,
+                receiver_actor_id=vendor.id_,
+                reporter_actor_id=finder.id_,
+            )
 
     case = as_VulnerabilityCase.model_validate(
         vendor_client.get(f"/datalayer/{case.id_}")
@@ -568,42 +569,42 @@ def _phase_sync_verification(
     # than accepted, extending the time needed to reach full coverage.  Failing
     # here fast surfaces the real problem instead of a confusing coverage timeout
     # (SYNC-15-001, issue #1873).
-    with demo_check(
-        "Finder case seeded before ledger coverage wait (SYNC-15)"
-    ):
+    with demo_gate("Finder case seeded before ledger coverage wait (SYNC-15)"):
         wait_for_case_on_container(
             client=finder_client,
             case_id=case.id_,
         )
 
-    vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
-    if vendor_entries:
-        vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
-        vendor_tail_index: int = vendor_tail["log_index"]
-        logger.info(
-            "Waiting for finder to replicate all vendor entries (0…%d)",
-            vendor_tail_index,
-        )
-        with demo_check("Finder ledger coverage (sync-verification phase)"):
-            wait_for_contiguous_ledger_coverage(
-                client=finder_client,
-                case_id=case.id_,
-                expected_tail_index=vendor_tail_index,
+        vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
+        if vendor_entries:
+            vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
+            vendor_tail_index: int = vendor_tail["log_index"]
+            logger.info(
+                "Waiting for finder to replicate all vendor entries (0…%d)",
+                vendor_tail_index,
             )
+            with demo_gate("Finder ledger coverage (sync-verification phase)"):
+                wait_for_contiguous_ledger_coverage(
+                    client=finder_client,
+                    case_id=case.id_,
+                    expected_tail_index=vendor_tail_index,
+                )
 
-    logger.info(
-        "Verifying LedgerFanout replication by comparing vendor ↔ finder replica"
-        " state (ADR-0019: synthetic entries omitted from canonical ledger)"
-    )
+                logger.info(
+                    "Verifying LedgerFanout replication by comparing vendor ↔ finder replica"
+                    " state (ADR-0019: synthetic entries omitted from canonical ledger)"
+                )
 
-    with demo_check("Finder replica state matches authoritative Vendor state"):
-        verify_finder_replica_state(
-            finder_client=finder_client,
-            vendor_client=vendor_client,
-            case_id=case.id_,
-            vendor_actor_id=vendor.id_,
-            reporter_actor_id=finder.id_,
-        )
+                with demo_check(
+                    "Finder replica state matches authoritative Vendor state"
+                ):
+                    verify_finder_replica_state(
+                        finder_client=finder_client,
+                        vendor_client=vendor_client,
+                        case_id=case.id_,
+                        vendor_actor_id=vendor.id_,
+                        reporter_actor_id=finder.id_,
+                    )
 
     with demo_check(
         "Dedicated external CaseActor container holds no case data "
@@ -796,29 +797,27 @@ def _phase_case_closure(
     #
     # Bug B fix: wait for close_case entry on the authoritative actor before
     # reading the tail, so we don't snapshot a tail that omits close_case.
-    with demo_check(
-        "close_case entry present on authoritative actor (vendor)"
-    ):
+    with demo_gate("close_case entry present on authoritative actor (vendor)"):
         wait_for_event_type_in_ledger(
             client=vendor_client,
             case_id=case.id_,
             event_type="close_case",
         )
-    vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
-    if vendor_entries:
-        vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
-        vendor_tail_index: int = vendor_tail["log_index"]
-        logger.info(
-            "Waiting for finder to replicate all vendor entries after closure"
-            " (0…%d)",
-            vendor_tail_index,
-        )
-        with demo_check("Finder ledger coverage (close phase)"):
-            wait_for_contiguous_ledger_coverage(
-                client=finder_client,
-                case_id=case.id_,
-                expected_tail_index=vendor_tail_index,
+        vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
+        if vendor_entries:
+            vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
+            vendor_tail_index: int = vendor_tail["log_index"]
+            logger.info(
+                "Waiting for finder to replicate all vendor entries after closure"
+                " (0…%d)",
+                vendor_tail_index,
             )
+            with demo_gate("Finder ledger coverage (close phase)"):
+                wait_for_contiguous_ledger_coverage(
+                    client=finder_client,
+                    case_id=case.id_,
+                    expected_tail_index=vendor_tail_index,
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -46,6 +46,7 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     assert_demo_success,
     check_server_availability,
     demo_check,
+    demo_gate,
     demo_step,
     post_to_trigger,
     reset_datalayer,
@@ -260,19 +261,20 @@ def _phase_report_submission(
     )
 
     # Wait for initial participants (Finder + Vendor1 + CaseActor).
-    wait_for_case_participants(
-        vendor_client=vendor_client,
-        case_id=case.id_,
-        expected_count=3,
-    )
-
-    with demo_check(
-        "Finder's DataLayer received case replica (genesis hash available)"
-    ):
-        wait_for_case_on_container(
-            client=finder_client,
+    with demo_gate("participant count ≥3 before M1 verify_case_active"):
+        wait_for_case_participants(
+            vendor_client=vendor_client,
             case_id=case.id_,
+            expected_count=3,
         )
+
+        with demo_check(
+            "Finder's DataLayer received case replica (genesis hash available)"
+        ):
+            wait_for_case_on_container(
+                client=finder_client,
+                case_id=case.id_,
+            )
 
     case = as_VulnerabilityCase.model_validate(
         vendor_client.get(f"/datalayer/{case.id_}")


### PR DESCRIPTION
- Closes #2375

## Summary

Migrates 7 causal wait sites across `workflow.py`, `fv_demo.py`, and `fvcv_handoff_demo.py` from `demo_check` (advisory, continues on failure) to `demo_gate` (nested-block model — dependent steps only execute when precondition commits). Implements ADR-0058 / EDF-06-005: demo scenarios must express causal preconditions using `demo_gate`, not `demo_check`.

## Changes

- **`vultron/demo/helpers/workflow.py`**: migrate `run_direct_path_rm_triage` RM.VALID wait to `demo_gate`; nest `receiver_engages_case` + RM.ACCEPTED wait inside gate body
- **`vultron/demo/scenario/fv_demo.py`**: migrate 3 causal wait sites to `demo_gate` in `_phase_report_submission`, `_phase_sync_verification`, and `_phase_case_closure`; `verify_finder_replica_state` and `verify_case_active` nested inside their respective gates
- **`vultron/demo/scenario/fvcv_handoff_demo.py`**: migrate `_phase_report_submission` participant-count wait to `demo_gate`; nest `wait_for_case_on_container` inside
- **`test/demo/test_fv_demo.py`**: add `TestFvCausalGates` with 4 gate-skip tests (3 outer-gate + 1 inner-gate for sync-verification ledger coverage)
- **`test/demo/test_fvcv_handoff_demo.py`**: add `TestFvcvHandoffCausalGates` with 1 gate-skip test
- **`test/demo/test_workflow_rm_triage.py`**: remove `_nullcontext` helper and `demo_check` patch; both tests use real `demo_gate`

## Verification

- [x] All 8253 existing unit tests pass (0 regressions); 5 new gate-skip tests added
- [x] `black`, `flake8`, `mypy` all clean
- [x] AC: each migrated `demo_check` causal site replaced with `demo_gate`
- [x] AC: dependent steps nested inside gate body at every migrated site
- [x] AC: gate-skip test for each migrated site confirms dependent step skipped on timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)