### PR TITLE
fix(specs): eliminate vague terms and remove superseded requirements

### DIFF
--- a/plan/incoming/learnings/20260820-SPEC-VAGUE-TERMS.md
+++ b/plan/incoming/learnings/20260820-SPEC-VAGUE-TERMS.md
@@ -1,0 +1,11 @@
+---
+title: "Single-quoted YAML strings require '' to escape internal apostrophes"
+type: learning
+timestamp: "2026-08-20T00:00:00Z"
+source: 20260820-SPEC-VAGUE-TERMS
+signal: spec-gap
+---
+
+When editing YAML spec statements that use single-quoted strings (e.g. CS-21-001 statement field starting with `'Pydantic model fields...`), any apostrophe introduced in the replacement text must be doubled (`''`) to avoid YAML parse errors. The linter fails with an opaque "did not find expected key" parse error rather than pointing directly at the apostrophe. Symptom: `yaml.parser.ParserError` mentioning a column position coinciding with the apostrophe character.
+
+**How to apply:** Before saving a spec edit that introduces `'s` or other apostrophes inside a single-quoted YAML value, either escape as `''s` or convert the field to a `>-` block scalar.

--- a/specs/README.md
+++ b/specs/README.md
@@ -520,8 +520,8 @@ Some specifications consolidate requirements from multiple sources to create a s
 
 - **`actor-knowledge-model.yaml`** consolidates Actor isolation and inline-object
   requirements from `case-management.yaml` (CM-01-001) and
-  `message-validation.yaml` (MV-09-001); it is the authoritative basis for
-  both.
+  `message-validation.yaml` (MV-09-001, removed — now AKM-03-001); it is the
+  authoritative basis for both.
 - **`http-protocol.yaml`** consolidates HTTP requirements from `inbox-endpoint.yaml`,
   `message-validation.yaml`, `error-handling.yaml`, and `agentic-readiness.yaml`
 - **`structured-logging.yaml`** consolidates logging requirements from `observability.yaml`,

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -146,7 +146,7 @@ groups:
   - id: BT-07-003
     priority: MUST
     kind: protocol
-    statement: State transitions MUST be logged at the appropriate level
+    statement: State transitions MUST be logged at the level specified by SL-04-001
     relationships:
     - rel_type: depends_on
       spec_id: SL-03-001
@@ -178,10 +178,6 @@ groups:
     priority: MUST_NOT
     kind: project
     statement: Actor blackboards MUST NOT share state
-  - id: BT-09-003
-    priority: MUST
-    kind: protocol
-    statement: Actor interaction MUST occur only via protocol messages
 - id: BT-10
   title: CaseActor Management
   specs:

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -137,7 +137,7 @@ groups:
     kind: project
     statement: A decomposed BT leaf node that encounters a domain-layer error MUST write the error to the `result_out["error"]`
       blackboard key before returning `FAILURE`, and MUST re-raise the original exception in `execute()` after the write so
-      that the bridge layer can translate it into an appropriate HTTP or protocol response.
+      that the bridge layer can map it to the corresponding HTTP error response.
     rationale: Without a written error key the bridge layer sees only `FAILURE` with no diagnostic context; the error is silently
       swallowed. Writing to `result_out["error"]` ensures the error propagates to the caller via the result channel even when
       the BT stops traversal at the failing leaf.
@@ -149,7 +149,7 @@ groups:
     kind: project
     statement: A decomposed BT leaf node MUST convert `KeyError` (missing blackboard key) to a `FAILURE` status and MUST NOT
       allow the `KeyError` to propagate uncaught to the bridge layer. The leaf is responsible for catching `KeyError` in its
-      `update()` method and returning `FAILURE` with an appropriate diagnostic message.
+      `update()` method and returning `FAILURE` with a diagnostic message naming the missing key.
     rationale: A `KeyError` propagating to the bridge results in an unhandled 500-level error for the caller. At the leaf
       level the semantics of "key not present" are known — this is a precondition failure, not an unexpected crash, so `FAILURE`
       is the correct BT response.

