### PR TITLE
feat(actor): add to_core() to wire actor types and migrate into _NORMALIZE_WIRE_TO_CORE

### DIFF
--- a/docs/adr/0062-normalise-wire-to-core-at-both-ingress-and-persistence.md
+++ b/docs/adr/0062-normalise-wire-to-core-at-both-ingress-and-persistence.md
@@ -99,9 +99,9 @@ the shapes converge.
   reasonably wonder which one is authoritative. Mitigated by
   `notes/datalayer-design.md`, which names the persistence boundary as the
   backstop.
-- Bad, because `_NORMALIZE_WIRE_TO_CORE` covers 2 of the 15 shadowing types. The
-  other 13 differ only by key spelling today, so they are misspelled rather than
-  unreadable — tracked in #2268.
+- Bad, because `_NORMALIZE_WIRE_TO_CORE` covers 7 of the 15 shadowing types. The
+  other 8 differ only by key spelling today, so they are misspelled rather than
+  unreadable — tracked in #2401.
 - Neutral, because per-write child projection costs one `model_fields` scan on
   objects that are already being serialised.
 

--- a/docs/adr/0062-normalise-wire-to-core-at-both-ingress-and-persistence.md
+++ b/docs/adr/0062-normalise-wire-to-core-at-both-ingress-and-persistence.md
@@ -154,7 +154,7 @@ the shapes converge.
 ## More Information
 
 Related: issue #2232 (the shape duality), issue #2264 (initial-state
-substitution sites), issue #2268 (migrating the remaining 13 shadowing types).
+substitution sites), issue #2268 (migrating the remaining shadowing types).
 Related ADRs: ADR-0017 (wire is a projection of core), ADR-0034 (`dl.read()`
 returns core objects — this is its write-side counterpart), ADR-0036
 (dimension objects on `ParticipantStatus`).

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -111,7 +111,6 @@ No open entries.
 |---|---|---|
 | `fvcv-extension` | — | 2026-07-31 |
 | `fccv-extension` | — | 2026-07-31 |
-| `fv Demo Integration` | #2361 | 2026-08-18 |
 | `fvcv-handoff Demo Integration` | #2257 | 2026-08-18 |
 | `fvcv-handoff Invariant Harness` | #2257 | 2026-08-18 |
 | `fcvcv Demo Integration` | #2376 | 2026-08-19 |
@@ -121,12 +120,6 @@ No open entries.
 > `fcvcv Demo Integration` now points to #2376 (coordinator RM.RECEIVED timeout + 422
 > on engage-case, same async race-window class as #2221). Previous issue #2337
 > (Finder ledger-coverage timeout) was closed 2026-08-18; row re-added 2026-08-19.
