### PR TITLE
fix(arch): guard CORE_TYPE_MAP against wire types; document two-registry model

### DIFF
--- a/notes/vocabulary-registry.md
+++ b/notes/vocabulary-registry.md
@@ -146,10 +146,12 @@ inherit `VultronObject` directly (not through `CoreObject`), so the hook must
 live on the shared root. See
 `plan/incoming/learnings/20260819-core-type-map-hook-on-vultronobject-not-coreobject.md`.
 
-**Known side-effect**: because `as_Object` also inherits `VultronObject`
-(ARCH-12-001), wire-layer types also trigger `VultronObject.__init_subclass__`
-and land in `CORE_TYPE_MAP`. This is functionally harmless — `VOCABULARY` is
-checked first — but is architecturally imprecise. Tracked in a separate issue.
+**Wire-branch guard** (issue #2416): `as_Object` (the wire-branch root)
+overrides `_is_core_branch: ClassVar[bool] = False`. All wire subclasses
+inherit this value; `VultronObject.__init_subclass__` checks
+`cls._is_core_branch` at entry and returns immediately for any wire-branch
+type. Confirmed by `test_no_wire_types_in_core_type_map` in
+`test/architecture/test_hierarchy_invariants.py`.
 
 ---
 

--- a/plan/history/2608/implementation/ISSUE-2416,ISSUE-2417.md
+++ b/plan/history/2608/implementation/ISSUE-2416,ISSUE-2417.md
@@ -1,0 +1,24 @@
+---
+source: ISSUE-2416,ISSUE-2417
+timestamp: '2026-08-20T14:05:15.991294+00:00'
+title: guard CORE_TYPE_MAP against wire types; document two-registry model
+type: implementation
+---
+
+Issues #2416 and #2417 batched. PR: <https://github.com/CERTCC/Vultron/pull/2424>
+
+## #2416 — wire types contaminating CORE_TYPE_MAP
+
+Symptom: importing any wire vocabulary type (e.g. `as_CaseLedgerEntry`) caused 74+ wire types (`as_Accept`, `as_Create`, `as_Activity`, etc.) to self-register in `CORE_TYPE_MAP`, contradicting the module docstring ("catches non-CoreObject core types") and creating a maintenance hazard.
+
+Root cause: `VultronObject.__init_subclass__` fires for ALL `VultronObject` subclasses including wire-layer `as_Object` descendants. No branch guard existed to distinguish core from wire subclasses at registration time.
+
+Fix: Added `_is_core_branch: ClassVar[bool] = True` sentinel to `VultronObject` (default: assume core branch). Overrode it to `False` on `as_Object` (propagates to all wire subclasses via inheritance). Added `if not cls._is_core_branch: return` guard at the top of `VultronObject.__init_subclass__`.
+
+## #2417 — ARCH-12-004 spec did not document the two-registry model
+
+Symptom: ARCH-12-004 stated "core-branch types MUST register in `CORE_VOCABULARY`" but five `VultronObject`-direct types (`VultronOfferRecord`, `VultronPendingCaseInbox`, `PendingCreateCaseActivity`, `VultronReplicationState`, `VultronReportCaseLink`) correctly register in `CORE_TYPE_MAP`, not `CORE_VOCABULARY`. Investigation found `CORE_VOCABULARY` is the DataLayer primary path (must be `CoreObject` subclasses only; enforced by existing test). `CORE_TYPE_MAP` is the wire-layer fallback path. Both roles are legitimate and distinct.
+
+Root cause: ARCH-12-004 was written before the two-registry model was introduced (PR #2410, ISSUE-1992). The spec was never updated.
+
+Fix: Updated ARCH-12-004 in `specs/architecture.yaml` to document the two-registry model with rationale. Option 2 (update spec) chosen over Option 3 (retire CORE_VOCABULARY) because `CORE_VOCABULARY` serves the distinct DataLayer primary reconstruction role and retiring it would break `_from_row()`.

--- a/plan/incoming/learnings/20260820-is-core-branch-sentinel-polarity.md
+++ b/plan/incoming/learnings/20260820-is-core-branch-sentinel-polarity.md
@@ -1,0 +1,25 @@
+---
+title: "_is_core_branch sentinel: True default on VultronObject, not False"
+type: learning
+timestamp: '2026-08-20T14:15:00+00:00'
+source: ISSUE-2416
+signal: design-question
+---
+
+Issue #2416 described the `_is_core_branch` sentinel as `False` on `VultronObject` with
+`True` on `CoreObject`. This polarity is wrong: `VultronObject`-direct core subclasses
+(e.g. `VultronOfferRecord`) inherit from `VultronObject`, not `CoreObject`, so setting
+`False` on `VultronObject` would cause those five types to be skipped by the guard and
+never register in `CORE_TYPE_MAP`.
+
+The correct polarity is `True` as the default on `VultronObject` (assume core branch
+unless told otherwise) and `False` overridden on `as_Object` (wire root opts all wire
+subclasses out). This way:
+
+- `VultronObject`-direct core types: inherit `True` from `VultronObject` → register
+- `CoreObject` subclasses: inherit `True` from `VultronObject` via `CoreObject` → hook
+  fires, but `CoreObject.__init_subclass__` registers them in `CORE_VOCABULARY` instead
+- Wire types (`as_Object` subclasses): inherit `False` from `as_Object` → skipped
+
+The lesson: when a sentinel guards a hook on a shared root, the default must be the
+value inherited by the *positive* case (core), not the exclusion case (wire).

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -228,6 +228,10 @@ groups:
       not representable via `CoreObject`. Contaminating `CORE_TYPE_MAP` with wire types (issue #2416) would silently
       allow wire-shaped objects to be reconstructed via `find_in_vocabulary()`, bypassing the `CORE_VOCABULARY` primary
       path and contradicting ARCH-12-003.
+    verification: 'Confirmed by `test_no_wire_types_in_core_type_map` (imports wire vocab and asserts no `vultron.wire`
+      module class appears in `CORE_TYPE_MAP`) and `test_vultron_object_direct_types_in_core_type_map` (asserts the five
+      `VultronObject`-direct core types are reachable by class name and Literal value) in
+      `test/architecture/test_hierarchy_invariants.py`. Both MUST NOT be marked `xfail`.'
   - id: ARCH-12-005
     priority: MUST
     kind: project

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -213,9 +213,21 @@ groups:
   - id: ARCH-12-004
     priority: MUST
     kind: project
-    statement: The wire branch MUST NOT carry domain validators. Wire-branch overrides exist solely for AS2 serialization
-      shape (field aliases, `@context`, lenient `Any | None` types). Wire-branch types MUST register in `VOCABULARY`; core-branch
-      types MUST register in `CORE_VOCABULARY`.
+    statement: >-
+      The wire branch MUST NOT carry domain validators. Wire-branch overrides exist solely for AS2 serialization
+      shape (field aliases, `@context`, lenient `Any | None` types). Wire-branch types MUST register in `VOCABULARY`.
+      Core-branch types use a two-registry model: `CoreObject` subclasses MUST register in `CORE_VOCABULARY` (the
+      DataLayer primary reconstruction path); `VultronObject`-direct subclasses that do not extend `CoreObject` MUST
+      register in `CORE_TYPE_MAP` (the wire-layer fallback path). Both registries are consulted by `find_in_vocabulary()`:
+      `VOCABULARY` first, then `CORE_TYPE_MAP`. Wire-branch types MUST NOT register in either core registry.
+    rationale: >-
+      `CORE_VOCABULARY` is the DataLayer primary reconstruction path (used by `_from_row()` in `SqliteDataLayer`);
+      every entry must be a `CoreObject` subclass. `CORE_TYPE_MAP` is the fallback for `find_in_vocabulary()` in the
+      wire registry layer, catching core types that are not `CoreObject` subclasses (e.g. `VultronOfferRecord`,
+      `VultronPendingCaseInbox`). These types extend `VultronObject` directly and carry Vultron-specific domain state
+      not representable via `CoreObject`. Contaminating `CORE_TYPE_MAP` with wire types (issue #2416) would silently
+      allow wire-shaped objects to be reconstructed via `find_in_vocabulary()`, bypassing the `CORE_VOCABULARY` primary
+      path and contradicting ARCH-12-003.
   - id: ARCH-12-005
     priority: MUST
     kind: project

--- a/test/architecture/test_hierarchy_invariants.py
+++ b/test/architecture/test_hierarchy_invariants.py
@@ -233,6 +233,78 @@ class TestWireVocabularyHierarchy:
         ), f"Non-VultronBase classes in VOCABULARY: {list(non_vultron_base.keys())}"
 
 
+class TestCoreTypeMapHierarchy:
+    """Tests for CORE_TYPE_MAP hierarchy invariants (ARCH-12-003, ARCH-12-004)."""
+
+    def test_no_wire_types_in_core_type_map(self) -> None:
+        """CORE_TYPE_MAP must contain only core-branch types, never wire types.
+
+        VultronObject.__init_subclass__ must guard against wire-layer types
+        self-registering via the shared root hook (issue #2416).
+
+        Spec: ARCH-12-003 — core-branch types MUST NOT carry wire-specific
+        concerns; the converse also holds: CORE_TYPE_MAP must not be
+        contaminated with wire types.
+        """
+        import vultron.wire.as2.vocab.objects  # noqa: F401
+        import vultron.wire.as2.vocab.activities  # noqa: F401
+
+        from vultron.core.models.registry import CORE_TYPE_MAP
+
+        _WIRE_MODULE_PREFIX = "vultron.wire"
+        wire_intruders = {
+            name: cls
+            for name, cls in CORE_TYPE_MAP.items()
+            if cls.__module__.startswith(_WIRE_MODULE_PREFIX)
+        }
+        assert not wire_intruders, (
+            f"Wire types found in CORE_TYPE_MAP: {sorted(wire_intruders.keys())}\n"
+            "CORE_TYPE_MAP must contain only core-branch types (issue #2416)."
+        )
+
+    def test_vultron_object_direct_types_in_core_type_map(self) -> None:
+        """VultronObject-direct core types must be reachable via CORE_TYPE_MAP.
+
+        These five types extend VultronObject but not CoreObject; they must
+        register in CORE_TYPE_MAP (not CORE_VOCABULARY) so that
+        find_in_vocabulary() can reconstruct them without VOCABULARY
+        registration (ARCH-12-003). Enforces ARCH-12-004 as updated per
+        issue #2417.
+        """
+        from vultron.core.models.offer_record import VultronOfferRecord
+        from vultron.core.models.pending_case_inbox import (
+            VultronPendingCaseInbox,
+        )
+        from vultron.core.models.pending_create_case_activity import (
+            PendingCreateCaseActivity,
+        )
+        from vultron.core.models.registry import CORE_TYPE_MAP
+        from vultron.core.models.replication_state import (
+            VultronReplicationState,
+        )
+        from vultron.core.models.report_case_link import VultronReportCaseLink
+
+        expected = [
+            ("OfferRecord", VultronOfferRecord),
+            ("VultronOfferRecord", VultronOfferRecord),
+            ("PendingCaseInbox", VultronPendingCaseInbox),
+            ("VultronPendingCaseInbox", VultronPendingCaseInbox),
+            ("PendingCreateCaseActivity", PendingCreateCaseActivity),
+            ("ReplicationState", VultronReplicationState),
+            ("VultronReplicationState", VultronReplicationState),
+            ("ReportCaseLink", VultronReportCaseLink),
+            ("VultronReportCaseLink", VultronReportCaseLink),
+        ]
+        missing = [
+            key for key, cls in expected if CORE_TYPE_MAP.get(key) is not cls
+        ]
+        assert not missing, (
+            f"Expected CORE_TYPE_MAP entries missing or wrong: {missing}\n"
+            "VultronObject-direct core types must register in CORE_TYPE_MAP"
+            " (ARCH-12-004, issue #2417)."
+        )
+
+
 class TestCoreObjectModelConfig:
     """Tests for CoreObject model_config invariants."""
 

--- a/vultron/core/models/base.py
+++ b/vultron/core/models/base.py
@@ -19,7 +19,7 @@ import re
 import types as _types
 import typing as _typing
 from datetime import datetime, timedelta
-from typing import Annotated, Any
+from typing import Annotated, Any, ClassVar
 
 from pydantic import (
     AfterValidator,
@@ -93,8 +93,18 @@ class VultronObject(ValidatedAssignmentMixin, VultronBase):
     this base rather than directly from ``BaseModel``.
     """
 
+    # Sentinel: True on the core branch (default), overridden to False on
+    # as_Object so wire-branch types never self-register in CORE_TYPE_MAP
+    # (issue #2416).  CoreObject subclasses inherit True and are guarded by
+    # CoreObject.__init_subclass__ instead.
+    _is_core_branch: ClassVar[bool] = True
+
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)  # type: ignore[arg-type]
+        # Wire-branch types inherit _is_core_branch=False from as_Object and
+        # must not self-register in CORE_TYPE_MAP (issue #2416).
+        if not cls._is_core_branch:
+            return
         # Register every concrete VultronObject subclass in CORE_TYPE_MAP so
         # that find_in_vocabulary() can locate them without placing them in the
         # wire VOCABULARY dict (ARCH-12-003). Only subclasses that declare

--- a/vultron/wire/as2/vocab/base/objects/base.py
+++ b/vultron/wire/as2/vocab/base/objects/base.py
@@ -15,7 +15,7 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 from datetime import datetime, timedelta
-from typing import Any, TypeAlias, cast
+from typing import Any, ClassVar, TypeAlias, cast
 
 import isodate  # type: ignore[import-untyped]
 from pydantic import ConfigDict, field_serializer, field_validator, Field
@@ -41,6 +41,11 @@ class as_Object(as_Base, VultronObject):
     # carries ValidatedAssignmentMixin, so without this override the flag
     # propagates here via the cross-branch MRO.
     model_config = ConfigDict(validate_assignment=False)
+
+    # Wire-branch types must NOT self-register in CORE_TYPE_MAP (issue #2416).
+    # Setting False here propagates to all as_Object subclasses via inheritance,
+    # so VultronObject.__init_subclass__ skips them entirely.
+    _is_core_branch: ClassVar[bool] = False
 
     replies: Any | None = None
     url: Any | None = None


### PR DESCRIPTION
- Closes #2416
- Closes #2417

## Summary

Guards `CORE_TYPE_MAP` against wire-type contamination via a `_is_core_branch` sentinel, and updates ARCH-12-004 to document the two-registry model that was already in use but not specified.

## Changes

- **`vultron/core/models/base.py`**: Add `_is_core_branch: ClassVar[bool] = True` to `VultronObject`; add `if not cls._is_core_branch: return` guard at top of `__init_subclass__`; import `ClassVar`
- **`vultron/wire/as2/vocab/base/objects/base.py`**: Override `_is_core_branch: ClassVar[bool] = False` on `as_Object`; import `ClassVar`
- **`specs/architecture.yaml`**: Update ARCH-12-004 to document the two-registry model: `CORE_VOCABULARY` for `CoreObject` subclasses (DataLayer primary path), `CORE_TYPE_MAP` for `VultronObject`-direct core subclasses (wire-layer fallback)
- **`test/architecture/test_hierarchy_invariants.py`**: Add `TestCoreTypeMapHierarchy` with two regression tests

## Verification

- `test_no_wire_types_in_core_type_map`: was failing before fix (74 wire types in `CORE_TYPE_MAP` on import); passes after
- `test_vultron_object_direct_types_in_core_type_map`: all 5 `VultronObject`-direct types reachable by both class name and Literal value
- 7136 unit tests pass, 1167 integration tests pass
- black, flake8, mypy, pyright all clean