### PR TITLE
fix: invariant harness — per-actor divergence invariants and single-scenario silent-skip fix

### DIFF
--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -87,7 +87,8 @@ These cover any failure that happens *inside* `scenario_harness()`.
    | State of the downloaded artifact | Outcome |
    |---|---|
    | no `devlogs/`, or no `devlogs/<demo>/` | `skip` — the demo genuinely did not run |
-   | no ledger files **and** no `dump-manifest.json` | `skip` — same |
+   | `devlogs/<demo>/` exists, no ledger files, no manifest | **`fail`** — directory created but dump never ran (ISSUE-2411) |
+   | no ledger files **and** no `dump-manifest.json`, no `demo_name` | `skip` — unscoped load with no data |
    | no ledger files **but** a manifest exists | **`fail`** — real invariant failure |
    | manifest present but unparseable | **`fail`** |
    | ledger files present | load and check normally |
@@ -146,6 +147,7 @@ reporting a protocol result.
 - `test/demo/test_scenario_harness.py`
 - `test/ci/invariants/test_common.py::TestLoadDevlogsManifestHandling`
 - `test/ci/invariants/test_common.py::TestAllSkipGuard`
+- `test/ci/invariants/test_common.py::TestCheckPerActorReplicaDivergence` (ISSUE-2411 Gap 1)
 - `test/demo/test_ledger_dump.py::TestWritePrerunSentinel` (AC4 for #2281)
 
 ---
@@ -166,6 +168,11 @@ existing nine:
    `_<SCENARIO>_EXPECTED_EVENT_TYPES`.
 4. Call the shared check functions from `common.py`; keep scenario-specific
    assertions in the scenario file.
+5. Include `test_invariant_per_actor_replica_divergence` calling
+   `check_per_actor_replica_divergence(replicas)`.  Pass
+   `check_fix_ready=False` for scenarios where no Vendor ever becomes a case
+   participant (currently only `fcv-reject`), mirroring the canonical
+   `test_invariant_15_cs_state_transitions_observed` rule (ISSUE-2411 Gap 1).
 
 **The scenario→harness registry is the CI matrix**, not a Python module. The
 `demo:` / `test_file:` pairs in `.github/demo-scenarios.json` (read by the

--- a/test/ci/invariants/common.py
+++ b/test/ci/invariants/common.py
@@ -242,11 +242,18 @@ def load_devlogs(
         if manifests:
             _fail_no_ledgers_despite_dump(search_root, manifests)
         skip_hint = f"devlogs/{demo_name}/" if demo_name else "devlogs/"
-        pytest.skip(
+        msg = (
             f"No *-case-ledger.jsonl files found under {skip_hint} and no "
             f"{DUMP_MANIFEST_FILENAME} — run the demo first "
             "(see test/ci/README-case-log-ratchet.md)"
         )
+        if demo_name:
+            # The scenario directory exists but contains neither ledger files
+            # nor a dump manifest — the dump never ran at all.  This is a
+            # real failure (crashed before any output was written), not a
+            # "demo has not been run yet" skip (ISSUE-2411 Gap 2).
+            pytest.fail(msg)
+        pytest.skip(msg)
 
     for actor in replicas:
         replicas[actor] = sorted(replicas[actor], key=log_index)
@@ -778,4 +785,52 @@ def check_no_rejected_invite_entries(
                     f"Actor {actor!r} logIndex={log_index(e)}: spurious"
                     f" rejected invite_actor_to_case entry (CLP-13-001 violation)"
                 )
+    return violations
+
+
+def check_per_actor_replica_divergence(
+    replicas: dict[str, list[dict]],
+    *,
+    check_fix_ready: bool = True,
+) -> list[str]:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log.
+
+    Runs RM-state and CS-transition invariants against every replica that is
+    not ``case-actor``.  The ``{actor: entries}`` single-actor dict causes
+    ``auth_entries()`` to fall back to the actor's own entries, reusing the
+    existing canonical check logic without modification (ISSUE-2411 Gap 1).
+
+    Actors whose replica contains no ``add_participant_status_to_participant``
+    entries are skipped for the three status-dependent checks; they have no
+    state-machine observations to verify.
+
+    Args:
+        replicas: All loaded replicas for the scenario.
+        check_fix_ready: Passed through to ``check_cs_state_transitions_observed``.
+            Set ``False`` for scenarios where no Vendor ever becomes a participant
+            (e.g. fcv-reject), matching the canonical invariant's behaviour.
+    """
+    violations: list[str] = []
+    for actor, entries in replicas.items():
+        if actor == "case-actor":
+            continue
+        actor_dict = {actor: entries}
+        prefix = f"Actor {actor!r}"
+        for msg in check_no_rm_state_oscillation(actor_dict):
+            violations.append(f"{prefix}: {msg}")
+        has_status_entries = any(
+            event_type(e) == "add_participant_status_to_participant"
+            for e in entries
+        )
+        if has_status_entries:
+            for msg in check_rm_closed_termination(actor_dict):
+                violations.append(f"{prefix}: {msg}")
+            for msg in check_participant_status_schema_completeness(
+                actor_dict
+            ):
+                violations.append(f"{prefix}: {msg}")
+            for msg in check_cs_state_transitions_observed(
+                actor_dict, check_fix_ready=check_fix_ready
+            ):
+                violations.append(f"{prefix}: {msg}")
     return violations

--- a/test/ci/invariants/test_common.py
+++ b/test/ci/invariants/test_common.py
@@ -634,6 +634,19 @@ class TestLoadDevlogsManifestHandling:
             common.load_devlogs("fvv")
         assert "run the" in (excinfo.value.msg or "")
 
+    def test_skips_when_unscoped_and_no_files(self, tmp_path, monkeypatch):
+        """Unscoped load_devlogs() (no demo_name) still skips when no ledger files exist.
+
+        The ISSUE-2411 Gap-2 fix adds an ``if demo_name:`` branch so that only
+        named-scenario calls fail on an empty directory; unscoped calls must
+        continue to skip so that running the invariant harness locally against
+        an empty devlogs/ tree does not error.
+        """
+        monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
+        with pytest.raises(Skipped) as excinfo:
+            common.load_devlogs()
+        assert "devlogs/" in str(excinfo.value)
+
     def test_fails_when_manifest_reports_no_ledgers(
         self, tmp_path, monkeypatch
     ):

--- a/test/ci/invariants/test_common.py
+++ b/test/ci/invariants/test_common.py
@@ -33,6 +33,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
 )
 from vultron.demo.helpers.ledger_dump import DUMP_MANIFEST_FILENAME
@@ -617,13 +618,21 @@ class TestLoadDevlogsManifestHandling:
             common.load_devlogs("fvv")
         assert "devlogs/" in str(excinfo.value)
 
-    def test_skips_when_scenario_ran_no_dump(self, tmp_path, monkeypatch):
-        """No manifest means the dump never ran, so there is nothing to judge."""
+    def test_fails_when_scenario_dir_exists_but_no_dump(
+        self, tmp_path, monkeypatch
+    ):
+        """Directory exists with no manifest means the dump never ran — a real failure.
+
+        When a named scenario directory exists but contains neither ledger
+        files nor a manifest, the demo runner wrote the directory but exited
+        before producing any output.  This is a crashed run, not a missing
+        run, so the harness must fail rather than skip (ISSUE-2411 Gap 2).
+        """
         monkeypatch.setattr(common, "_DEVLOGS_DIR", tmp_path)
         (tmp_path / "fvv").mkdir()
-        with pytest.raises(Skipped) as excinfo:
+        with pytest.raises(Failed) as excinfo:
             common.load_devlogs("fvv")
-        assert "run the" in str(excinfo.value)
+        assert "run the" in (excinfo.value.msg or "")
 
     def test_fails_when_manifest_reports_no_ledgers(
         self, tmp_path, monkeypatch
@@ -896,3 +905,134 @@ class TestAllSkipGuard:
         session = _ses(0)
         guard.pytest_sessionfinish(session=session)
         assert session.exitstatus == 0
+
+
+# ---------------------------------------------------------------------------
+# check_per_actor_replica_divergence (ISSUE-2411 Gap 1)
+# ---------------------------------------------------------------------------
+
+_ACTOR_A_ID = "https://example.org/actors/actor-a"
+_ACTOR_B_ID = "https://example.org/actors/actor-b"
+
+
+def _status_entry(
+    log_idx: int,
+    rm_state: str,
+    vfd_state: str,
+    pxa_state: str,
+    actor_id: str = _ACTOR_A_ID,
+) -> dict:
+    h = _SHA256(f"status:{log_idx}:{rm_state}")
+    return _entry(
+        log_idx,
+        h,
+        _SHA256(f"prev:{log_idx}"),
+        event_type="add_participant_status_to_participant",
+        payload={
+            "object": {
+                "attributedTo": actor_id,
+                "rmState": rm_state,
+                "emConsentState": "SIGNATORY",
+                "cvdRole": ["FINDER"],
+                "vfdState": vfd_state,
+                "caseStatus": {"pxaState": pxa_state},
+            }
+        },
+    )
+
+
+def _vendor_entries_valid() -> list[dict]:
+    """Minimal vendor replica that passes all per-actor checks."""
+    return [
+        _status_entry(0, "ACCEPTED", "VFd", "Pxa"),
+        _status_entry(1, "CLOSED", "VFd", "PXA"),
+    ]
+
+
+class TestCheckPerActorReplicaDivergence:
+    """check_per_actor_replica_divergence detects per-replica state violations.
+
+    Tests confirm: (a) case-actor replica is exempt; (b) actors without status
+    entries are exempt; (c) violations are found on invalid replicas; (d)
+    check_fix_ready is honoured per-actor (ISSUE-2411 Gap 1).
+    """
+
+    def test_passes_on_valid_multi_actor_replicas(self):
+        replicas = {
+            "case-actor": _vendor_entries_valid(),
+            "vendor": _vendor_entries_valid(),
+        }
+        assert check_per_actor_replica_divergence(replicas) == []
+
+    def test_case_actor_is_exempt(self):
+        """case-actor replica is never checked by this function."""
+        # Inject a defect only in case-actor — should produce no violations.
+        bad_entry = _status_entry(0, "ACCEPTED", "VFd", "Pxa")
+        bad_entry["payloadSnapshot"]["object"].pop("emConsentState")
+        replicas = {"case-actor": [bad_entry]}
+        assert check_per_actor_replica_divergence(replicas) == []
+
+    def test_actor_without_status_entries_is_exempt(self):
+        """An actor whose log has no status entries is not checked."""
+        h0 = _SHA256("nonstatus:0")
+        nonstatus = [_entry(0, h0, GENESIS_HASH, event_type="create_case")]
+        replicas = {"case-actor": _vendor_entries_valid(), "vendor": nonstatus}
+        assert check_per_actor_replica_divergence(replicas) == []
+
+    def test_detects_rm_oscillation_in_non_case_actor(self):
+        """RM state oscillation after CLOSED is detected in non-case-actor."""
+        actor_id = _ACTOR_A_ID
+        entries = [
+            _status_entry(0, "ACCEPTED", "VFd", "Pxa", actor_id),
+            _status_entry(1, "CLOSED", "VFd", "PXA", actor_id),
+            _status_entry(
+                2, "ACCEPTED", "VFd", "PXA", actor_id
+            ),  # oscillation
+        ]
+        replicas = {"case-actor": _vendor_entries_valid(), "vendor": entries}
+        violations = check_per_actor_replica_divergence(replicas)
+        assert violations
+        assert "vendor" in violations[0]
+
+    def test_detects_rm_closed_termination_failure_in_non_case_actor(self):
+        """Actor that never reaches CLOSED is flagged."""
+        entries = [_status_entry(0, "ACCEPTED", "VFd", "Pxa")]
+        replicas = {"case-actor": _vendor_entries_valid(), "vendor": entries}
+        violations = check_per_actor_replica_divergence(replicas)
+        assert violations
+        assert "vendor" in violations[0]
+
+    def test_detects_missing_cs_transition_in_non_case_actor(self):
+        """Actor whose replica never observes the P-transition is flagged."""
+        entries = [
+            _status_entry(0, "ACCEPTED", "VFd", "pxa"),  # no P yet
+            _status_entry(1, "CLOSED", "VFd", "pxa"),  # still no P
+        ]
+        replicas = {"case-actor": _vendor_entries_valid(), "vendor": entries}
+        violations = check_per_actor_replica_divergence(replicas)
+        assert violations
+        assert "vendor" in violations[0]
+
+    def test_check_fix_ready_false_skips_vfd_check_per_actor(self):
+        """check_fix_ready=False exempts VFd check for each non-case-actor replica."""
+        # vendor has P-transition but no VFd — valid when check_fix_ready=False
+        entries = [
+            _status_entry(0, "ACCEPTED", "vfd", "Pxa"),  # no VFd
+            _status_entry(1, "CLOSED", "vfd", "PXA"),  # still no VFd
+        ]
+        replicas = {"case-actor": _vendor_entries_valid(), "vendor": entries}
+        violations = check_per_actor_replica_divergence(
+            replicas, check_fix_ready=False
+        )
+        assert not violations
+
+    def test_check_fix_ready_true_enforces_vfd_check_per_actor(self):
+        """check_fix_ready=True (default) flags missing VFd in non-case-actor."""
+        entries = [
+            _status_entry(0, "ACCEPTED", "vfd", "Pxa"),  # no VFd
+            _status_entry(1, "CLOSED", "vfd", "PXA"),  # still no VFd
+        ]
+        replicas = {"case-actor": _vendor_entries_valid(), "vendor": entries}
+        violations = check_per_actor_replica_divergence(replicas)
+        assert violations
+        assert "vendor" in violations[0]

--- a/test/ci/invariants/test_fccv_extension_invariants.py
+++ b/test/ci/invariants/test_fccv_extension_invariants.py
@@ -51,6 +51,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
     load_devlogs,
 )
@@ -407,3 +408,16 @@ def test_fccv_extension_accept_invite_at_least_twice(
         fccv_extension_replicas, "accept_invite_actor_to_case", min_count=2
     )
     assert not violations, violations[0] if violations else ""
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_per_actor_replica_divergence(
+    fccv_extension_replicas: dict[str, list[dict]],
+) -> None:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
+    violations = check_per_actor_replica_divergence(fccv_extension_replicas)
+    assert (
+        not violations
+    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
+        violations
+    )

--- a/test/ci/invariants/test_fccv_handoff_invariants.py
+++ b/test/ci/invariants/test_fccv_handoff_invariants.py
@@ -48,6 +48,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
     load_devlogs,
 )
@@ -409,3 +410,16 @@ def test_fccv_handoff_vendor_late_joiner_has_full_history(
         fccv_handoff_replicas, early_actor="vendor", late_actor="vendor2"
     )
     assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_per_actor_replica_divergence(
+    fccv_handoff_replicas: dict[str, list[dict]],
+) -> None:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
+    violations = check_per_actor_replica_divergence(fccv_handoff_replicas)
+    assert (
+        not violations
+    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
+        violations
+    )

--- a/test/ci/invariants/test_fcv_invariants.py
+++ b/test/ci/invariants/test_fcv_invariants.py
@@ -42,6 +42,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
     cs_observations_from_snap,
     event_type,
@@ -412,4 +413,17 @@ def test_fcv_coordinator_p_transition_observed(
     assert saw_published, (
         "Coordinator: pxa_state starting with 'P' (public-aware) never observed "
         "in add_participant_status_to_participant entries"
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_per_actor_replica_divergence(
+    fcv_replicas: dict[str, list[dict]],
+) -> None:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
+    violations = check_per_actor_replica_divergence(fcv_replicas)
+    assert (
+        not violations
+    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
+        violations
     )

--- a/test/ci/invariants/test_fcv_reject_invariants.py
+++ b/test/ci/invariants/test_fcv_reject_invariants.py
@@ -42,6 +42,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
     cs_observations_from_snap,
     event_type,
@@ -430,4 +431,23 @@ def test_fcv_reject_coordinator_p_transition_observed(
     assert saw_published, (
         "Coordinator: pxa_state starting with 'P' (public-aware) never observed "
         "in add_participant_status_to_participant entries"
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_per_actor_replica_divergence(
+    fcv_reject_replicas: dict[str, list[dict]],
+) -> None:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log.
+
+    check_fix_ready=False because Vendor rejected the invitation and never
+    advanced the VFD state machine (matching the canonical invariant 15 rule).
+    """
+    violations = check_per_actor_replica_divergence(
+        fcv_reject_replicas, check_fix_ready=False
+    )
+    assert (
+        not violations
+    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
+        violations
     )

--- a/test/ci/invariants/test_fcvcv_invariants.py
+++ b/test/ci/invariants/test_fcvcv_invariants.py
@@ -52,6 +52,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
     load_devlogs,
 )
@@ -413,3 +414,16 @@ def test_fcvcv_v1_late_joiner_has_full_history(
         fcvcv_replicas, early_actor="c1", late_actor="v1"
     )
     assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_per_actor_replica_divergence(
+    fcvcv_replicas: dict[str, list[dict]],
+) -> None:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
+    violations = check_per_actor_replica_divergence(fcvcv_replicas)
+    assert (
+        not violations
+    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
+        violations
+    )

--- a/test/ci/invariants/test_fv_invariants.py
+++ b/test/ci/invariants/test_fv_invariants.py
@@ -31,6 +31,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
     load_devlogs,
 )
@@ -293,6 +294,19 @@ def test_invariant_clp13_no_rejected_invite_entries(
     assert not violations, (
         f"Found {len(violations)} spurious rejected invite_actor_to_case"
         f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
+    )
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_per_actor_replica_divergence(
+    fv_replicas: dict[str, list[dict]],
+) -> None:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
+    violations = check_per_actor_replica_divergence(fv_replicas)
+    assert (
+        not violations
+    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
+        violations
     )
 
 

--- a/test/ci/invariants/test_fvcv_extension_invariants.py
+++ b/test/ci/invariants/test_fvcv_extension_invariants.py
@@ -43,6 +43,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
     load_devlogs,
 )
@@ -400,3 +401,16 @@ def test_fvcv_extension_coordinator_late_joiner_has_full_history(
         fvcv_extension_replicas, early_actor="vendor", late_actor="coordinator"
     )
     assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_per_actor_replica_divergence(
+    fvcv_extension_replicas: dict[str, list[dict]],
+) -> None:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
+    violations = check_per_actor_replica_divergence(fvcv_extension_replicas)
+    assert (
+        not violations
+    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
+        violations
+    )

--- a/test/ci/invariants/test_fvcv_handoff_invariants.py
+++ b/test/ci/invariants/test_fvcv_handoff_invariants.py
@@ -48,6 +48,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
     load_devlogs,
 )
@@ -379,3 +380,16 @@ def test_fvcv_handoff_vendor2_late_joiner_has_full_history(
         fvcv_handoff_replicas, early_actor="vendor", late_actor="vendor2"
     )
     assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_per_actor_replica_divergence(
+    fvcv_handoff_replicas: dict[str, list[dict]],
+) -> None:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
+    violations = check_per_actor_replica_divergence(fvcv_handoff_replicas)
+    assert (
+        not violations
+    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
+        violations
+    )

--- a/test/ci/invariants/test_fvv_invariants.py
+++ b/test/ci/invariants/test_fvv_invariants.py
@@ -41,6 +41,7 @@ from test.ci.invariants.common import (
     check_non_empty_payload_snapshots,
     check_participant_status_schema_completeness,
     check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
     check_rm_closed_termination,
     load_devlogs,
 )
@@ -338,3 +339,16 @@ def test_fvv_finder_late_joiner_has_full_history(
         fvv_replicas, early_actor="vendor", late_actor="finder"
     )
     assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_invariant_per_actor_replica_divergence(
+    fvv_replicas: dict[str, list[dict]],
+) -> None:
+    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
+    violations = check_per_actor_replica_divergence(fvv_replicas)
+    assert (
+        not violations
+    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
+        violations
+    )


### PR DESCRIPTION
- Closes #2411
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Fixes two gaps in `test/ci/invariants/` that allowed real invariant failures to go undetected: eight canonical check functions never inspected non-case-actor replicas (Gap 1), and `load_devlogs()` silently skipped a scenario directory that existed but was empty (Gap 2).

## Changes

- **`test/ci/invariants/common.py`**: Gap 2 — changed `pytest.skip` to `pytest.fail` in `load_devlogs()` when `demo_name` is set and directory exists but has no ledger files or manifest. Gap 1 — added `check_per_actor_replica_divergence(replicas, *, check_fix_ready=True)` that runs four state invariants against each non-`case-actor` replica.
- **`test/ci/invariants/test_common.py`**: renamed and updated Gap-2 regression test to expect `Failed`; added 8 new `TestCheckPerActorReplicaDivergence` tests.
- **`test/ci/invariants/test_fv_invariants.py`** (and 8 other scenario harness files): added `check_per_actor_replica_divergence` import and `test_invariant_per_actor_replica_divergence`; `fcv-reject` passes `check_fix_ready=False`.
- **`notes/demo-ci-invariants.md`**: updated DEMOCI-10-003 artifact-availability table and harness-file conventions section.

## Verification

- 7124 unit tests pass (8 new in `TestCheckPerActorReplicaDivergence`; Gap-2 regression test updated)
- Black, flake8, mypy clean