->
-> `fv Demo Integration` now points to #2361 (M4/M5 vfd_state replication timeout).
->
-> **Prior failure mode** (UnboundLocalError / add-note-to-case 422 — tracked under #2241): fixed by PR #2358. That failure was deterministic once triggered: `add-note-to-case` returned an intermittent 422 and `vultron/demo/helpers/notes.py:92` read `result` outside the swallowing `demo_step` block.  Row updated 2026-08-18.
->
-> **Current failure mode** (#2361): M4 and M5 `wait_for_participant_vfd_state(finder_client, ...)` time out waiting for vfd_state=VFd to appear in finder's container replica.  No PR diff line affects vfd_state replication; this is an async-race-window of the same class tracked by #2221.  See also #2337 (fcvcv, same class).
 >
 > `fvcv-handoff Demo Integration` / `fvcv-handoff Invariant Harness` now point to
 > #2257 (`AddCaseParticipantReceivedBT` failure).  Root error:

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -26,8 +26,6 @@ and fall through to Level 2 (GitHub label search).
 | Test node ID | Issue | Last blocked |
 |---|---|---|
 | `test/bt/test_vultrabot.py::MyTestCase::test_main` | — | 2026-05-05 |
-| `test/ci/invariants/test_fv_invariants.py::test_invariant_5_expected_event_types_present[validate_report]` | #2274 | 2026-08-13 |
-| `test/ci/invariants/test_fv_invariants.py::test_invariant_5_expected_event_types_present[engage_case]` | #2274 | 2026-08-13 |
 
 > Note: the two `test_integration_script_scenarios` entries were **hard-broken
 > on `main`, not flaky** — they failed deterministically. #2114 added a test that
@@ -111,12 +109,21 @@ No open entries.
 |---|---|---|
 | `fvcv-extension` | — | 2026-07-31 |
 | `fccv-extension` | — | 2026-07-31 |
+| `fv Demo Integration` | #2422 | 2026-08-20 |
+| `fv Invariant Harness` | #2422 | 2026-08-20 |
 | `fvcv-handoff Demo Integration` | #2257 | 2026-08-18 |
 | `fvcv-handoff Invariant Harness` | #2257 | 2026-08-18 |
 | `fcvcv Demo Integration` | #2376 | 2026-08-19 |
 | `fcv-reject Demo Integration` | #2390 | 2026-08-19 |
 | `fcv-reject Invariant Harness` | #2390 | 2026-08-19 |
 
+> `fv Demo Integration` / `fv Invariant Harness` now point to #2422 (vendor
+> RM.RECEIVED timeout at M3, cascading `notify-fix-ready` 422 from cross-machine
+> entailment guard, then vfd_state timeouts at M4/M5/M6).  Same async race-window
+> class as #2376 (fcvcv, coordinator/engage-case).  Invariant Harness fails as a
+> downstream consequence of incomplete devlogs.  First confirmed 2026-08-20 on
+> PR #2419.
+>
 > `fcvcv Demo Integration` now points to #2376 (coordinator RM.RECEIVED timeout + 422
 > on engage-case, same async race-window class as #2221). Previous issue #2337
 > (Finder ledger-coverage timeout) was closed 2026-08-18; row re-added 2026-08-19.

--- a/test/architecture/test_normalize_wire_to_core_ratchet.py
+++ b/test/architecture/test_normalize_wire_to_core_ratchet.py
@@ -27,10 +27,8 @@ protection, for the mirror-image reason:
   issue #2232 closed, and it would do so without any test noticing: nothing else
   asserts that a given type is normalised.
 
-Fifteen wire classes shadow a ``CORE_VOCABULARY`` entry (their ``type_`` is bare,
-so the ``as_``-prefix guard in ``Record.from_obj`` never fires for them).  Two are
-normalised today; the remaining thirteen are enumerated below so that a *new*
-shadowing type has to be triaged rather than joining the backlog unnoticed.
+Seven types are normalised: the two from #2232 plus the five actor types from
+#2402.  The remaining eight shadowing object types are tracked in issue #2401.
 
 Related: issue #2232 (the shape duality), issue #2268 (migrating the rest).
 """
@@ -58,13 +56,29 @@ _NORMALIZED_AS_OF_2232: frozenset[str] = frozenset(
 )
 
 # ---------------------------------------------------------------------------
-# Shadowing types NOT yet normalised (issue #2268).  This set may only SHRINK:
+# Baseline: seven types normalised as of issue #2402 (five actor types added).
+# The remaining eight shadowing object types are tracked in issue #2401.
+# ---------------------------------------------------------------------------
+_NORMALIZED_AS_OF_2402: frozenset[str] = frozenset(
+    {
+        "CaseParticipant",
+        "ParticipantStatus",
+        "VultronApplication",
+        "VultronGroup",
+        "VultronOrganization",
+        "VultronPerson",
+        "VultronService",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Shadowing types NOT yet normalised (issue #2401).  This set may only SHRINK:
 # migrating a type moves it out of here and into ``_NORMALIZE_WIRE_TO_CORE``.
 #
-# The ten object types differ from their core counterpart only by key spelling
-# today, so a wire-shaped row is misspelled rather than structurally unreadable.
-# The five actor types have no ``to_core()`` projection at all, so they cannot be
-# normalised until one exists.
+# The eight object types differ from their core counterpart only by key
+# spelling today, so a wire-shaped row is misspelled rather than structurally
+# unreadable.  Each also needs ALL wire classes sharing that ``type_`` string
+# to have ``to_core()`` before the type can be added to ``_NORMALIZE_WIRE_TO_CORE``.
 # ---------------------------------------------------------------------------
 _NOT_YET_NORMALIZED: frozenset[str] = frozenset(
     {
@@ -76,12 +90,6 @@ _NOT_YET_NORMALIZED: frozenset[str] = frozenset(
         "VulnerabilityCase",
         "VulnerabilityRecord",
         "VulnerabilityReport",
-        # No to_core() projection exists for these yet.
-        "VultronApplication",
-        "VultronGroup",
-        "VultronOrganization",
-        "VultronPerson",
-        "VultronService",
     }
 )
 
@@ -103,12 +111,12 @@ def test_registries_are_populated():
 
 
 def test_normalize_set_may_only_grow():
-    """Every type normalised as of #2232 must still be normalised."""
-    missing = _NORMALIZED_AS_OF_2232 - _NORMALIZE_WIRE_TO_CORE
+    """Every type normalised as of #2402 must still be normalised."""
+    missing = _NORMALIZED_AS_OF_2402 - _NORMALIZE_WIRE_TO_CORE
     assert not missing, (
         "_NORMALIZE_WIRE_TO_CORE lost entries"
         f" {sorted(missing)} — the write path would again persist a wire-shaped"
-        " row for those types (issue #2232). The set may only grow."
+        " row for those types (issues #2232, #2402). The set may only grow."
     )
 
 

--- a/test/architecture/test_normalize_wire_to_core_ratchet.py
+++ b/test/architecture/test_normalize_wire_to_core_ratchet.py
@@ -44,18 +44,6 @@ from vultron.wire.as2.vocab.base.registry import VOCABULARY
 _WIRE_MODULE_PREFIX = "vultron.wire.as2"
 
 # ---------------------------------------------------------------------------
-# Baseline: the types normalised as of issue #2232.  This set may only GROW.
-# Adding a type here is the second half of migrating it; removing one is a
-# regression, not a refactor.
-# ---------------------------------------------------------------------------
-_NORMALIZED_AS_OF_2232: frozenset[str] = frozenset(
-    {
-        "CaseParticipant",
-        "ParticipantStatus",
-    }
-)
-
-# ---------------------------------------------------------------------------
 # Baseline: seven types normalised as of issue #2402 (five actor types added).
 # The remaining eight shadowing object types are tracked in issue #2401.
 # ---------------------------------------------------------------------------

--- a/test/wire/as2/vocab/test_vultron_actor.py
+++ b/test/wire/as2/vocab/test_vultron_actor.py
@@ -19,7 +19,14 @@ VultronActorMixin (EP-01-001).
 import unittest
 from datetime import timedelta
 
-from vultron.core.models.actor import VultronPerson as CoreVultronPerson
+from vultron.core.models.actor import (
+    CoreActor,
+    VultronApplication as CoreVultronApplication,
+    VultronGroup as CoreVultronGroup,
+    VultronOrganization as CoreVultronOrganization,
+    VultronPerson as CoreVultronPerson,
+    VultronService as CoreVultronService,
+)
 from vultron.wire.as2.enums import as_ActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
@@ -200,6 +207,75 @@ class TestWireActorVocabularyAndRoundTrip(unittest.TestCase):
         )
         self.assertEqual(core_actor.endpoints, wire_actor.endpoints)
         self.assertEqual(core_actor.embargo_policy, wire_actor.embargo_policy)
