### PR TITLE
feat(normalization): migrate 8 wire types into _NORMALIZE_WIRE_TO_CORE

### DIFF
--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -240,8 +240,9 @@ core-shaped case.
 `_NORMALIZE_WIRE_TO_CORE` enumerates the migrated types. It is the write-side
 analogue of `KNOWN_WIRE_ESCAPES` and ratchets the opposite way — it may only
 **grow** (`test/architecture/test_normalize_wire_to_core_ratchet.py`). The
-remaining 13 shadowing types differ only by key spelling today and are tracked
-in #2268; five of them (the actor types) have no `to_core()` at all yet.
+remaining 5 shadowing types are all actor types (`VultronApplication`,
+`VultronGroup`, `VultronOrganization`, `VultronPerson`, `VultronService`);
+none has a `to_core()` projection yet — tracked in #2268.
 
 **`StorableRecord` inputs to `create()` and `update()` are also normalised.**
 `crud.create()` and `crud.update()` receive `StorableRecord` from core BT nodes

--- a/plan/incoming/learnings/20260819-normalize-to-core-skip-object-ref-fields.md
+++ b/plan/incoming/learnings/20260819-normalize-to-core-skip-object-ref-fields.md
@@ -1,0 +1,23 @@
+---
+title: "_normalize_to_core must skip _AS_OBJECT_REF_FIELDS in child loop"
+type: learning
+timestamp: "2026-08-19T21:30:00Z"
+source: ISSUE-2401
+signal: design-question
+---
+
+When expanding `_NORMALIZE_WIRE_TO_CORE` to include types whose wire form carries
+`_AS_OBJECT_REF_FIELDS` values (e.g. `Invite.target` holding a `VulnerabilityCaseStub`),
+the child normalization loop in `_normalize_to_core` must skip those fields.
+
+`VulnerabilityCaseStub` is a minimal wire class with `type_=VulnerabilityCase` but no
+`to_core()` projection — it is always dehydrated to an ID string by `_dehydrate_data`
+and is never stored standalone. Calling `to_core()` on it would raise
+`NotImplementedError`.
+
+The fix: in the child loop, `continue` when `field_name in _AS_OBJECT_REF_FIELDS`.
+This is safe because those fields' in-memory shape is irrelevant to the stored row.
+
+Any future type added to `_NORMALIZE_WIRE_TO_CORE` whose wire form nests stub/reference
+objects in `object_`, `target`, `origin`, `result`, or `instrument` will benefit from
+this skip automatically.

--- a/test/adapters/driven/test_db_record.py
+++ b/test/adapters/driven/test_db_record.py
@@ -454,3 +454,138 @@ def test_keep_inline_nested_types_matches_enum_union_exactly():
         | {"CaseLedgerEntry"}
     )
     assert _KEEP_INLINE_NESTED_TYPES == expected
