### PR TITLE
feat(guard): enforce RM↔VFD cross-machine entailment at emit time (CSB-18-001)

### DIFF
--- a/plan/incoming/learnings/20260819-csb18-spec-gap.md
+++ b/plan/incoming/learnings/20260819-csb18-spec-gap.md
@@ -1,0 +1,18 @@
+---
+title: CSB-18-001..004 referenced in code but absent from spec registry
+type: learning
+timestamp: 2026-08-19
+source: ISSUE-2236
+signal: spec-gap
+---
+
+The implementation of #2236 references CSB-18-001 (RM↔VFD cross-machine
+entailment) in docstrings, module-level comments, and `Closes` lines, and
+mentions CSB-18-002..004 (PXA→EM entailments) in `cross_machine_invariants.py`.
+None of these entries exist in `specs/cs-behavior.yaml` or any other spec file.
+
+`PYTHONPATH= uv run spec-dump | grep CSB-18` returns empty.
+
+A follow-up task should add CSB-18-001 (the RM↔VFD rule now enforced) and
+CSB-18-002..004 (PXA→EM rules reserved for the receive path) to
+`specs/cs-behavior.yaml`.

--- a/plan/incoming/learnings/20260819-pxa-em-emit-path-decision.md
+++ b/plan/incoming/learnings/20260819-pxa-em-emit-path-decision.md
@@ -1,0 +1,23 @@
+---
+title: PXA→EM entailment is causal — not enforced on emit path
+type: learning
+timestamp: 2026-08-19
+source: ISSUE-2236
+signal: design-question
+---
+
+Issue #2236 asked for a "pre-emit guard" on cross-machine entailments.
+The initial implementation included both RM↔VFD and PXA→EM checks on the
+emit path. The PXA→EM check was removed after it broke the FV demo: in the
+FV scenario, an actor intentionally asserts P (public disclosure) WHILE an
+embargo is active — this is the causal act that terminates the embargo,
+not a logical contradiction from the emitter's perspective.
+
+Decision: only RM↔VFD is enforced at emit time (both are per-actor attributes;
+a contradictory combination is an error at the source). PXA→EM constraints
+belong on the receive path and are provided in `violation_pxa_em_entailment()`
+for future use but not called in `ValidateTriggerTransitionsNode`.
+
+This distinction (per-actor contradiction vs. cross-level causal trigger)
+should be documented in `rm_em_cs.md` and/or the spec entries for
+CSB-18-002..004 when they are written.

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -1134,3 +1134,68 @@ class TestCrossMachineEntailments:
         before = self._status_count()
         self._execute(pxa_state=CS_pxa.Pxa)
         assert self._status_count() == before + 1
+
+
+class TestViolationPxaEmEntailment:
+    """Unit tests for violation_pxa_em_entailment() (CSB-18-002..004).
+
+    These rules are provided for future receive-path enforcement and are NOT
+    wired into the emit path.  Tests document the expected semantics so future
+    maintainers have a baseline when adding the receive-path guard.
+    """
+
+    def _check(self, pxa, em):
+        from vultron.core.states.cross_machine_invariants import (
+            violation_pxa_em_entailment,
+        )
+
+        return violation_pxa_em_entailment(pxa, em)
+
+    def test_p_bit_with_active_embargo_returns_error(self):
+        """CSB-18-002: P bit (public aware) with EM.ACTIVE is a violation."""
+        from vultron.core.states.cs import CS_pxa
+        from vultron.core.states.em import EM
+
+        result = self._check(CS_pxa.Pxa, EM.ACTIVE)
+        assert result is not None
+        assert "P bit" in result
+
+    def test_x_bit_with_active_embargo_returns_error(self):
+        """CSB-18-003: X bit (exploit public) with EM.ACTIVE is a violation."""
+        from vultron.core.states.cs import CS_pxa
+        from vultron.core.states.em import EM
+
+        result = self._check(CS_pxa.PXa, EM.ACTIVE)
+        assert result is not None
+        assert "X bit" in result
+
+    def test_a_bit_with_active_embargo_returns_error(self):
+        """CSB-18-004: A bit (attacks observed) with EM.ACTIVE is a violation."""
+        from vultron.core.states.cs import CS_pxa
+        from vultron.core.states.em import EM
+
+        result = self._check(CS_pxa.pxA, EM.ACTIVE)
+        assert result is not None
+        assert "A bit" in result
+
+    def test_p_bit_with_revise_embargo_returns_error(self):
+        """CSB-18-002: P bit with EM.REVISE (also active) is a violation."""
+        from vultron.core.states.cs import CS_pxa
+        from vultron.core.states.em import EM
+
+        result = self._check(CS_pxa.Pxa, EM.REVISE)
+        assert result is not None
+
+    def test_pxa_no_bits_with_active_embargo_returns_none(self):
+        """No bit set with EM.ACTIVE — no entailment violated."""
+        from vultron.core.states.cs import CS_pxa
+        from vultron.core.states.em import EM
+
+        assert self._check(CS_pxa.pxa, EM.ACTIVE) is None
+
+    def test_p_bit_without_active_embargo_returns_none(self):
+        """P bit with EM.NONE — no embargo, no constraint."""
+        from vultron.core.states.cs import CS_pxa
+        from vultron.core.states.em import EM
+
+        assert self._check(CS_pxa.Pxa, EM.NONE) is None

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -1161,11 +1161,15 @@ class TestViolationPxaEmEntailment:
         assert "P bit" in result
 
     def test_x_bit_with_active_embargo_returns_error(self):