--- a/specs/build-workflow.yaml
+++ b/specs/build-workflow.yaml
@@ -90,7 +90,7 @@ groups:
         kind: process
         statement: >-
           The `update-plan` skill MUST write observations and open questions
-          directly to appropriate `notes/*.md` files. It MUST NOT use
+          to the `notes/*.md` file whose topic matches the content. It MUST NOT use
           `plan/incoming/learnings/` as an intermediate staging area.
         relationships:
           - rel_type: refines
@@ -141,9 +141,10 @@ groups:
         kind: process
         statement: >-
           When the `learn` skill processes `plan/incoming/learnings/`, each
-          file MUST be promoted to the appropriate durable destination
-          (`specs/*.yaml`, `notes/*.md`, or `AGENTS.md`) before being
-          archived via `uv run append-history --from-file <path>`.
+          file MUST be promoted to the durable destination matching the content
+          type — requirements to `specs/*.yaml`, design insights to `notes/*.md`,
+          agent guidance to `AGENTS.md` — before being archived via
+          `uv run append-history --from-file <path>`.
         relationships:
           - rel_type: depends_on
             spec_id: HM-02-002

--- a/specs/case-bootstrap-trust.yaml
+++ b/specs/case-bootstrap-trust.yaml
@@ -95,8 +95,8 @@ groups:
   - id: CBT-02-002
     priority: MUST_NOT
     kind: protocol
-    statement: Transport authentication or encrypted direct messaging alone MUST NOT be treated as sufficient authority to
-      trust a previously unknown CaseActor without the explicit bootstrap trust handoff.
+    statement: Transport authentication or encrypted direct messaging alone MUST NOT be treated as establishing authority to
+      trust a previously unknown CaseActor; the explicit bootstrap trust handoff is required.
     relationships:
     - rel_type: refines
       spec_id: AKM-01-002

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -48,8 +48,8 @@ groups:
   - id: CLP-02-003
     priority: MUST
     kind: protocol
-    statement: '`CaseLedgerEntry` MUST include the asserted activity payload, or a normalized immutable snapshot of it, sufficient
-      for deterministic replay'
+    statement: '`CaseLedgerEntry` MUST include the asserted activity payload, or a normalized immutable snapshot of it, containing
+      all fields required for deterministic replay'
   - id: CLP-02-004
     priority: MUST
     kind: protocol

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -184,7 +184,7 @@ groups:
     priority: MUST
     kind: protocol
     statement: >-
-      Handlers processing EM state transitions MUST update the appropriate EM state field as follows:
+      Handlers processing EM state transitions MUST update the EM state field as follows:
       (a) when the accepting actor is the case owner, MUST update CaseStatus.em_state;
       (b) when the accepting actor is any other participant, MUST update that participant's
       ParticipantStatus.embargo_adherence;

--- a/specs/case-proposal.yaml
+++ b/specs/case-proposal.yaml
@@ -116,8 +116,8 @@ groups:
   - id: CP-05-002
     priority: MUST
     kind: protocol
-    statement: '`CreateCaseProposalReceivedUseCase` MUST evaluate the proposal and either accept or reject it, emitting the
-      appropriate response activity.'
+    statement: '`CreateCaseProposalReceivedUseCase` MUST evaluate the proposal and either accept or reject it, emitting an
+      `Accept(CaseProposal)` or `Reject(CaseProposal)` activity accordingly.'
   - id: CP-05-003
     priority: MUST
     kind: protocol

--- a/specs/code-style.yaml
+++ b/specs/code-style.yaml
@@ -411,7 +411,7 @@ groups:
     kind: project
     statement: 'Pydantic model fields whose type is a collection (`dict`, `set`, `list`, or any generic alias thereof) MUST
       NOT use `None` as their default value when the intent is "empty collection if not provided". Use `Field(default_factory=list)`,
-      `Field(default_factory=dict)`, or `Field(default_factory=set)` as appropriate. `None` is only acceptable as a field
+      `Field(default_factory=dict)`, or `Field(default_factory=set)` matching the field''s collection type. `None` is only acceptable as a field
       default when it is an intentional sentinel meaning "absent" (as distinct from "empty"), and that distinction must be
       observable in the model''s behaviour or serialisation. Plain function and method parameters are out of scope for this
       rule: `param: set[str] | None = None` with an `x or set()` guard in the body is the correct idiom for optional collection