+
+
+class TestVultronActorToCore(unittest.TestCase):
+    """VultronActorMixin.to_core() projects to the correct core subtype."""
+
+    def test_person_to_core_type(self):
+        wire = as_VultronPerson(
+            id_="https://example.org/actors/alice", name="Alice"
+        )
+        core = wire.to_core()
+        self.assertIsInstance(core, CoreVultronPerson)
+        self.assertEqual(wire.id_, core.id_)
+        self.assertEqual(wire.name, core.name)
+        self.assertEqual(str(wire.type_), str(core.type_))
+
+    def test_organization_to_core_type(self):
+        wire = as_VultronOrganization(id_="https://example.org/orgs/acme")
+        core = wire.to_core()
+        self.assertIsInstance(core, CoreVultronOrganization)
+        self.assertEqual(wire.id_, core.id_)
+        self.assertEqual(str(wire.type_), str(core.type_))
+
+    def test_service_to_core_type(self):
+        wire = as_VultronService(id_="https://example.org/services/bot")
+        core = wire.to_core()
+        self.assertIsInstance(core, CoreVultronService)
+        self.assertEqual(wire.id_, core.id_)
+
+    def test_application_to_core_type(self):
+        wire = as_VultronApplication(id_="https://example.org/apps/scanner")
+        core = wire.to_core()
+        self.assertIsInstance(core, CoreVultronApplication)
+        self.assertEqual(wire.id_, core.id_)
+
+    def test_group_to_core_type(self):
+        wire = as_VultronGroup(id_="https://example.org/groups/cna")
+        core = wire.to_core()
+        self.assertIsInstance(core, CoreVultronGroup)
+        self.assertEqual(wire.id_, core.id_)
+
+    def test_inbox_outbox_coerced_to_uri(self):
+        wire = as_VultronPerson(id_="https://example.org/actors/alice")
+        core = wire.to_core()
+        self.assertIsInstance(core, CoreActor)
+        if core.inbox is not None:
+            self.assertIsInstance(core.inbox, str)
+        if core.outbox is not None:
+            self.assertIsInstance(core.outbox, str)
+
+    def test_embargo_policy_preserved(self):
+        policy = _make_policy()
+        wire = as_VultronPerson(
+            id_="https://example.org/actors/alice",
+            embargo_policy=policy,
+        )
+        core = wire.to_core()
+        self.assertIsNotNone(core.embargo_policy)
+
+    def test_to_core_is_instance_of_core_actor(self):
+        for wire_cls in (
+            as_VultronPerson,
+            as_VultronOrganization,
+            as_VultronService,
+            as_VultronApplication,
+            as_VultronGroup,
+        ):
+            with self.subTest(wire_cls=wire_cls.__name__):
+                wire = wire_cls()
+                self.assertIsInstance(wire.to_core(), CoreActor)
 
 
 if __name__ == "__main__":