-        """CSB-18-003: X bit (exploit public) with EM.ACTIVE is a violation."""
+        """CSB-18-003: X bit (exploit public) with EM.ACTIVE is a violation.
+
+        Uses pXa (X set, P not set) to isolate the X-bit check from the P-bit
+        check (P is tested first in violation_pxa_em_entailment).
+        """
         from vultron.core.states.cs import CS_pxa
         from vultron.core.states.em import EM
 
-        result = self._check(CS_pxa.PXa, EM.ACTIVE)
+        result = self._check(CS_pxa.pXa, EM.ACTIVE)
         assert result is not None
         assert "X bit" in result
 

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -939,3 +939,198 @@ class TestValidateTriggerTransitions:
         before = self._status_count()
         self._execute(rm_state=RM.RECEIVED)
         assert self._status_count() == before + 1
+
+
+# ---------------------------------------------------------------------------
+# ValidateTriggerTransitionsNode — cross-machine entailments (#2236)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossMachineEntailments:
+    """Trigger-path cross-machine entailment guard (#2236).
+
+    CSB-18-001: VFD F bit (VFd/VFD) requires RM ∈ {ACCEPTED, DEFERRED, CLOSED}.
+    Both RM and VFD are per-actor attributes; a contradictory combination is
+    rejected at emit time.
+
+    Motivating case: FCV failure shipped VFd + RM.RECEIVED — an impossible
+    combination because fix readiness entails RM.ACCEPTED.
+
+    Note: PXA→EM entailments (CSB-18-002..004) are causal, not contradictory
+    from the emitter's perspective: asserting P CAUSES EM to terminate. Those
+    constraints are enforced on the receive path.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from vultron.adapters.driven.datalayer_sqlite import (
+            SqliteDataLayer,
+            reset_datalayer,
+        )
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+        from vultron.enums.roles import CVDRole
+        from vultron.wire.as2.vocab.base.objects.actors import as_Service
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            as_CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        self.actor = as_Service(name="Vendor")
+        actor_id = self.actor.id_
+        reset_datalayer(actor_id)
+        self.dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
+        self.dl.clear_all()
+        self.dl.create(self.actor)
+
+        self.case_actor = as_Service(name="Case Actor")
+        reset_datalayer(self.case_actor.id_)
+        self.dl.create(self.case_actor)
+
+        self.case = as_VulnerabilityCase(name="Test Case #2236")
+        self.actor_participant = as_CaseParticipant(
+            attributed_to=actor_id,
+            context=self.case.id_,
+            case_roles=[CVDRole.VENDOR],
+        )
+        self.case_manager_participant = as_CaseParticipant(
+            attributed_to=self.case_actor.id_,
+            context=self.case.id_,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        self.case.actor_participant_index[actor_id] = (
+            self.actor_participant.id_
+        )
+        self.case.actor_participant_index[self.case_actor.id_] = (
+            self.case_manager_participant.id_
+        )
+        self.dl.create(self.case)
+        self.dl.create(self.actor_participant)
+        self.dl.create(self.case_manager_participant)
+        self.trigger_activity = TriggerActivityAdapter(self.dl)
+        yield
+        try:
+            self.dl.clear_all()
+        finally:
+            self.dl.close()
+            reset_datalayer(actor_id)
+            reset_datalayer(self.case_actor.id_)
+
+    def _execute(self, rm_state=None, vfd_state=None, pxa_state=None):
+        from vultron.core.use_cases.triggers.case import (
+            SvcAddParticipantStatusUseCase,
+        )
+        from vultron.core.use_cases.triggers.requests import (
+            AddParticipantStatusTriggerRequest,
+        )
+
+        request = AddParticipantStatusTriggerRequest(
+            actor_id=self.actor.id_,
+            case_id=self.case.id_,
+            rm_state=rm_state,
+            vfd_state=vfd_state,
+            pxa_state=pxa_state,
+        )
+        return SvcAddParticipantStatusUseCase(
+            self.dl, request, trigger_activity=self.trigger_activity
+        ).execute()
+
+    def _status_count(self):
+        participant = self.dl.read(self.actor_participant.id_)
+        return len(getattr(participant, "participant_statuses", []))
+
+    def _advance_rm_to_accepted(self):
+        """Step the actor through RM.START → RECEIVED → VALID → ACCEPTED."""
+        self._execute(rm_state=RM.RECEIVED)
+        self._execute(rm_state=RM.VALID)
+        self._execute(rm_state=RM.ACCEPTED)
+
+    # --- CSB-18-001: RM ↔ VFD entailment ---
+
+    def test_csb18_001_vfd_fix_ready_with_rm_received_raises(self):
+        """CSB-18-001: Vfd → VFd while RM is RECEIVED raises (FCV motivating case).
+
+        The actor advances to vendor-aware (Vfd) while still at RM.RECEIVED,
+        then tries to assert fix-ready (VFd). This is the FCV failure pattern:
+        fix readiness requires RM.ACCEPTED.
+        """
+        from vultron.errors import VultronValidationError
+
+        # Valid combined step: vendor becomes aware while reporting received.
+        self._execute(rm_state=RM.RECEIVED, vfd_state=CS_vfd.Vfd)
+        before = self._status_count()
+        # Cross-machine violation: VFd requires RM ≥ ACCEPTED; current is RECEIVED.
+        with pytest.raises(VultronValidationError, match="Cross-machine"):
+            self._execute(vfd_state=CS_vfd.VFd)
+        assert self._status_count() == before
+
+    def test_csb18_001_vfd_fix_ready_with_current_rm_valid_raises(self):
+        """CSB-18-001: Vfd → VFd when actor is at RM.VALID raises.
+
+        After advancing to RM.VALID and Vfd, the actor must not assert VFd
+        because fix readiness requires RM.ACCEPTED.
+        """
+        from vultron.errors import VultronValidationError
+
+        self._execute(rm_state=RM.RECEIVED)
+        self._execute(rm_state=RM.VALID)
+        self._execute(vfd_state=CS_vfd.Vfd)
+        before = self._status_count()
+        with pytest.raises(VultronValidationError, match="Cross-machine"):
+            self._execute(vfd_state=CS_vfd.VFd)
+        assert self._status_count() == before
+
+    def test_csb18_001_vfd_fix_ready_with_rm_accepted_succeeds(self):
+        """CSB-18-001: Vfd → VFd when actor is at RM.ACCEPTED is valid."""
+        self._advance_rm_to_accepted()
+        self._execute(vfd_state=CS_vfd.Vfd)
+        before = self._status_count()
+        self._execute(vfd_state=CS_vfd.VFd)
+        assert self._status_count() == before + 1
+
+    def test_csb18_001_vfd_fix_deployed_with_rm_accepted_succeeds(self):
+        """CSB-18-001: VFd → VFD when actor is at RM.ACCEPTED is valid.
+
+        DEPLOYER role is required for the d→D transition (CSB-15-002); the
+        participant is re-registered with CVDRole.DEPLOYER before the test.
+        """
+        from vultron.enums.roles import CVDRole
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            as_CaseParticipant,
+        )
+
+        # Re-register the participant as DEPLOYER so the role guard passes.
+        deployer_participant = as_CaseParticipant(
+            id_=self.actor_participant.id_,
+            attributed_to=self.actor.id_,
+            context=self.case.id_,
+            case_roles=[CVDRole.VENDOR, CVDRole.DEPLOYER],
+        )
+        self.dl.save(deployer_participant)
+
+        self._advance_rm_to_accepted()
+        self._execute(vfd_state=CS_vfd.Vfd)
+        self._execute(vfd_state=CS_vfd.VFd)
+        before = self._status_count()
+        self._execute(vfd_state=CS_vfd.VFD)
+        assert self._status_count() == before + 1
+
+    def test_csb18_001_vfd_vendor_aware_with_rm_received_succeeds(self):
+        """CSB-18-001: vfd → Vfd when actor is at RM.RECEIVED is valid.
+
+        The V bit (vendor aware) has no RM constraint; only F/D bits do.
+        """
+        before = self._status_count()
+        self._execute(rm_state=RM.RECEIVED, vfd_state=CS_vfd.Vfd)
+        assert self._status_count() == before + 1
+
+    def test_pxa_public_aware_succeeds(self):
+        """Asserting Pxa (P bit) is valid — PXA is an actor-level attribute."""
+        from vultron.core.states.cs import CS_pxa
+
+        before = self._status_count()
+        self._execute(pxa_state=CS_pxa.Pxa)
+        assert self._status_count() == before + 1

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -826,10 +826,12 @@ class TestVerifyFinderReplicaState:
 
 
 def _setup_case_with_3_participants(base: str):
-    """Helper: seed, submit report, validate, and return (finder, vendor, case).
+    """Helper: seed, submit report, validate, engage, and return (finder, vendor, case).
 
     Returns a tuple of (finder_client, vendor_client, finder, vendor, case).
-    The shared DataLayer will have 3 participants (Vendor + Finder + Case Actor).
+    The shared DataLayer will have 3 participants (Vendor + Finder + Case Actor)
+    and the vendor's RM state will be at RM.ACCEPTED (the minimum required for
+    fix-ready assertions per CSB-18-001).
     """
     finder_client = make_client(base)
     vendor_client = make_client(base)
