### PR TITLE
Derive _KEEP_INLINE_NESTED_TYPES from AS2 enums instead of hand-maintaining it

### DIFF
--- a/test/adapters/driven/test_db_record.py
+++ b/test/adapters/driven/test_db_record.py
@@ -18,11 +18,16 @@ from pydantic import BaseModel
 
 from vultron.adapters.driven.db_record import (
     Record,
+    _KEEP_INLINE_NESTED_TYPES,
     _dehydrate_data,
     object_to_record,
     record_to_object,
 )
 from vultron.errors import VultronValidationError
+from vultron.wire.as2.enums import (
+    as_IntransitiveActivityType,
+    as_TransitiveActivityType,
+)
 from vultron.wire.as2.factories import rm_submit_report_activity
 
 
@@ -411,3 +416,41 @@ def test_object_to_record_still_accepts_wire_activities():
 
     record = object_to_record(offer)
     assert record.type_ == "Offer"
+
+
+# ---------------------------------------------------------------------------
+# _KEEP_INLINE_NESTED_TYPES derivation guard (issue #2218)
+# ---------------------------------------------------------------------------
+
+
+def test_keep_inline_nested_types_contains_all_transitive_activity_values():
+    """_KEEP_INLINE_NESTED_TYPES must cover every as_TransitiveActivityType value."""
+    for member in as_TransitiveActivityType:
+        assert member.value in _KEEP_INLINE_NESTED_TYPES, (
+            f"as_TransitiveActivityType.{member.name} ({member.value!r}) "
+            "is missing from _KEEP_INLINE_NESTED_TYPES"
+        )
+
+
+def test_keep_inline_nested_types_contains_all_intransitive_activity_values():
+    """_KEEP_INLINE_NESTED_TYPES must cover every as_IntransitiveActivityType value."""
+    for member in as_IntransitiveActivityType:
+        assert member.value in _KEEP_INLINE_NESTED_TYPES, (
+            f"as_IntransitiveActivityType.{member.name} ({member.value!r}) "
+            "is missing from _KEEP_INLINE_NESTED_TYPES"
+        )
+
+
+def test_keep_inline_nested_types_contains_case_ledger_entry():
+    """_KEEP_INLINE_NESTED_TYPES must include the Vultron-specific CaseLedgerEntry."""
+    assert "CaseLedgerEntry" in _KEEP_INLINE_NESTED_TYPES
+
+
+def test_keep_inline_nested_types_matches_enum_union_exactly():
+    """_KEEP_INLINE_NESTED_TYPES must equal the union of both enum value sets plus CaseLedgerEntry."""
+    expected = (
+        frozenset(e.value for e in as_TransitiveActivityType)
+        | frozenset(e.value for e in as_IntransitiveActivityType)
+        | {"CaseLedgerEntry"}
+    )
+    assert _KEEP_INLINE_NESTED_TYPES == expected

--- a/vultron/adapters/driven/db_record.py
+++ b/vultron/adapters/driven/db_record.py
@@ -25,6 +25,10 @@ from vultron.core.models.protocols import PersistableModel
 from vultron.core.models.registry import CORE_VOCABULARY
 from vultron.core.ports.datalayer import StorableRecord
 from vultron.errors import VultronValidationError
+from vultron.wire.as2.enums import (
+    as_IntransitiveActivityType,
+    as_TransitiveActivityType,
+)
 from vultron.wire.as2.vocab.base.registry import find_in_vocabulary
 
 _WIRE_MODULE_PREFIX = "vultron.wire.as2"
@@ -77,40 +81,9 @@ _AS_OBJECT_REF_FIELDS: frozenset[str] = frozenset(
 # Announce envelope), so dehydrating them would make rehydration impossible on
 # read-back and cause MV-09-001 outbox-gate failures.
 _KEEP_INLINE_NESTED_TYPES: frozenset[str] = frozenset(
-    {
-        # as_TransitiveActivityType values
-        "Accept",
-        "Add",
-        "Announce",
-        "Block",
-        "Create",
-        "Delete",
-        "Dislike",
-        "Flag",
-        "Follow",
-        "Ignore",
-        "Invite",
-        "Join",
-        "Leave",
-        "Like",
-        "Listen",
-        "Move",
-        "Offer",
-        "Read",
-        "Reject",
-        "Remove",
-        "TentativeAccept",
-        "TentativeReject",
-        "Undo",
-        "Update",
-        "View",
-        # as_IntransitiveActivityType values
-        "Arrive",
-        "Question",
-        "Travel",
-        # Vultron-specific type kept inline for the same reason
-        "CaseLedgerEntry",
-    }
+    {e.value for e in as_TransitiveActivityType}
+    | {e.value for e in as_IntransitiveActivityType}
+    | {"CaseLedgerEntry"}
 )
 
 # Fields that hold a *list* of object references (ID strings or inline


### PR DESCRIPTION
- Closes #2218

## Summary

Replaces the 31-line hand-maintained `frozenset` `_KEEP_INLINE_NESTED_TYPES` in
`vultron/adapters/driven/db_record.py` with a 3-line expression derived from
`as_TransitiveActivityType` and `as_IntransitiveActivityType` at module
initialisation, eliminating silent drift when new AS2 Activity types are added.

## Changes

- **`vultron/adapters/driven/db_record.py`**: import the two enums; replace
  the literal set body with a set-comprehension union. Behaviour is unchanged —
  the frozenset values are identical to what was hard-coded.
- **`test/adapters/driven/test_db_record.py`**: 4 new guard tests verify that
  `_KEEP_INLINE_NESTED_TYPES` covers all transitive and intransitive enum values
  plus `"CaseLedgerEntry"`, and that the set equals the exact expected union.

## Verification

- All 25 `test_db_record` tests pass (21 pre-existing + 4 new)
- Full unit suite: 7092 passed, 0 failures
- Integration suite: 1162 passed, 0 failures
- Black, flake8, mypy, pyright clean