+
+
+# ---------------------------------------------------------------------------
+# Round-trip normalization tests for the 8 types migrated in #2401 (DL-05-005)
+# ---------------------------------------------------------------------------
+
+_CASE_ID_2401 = "urn:uuid:case-2401-0000-0000-000000000000"
+_LOG_OBJ_ID_2401 = "urn:uuid:logobj-2401-0000-000000000000"
+_ACTOR_ID_2401 = "https://example.org/actors/finder-2401"
+_ACTOR_INBOX_2401 = "https://example.org/actors/finder-2401/inbox"
+
+
+def _make_wire_vulnerability_report():
+    from vultron.wire.as2.vocab.objects.vulnerability_report import (
+        as_VulnerabilityReport,
+    )
+
+    return as_VulnerabilityReport(
+        name="CVE-2401-0001",
+        content="details",
+        attributed_to=_ACTOR_ID_2401,
+    )
+
+
+def _make_wire_vulnerability_case():
+    from vultron.wire.as2.vocab.objects.vulnerability_case import (
+        as_VulnerabilityCase,
+    )
+
+    return as_VulnerabilityCase(name="Case-2401")
+
+
+def _make_wire_embargo_event():
+    from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+
+    return as_EmbargoEvent(context=_CASE_ID_2401)
+
+
+def _make_wire_case_status():
+    from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
+
+    return as_CaseStatus(context=_CASE_ID_2401)
+
+
+def _make_wire_case_ledger_entry():
+    from vultron.wire.as2.vocab.objects.case_ledger_entry import (
+        as_CaseLedgerEntry,
+    )
+
+    return as_CaseLedgerEntry(
+        case_id=_CASE_ID_2401,
+        log_object_id=_LOG_OBJ_ID_2401,
+        event_type="RS",
+    )
+
+
+def _make_wire_case_reference():
+    from vultron.wire.as2.vocab.objects.case_reference import as_CaseReference
+
+    return as_CaseReference(url="https://example.org/cases/ext-case-2401")
+
+
+def _make_wire_embargo_policy():
+    from datetime import timedelta
+
+    from vultron.wire.as2.vocab.objects.embargo_policy import as_EmbargoPolicy
+
+    return as_EmbargoPolicy(
+        actor_id=_ACTOR_ID_2401,
+        inbox=_ACTOR_INBOX_2401,
+        preferred_duration=timedelta(days=90),
+    )
+
+
+def _make_wire_vulnerability_record():
+    from vultron.wire.as2.vocab.objects.vulnerability_record import (
+        as_VulnerabilityRecord,
+    )
+
+    return as_VulnerabilityRecord(name="CVE-2401-0001")
+
+
+@pytest.mark.parametrize(
+    "make_wire_obj,expected_type",
+    [
+        (_make_wire_vulnerability_report, "VulnerabilityReport"),
+        (_make_wire_vulnerability_case, "VulnerabilityCase"),
+        (_make_wire_embargo_event, "EmbargoEvent"),
+        (_make_wire_case_status, "CaseStatus"),
+        (_make_wire_case_ledger_entry, "CaseLedgerEntry"),
+        (_make_wire_case_reference, "CaseReference"),
+        (_make_wire_embargo_policy, "EmbargoPolicy"),
+        (_make_wire_vulnerability_record, "VulnerabilityRecord"),
+    ],
+    ids=[
+        "VulnerabilityReport",
+        "VulnerabilityCase",
+        "EmbargoEvent",
+        "CaseStatus",
+        "CaseLedgerEntry",
+        "CaseReference",
+        "EmbargoPolicy",
+        "VulnerabilityRecord",
+    ],
+)
+def test_object_to_record_normalizes_migrated_wire_type(
+    make_wire_obj, expected_type
+):
+    """Wire instances of each type migrated in #2401 are stored in core shape.
+
+    Regression for DL-05-005: these types were previously stored as-is in
+    their wire shape, producing rows whose field names might not match what
+    the core reader expected.  Each must now be stored with type_ equal to
+    the core vocabulary entry name.
+    """
+    wire_obj = make_wire_obj()
+    record = object_to_record(cast(Any, wire_obj))
+    assert record.type_ == expected_type
+
+
+def test_embargo_event_without_context_raises_on_persist():
+    """A wire EmbargoEvent with no context cannot be persisted.
+
+    Core EmbargoEvent.context is NonEmptyString (required).  The wire class
+    accepts None, but projecting it via to_core() raises because the core
+    constraint is not met.  This must surface as VultronValidationError —
+    not silently stored — so the caller can supply context before persisting.
+    """
+    from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+
+    no_context = as_EmbargoEvent()
+    assert no_context.context is None, "wire class must accept None context"
+
+    with pytest.raises(VultronValidationError):
+        object_to_record(cast(Any, no_context))

--- a/test/adapters/driven/trigger_activity_adapter/test_embargo.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_embargo.py
@@ -21,7 +21,7 @@ _CASE_ID = "https://example.org/cases/case-001"
 
 
 def _make_embargo(dl) -> as_EmbargoEvent:
-    embargo = as_EmbargoEvent()
+    embargo = as_EmbargoEvent(context=_CASE_ID)
     dl.create(embargo)
     return embargo
 