@@ -845,13 +847,22 @@ def _setup_case_with_3_participants(base: str):
         finder=finder,
         vendor=vendor_in_vendor,
     )
+    # ADR-0041: no case after validate-report; create one directly for setup.
+    # validate-report requires a live case (EnsureEmbargoExists needs an active
+    # embargo), so create the case first, then run the RM triage sequence.
+    case = _create_case_from_offer(vendor_client, vendor_in_vendor, offer)
+    # Advance vendor RM: RECEIVED → VALID (validate-report) → ACCEPTED (engage-case).
+    # CSB-18-001: VFd (F bit set) requires RM ∈ {ACCEPTED, DEFERRED, CLOSED}.
     demo.vendor_validates_report(
         vendor_client=vendor_client,
         vendor=vendor_in_vendor,
         offer_id=offer.id_,
     )
-    # ADR-0041: no case after validate-report; create one directly for setup.
-    case = _create_case_from_offer(vendor_client, vendor_in_vendor, offer)
+    demo.vendor_engages_case(
+        vendor_client=vendor_client,
+        vendor=vendor_in_vendor,
+        case_id=case.id_,
+    )
     return finder_client, vendor_client, finder, vendor_in_vendor, case
 
 

--- a/vultron/core/behaviors/case/nodes/participant/trigger_validation.py
+++ b/vultron/core/behaviors/case/nodes/participant/trigger_validation.py
@@ -32,8 +32,8 @@ steps).
 
 Per specs/behavior-tree-node-design.yaml BTND-10-001,
 specs/status-dimension-objects.yaml SDO-02-004,
