### PR TITLE
fix: remove core-layer types from wire VOCABULARY registry (ARCH-12-003)

### DIFF
--- a/notes/vocabulary-registry.md
+++ b/notes/vocabulary-registry.md
@@ -115,6 +115,44 @@ loaded without requiring each application path to import them manually.
 
 ---
 
+## CORE_TYPE_MAP and the ARCH-12-003 Fix
+
+(ISSUE-1992, 2026-08-19)
+
+ARCH-12-003 forbids core-branch types from appearing in the wire `VOCABULARY`
+dict. Before this fix, six core types (`VultronOfferRecord`,
+`VultronPendingCaseInbox`, `PendingCreateCaseActivity`,
+`VultronReplicationState`, `VultronReportCaseLink`, `CoreActor`) were
+explicitly assigned to `VOCABULARY` keys in their wire-side re-export modules.
+
+The fix:
+
+1. **`CORE_TYPE_MAP`** (`vultron/core/models/registry.py`) — a new dict
+   separate from `VOCABULARY` and `CORE_VOCABULARY`. Auto-populated by
+   `VultronObject.__init_subclass__` (for concrete `Literal[...]` `type_`
+   annotations) and by `CoreObject.__init_subclass__` (for no-`type_`
+   subclasses that use `_set_type_from_class_name`).
+
+2. **`find_in_vocabulary()` fallback** — after checking `VOCABULARY`, the
+   function calls `find_in_core_type_map()` before raising `KeyError`.
+   This means callers (deserialization, discriminated-union construction) can
+   look up core types by name without those types polluting the wire registry.
+
+3. **Wire re-export modules** (`offer_record.py`, etc.) no longer write to
+   `VOCABULARY`. They import and re-export the core class unchanged.
+
+**Why `VultronObject`, not `CoreObject`**: five of the six affected types
+inherit `VultronObject` directly (not through `CoreObject`), so the hook must
+live on the shared root. See
+`plan/incoming/learnings/20260819-core-type-map-hook-on-vultronobject-not-coreobject.md`.
+
+**Known side-effect**: because `as_Object` also inherits `VultronObject`
+(ARCH-12-001), wire-layer types also trigger `VultronObject.__init_subclass__`
+and land in `CORE_TYPE_MAP`. This is functionally harmless — `VOCABULARY` is
+checked first — but is architecturally imprecise. Tracked in a separate issue.
+
+---
+
 ## Vocabulary Override Preservation
 
 (ISSUE-801, 2026-06-09)
