### PR TITLE
chore(demo-ci): remove fix/demo-ci from workflow branch triggers

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -6,11 +6,11 @@
 #
 # Triggers:
 #   pull_request  — minimum PR validation set (4 scenarios, DEMOCI-06-002);
-#                   targets both `main` and `fix/demo-ci` integration branches
-#   push to main/fix/demo-ci — full 9-scenario suite (DEMOCI-06-003, DEMOCI-05-001)
+#                   targets `main`
+#   push to main — full 9-scenario suite (DEMOCI-06-003, DEMOCI-05-001)
 #   workflow_dispatch — full 9-scenario suite; accepts optional `ref` input
-#                       so the suite can be run against any branch (e.g.
-#                       `fix/demo-ci`) without opening a PR to `main`
+#                       so the suite can be run against any branch without
+#                       opening a PR to `main`
 #
 # Dependabot PRs are skipped — python-app.yml still guards broken deps.
 # See DEMOCI-02-002, DEMOCI-02-003, DEMOCI-02-004.
@@ -63,8 +63,7 @@ name: Demo Integration
 
 on:
   pull_request:
-    # fix/demo-ci: temporary integration branch — remove when merged (#2144).
-    branches: ["main", "fix/demo-ci"]
+    branches: ["main"]
     paths:
       - "vultron/**"
       - "!vultron/metadata/**"
@@ -82,8 +81,7 @@ on:
       # The scenario matrix itself gates which demos run.
       - ".github/demo-scenarios.json"
   push:
-    # fix/demo-ci: temporary integration branch — remove when merged (#2144).
-    branches: ["main", "fix/demo-ci"]
+    branches: ["main"]
     paths:
       - "vultron/**"
       - "!vultron/metadata/**"
@@ -103,8 +101,7 @@ on:
         description: >-
           Branch, tag, or SHA to check out and run the full demo suite against.
           Defaults to the branch the workflow is dispatched from. Use this to
-          manually validate an integration branch (e.g. fix/demo-ci) before
-          merging it to main.
+          manually validate an integration branch before merging it to main.
         required: false
         default: ""
 

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -840,6 +840,27 @@ groups:
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-05-001
+      - id: DEMOCI-09-002
+        priority: MUST
+        kind: project
+        statement: >-
+          When an integration branch (e.g. `fix/demo-ci`) has merged to `main`
+          and all its child issues are closed, the branch name MUST be removed
+          from the `pull_request` and `push` trigger `branches:` arrays in
+          `demo-integration.yml`. Any inline comments that referenced the
+          temporary branch as a `# remove when merged` note MUST also be
+          removed at the same time.
+        rationale: >-
+          Stale branch entries in trigger arrays are dead configuration: the
+          branch no longer exists, so the entries neither fire nor provide
+          documentation value. Leaving them risks confusing future maintainers
+          about which branches are legitimate targets. Removing them (together
+          with any accompanying comments) keeps the trigger configuration
+          self-consistent and matches the actual lifecycle of integration
+          branches.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-09-001
 
   - id: DEMOCI-10
     title: Case-Ledger Artifact Availability on Failure


### PR DESCRIPTION
- Closes #2144
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Removes all `fix/demo-ci` references from `.github/workflows/demo-integration.yml`
now that the integration branch has merged to `main` (blocker #2143 closed).

## Changes

- **`.github/workflows/demo-integration.yml`**: Remove `fix/demo-ci` from both
  the `pull_request` and `push` trigger `branches:` arrays; remove the inline
  temporary-branch comments; update the header comment block and
  `workflow_dispatch` input description to no longer reference the retired
  branch. Per DEMOCI-09-002.

## Verification

- Black, flake8, mypy, pyright clean
- No Python files changed; unit suite result unchanged
- actionlint passed via pre-commit hook