-specs/cs-behavior.yaml CSB-16-001, CSB-16-002.
-Closes #2081 (AC-1, AC-2, AC-3, AC-6), #1903 (AC-1, AC-2, AC-3).
+specs/cs-behavior.yaml CSB-16-001, CSB-16-002, CSB-18-001.
+Closes #2081 (AC-1, AC-2, AC-3, AC-6), #1903 (AC-1, AC-2, AC-3), #2236.
 """
 
 import logging
@@ -46,6 +46,9 @@ from vultron.core.behaviors.case.nodes.participant.common import (
 from vultron.core.behaviors.helpers import DataLayerCondition
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.states.cross_machine_invariants import (
+    violation_rm_vfd_entailment,
+)
 from vultron.core.states.cs import (
     CS_pxa,
     CS_vfd,
@@ -88,11 +91,13 @@ class ValidateTriggerTransitionsNode(DataLayerCondition):
     descriptive ``feedback_message`` when any dimension would be an illegal
     jump; returns ``SUCCESS`` otherwise.
 
-    Rules (per BTND-10-001):
+    Rules (per BTND-10-001, CSB-18-001):
 
     - ``None`` target → skip that dimension (AC-5).
     - ``target == current`` → same-state confirmation, always valid (AC-4).
     - ``target != current`` and invalid adjacent step → ``FAILURE`` (AC-1/2/3).
+    - VFD has F bit (VFd/VFD) and effective RM ∉ {ACCEPTED, DEFERRED, CLOSED}
+      → ``FAILURE`` (CSB-18-001, #2236).
 
     When the participant has no current status (first write) the initial states
     ``RM.START``, ``CS_vfd.vfd``, ``CS_pxa.pxa`` are used as the baseline, so
@@ -179,5 +184,22 @@ class ValidateTriggerTransitionsNode(DataLayerCondition):
                 )
                 self.logger.info("%s: %s", self.name, self.feedback_message)
                 return Status.FAILURE
+
+        # --- Cross-machine: RM ↔ VFD entailment (CSB-18-001, #2236) ---
+        # Fix readiness (F bit) requires RM ∈ {ACCEPTED, DEFERRED, CLOSED}.
+        # Both RM and VFD are per-actor attributes, so a contradictory
+        # combination is an error at the emitter.
+        effective_rm = (
+            self._rm_state if self._rm_state is not None else current_rm
+        )
+        effective_vfd = (
+            self._vfd_state if self._vfd_state is not None else current_vfd
+        )
+        if (
+            msg := violation_rm_vfd_entailment(effective_rm, effective_vfd)
+        ) is not None:
+            self.feedback_message = msg
+            self.logger.info("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
 
         return Status.SUCCESS

--- a/vultron/core/states/cross_machine_invariants.py
+++ b/vultron/core/states/cross_machine_invariants.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Cross-machine entailment invariants for the Vultron composite state.
+
+Validates that combinations of RM, VFD, and EM states are mutually consistent.
+
+:func:`violation_rm_vfd_entailment` is enforced at emit time via
+:class:`~vultron.core.behaviors.case.nodes.participant.trigger_validation\
+.ValidateTriggerTransitionsNode` in the trigger path.  Both RM and VFD are
+per-actor attributes, so a contradictory combination is an error at the source.
+
+:func:`violation_pxa_em_entailment` expresses the PXA→EM consistency rules
+but is NOT enforced on the emit path: asserting P CAUSES the embargo to
+terminate (the embargo teardown is a consequence, not a prerequisite).  These
+constraints belong on the receive path and are provided here for future use.
+
+Source: docs/topics/process_models/model_interactions/rm_em_cs.md
+Spec: CSB-18-001 (emit path), CSB-18-002..004 (receive path, future)
+Closes #2236.
+"""
+
+from vultron.core.states.cs import (
+    CS_pxa,
+    CS_vfd,
+    PXA_ATTACKS_OBSERVED,
+    PXA_EXPLOIT_PUBLIC,
+    PXA_PUBLIC_AWARE,
+    VFD_FIX_READY,
+)
+from vultron.core.states.em import EM, EM_EMBARGO_ACTIVE
+from vultron.core.states.rm import RM
+
+# RM states consistent with asserting fix readiness or deployment.
+# The fix-ready event (F) can occur only when the vendor has passed through
+# RM.ACCEPTED; since RM is monotonic, DEFERRED and CLOSED are also consistent
+# with F having been reached.
+# Source: rm_em_cs.md § "Fix Readiness", § "Fix Deployment"
+RM_STATES_CONSISTENT_WITH_FIX: frozenset[RM] = frozenset(
+    {RM.ACCEPTED, RM.DEFERRED, RM.CLOSED}
+)
+
+
+def violation_rm_vfd_entailment(rm: RM, vfd: CS_vfd) -> str | None:
+    """Return an error string if (rm, vfd) violates the Fix Readiness entailment.
+
+    Fix readiness (F bit set: CS_vfd.VFd or CS_vfd.VFD) can only be asserted
+    when the vendor has accepted the report (RM ∈ {ACCEPTED, DEFERRED, CLOSED}).
+    RM is monotonic, so once ACCEPTED the vendor may later be at DEFERRED or
+    CLOSED; all three are consistent with the F/D bits being set.
+
+    Returns:
+        None when the combination is valid.
+        A descriptive error string when the entailment is violated.
+
+    Source: rm_em_cs.md § "Fix Readiness", § "Fix Deployment"
+    Spec: CSB-18-001
+    """
+    if vfd not in VFD_FIX_READY:
+        return None  # F bit not set — no RM constraint from this rule
+    if rm in RM_STATES_CONSISTENT_WITH_FIX:
+        return None
+    return (
+        f"Cross-machine entailment violated: VFD={vfd.name!r} (F bit set)"
+        f" requires RM ∈ {{ACCEPTED, DEFERRED, CLOSED}},"
+        f" but RM={rm.name!r}."
+        " Fix readiness cannot precede RM.ACCEPTED"
+        " (rm_em_cs.md § Fix Readiness)."
+    )
+
+
+def violation_pxa_em_entailment(pxa: CS_pxa, em: EM) -> str | None:
+    """Return an error string if (pxa, em) violates the disclosure/embargo entailment.
+
+    Public awareness (P), exploit publication (X), or attack observations (A)
+    are logically inconsistent with an active embargo (EM.ACTIVE or EM.REVISE).
+
+    Returns:
+        None when the combination is valid.
+        A descriptive error string when the entailment is violated.
+
+    Source: rm_em_cs.md § "Public Awareness", § "Exploit Public", § "Attacks Observed"
+    Spec: CSB-18-002, CSB-18-003, CSB-18-004
+    """
+    if em not in EM_EMBARGO_ACTIVE:
+        return None  # no active embargo — all PXA values are consistent
+    if pxa in PXA_PUBLIC_AWARE:
+        return (
+            f"Cross-machine entailment violated: PXA={pxa.name!r} (P bit set)"
+            f" is incompatible with EM={em.name!r}."
+            " An active embargo cannot coexist with public awareness"
+            " (rm_em_cs.md § Public Awareness)."
+        )
+    if pxa in PXA_EXPLOIT_PUBLIC:
+        return (
+            f"Cross-machine entailment violated: PXA={pxa.name!r} (X bit set)"
+            f" is incompatible with EM={em.name!r}."
+            " An active embargo cannot coexist with exploit publication"
+            " (rm_em_cs.md § Exploit Public)."
+        )
+    if pxa in PXA_ATTACKS_OBSERVED:
+        return (
+            f"Cross-machine entailment violated: PXA={pxa.name!r} (A bit set)"
+            f" is incompatible with EM={em.name!r}."
+            " An active embargo cannot coexist with observed attacks"
+            " (rm_em_cs.md § Attacks Observed)."
+        )
+    return None