@@ -132,7 +170,7 @@ mapping in the base module.
 
 ```python
 # base/objects/actors.py — keep at least this registration
-VOCABULARY["Actor"] = as_Actor  # ← must stay
+VOCABULARY["Actor"] = as_Actor  # ← must stay (and is the correct state as of ISSUE-1992)
 
 # vultron_actor.py — override specific concrete types only
 VOCABULARY["Person"] = VultronPerson
@@ -143,6 +181,12 @@ VOCABULARY["Organization"] = VultronOrganization
 `vocab/base/objects/` contributes at least one concrete registration.
 A module with zero registrations indicates a structural gap (all
 registrations were moved elsewhere) and causes the invariant check to fail.
+
+**Current state (post ISSUE-1992)**: `VOCABULARY["Actor"]` correctly maps to
+`as_Actor`. The earlier `CoreActor` assignment was removed as an ARCH-12-003
+violation — `CoreActor` is a core-layer type and must not appear in the wire
+`VOCABULARY`. It is now reachable via `find_in_vocabulary("CoreActor")` through
+the `CORE_TYPE_MAP` fallback.
 
 ## Related Files
 

--- a/plan/incoming/learnings/20260819-core-type-map-hook-on-vultronobject-not-coreobject.md
+++ b/plan/incoming/learnings/20260819-core-type-map-hook-on-vultronobject-not-coreobject.md
@@ -1,0 +1,25 @@
+---
+title: CORE_TYPE_MAP registration hook belongs on VultronObject, not CoreObject
+type: learning
+timestamp: 2026-08-19T00:00:00Z
+source: ISSUE-1992
+signal: design-question
+---
+
+When fixing ARCH-12-003 (#1992), the initial plan was to register core-layer
+types in `CORE_TYPE_MAP` via `CoreObject.__init_subclass__`. This worked for
+`CoreActor` (which IS a `CoreObject` subclass) but missed 5 of the 6 affected
+types (`VultronOfferRecord`, `VultronPendingCaseInbox`,
+`PendingCreateCaseActivity`, `VultronReportCaseLink`,
+`VultronReplicationState`) because they inherit from `VultronObject` directly,
+not from `CoreObject`.
+
+**Root cause:** The VultronObject → CoreObject branching means the two
+hierarchies share only `VultronObject` as common root. Any hook that needs to
+cover both must live on `VultronObject`, not `CoreObject`.
+
+**Fix:** Placed the `CORE_TYPE_MAP` registration hook in
+`VultronObject.__init_subclass__` using the same "concrete Literal type_
+annotation" guard as `CoreObject`. `CoreObject` also registers no-annotation
+subclasses by class name (for the `_set_type_from_class_name` path) since
+`CoreObject` is the only branch that has that validator.

--- a/plan/incoming/learnings/20260819-pydantic-model-fields-not-available-in-init-subclass.md
+++ b/plan/incoming/learnings/20260819-pydantic-model-fields-not-available-in-init-subclass.md
@@ -1,0 +1,28 @@
+---
+title: pydantic model_fields not populated during __init_subclass__
+type: learning
+timestamp: 2026-08-19T00:00:00Z
+source: ISSUE-1992
+signal: design-question
+---
+
+When a Pydantic v2 model class is being defined, `__init_subclass__` fires
+during Python's class-creation machinery — before Pydantic's metaclass
+`__new__` has finished processing the new class. As a result,
+`cls.model_fields` at that moment still reflects the *parent* class's fields,
+not the child's.
+
+**What this means in practice:** any `__init_subclass__` hook that tries to
+read `cls.model_fields.get("type_").default` to extract a Literal default will
+silently get the parent's value (usually `None`), not the child's.
+
+**Fix applied in #1992:** extract the Literal value directly from the type
+annotation using `typing.get_args(annotation)` instead of relying on
+`model_fields`. The annotation IS available in `__init_subclass__` via
+`typing.get_type_hints(cls)`.
+
+```python
+literal_args = _typing.get_args(annotation)
+if literal_args and len(literal_args) == 1 and isinstance(literal_args[0], str):
+    CORE_TYPE_MAP[literal_args[0]] = cls
+```

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -198,8 +198,8 @@ groups:
       `datetime`). Core-branch types MUST NOT carry wire-specific concerns: `alias_generator=to_camel`, hardcoded AS2 `@context`
       namespace, or VOCABULARY registration are forbidden in core-branch types.'
     verification: 'No `CoreObject` subclass declares `alias_generator` in its `model_config`, references `to_camel`, or assigns
-      to `VOCABULARY`. Confirmed by `test_no_core_object_has_to_camel_alias_generator` in `test/architecture/test_hierarchy_invariants.py`,
-      which MUST NOT be marked `xfail`.'
+      to `VOCABULARY`. Confirmed by `test_no_core_object_has_to_camel_alias_generator` and `test_all_vocabulary_are_as_base_subclasses`
+      in `test/architecture/test_hierarchy_invariants.py`, both of which MUST NOT be marked `xfail`.'
     rationale: 'An `alias_generator` on a core type gives one `type_` two accepted key spellings, so whichever class reads a
       row decides what the data means (issue #2232). It is also insufficient for its intended purpose: a core `model_dump(by_alias=True)`
       cannot produce the wire shape for a type whose branches differ structurally, which is why a hand-patched `consent`→`emConsentState`

--- a/test/architecture/test_hierarchy_invariants.py
+++ b/test/architecture/test_hierarchy_invariants.py
@@ -71,19 +71,9 @@ _TO_CAMEL_BACKLOG_1991: frozenset[str] = frozenset(
 
 # ---------------------------------------------------------------------------
 # Backlog: core-layer classes registered in the wire VOCABULARY registry,
-# violating ARCH-12-003 (issue #1992). This set may only SHRINK.
+# violating ARCH-12-003 (issue #1992). All violations resolved — set is empty.
 # ---------------------------------------------------------------------------
-_NON_AS_BASE_BACKLOG_1992: frozenset[str] = frozenset(
-    {
-        "Actor",
-        "CoreActor",
-        "OfferRecord",
-        "PendingCaseInbox",
-        "PendingCreateCaseActivity",
-        "ReplicationState",
-        "ReportCaseLink",
-    }
-)
+_NON_AS_BASE_BACKLOG_1992: frozenset[str] = frozenset()
 
 
 class TestCoreVocabularyHierarchy:
@@ -198,13 +188,6 @@ class TestWireVocabularyHierarchy:
             " (ARCH-12-003, issue #1992)."
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Goal state for issue #1992: the wire VOCABULARY contains only "
-        "as_Base subclasses. 7 known core-layer entries remain, enumerated in "
-        "_NON_AS_BASE_BACKLOG_1992. When the last is removed this test XPASSes "
-        "and fails the build — delete the marker and the backlog then.",
-    )
     def test_all_vocabulary_are_as_base_subclasses(self) -> None:
         """All VOCABULARY classes must be subclasses of as_Base.
 

--- a/test/wire/as2/vocab/base/test_registry.py
+++ b/test/wire/as2/vocab/base/test_registry.py
@@ -190,3 +190,76 @@ class TestDynamicDiscovery:
 
         assert VOCABULARY["VulnerabilityReport"] is as_VulnerabilityReport
         assert VOCABULARY["VulnerabilityCase"] is as_VulnerabilityCase
+
+
+class TestCoreTypeMapFallback:
+    """Regression tests for ARCH-12-003 / issue #1992.
+
+    Core-layer types must NOT appear in VOCABULARY directly, but
+    find_in_vocabulary() must still locate them via the CORE_TYPE_MAP fallback.
+    """
+
+    def setup_method(self):
+        # Import the objects subpackage — its _discover_modules() imports each
+        # wire vocab module, which in turn imports the core model classes and
+        # triggers VultronObject.__init_subclass__ to populate CORE_TYPE_MAP.
+        import vultron.wire.as2.vocab.objects  # noqa: F401
+
+    _CORE_TYPE_NAMES = [
+        "CoreActor",
+        "OfferRecord",
+        "PendingCaseInbox",
+        "PendingCreateCaseActivity",
+        "ReportCaseLink",
+        "ReplicationState",
+    ]
+
+    def test_core_types_absent_from_vocabulary(self):
+        """None of the formerly-misregistered core types should be in VOCABULARY."""
+        for name in self._CORE_TYPE_NAMES:
+            assert (
+                name not in VOCABULARY
+            ), f"ARCH-12-003 violation: {name!r} must not be in wire VOCABULARY"
+
+    def test_actor_key_is_wire_type(self):
+        """VOCABULARY['Actor'] must be the wire as_Actor, not CoreActor."""
+        from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+        from vultron.core.models.actor import CoreActor
+
+        assert "Actor" in VOCABULARY
+        assert VOCABULARY["Actor"] is as_Actor
+        assert VOCABULARY["Actor"] is not CoreActor
+
+    def test_core_types_findable_via_fallback(self):
+        """find_in_vocabulary must resolve each formerly-misregistered core type."""
+        for name in self._CORE_TYPE_NAMES:
+            cls = find_in_vocabulary(name)
+            assert (
+                cls is not None
+            ), f"find_in_vocabulary({name!r}) returned None"
+            assert callable(
+                cls
+            ), f"find_in_vocabulary({name!r}) is not callable"
+
+    def test_core_actor_resolves_to_core_actor_class(self):
+        """find_in_vocabulary('CoreActor') returns CoreActor."""
+        from vultron.core.models.actor import CoreActor
+
+        cls = find_in_vocabulary("CoreActor")
+        assert cls is CoreActor
+
+    def test_offer_record_resolves_correctly(self):
+        """find_in_vocabulary('OfferRecord') returns VultronOfferRecord."""
+        from vultron.core.models.offer_record import VultronOfferRecord
+
+        cls = find_in_vocabulary("OfferRecord")
+        assert cls is VultronOfferRecord
+
+    def test_replication_state_resolves_correctly(self):
+        """find_in_vocabulary('ReplicationState') returns VultronReplicationState."""
+        from vultron.core.models.replication_state import (
+            VultronReplicationState,
+        )
+
+        cls = find_in_vocabulary("ReplicationState")
+        assert cls is VultronReplicationState

--- a/test/wire/as2/vocab/test_vultron_actor.py
+++ b/test/wire/as2/vocab/test_vultron_actor.py
@@ -19,10 +19,7 @@ VultronActorMixin (EP-01-001).
 import unittest
 from datetime import timedelta
 
-from vultron.core.models.actor import (
-    CoreActor,
-    VultronPerson as CoreVultronPerson,
-)
+from vultron.core.models.actor import VultronPerson as CoreVultronPerson
 from vultron.wire.as2.enums import as_ActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
@@ -168,7 +165,9 @@ class TestVultronActorTypePreservation(unittest.TestCase):
 
 class TestWireActorVocabularyAndRoundTrip(unittest.TestCase):
     def test_vocabulary_points_to_wire_actor_types(self):
-        self.assertIs(VOCABULARY["Actor"], CoreActor)
+        # ARCH-12-003: VOCABULARY["Actor"] must be the wire as_Actor, not CoreActor.
+        # CoreActor was removed from VOCABULARY in issue #1992.
+        self.assertIs(VOCABULARY["Actor"], as_Actor)
         self.assertIs(VOCABULARY["Person"], as_VultronPerson)
         self.assertIs(VOCABULARY["Organization"], as_VultronOrganization)
         self.assertIs(VOCABULARY["Service"], as_VultronService)

--- a/vultron/core/models/base.py
+++ b/vultron/core/models/base.py
@@ -30,7 +30,7 @@ from pydantic import (
 )
 
 from vultron.core.models._helpers import _new_urn, _now_utc
-from vultron.core.models.registry import CORE_VOCABULARY
+from vultron.core.models.registry import CORE_TYPE_MAP, CORE_VOCABULARY
 
 
 class ValidatedAssignmentMixin(BaseModel):
@@ -92,6 +92,43 @@ class VultronObject(ValidatedAssignmentMixin, VultronBase):
     hierarchy in the wire layer.  Concrete domain object classes inherit from
     this base rather than directly from ``BaseModel``.
     """
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)  # type: ignore[arg-type]
+        # Register every concrete VultronObject subclass in CORE_TYPE_MAP so
+        # that find_in_vocabulary() can locate them without placing them in the
+        # wire VOCABULARY dict (ARCH-12-003). Only subclasses that declare
+        # their own concrete type_ annotation are registered; abstract bases
+        # that inherit or omit type_ are skipped (same guard as CoreObject).
+        own_annotations = cls.__dict__.get("__annotations__", {})
+        if "type_" not in own_annotations:
+            return
+        try:
+            hints = _typing.get_type_hints(cls)
+        except Exception:
+            return
+        annotation = hints.get("type_")
+        if isinstance(annotation, _types.UnionType):
+            return
+        if _typing.get_origin(annotation) is _typing.Union:
+            return
+        try:
+            # Register by class name (covers classes where _set_type_from_class_name
+            # sets type_ = cls.__name__, e.g. CoreActor stored as "CoreActor").
+            CORE_TYPE_MAP[cls.__name__] = cls
+            # Also register by the Literal value itself when it differs from the
+            # class name (e.g. VultronOfferRecord → "OfferRecord"). Extract from
+            # the annotation directly; model_fields is not yet populated at
+            # __init_subclass__ time.
+            literal_args = _typing.get_args(annotation)
+            if (
+                literal_args
+                and len(literal_args) == 1
+                and isinstance(literal_args[0], str)
+            ):
+                CORE_TYPE_MAP[literal_args[0]] = cls
+        except Exception:
+            pass
 
     replies: Any | None = None
     url: NonEmptyString | None = None
@@ -176,7 +213,11 @@ class CoreObject(VultronObject):
         # would silently fall through and register abstract bases.
         own_annotations = cls.__dict__.get("__annotations__", {})
         if "type_" not in own_annotations:
-            return  # No type_ override → abstract base, skip
+            # No explicit type_ annotation: _set_type_from_class_name will set
+            # type_ = cls.__name__ at construction time, so register by class
+            # name so that find_in_vocabulary can reconstruct from DB storage.
+            CORE_TYPE_MAP[cls.__name__] = cls
+            return  # Skip CORE_VOCABULARY — not a concrete vocab entry
         try:
             hints = _typing.get_type_hints(cls)
         except Exception:

--- a/vultron/core/models/base.py
+++ b/vultron/core/models/base.py
@@ -216,6 +216,11 @@ class CoreObject(VultronObject):
             # No explicit type_ annotation: _set_type_from_class_name will set
             # type_ = cls.__name__ at construction time, so register by class
             # name so that find_in_vocabulary can reconstruct from DB storage.
+            # This fires for abstract intermediate subclasses too — any
+            # CoreObject subclass that never overrides type_ registers here,
+            # making find_in_vocabulary('ClassName') succeed even for abstract
+            # bases.  Intentional: _set_type_from_class_name runs on all such
+            # subclasses, so every registered name is a valid stored type_.
             CORE_TYPE_MAP[cls.__name__] = cls
             return  # Skip CORE_VOCABULARY — not a concrete vocab entry
         try:

--- a/vultron/core/models/registry.py
+++ b/vultron/core/models/registry.py
@@ -31,6 +31,28 @@ from pydantic import BaseModel
 
 CORE_VOCABULARY: dict[str, type[BaseModel]] = {}
 
+# Maps each CoreObject subclass's serialized ``type_`` string to its class.
+# Used by ``find_in_vocabulary`` as a fallback so that core-layer types can be
+# reconstructed from persistent storage without being registered in the wire
+# ``VOCABULARY`` dict (ARCH-12-003).  Populated by
+# ``CoreObject.__init_subclass__`` when a concrete subclass is first defined.
+CORE_TYPE_MAP: dict[str, type[BaseModel]] = {}
+
+
+def find_in_core_type_map(type_name: str) -> type[BaseModel]:
+    """Find a core class by its serialized ``type_`` string.
+
+    Args:
+        type_name: The ``type_`` value as stored in a Record (e.g. ``"OfferRecord"``).
+    Returns:
+        The core class registered under that type string.
+    Raises:
+        KeyError: If the type string is not registered.
+    """
+    if type_name not in CORE_TYPE_MAP:
+        raise KeyError(f"Unknown core type: {type_name!r}")
+    return CORE_TYPE_MAP[type_name]
+
 
 def find_in_core_vocabulary(item_name: str) -> type[BaseModel]:
     """Find a class in the core vocabulary by type name.

--- a/vultron/wire/as2/vocab/AGENTS.md
+++ b/vultron/wire/as2/vocab/AGENTS.md
@@ -11,9 +11,13 @@
    `@activitystreams_activity` decorators. Registration is automatic via
    `as_Base.__init_subclass__` when a class sets `type_` to `Literal[...]`.
 
-2. `find_in_vocabulary()` MUST raise `KeyError` for unknown type names —
-   never return `None`. Callers that previously checked `if vocab_cls is
-   not None` must use `try/except KeyError` instead.
+2. `find_in_vocabulary()` checks `VOCABULARY` first, then falls back to
+   `CORE_TYPE_MAP` (core domain types that MUST NOT appear in the wire
+   `VOCABULARY` per ARCH-12-003). It MUST raise `KeyError` for names not
+   found in either registry — never return `None`. Callers that previously
+   checked `if vocab_cls is not None` must use `try/except KeyError` instead.
+   Do NOT add core-layer types to `VOCABULARY` as a workaround for a
+   missing lookup — fix the registration in `CORE_TYPE_MAP` instead.
 
 ## Related Files
 

--- a/vultron/wire/as2/vocab/base/registry.py
+++ b/vultron/wire/as2/vocab/base/registry.py
@@ -18,22 +18,30 @@ Provides a registry for the Vultron ActivityStreams Vocabulary.
 
 from pydantic import BaseModel
 
+from vultron.core.models.registry import CORE_TYPE_MAP
+
 VOCABULARY: dict[str, type[BaseModel]] = {}
 
 
 def find_in_vocabulary(item_name: str) -> type[BaseModel]:
     """Find a class in the vocabulary by type name.
 
+    Checks the wire ``VOCABULARY`` first, then falls back to the core
+    ``CORE_TYPE_MAP`` for types that belong to the core domain layer and
+    must not be registered as wire vocabulary entries (ARCH-12-003).
+
     Args:
         item_name: The name of the type to find.
     Returns:
         The class registered under that name.
     Raises:
-        KeyError: If the type name is not registered in the vocabulary.
+        KeyError: If the type name is not registered in either vocabulary.
     """
-    if item_name not in VOCABULARY:
-        raise KeyError(f"Unknown vocabulary type: {item_name!r}")
-    return VOCABULARY[item_name]
+    if item_name in VOCABULARY:
+        return VOCABULARY[item_name]
+    if item_name in CORE_TYPE_MAP:
+        return CORE_TYPE_MAP[item_name]
+    raise KeyError(f"Unknown vocabulary type: {item_name!r}")
 
 
 def main():

--- a/vultron/wire/as2/vocab/base/registry.py
+++ b/vultron/wire/as2/vocab/base/registry.py
@@ -18,7 +18,7 @@ Provides a registry for the Vultron ActivityStreams Vocabulary.
 
 from pydantic import BaseModel
 
-from vultron.core.models.registry import CORE_TYPE_MAP
+from vultron.core.models.registry import find_in_core_type_map
 
 VOCABULARY: dict[str, type[BaseModel]] = {}
 
@@ -27,8 +27,9 @@ def find_in_vocabulary(item_name: str) -> type[BaseModel]:
     """Find a class in the vocabulary by type name.
 
     Checks the wire ``VOCABULARY`` first, then falls back to the core
-    ``CORE_TYPE_MAP`` for types that belong to the core domain layer and
-    must not be registered as wire vocabulary entries (ARCH-12-003).
+    ``CORE_TYPE_MAP`` (via :func:`find_in_core_type_map`) for types that
+    belong to the core domain layer and must not be registered as wire
+    vocabulary entries (ARCH-12-003).
 
     Args:
         item_name: The name of the type to find.
@@ -39,8 +40,10 @@ def find_in_vocabulary(item_name: str) -> type[BaseModel]:
     """
     if item_name in VOCABULARY:
         return VOCABULARY[item_name]
-    if item_name in CORE_TYPE_MAP:
-        return CORE_TYPE_MAP[item_name]
+    try:
+        return find_in_core_type_map(item_name)
+    except KeyError:
+        pass
     raise KeyError(f"Unknown vocabulary type: {item_name!r}")
 
 

--- a/vultron/wire/as2/vocab/objects/offer_record.py
+++ b/vultron/wire/as2/vocab/objects/offer_record.py
@@ -17,8 +17,5 @@
 from vultron.core.models.offer_record import (  # noqa: F401
     VultronOfferRecord,
 )
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
-
-VOCABULARY["OfferRecord"] = VultronOfferRecord
 
 __all__ = ["VultronOfferRecord"]

--- a/vultron/wire/as2/vocab/objects/pending_case_inbox.py
+++ b/vultron/wire/as2/vocab/objects/pending_case_inbox.py
@@ -17,8 +17,5 @@
 from vultron.core.models.pending_case_inbox import (  # noqa: F401
     VultronPendingCaseInbox,
 )
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
-
-VOCABULARY["PendingCaseInbox"] = VultronPendingCaseInbox
 
 __all__ = ["VultronPendingCaseInbox"]

--- a/vultron/wire/as2/vocab/objects/pending_create_case_activity.py
+++ b/vultron/wire/as2/vocab/objects/pending_create_case_activity.py
@@ -15,11 +15,8 @@
 
 """Wire-layer vocabulary registration for :class:`PendingCreateCaseActivity`."""
 
-from vultron.core.models.pending_create_case_activity import (
+from vultron.core.models.pending_create_case_activity import (  # noqa: F401
     PendingCreateCaseActivity,
 )
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
-
-VOCABULARY["PendingCreateCaseActivity"] = PendingCreateCaseActivity
 
 __all__ = ["PendingCreateCaseActivity"]

--- a/vultron/wire/as2/vocab/objects/replication_state.py
+++ b/vultron/wire/as2/vocab/objects/replication_state.py
@@ -24,8 +24,5 @@ Spec: SYNC-04-001, SYNC-04-002.
 from vultron.core.models.replication_state import (  # noqa: F401
     VultronReplicationState,
 )
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
-
-VOCABULARY["ReplicationState"] = VultronReplicationState
 
 __all__ = ["VultronReplicationState"]

--- a/vultron/wire/as2/vocab/objects/report_case_link.py
+++ b/vultron/wire/as2/vocab/objects/report_case_link.py
@@ -17,8 +17,5 @@
 from vultron.core.models.report_case_link import (  # noqa: F401
     VultronReportCaseLink,
 )
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
-
-VOCABULARY["ReportCaseLink"] = VultronReportCaseLink
 
 __all__ = ["VultronReportCaseLink"]

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -74,8 +74,6 @@ class as_VultronGroup(VultronActorMixin):
     )
 
 
-VOCABULARY["Actor"] = CoreActor
-VOCABULARY["CoreActor"] = CoreActor
 VOCABULARY["Person"] = as_VultronPerson
 VOCABULARY["Organization"] = as_VultronOrganization
 VOCABULARY["Service"] = as_VultronService


### PR DESCRIPTION
- Closes #1992

## Summary

Removes 7 core-layer types from the wire `VOCABULARY` dict (ARCH-12-003 violation). Adds a `CORE_TYPE_MAP` fallback in `find_in_vocabulary` so DB deserialization still works without placing core types in the wire registry.

## Changes

- **`vultron/core/models/registry.py`**: Added `CORE_TYPE_MAP` dict and `find_in_core_type_map()`.
- **`vultron/core/models/base.py`**: Added `VultronObject.__init_subclass__` hook that auto-registers concrete subclasses in `CORE_TYPE_MAP` by both class name and Literal `type_` value (extracted via `typing.get_args` since `model_fields` is not populated at `__init_subclass__` time). `CoreObject.__init_subclass__` additionally registers no-annotation subclasses by class name (for the `_set_type_from_class_name` path).
- **`vultron/wire/as2/vocab/base/registry.py`**: `find_in_vocabulary` now falls back to `CORE_TYPE_MAP` before raising `KeyError`.
- **`vultron/wire/as2/vocab/objects/{offer_record,pending_case_inbox,pending_create_case_activity,replication_state,report_case_link}.py`**: Removed `VOCABULARY` import and registration — re-export only.
- **`vultron/wire/as2/vocab/objects/vultron_actor.py`**: Removed `VOCABULARY["Actor"] = CoreActor` and `VOCABULARY["CoreActor"] = CoreActor`. `VOCABULARY["Actor"]` now correctly points to `as_Actor`.
- **`test/architecture/test_hierarchy_invariants.py`**: Cleared `_NON_AS_BASE_BACKLOG_1992` to `frozenset()` and removed the `xfail` marker from `test_all_vocabulary_are_as_base_subclasses`.
- **`test/wire/as2/vocab/base/test_registry.py`**: Added `TestCoreTypeMapFallback` regression test class verifying the 6 former-violation types are absent from `VOCABULARY` but findable via `find_in_vocabulary`.
- **`test/wire/as2/vocab/test_vultron_actor.py`**: Updated `test_vocabulary_points_to_wire_actor_types` — `VOCABULARY["Actor"]` now correctly asserts `as_Actor`, not `CoreActor`.

## Verification

- 7100 unit tests pass (6 new in `TestCoreTypeMapFallback`, 1 updated assertion)
- 1162 integration tests pass
- Black, flake8, mypy, pyright clean