--- a/specs/diataxis-requirements.yaml
+++ b/specs/diataxis-requirements.yaml
@@ -135,7 +135,7 @@ groups:
   - id: DF-04-004
     priority: MUST
     kind: process
-    statement: Use conditional imperatives (e.g., "If you want X, do Y") when appropriate.
+    statement: Use conditional imperatives (e.g., "If you want X, do Y") when the step applies only under a specific condition.
   - id: DF-04-005
     priority: MUST_NOT
     kind: process

--- a/specs/error-handling.yaml
+++ b/specs/error-handling.yaml
@@ -67,7 +67,7 @@ groups:
   - id: EH-06-001
     priority: MUST
     kind: project
-    statement: All errors MUST be logged at the appropriate level per log level semantics
+    statement: All errors MUST be logged at the level defined by SL-03-001 log level semantics
     relationships:
     - rel_type: depends_on
       spec_id: SL-03-001

--- a/specs/history-management.yaml
+++ b/specs/history-management.yaml
@@ -177,7 +177,7 @@ groups:
     priority: MUST
     kind: process
     statement: The `learn` skill MUST NOT read `plan/*HISTORY.md` files directly. When historical context is needed, the `learn`
-      skill MUST invoke `study-project-docs` and let that skill mediate which plan files are appropriate to load.
+      skill MUST invoke `study-project-docs` and let that skill mediate which plan files are relevant to load.
 - id: HM-06
   title: Timestamp Field and Future-Date Rejection
   specs:

--- a/specs/inbox-pipeline.yaml
+++ b/specs/inbox-pipeline.yaml
@@ -31,8 +31,8 @@ groups:
     statement: >-
       `InboxPipeline.process(activity_id: str)` MUST execute the full inbox
       processing chain: rehydrate the activity from the DataLayer, extract
-      the domain event, check case context, defer or dispatch as appropriate,
-      and handle errors with requeue logic.
+      the domain event, check case context, defer to the wait queue or dispatch via
+      the activity dispatcher, and handle errors with requeue logic.
     rationale: >-
       Wrapping the full `_process_inbox_item` path (not the simpler
       `handle_inbox_item`) ensures that deferral and error-requeue behaviours

--- a/specs/message-validation.yaml
+++ b/specs/message-validation.yaml
@@ -83,13 +83,6 @@ groups:
 - id: MV-09
   title: Outbound Activity Object Integrity
   specs:
-  - id: MV-09-001
-    priority: MUST
-    kind: protocol
-    statement: >-
-      Outbound initiating activities (Create, Offer, Invite, Announce, Add, Remove, Update,
-      Join, Ignore, Leave) MUST carry the `object` field as a fully inline typed domain object
-      — bare string URIs and `as_Link` references are NOT permitted in outbound activities.
   - id: MV-09-002
     priority: MUST
     kind: protocol
@@ -164,13 +157,3 @@ groups:
     relationships:
     - rel_type: depends_on
       spec_id: CM-03-008
-- id: MV-08
-  title: Duplicate Detection
-  specs:
-  - id: MV-08-001
-    priority: SHOULD
-    kind: protocol
-    statement: The system SHOULD detect duplicate activity submissions during validation
-    relationships:
-    - rel_type: depends_on
-      spec_id: ID-02-001

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1756,7 +1756,7 @@ groups:
       `--finder-url`, `--c1-url`, `--c2-url`, `--vendor-url`,
       `--case-actor-url`, `--finder-id`, `--c1-id`, `--c2-id`,
       `--vendor-id`, `--case-actor-id`, and `--skip-health-check`
-      options with appropriate env-var bindings.
+      options with corresponding environment variable bindings.
     rationale: >-
       CLI consistency and Docker-entrypoint compatibility require the
       `DEMO=fccv-handoff` env var to map to `vultron-demo fccv-handoff`

--- a/specs/outbox.yaml
+++ b/specs/outbox.yaml
@@ -127,7 +127,7 @@ groups:
     statement: The `object_` field of outbound activities MUST NOT be dehydrated
     relationships:
     - rel_type: depends_on