### PR DESCRIPTION
- Closes #2236
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Adds a pre-emit guard that prevents any actor from asserting fix readiness (VFD F bit) while their RM state is below ACCEPTED, catching the logical contradiction first surfaced in the FCV failure demo (`VFd + RM.RECEIVED`). The guard lives in a new pure-state module (`cross_machine_invariants.py`) and is wired into `ValidateTriggerTransitionsNode` at the end of the per-dimension adjacency checks.

## Changes

- **`vultron/core/states/cross_machine_invariants.py`** (new): `violation_rm_vfd_entailment()` returns an error string when VFD has the F bit set and RM ∉ {ACCEPTED, DEFERRED, CLOSED}; `violation_pxa_em_entailment()` provided for future receive-path use (not called on emit — PXA→EM is causal, not contradictory from the emitter's perspective).
- **`vultron/core/behaviors/case/nodes/participant/trigger_validation.py`**: import and invoke `violation_rm_vfd_entailment()` using `effective_rm`/`effective_vfd` (requested state when supplied, current state otherwise); extend docstring to reference CSB-18-001 and close #2236.
- **`test/core/use_cases/triggers/case/test_add_participant_status.py`**: add `TestCrossMachineEntailments` (6 tests): FCV motivating case, RM.VALID rejection, RM.ACCEPTED pass, VFD deployment with DEPLOYER role, V-bit-only pass (no RM constraint), PXA pass. Add `TestViolationPxaEmEntailment` (6 tests) covering P/X/A bit violations and passing cases.
- **`test/demo/test_fv_demo.py`**: fix `_setup_case_with_3_participants()` to create the case before running validate-report, then call `vendor_engages_case` to advance vendor RM to ACCEPTED — the minimum state required by CSB-18-001.

## Verification

- 7100 unit tests pass (12 new: 6 in `TestCrossMachineEntailments`, 6 in `TestViolationPxaEmEntailment`)
- 1162 integration tests pass (previously 3 were failing due to the missing RM.ACCEPTED setup)
- Black, flake8, mypy, pyright all clean