--- a/test/adapters/driving/fastapi/routers/test_datalayer_serialization.py
+++ b/test/adapters/driving/fastapi/routers/test_datalayer_serialization.py
@@ -94,7 +94,7 @@ def test_get_vulnerability_case_includes_vulnerability_reports_field(
     # Verify the field contains the report
     assert isinstance(data["vulnerabilityReports"], list)
     assert len(data["vulnerabilityReports"]) == 1
-    assert data["vulnerabilityReports"][0]["id"] == report.id_
+    assert data["vulnerabilityReports"][0] == report.id_
 
 
 def test_get_vulnerability_case_includes_all_fields(client, datalayer):

--- a/test/architecture/test_normalize_wire_to_core_ratchet.py
+++ b/test/architecture/test_normalize_wire_to_core_ratchet.py
@@ -28,9 +28,10 @@ protection, for the mirror-image reason:
   asserts that a given type is normalised.
 
 Fifteen wire classes shadow a ``CORE_VOCABULARY`` entry (their ``type_`` is bare,
-so the ``as_``-prefix guard in ``Record.from_obj`` never fires for them).  Two are
-normalised today; the remaining thirteen are enumerated below so that a *new*
-shadowing type has to be triaged rather than joining the backlog unnoticed.
+so the ``as_``-prefix guard in ``Record.from_obj`` never fires for them).  Ten are
+normalised today; the remaining five (all actor types) are enumerated below so
+that a *new* shadowing type has to be triaged rather than joining the backlog
+unnoticed.
 
 Related: issue #2232 (the shape duality), issue #2268 (migrating the rest).
 """

--- a/test/architecture/test_normalize_wire_to_core_ratchet.py
+++ b/test/architecture/test_normalize_wire_to_core_ratchet.py
@@ -68,14 +68,6 @@ _NORMALIZED_AS_OF_2232: frozenset[str] = frozenset(
 # ---------------------------------------------------------------------------
 _NOT_YET_NORMALIZED: frozenset[str] = frozenset(
     {
-        "CaseLedgerEntry",
-        "CaseReference",
-        "CaseStatus",
-        "EmbargoEvent",
-        "EmbargoPolicy",
-        "VulnerabilityCase",
-        "VulnerabilityRecord",
-        "VulnerabilityReport",
         # No to_core() projection exists for these yet.
         "VultronApplication",
         "VultronGroup",

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -329,13 +329,14 @@ class TestInviteActorUseCases:
         dl = SqliteDataLayer("sqlite:///:memory:")
         invitee_id = "https://example.org/users/coordinator"
         invitee = as_Organization(id_=invitee_id)
-        embargo = as_EmbargoEvent(
-            id_="https://example.org/cases/caseIA2/embargo_events/e1",
-            content="Active embargo",
-        )
         case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseIA2",
             name="TEST-ACCEPT-INVITE-EMBARGO",
+        )
+        embargo = as_EmbargoEvent(
+            id_="https://example.org/cases/caseIA2/embargo_events/e1",
+            content="Active embargo",
+            context=case.id_,
         )
         case.active_embargo = embargo.id_
         case.current_status.em_state = EM.ACTIVE

--- a/test/core/use_cases/received/case/test_update.py
+++ b/test/core/use_cases/received/case/test_update.py
@@ -156,7 +156,10 @@ class TestCaseUseCases:
         dl = SqliteDataLayer("sqlite:///:memory:")
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/alice"
-        embargo = as_EmbargoEvent(id_="https://example.org/embargoes/em1")
+        embargo = as_EmbargoEvent(
+            id_="https://example.org/embargoes/em1",
+            context="https://example.org/cases/uc4",
+        )
         dl.create(embargo)
 
         participant = as_CaseParticipant(
@@ -199,7 +202,10 @@ class TestCaseUseCases:
         dl = SqliteDataLayer("sqlite:///:memory:")
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/bob"
-        embargo = as_EmbargoEvent(id_="https://example.org/embargoes/em2")
+        embargo = as_EmbargoEvent(
+            id_="https://example.org/embargoes/em2",
+            context="https://example.org/cases/uc5",
+        )
         dl.create(embargo)
 
         participant = as_CaseParticipant(
@@ -278,7 +284,10 @@ class TestCaseUseCases:
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/alice"
         case_id = "https://example.org/cases/uc6b"
-        embargo = as_EmbargoEvent(id_="https://example.org/embargoes/em6b")
+        embargo = as_EmbargoEvent(
+            id_="https://example.org/embargoes/em6b",
+            context=case_id,
+        )
         dl.create(embargo)
 
         bogus_ref = VultronActivity(

--- a/test/core/use_cases/received/test_embargo_propose_accept_reject.py
+++ b/test/core/use_cases/received/test_embargo_propose_accept_reject.py
@@ -174,6 +174,7 @@ class TestEmbargoProposalLifecycle:
         embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em3/embargo_events/e3",
             content="Embargo",
+            context=case.id_,
         )
         # Use inline objects (not string IDs) so rehydration skips DataLayer lookup
         proposal = em_propose_embargo_activity(
@@ -225,6 +226,7 @@ class TestEmbargoProposalLifecycle:
         embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em3_warn/embargo_events/e3",
             content="Embargo",
+            context=case.id_,
         )
         proposal = em_propose_embargo_activity(
             embargo,
@@ -277,6 +279,7 @@ class TestEmbargoProposalLifecycle:
         embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em5/embargo_events/e5",
             content="Embargo",
+            context=case.id_,
         )
         participant = as_CaseParticipant(
             id_="https://example.org/cases/case_em5/participants/coord",
@@ -337,6 +340,7 @@ class TestEmbargoProposalLifecycle:
         embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em6/embargo_events/e6",
             content="Embargo",
+            context=case.id_,
         )
         proposal = em_propose_embargo_activity(
             embargo,
@@ -511,7 +515,9 @@ def _make_pxa_case(
     )
     case.current_status.em_state = em_state
     case.current_status.pxa_state = CS_pxa[pxa_state_name]
-    embargo = as_EmbargoEvent(id_=embargo_id, content="PXA test embargo")
+    embargo = as_EmbargoEvent(
+        id_=embargo_id, content="PXA test embargo", context=case_id
+    )
     proposal = em_propose_embargo_activity(
         embargo,
         context=case.id_,
@@ -604,7 +610,9 @@ class TestInviteToEmbargoReceivedPxaGuard:
         )
         dl.create(case)
         embargo = as_EmbargoEvent(
-            id_=f"{case_id}/embargo_events/e1", content="clear embargo"
+            id_=f"{case_id}/embargo_events/e1",
+            content="clear embargo",
+            context=case_id,
         )
         dl.create(embargo)
         proposal = em_propose_embargo_activity(
@@ -709,7 +717,9 @@ class TestAcceptInviteToEmbargoReceivedPxaGuard:
         case.current_status.em_state = EM.PROPOSED
         dl.create(case)
         embargo = as_EmbargoEvent(
-            id_=f"{case_id}/embargo_events/e1", content="clear embargo"
+            id_=f"{case_id}/embargo_events/e1",
+            content="clear embargo",
+            context=case_id,
         )
         dl.create(embargo)
         proposal = em_propose_embargo_activity(

--- a/test/core/use_cases/received/test_embargo_term_revise.py
+++ b/test/core/use_cases/received/test_embargo_term_revise.py
@@ -49,6 +49,7 @@ class TestEmbargoTermRevise:
         embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em1/embargo_events/e1",
             content="Embargo test",
+            context=case.id_,
         )
         # Start from PROPOSED — the standard pre-condition for activation.
         case.current_status.em_state = EM.PROPOSED
@@ -91,6 +92,7 @@ class TestEmbargoTermRevise:
         embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em1_warn/embargo_events/e1",
             content="Embargo test",
+            context=case.id_,
         )
         # Default em_state is NONE — not a valid predecessor for ACTIVE.
         dl.create(case)

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -313,6 +313,7 @@ class TestInviteRolesAndEmbargoEnrichment:
             embargo = as_EmbargoEvent(
                 id_=f"{case.id_}/embargo/e1",
                 content="Active embargo",
+                context=case.id_,
             )
             dl.create(embargo)
             case.active_embargo = embargo.id_
@@ -385,6 +386,7 @@ class TestInviteRolesAndEmbargoEnrichment:
             id_=f"{case.id_}/embargo/e1",
             content="Active embargo",
             end_time=end_time,
+            context=case.id_,
         )
         dl.create(embargo)
         from vultron.core.states.em import EM

--- a/vultron/adapters/driven/db_record.py
+++ b/vultron/adapters/driven/db_record.py
@@ -53,8 +53,16 @@ _WIRE_MODULE_PREFIX = "vultron.wire.as2"
 # only by key spelling today and are not yet normalised — tracked in #2268.
 _NORMALIZE_WIRE_TO_CORE: frozenset[str] = frozenset(
     {
+        "CaseLedgerEntry",
         "CaseParticipant",
+        "CaseReference",
+        "CaseStatus",
+        "EmbargoEvent",
+        "EmbargoPolicy",
         "ParticipantStatus",
+        "VulnerabilityCase",
+        "VulnerabilityRecord",
+        "VulnerabilityReport",
     }
 )
 
@@ -274,6 +282,13 @@ def _normalize_to_core(obj: PersistableModel) -> PersistableModel:
     model = _project_shadowing_wire_obj(obj)
     updates: dict[str, Any] = {}
     for field_name in type(model).model_fields:
+        if field_name in _AS_OBJECT_REF_FIELDS:
+            # These fields are dehydrated to ID strings by _dehydrate_data; their
+            # in-memory shape is irrelevant to the stored row.  Skipping them
+            # prevents spurious to_core() calls on stub/reference objects (e.g.
+            # VulnerabilityCaseStub in Invite.target) that are never stored
+            # standalone and have no full core projection.
+            continue
         value = getattr(model, field_name, None)
         if isinstance(value, BaseModel):
             projected = _project_shadowing_wire_obj(value)

--- a/vultron/adapters/driven/db_record.py
+++ b/vultron/adapters/driven/db_record.py
@@ -48,9 +48,11 @@ _WIRE_MODULE_PREFIX = "vultron.wire.as2"
 # ``ParticipantStatus`` and ``CaseParticipant`` are normalised because their
 # two shapes are structurally incompatible: core nests ``rm: RmDimension``
 # while wire uses a flat ``rm_state``, so a wire-shaped row silently yields
-# ``None`` for ``status.rm.state``.  The other thirteen shadowing types
-# (``VulnerabilityCase``, ``VulnerabilityReport``, the actor types, …) differ
-# only by key spelling today and are not yet normalised — tracked in #2268.
+# ``None`` for ``status.rm.state``.  The remaining five shadowing types are
+# all actor types (``VultronApplication``, ``VultronGroup``,
+# ``VultronOrganization``, ``VultronPerson``, ``VultronService``); none has a
+# ``to_core()`` projection yet and they are not yet normalised — tracked in
+# #2268.
 _NORMALIZE_WIRE_TO_CORE: frozenset[str] = frozenset(
     {
         "CaseLedgerEntry",


### PR DESCRIPTION
- Closes #2401

## Summary

Adds 8 wire types (`CaseLedgerEntry`, `CaseReference`, `CaseStatus`, `EmbargoEvent`, `EmbargoPolicy`, `VulnerabilityCase`, `VulnerabilityRecord`, `VulnerabilityReport`) to `_NORMALIZE_WIRE_TO_CORE` so they are projected to their core shape before persistence, closing the wire/core shape duality for these types (issue #2232).

## Changes

- **`vultron/adapters/driven/db_record.py`**: Expand `_NORMALIZE_WIRE_TO_CORE` with 8 types. Add skip for `_AS_OBJECT_REF_FIELDS` in child normalization loop to prevent spurious `to_core()` calls on stub/reference objects (e.g. `VulnerabilityCaseStub` in `Invite.target`) that are never stored standalone.
- **`test/architecture/test_normalize_wire_to_core_ratchet.py`**: Remove the 8 migrated types from `_NOT_YET_NORMALIZED`.
- **Test fixture fixes**: Add `context=<case_id>` to every `as_EmbargoEvent()` constructor that called `dl.create(embargo)` without it — `EmbargoEvent.context: NonEmptyString` is now enforced at the persistence boundary. Update `test_datalayer_serialization.py` assertion: `vulnerability_reports` entries are now ID strings after `as_VulnerabilityCase.to_core()` projection.

## Verification

- 7116 unit tests pass, 1167 integration tests pass
- Black, flake8, mypy, pyright clean