-      spec_id: MV-09-001
+      spec_id: AKM-03-001
 - id: OX-08
   title: Outbox Addressing
   specs:

--- a/specs/parallel-development.yaml
+++ b/specs/parallel-development.yaml
@@ -114,8 +114,9 @@ groups:
         kind: process
         statement: >-
           Epic Issues MUST be created using the GitHub `Epic` issue type (via
-          GraphQL `createIssue` with the appropriate `issueTypeId`) and MUST
-          be added to GitHub Project #24 with the appropriate `Schedule` value.
+          GraphQL `createIssue` with the Epic issue type's `issueTypeId`, discovered
+          via the GraphQL `issueTypes` query) and MUST be added to GitHub Project #24
+          with a `Schedule` value (Now/Next/Later/Someday) matching the work's priority.
       - id: PAD-02-013
         priority: MUST
         kind: process
@@ -308,7 +309,7 @@ groups:
         statement: >-
           After the docs-only PR is opened, `ingest-idea` MUST create a
           GitHub Issue with: a title and description derived from the spec,
-          the appropriate `size:` label (from AC count per PAD-05-001), and a
+          the `size:` label derived from the AC count per PAD-05-001, and a
           link to the spec file in the body. The Issue MUST be added to
           GitHub Project #24 (defaulting to `Schedule=Someday`).
       - id: PAD-09-003
@@ -403,8 +404,8 @@ groups:
         kind: process
         statement: >-
           Issues created by `update-plan` MUST be added to GitHub Project #24
-          with `Schedule=Someday` and the appropriate initial `size:` label
-          (from AC count per PAD-05-001).
+          with `Schedule=Someday` and the initial `size:` label derived from
+          the AC count per PAD-05-001.
 
   - id: PAD-14
     title: GitHub Actions Requirements

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -420,7 +420,7 @@ groups:
       Message ingress MUST NOT use the canonical ledger/DataLayer store as a scratch or
       lookup cache for routing, semantic classification, or rehydration of an inbound
       Announce(CaseLedgerEntry). The inline CaseLedgerEntry parsed from the wire envelope
-      MUST be carried forward in-memory (or via a clearly separate, non-ledger holding area)
+      MUST be carried forward in-memory (or via a dedicated, non-ledger holding area)
       so that semantic routing and effect application do not depend on pre-storing the entry.
   - id: SYNC-13-004
     priority: MUST

--- a/specs/vocabulary-model.yaml
+++ b/specs/vocabulary-model.yaml
@@ -111,7 +111,7 @@ groups:
     priority: MUST
     kind: project
     statement: 'When adding a new Vultron-specific object type, the new class MUST: 1. Inherit from `VultronObject` (or an
-      appropriate AS2 base such as `as_Object`, `as_Activity`, etc.) 2. Define `type_` as a `Literal[str]` field matching
+      AS2 base such as `as_Object`, `as_Activity`, etc.) 2. Define `type_` as a `Literal[str]` field matching
       the wire type name (registration via `__init_subclass__` fires automatically) 3. Be placed in the vocabulary subpackage
       that matches its category (`vocab/objects/`, `vocab/activities/`) 4. Be reachable via the dynamic discovery in the subpackage
       `__init__.py` (i.e., exist as a `.py` file in the package directory)'

--- a/specs/vultron-protocol-spec.yaml
+++ b/specs/vultron-protocol-spec.yaml
@@ -31,7 +31,7 @@ groups:
     priority: MUST_NOT
     kind: protocol
     statement: >-
-      Adequate operation of the protocol MUST NOT depend on perfect information across all
+      Correct operation of the protocol MUST NOT depend on perfect information across all
       Participants
 - id: VP-02
   title: 'Report Management (RM): Receiving Reports'
@@ -40,7 +40,7 @@ groups:
     priority: MUST
     kind: protocol
     statement: >-
-      Coordinators MUST have a clearly defined and publicly available mechanism for receiving
+      Coordinators MUST have a formally documented, publicly available mechanism for receiving
       reports
   - id: VP-02-002
     priority: MUST