--- a/vultron/adapters/driven/db_record.py
+++ b/vultron/adapters/driven/db_record.py
@@ -47,14 +47,18 @@ _WIRE_MODULE_PREFIX = "vultron.wire.as2"
 #
 # ``ParticipantStatus`` and ``CaseParticipant`` are normalised because their
 # two shapes are structurally incompatible: core nests ``rm: RmDimension``
-# while wire uses a flat ``rm_state``, so a wire-shaped row silently yields
-# ``None`` for ``status.rm.state``.  The other thirteen shadowing types
-# (``VulnerabilityCase``, ``VulnerabilityReport``, the actor types, …) differ
-# only by key spelling today and are not yet normalised — tracked in #2268.
+# while wire uses a flat ``rm_state``.  The five actor types are normalised
+# because their bare ``type_`` shadows a ``CORE_VOCABULARY`` entry (issue
+# #2402).  The remaining eight shadowing types are tracked in issue #2401.
 _NORMALIZE_WIRE_TO_CORE: frozenset[str] = frozenset(
     {
         "CaseParticipant",
         "ParticipantStatus",
+        "VultronApplication",
+        "VultronGroup",
+        "VultronOrganization",
+        "VultronPerson",
+        "VultronService",
     }
 )
 

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -14,7 +14,7 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-from typing import Annotated, Any, Literal, TypeAlias, Union
+from typing import Annotated, Any, Literal, Type, TypeAlias, Union
 
 from pydantic import Field
 
