### PR TITLE
fix: spec-dump now emits verification field; phantom-path lint now scans it

### DIFF
--- a/plan/incoming/learnings/20260819-spec-2290-schema-already-fixed.md
+++ b/plan/incoming/learnings/20260819-spec-2290-schema-already-fixed.md
@@ -1,0 +1,23 @@
+---
+title: "#2290 schema fix (verification field + extra=forbid) was already landed when work began"
+type: learning
+timestamp: 2026-08-19
+source: ISSUE-2290
+signal: process-issue
+---
+
+Issue #2290 described `verification:` as not a field on `Spec` model and
+`extra="forbid"` as absent. By the time work started, both had already been
+added in commit `a81b77ab` ("fix(schema): add extra=forbid + formalize 9
+undocumented spec fields") without a `Closes #2290` footer.
+
+The remaining work was:
+
+- `llm_export.py:_spec_record` not emitting `verification`
+- `lint.py:_check_phantom_paths` not scanning `verification`
+
+The "test asserts no silent key drop" AC was also already satisfied by
+`test_statement_spec_extra_field_rejected` (SR-02-022) in test_schema.py.
+
+Lesson: always verify ACs against current `main` before starting; a prior PR
+may have partially addressed an issue without a closing footer.

--- a/plan/incoming/learnings/20260819-verification-always-emitted-in-spec-dump.md
+++ b/plan/incoming/learnings/20260819-verification-always-emitted-in-spec-dump.md
@@ -1,0 +1,20 @@
+---
+title: verification field always emitted in spec-dump even when null
+type: learning
+timestamp: 2026-08-19
+source: ISSUE-2290
+signal: design-question
+---
+
+During #2290, the user explicitly requested that `verification` be always
+present in `spec-dump` output (including as `null` when not authored), rather
+than omitted when absent like `rationale`, `relationships`, and `adr`.
+
+The stated reason: "we're going to want to start enforcing non-null fields for
+some of these so we should probably always include it so that it's obvious when
+empty."
+
+This means `_spec_record` in `llm_export.py` unconditionally emits
+`"verification": spec.verification` while all other optional fields remain
+conditional. This intentional asymmetry sets a precedent — future mandatory
+fields should follow the always-emit pattern rather than the conditional one.

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -547,14 +547,15 @@ groups:
     priority: MUST
     kind: process
     statement: >-
-      A spec item's `statement` MUST NOT reference a file path that does not
-      exist, and MUST NOT use an absolute path or a `..` segment. A path rooted
-      at a top-level repo directory is resolved repo-relatively; any other path
-      is resolved as a suffix of some file in the tree, so a package-relative
-      illustration is permitted but a mistyped leading segment is not. A
-      spec-first requirement that deliberately names a file yet to be created
-      MUST either use a placeholder form (e.g. `test_XXX_invariants.py`) or opt
-      out with `lint_suppress: [phantom_path_ref]`. Enforced as a hard error by
+      A spec item's `statement` and `verification` fields MUST NOT reference a
+      file path that does not exist, and MUST NOT use an absolute path or a `..`
+      segment. A path rooted at a top-level repo directory is resolved
+      repo-relatively; any other path is resolved as a suffix of some file in
+      the tree, so a package-relative illustration is permitted but a mistyped
+      leading segment is not. A spec-first requirement that deliberately names a
+      file yet to be created MUST either use a placeholder form (e.g.
+      `test_XXX_invariants.py`) or opt out with
+      `lint_suppress: [phantom_path_ref]`. Enforced as a hard error by
       spec-lint.
     rationale: >-
       A normative statement naming non-existent infrastructure is a stale-premise
@@ -562,8 +563,9 @@ groups:
       the codebase or silently ignores a MUST, and the spec stops describing the
       system. DEMOMA-19-008 named a `conftest.py` registry that had never existed
       (CONCERN-2004); an audit found 18 such clauses across 13 phantom paths.
-      Only `statement` is checked — `rationale` narrates history by design and
-      legitimately cites paths that are gone.
+      `statement` and `verification` are checked — `verification` names live
+      test infrastructure and must refer to real paths. `rationale` narrates
+      history by design and legitimately cites paths that are gone.
     relationships:
     - rel_type: derives_from
       spec_id: MS-04-001

--- a/test/metadata/specs/test_lint.py
+++ b/test/metadata/specs/test_lint.py
@@ -833,3 +833,44 @@ def test_lint_phantom_path_suppress(tmp_path, capsys):
     captured = capsys.readouterr()
     assert result == 0
     assert "MS-15-001" not in captured.err
+
+
+def test_lint_phantom_path_in_verification_is_hard_error(tmp_path, capsys):
+    """A verification field naming a non-existent path fails (MS-15-001)."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "verification"
+    ] = "Assert via `vultron/nope.py` that the invariant holds."
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "MS-15-001" in captured.err
+    assert "vultron/nope.py" in captured.err
+
+
+def test_lint_phantom_path_in_verification_existing_passes(tmp_path):
+    """A verification field naming an existing path is accepted."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    (repo / "vultron" / "real.py").write_text("x = 1\n")
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "verification"
+    ] = "Assert via `vultron/real.py` that the invariant holds."
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_path_verification_suppress(tmp_path, capsys):
+    """lint_suppress: [phantom_path_ref] exempts phantom paths in verification."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec(extra={"lint_suppress": ["phantom_path_ref"]})
+    data["groups"][0]["specs"][0][
+        "verification"
+    ] = "A test at `vultron/future.py` will assert this."
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "MS-15-001" not in captured.err

--- a/test/metadata/specs/test_llm_export.py
+++ b/test/metadata/specs/test_llm_export.py
@@ -292,3 +292,42 @@ class TestLlmExport:
         assert data["topics"] == []
         assert data["requirements"] == []
         assert data["edges"] == []
+
+    def test_verification_always_present_when_null(self, graph_registry):
+        """verification is always in the output, even when not authored (null)."""
+        data = json.loads(to_llm_json(graph_registry))
+        for req in data["requirements"]:
+            assert "verification" in req
+            assert req["verification"] is None
+
+    def test_verification_value_emitted_when_set(self, tmp_path):
+        """When verification is authored, its value appears in spec-dump output."""
+        import yaml as _yaml
+
+        spec_data = {
+            "id": "VV",
+            "title": "Verification Test",
+            "description": "Tests verification emission",
+            "version": "0.1",
+            "scope": ["production"],
+            "groups": [
+                {
+                    "id": "VV-01",
+                    "title": "Group",
+                    "specs": [
+                        {
+                            "id": "VV-01-001",
+                            "priority": "MUST",
+                            "kind": "project",
+                            "statement": "VV-01-001 MUST do the thing",
+                            "verification": "A test in `test/foo.py` asserts this.",
+                        }
+                    ],
+                }
+            ],
+        }
+        (tmp_path / "vv.yaml").write_text(_yaml.dump(spec_data))
+        registry = load_registry(tmp_path)
+        data = json.loads(to_llm_json(registry, topic="VV"))
+        req = data["requirements"][0]
+        assert req["verification"] == "A test in `test/foo.py` asserts this."

--- a/vultron/metadata/specs/lint.py
+++ b/vultron/metadata/specs/lint.py
@@ -174,15 +174,18 @@ _IGNORED_TREE_DIRS = frozenset(
 
 
 def _check_phantom_paths(registry: SpecRegistry, repo_root: Path) -> list[str]:
-    """Hard error when a spec ``statement`` names a file that does not exist (MS-15-001).
+    """Hard error when a spec ``statement`` or ``verification`` names a file that does not exist (MS-15-001).
 
-    A normative statement that points at a non-existent path is a stale-premise
-    landmine: an agent reads the MUST, cannot find the infrastructure, and
-    either invents something inconsistent or silently ignores the requirement.
+    A normative statement or verification criterion that points at a
+    non-existent path is a stale-premise landmine: an agent reads the MUST,
+    cannot find the infrastructure, and either invents something inconsistent
+    or silently ignores the requirement.
     DEMOMA-19-008 (issue #2004) named a ``test/ci/invariants/conftest.py`` that
     had never existed on any branch.
 
-    Only ``statement`` is scanned. ``rationale`` narrates history by design
+    Both ``statement`` and ``verification`` are scanned — ``verification``
+    names live test infrastructure and must refer to real paths.
+    ``rationale`` narrates history by design
     ("X has been converted to Y", "if X stays in Z...") and legitimately
     references paths that no longer exist.
 
@@ -216,6 +219,10 @@ def _check_phantom_paths(registry: SpecRegistry, repo_root: Path) -> list[str]:
             problem = resolver.problem_with(match)
             if problem is not None:
                 errors.append(f"{spec_id}: statement references {problem}")
+        for match in _SPEC_PATH_RE.findall(spec.verification or ""):
+            problem = resolver.problem_with(match)
+            if problem is not None:
+                errors.append(f"{spec_id}: verification references {problem}")
     return errors
 
 

--- a/vultron/metadata/specs/llm_export.py
+++ b/vultron/metadata/specs/llm_export.py
@@ -72,6 +72,8 @@ def _spec_record(
     if spec.adr:
         rec["adr"] = list(spec.adr)
 
+    rec["verification"] = spec.verification
+
     if isinstance(spec, BehavioralSpec):
         if spec.preconditions:
             rec["preconditions"] = [p.description for p in spec.preconditions]


### PR DESCRIPTION
- Closes #2290

## Summary

`spec-dump` now emits `verification` for every spec (null when unset, value when authored). `_check_phantom_paths` now scans `verification` with the same hard-error semantics as `statement`.

## Changes

- **`vultron/metadata/specs/llm_export.py`**: add `rec["verification"] = spec.verification` always
- **`vultron/metadata/specs/lint.py`**: scan `spec.verification` for phantom paths; update docstring
- **`specs/meta-specifications.yaml`**: update MS-15-001 to name both fields
- **`test/metadata/specs/test_llm_export.py`**: 2 new tests
- **`test/metadata/specs/test_lint.py`**: 3 new tests

## Verification

- 402 metadata tests pass (5 new)
- 7093 unit tests pass
- Black, flake8, mypy, pyright clean
- spec-lint exits 0, no phantom paths in corpus