### PR DESCRIPTION
- Closes #2395
- Closes #2396
- Closes #2398

## Summary

Fixes 22 MUST/MUST_NOT requirements containing prohibited vague terms (MS-05-002), removes 3 confirmed-superseded requirements from their source specs (MS-09-001–003), and verifies that all 24 MUST "not yet" requirements are legitimate domain-state uses requiring no change.

## Changes

**Issue #2395 — Replace vague terms in MUST/MUST_NOT requirements (17 files):**

- **`specs/behavior-tree-integration.yaml`**: BT-07-003 — "appropriate level" → "level specified by SL-04-001"
- **`specs/behavior-tree-node-design.yaml`**: BTND-03-006 — "appropriate HTTP or protocol response" → "corresponding HTTP error response"; BTND-03-007 — "appropriate diagnostic message" → "diagnostic message naming the missing key"
- **`specs/build-workflow.yaml`**: BW-01-007 — "appropriate `notes/*.md` files" → "the `notes/*.md` file whose topic matches the content"; BW-03-001 — "appropriate durable destination" → enumerated by content type
- **`specs/case-bootstrap-trust.yaml`**: CBT-02-002 — "sufficient authority" → "establishing authority … the explicit bootstrap trust handoff is required"
- **`specs/case-ledger-processing.yaml`**: CLP-02-003 — "sufficient for deterministic replay" → "containing all fields required for deterministic replay"
- **`specs/case-management.yaml`**: CM-04-003 — "appropriate EM state field" → "EM state field" (the statement already enumerates the fields)
- **`specs/case-proposal.yaml`**: CP-05-002 — "appropriate response activity" → "`Accept(CaseProposal)` or `Reject(CaseProposal)`"
- **`specs/code-style.yaml`**: CS-21-001 — "as appropriate" → "matching the field's collection type"
- **`specs/diataxis-requirements.yaml`**: DF-04-004 — "when appropriate" → "when the step applies only under a specific condition"
- **`specs/error-handling.yaml`**: EH-06-001 — "appropriate level per log level semantics" → "level defined by SL-03-001 log level semantics"
- **`specs/history-management.yaml`**: HM-05-003 — "appropriate to load" → "relevant to load"
- **`specs/inbox-pipeline.yaml`**: IBP-01-002 — "defer or dispatch as appropriate" → "defer to the wait queue or dispatch via the activity dispatcher"
- **`specs/multi-actor-demo.yaml`**: DEMOMA-14-008 — "appropriate env-var bindings" → "corresponding environment variable bindings"
- **`specs/parallel-development.yaml`**: PAD-02-009 — two "appropriate" → Epic issueTypeId discovery phrase + Schedule enumeration; PAD-09-002 and PAD-13-002 — "appropriate size: label" → "size: label derived from the AC count per PAD-05-001"
- **`specs/sync-ledger-replication.yaml`**: SYNC-13-003 — "clearly separate" → "dedicated"
- **`specs/vocabulary-model.yaml`**: VM-05-001 — "an appropriate AS2 base" → "an AS2 base"
- **`specs/vultron-protocol-spec.yaml`**: VP-01-003 — "Adequate operation" → "Correct operation"; VP-02-001 — "clearly defined" → "formally documented"

**Issue #2396 — Remove superseded requirements:**

- **`specs/message-validation.yaml`**: Remove MV-09-001 (superseded by AKM-03-001); remove entire MV-08 group including MV-08-001 (superseded by ID-02-001)
- **`specs/behavior-tree-integration.yaml`**: Remove BT-09-003 (superseded by AKM-01-002)
- **`specs/outbox.yaml`**: Update OX-07-002 cross-reference from MV-09-001 → AKM-03-001

**Issue #2398 — "not yet" language review:**

All 24 MUST requirements using "not yet" are legitimate domain-state qualifiers (CSB/EMB state notation, CM-11-001 case-replica arrival, SYNC-15 pre-genesis state, PAD-02-001 unscheduled issues). No changes needed.

## Verification

- `PYTHONPATH= uv run spec-lint`: no ERRORs (pre-existing WARNs only)
- All YAML files parse cleanly
- 7148 tests pass, 0 failures