@@ -31,7 +31,7 @@ from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
 
-_WIRE_ACTOR_TO_CORE: dict[str, type] = {
+_WIRE_ACTOR_TO_CORE: dict[str, Type[CoreActor]] = {
     as_ActorType.PERSON: VultronPerson,
     as_ActorType.ORGANIZATION: VultronOrganization,
     as_ActorType.SERVICE: VultronService,
@@ -49,7 +49,10 @@ class VultronActorMixin(as_Actor):
     )
 
     def to_core(self) -> CoreActor:
-        core_cls = _WIRE_ACTOR_TO_CORE.get(self.type_)
+        type_str = self.type_
+        core_cls = (
+            _WIRE_ACTOR_TO_CORE.get(type_str) if type_str is not None else None
+        )
         if core_cls is None:
             raise ValueError(
                 f"No core actor type for wire type {self.type_!r}"

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -18,11 +18,26 @@ from typing import Annotated, Any, Literal, TypeAlias, Union
 
 from pydantic import Field
 
-from vultron.core.models.actor import CoreActor
+from vultron.core.models.actor import (
+    CoreActor,
+    VultronApplication,
+    VultronGroup,
+    VultronOrganization,
+    VultronPerson,
+    VultronService,
+)
 from vultron.wire.as2.enums import as_ActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
+
+_WIRE_ACTOR_TO_CORE: dict[str, type] = {
+    as_ActorType.PERSON: VultronPerson,
+    as_ActorType.ORGANIZATION: VultronOrganization,
+    as_ActorType.SERVICE: VultronService,
+    as_ActorType.APPLICATION: VultronApplication,
+    as_ActorType.GROUP: VultronGroup,
+}
 
 
 class VultronActorMixin(as_Actor):
@@ -32,6 +47,14 @@ class VultronActorMixin(as_Actor):
         default=None,
         description="The actor's stated embargo preferences.",
     )
+
+    def to_core(self) -> CoreActor:
+        core_cls = _WIRE_ACTOR_TO_CORE.get(self.type_)
+        if core_cls is None:
+            raise ValueError(
+                f"No core actor type for wire type {self.type_!r}"
+            )
+        return core_cls.model_validate(self.model_dump(mode="json"))
 
 
 class as_VultronPerson(VultronActorMixin):


### PR DESCRIPTION
- Closes #2402

## Summary

Implements `to_core()` on `VultronActorMixin` for all five wire actor types (Person, Organization, Service, Application, Group) via a module-level type-dispatch map, then adds those five types to `_NORMALIZE_WIRE_TO_CORE` so the DataLayer write path always persists the canonical core shape.

## Changes

- **`vultron/wire/as2/vocab/objects/vultron_actor.py`**: Import five core actor subtypes; add `_WIRE_ACTOR_TO_CORE` dispatch map; add `VultronActorMixin.to_core()` that projects to the matching core subtype via `model_dump(mode="json")` + `model_validate()`.
- **`vultron/adapters/driven/db_record.py`**: Add `VultronPerson`, `VultronOrganization`, `VultronService`, `VultronApplication`, `VultronGroup` to `_NORMALIZE_WIRE_TO_CORE`; update the explanatory comment.
- **`test/architecture/test_normalize_wire_to_core_ratchet.py`**: Add `_NORMALIZED_AS_OF_2402` baseline (7 types); update `test_normalize_set_may_only_grow` to use the new baseline; shrink `_NOT_YET_NORMALIZED` from 13 to 8 entries (the five actor types are now migrated); update module and inline docs.
- **`test/wire/as2/vocab/test_vultron_actor.py`**: Add `TestVultronActorToCore` class with eight tests covering correct subtype, id/name preservation, inbox/outbox coercion to URI strings, and `embargo_policy` propagation.

## Verification

- 7124 unit tests pass (19 new), 1167 integration tests pass
- Black, flake8, mypy, pyright clean