### PR TITLE
docs: plan issue #2322 — remove deprecated OFFER_CASE_MANAGER_ROLE and fix target_ strictness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -463,13 +463,14 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   see [notes/bt-pitfalls.md](notes/bt-pitfalls.md).
 - **Semantic Registry Pattern Must Match Inbound Wire Format** —
   see [notes/activitystreams-state-update.md](notes/activitystreams-state-update.md).
-- **`OFFER_CASE_MANAGER_ROLE` and `OFFER_CASE_OWNERSHIP_TRANSFER` Share
-  `Offer(VulnerabilityCase)` — Registry Order and Required `target` Field Are
-  the Current Guards** — `OFFER_CASE_MANAGER_ROLE` MUST appear before
-  `OFFER_CASE_OWNERSHIP_TRANSFER` in `SEMANTIC_REGISTRY` (enforced by
-  `_validate_registry_order()`). `_OfferCaseManagerRoleActivity.target` MUST
-  remain required. Do NOT add a third `Offer(VulnerabilityCase)` pattern without
-  a distinct object type. See SE-08-001, SE-08-002, ADR-0039,
+- **`ActivityPattern.target_` Is Always Permissive Unless `strict=True`** —
+  `_match_activity_field` hardcodes `strict=False` for the `target_` field pair,
+  so a bare URI string matches any typed target constraint. When `target_` is the
+  sole discriminator between two competing patterns (same `activity_` + `object_`),
+  set `strict=True` on the more-specific pattern; otherwise an unresolved target
+  URI bypasses the discriminator and makes registry ordering the only guard.
+  Prefer a dedicated object type (SE-08-003) over target-field discrimination
+  whenever possible. See SE-08-001, SE-08-004, ADR-0039, CONCERN-2322,
   [notes/activitystreams-state-update.md](notes/activitystreams-state-update.md)
   § "Target-Field Discriminators".
 - **`offer_case_participant_activity`: `event.object_id` Has `#participant` Suffix**

--- a/docs/adr/0039-offer-case-participant-role-wire-type.md
+++ b/docs/adr/0039-offer-case-participant-role-wire-type.md
@@ -39,32 +39,13 @@ Issue: CONCERN-1674.
    `Offer(CaseParticipantRole, target=Actor, context=VulnerabilityCase)`.
 2. **Keep `Offer(VulnerabilityCase)`; add `strict=True` to the pattern** —
    enforce the target discriminator at the pattern layer without a type change.
+   *Partially adopted as an implementation complement to Option 1 (CONCERN-2322):
+   `ActivityPattern._match_activity_field` hardcodes `strict=False` for `target_`
+   by default; any pattern using `target_` as the sole discriminator MUST set
+   `strict=True` so bare URI strings cannot match typed target constraints.
+   See SE-08-004.*
 3. **Spec-and-notes documentation only** — record the ordering requirement and
    the target-as-discriminator rationale; no wire format change.
-
-## Amendment — `strict=True` for `target_` (CONCERN-2322)
-
-CONCERN-2322 surfaced a second structural gap: even with Option 1 chosen,
-`ActivityPattern._match_activity_field` always treats the `target_` field as
-permissive (`strict=False`), meaning a bare URI string in `target` would match
-any typed target constraint. For the deprecated `Offer(VulnerabilityCase,
-target=CaseParticipant)` format this meant registry ordering was the **sole**
-protection against misrouting when `_rehydrate_fields` had not yet resolved
-the target.
-
-The amendment decision (CONCERN-2322) is:
-
-- **`strict=True` on `ActivityPattern` MUST also gate `target_` matching**:
-  when `strict=True`, a bare string in the `target` field must NOT match a
-  typed target constraint. This is implemented by passing `self.strict` to the
-  `target_` field pair in `_match_activity_field` instead of the hardcoded
-  `False`.
-- **`OFFER_CASE_MANAGER_ROLE` is removed** (not merely deprecated): the
-  backward-compat wire format was never emitted by any supported actor
-  implementation; retaining it as a fallback-only registry entry was a source
-  of registry-ordering fragility. Removed by CONCERN-2322.
-- **`ACCEPT_CASE_PARTICIPANT_ROLE` and `REJECT_CASE_PARTICIPANT_ROLE`** are
-  added to complete the three-way role-offer flow for the canonical wire format.
 
 ## Decision Outcome
 
@@ -77,6 +58,17 @@ Chosen option: **Option 1 — new `as_CaseParticipantRole` object type**, becaus
   generalises naturally to offering any `CVDRole` (VENDOR, COORDINATOR, etc.)
   rather than only CASE_MANAGER.
 - Options 2 and 3 leave the latent misrouting risk in place for external senders.
+
+**Implementation complement (CONCERN-2322)**: Option 2's `strict=True` mechanism
+is also applied as a structural hardening: `ActivityPattern._match_activity_field`
+now respects `self.strict` for the `target_` field pair rather than hardcoding
+`False`, so bare URI strings cannot match typed target constraints when
+`strict=True`. This closes the gap where registry ordering was the sole
+protection against misrouting even with Option 1 in place. Additionally:
+`OFFER_CASE_MANAGER_ROLE` was removed entirely (not merely deprecated) since
+its wire format was never emitted by any supported actor, and
+`ACCEPT_CASE_PARTICIPANT_ROLE` / `REJECT_CASE_PARTICIPANT_ROLE` were added to
+complete the three-way role-offer flow. See SE-08-004, SE-08-005.
 
 ### Consequences
 

--- a/docs/adr/0039-offer-case-participant-role-wire-type.md
+++ b/docs/adr/0039-offer-case-participant-role-wire-type.md
@@ -42,6 +42,30 @@ Issue: CONCERN-1674.
 3. **Spec-and-notes documentation only** — record the ordering requirement and
    the target-as-discriminator rationale; no wire format change.
 
+## Amendment — `strict=True` for `target_` (CONCERN-2322)
+
+CONCERN-2322 surfaced a second structural gap: even with Option 1 chosen,
+`ActivityPattern._match_activity_field` always treats the `target_` field as
+permissive (`strict=False`), meaning a bare URI string in `target` would match
+any typed target constraint. For the deprecated `Offer(VulnerabilityCase,
+target=CaseParticipant)` format this meant registry ordering was the **sole**
+protection against misrouting when `_rehydrate_fields` had not yet resolved
+the target.
+
+The amendment decision (CONCERN-2322) is:
+
+- **`strict=True` on `ActivityPattern` MUST also gate `target_` matching**:
+  when `strict=True`, a bare string in the `target` field must NOT match a
+  typed target constraint. This is implemented by passing `self.strict` to the
+  `target_` field pair in `_match_activity_field` instead of the hardcoded
+  `False`.
+- **`OFFER_CASE_MANAGER_ROLE` is removed** (not merely deprecated): the
+  backward-compat wire format was never emitted by any supported actor
+  implementation; retaining it as a fallback-only registry entry was a source
+  of registry-ordering fragility. Removed by CONCERN-2322.
+- **`ACCEPT_CASE_PARTICIPANT_ROLE` and `REJECT_CASE_PARTICIPANT_ROLE`** are
+  added to complete the three-way role-offer flow for the canonical wire format.
+
 ## Decision Outcome
 
 Chosen option: **Option 1 — new `as_CaseParticipantRole` object type**, because:
@@ -77,12 +101,15 @@ Chosen option: **Option 1 — new `as_CaseParticipantRole` object type**, becaus
 
 ## More Information
 
-- Interim protection while the migration is in flight: `SE-08-001` through
-  `SE-08-002` mandate registry ordering and required target field until the
-  wire type migration is complete.
+- `SE-08-001` through `SE-08-002` mandate registry ordering and required target
+  field for any pattern that discriminates by target.
 - `SE-08-003` records the SHOULD preference for dedicated object types over
   target-field discrimination.
-- Implementation issue: tracked as a GitHub Task issue blocked by CONCERN-1674.
+- `SE-08-004` mandates `strict=True` on patterns that use `target_` as the
+  sole discriminator (amended by CONCERN-2322).
+- `SE-08-005` records the removal of the `OFFER_CASE_MANAGER_ROLE` backward-compat
+  format (CONCERN-2322).
+- Implementation issues: tracked as GitHub Task issues blocked by CONCERN-2322.
 
 Generated spec requirements: `specs/semantic-extraction.yaml` SE-08-001,
-SE-08-002, SE-08-003.
+SE-08-002, SE-08-003, SE-08-004, SE-08-005.

--- a/notes/activitystreams-state-update.md
+++ b/notes/activitystreams-state-update.md
@@ -393,44 +393,44 @@ tracking issue for ADR update).
 
 ## Target-Field Discriminators: Wire Ambiguity Between Offer Semantics
 
-(CONCERN-1674, 2026-07-27)
+(CONCERN-1674, 2026-07-27; amended CONCERN-2322, 2026-08-20)
 
-`OFFER_CASE_MANAGER_ROLE` and `OFFER_CASE_OWNERSHIP_TRANSFER` both serialize as
-`Offer(VulnerabilityCase)` on the wire. They are disambiguated solely by the
+**Resolution summary**: The `OFFER_CASE_MANAGER_ROLE` wire format and all
+supporting infrastructure have been removed (CONCERN-2322). The canonical
+format is `OFFER_CASE_PARTICIPANT_ROLE` (`Offer(CaseParticipantRole,
+target=Actor, context=VulnerabilityCase)`). The historical context below is
+preserved for understanding ADR-0039 and the strictness fix.
+
+---
+
+`OFFER_CASE_MANAGER_ROLE` and `OFFER_CASE_OWNERSHIP_TRANSFER` both serialized
+as `Offer(VulnerabilityCase)` on the wire, disambiguated solely by the
 presence or absence of `target=CaseParticipant`:
 
 | Semantic | Pattern |
 |---|---|
-| `OFFER_CASE_MANAGER_ROLE` | `Offer(VulnerabilityCase, target=CaseParticipant)` |
+| `OFFER_CASE_MANAGER_ROLE` (removed) | `Offer(VulnerabilityCase, target=CaseParticipant)` |
 | `OFFER_CASE_OWNERSHIP_TRANSFER` | `Offer(VulnerabilityCase)` (no target) |
 
-**Current protections** (both required while the wire format migration is pending):
+**Structural gap (CONCERN-2322)**: `ActivityPattern._match_activity_field`
+always treated `target_` as permissive (`strict=False`), meaning a bare URI
+string in `target` would match any typed target constraint. Registry ordering
+was therefore the *sole* protection against misrouting when `_rehydrate_fields`
+had not yet resolved the target.
 
-1. **Registry ordering** — `OFFER_CASE_MANAGER_ROLE` appears before
-   `OFFER_CASE_OWNERSHIP_TRANSFER` in `SEMANTIC_REGISTRY` (enforced by
-   `_validate_registry_order()` at import time; raises `RegistryOrderError` on
-   violation). See SE-08-001.
-2. **Required target field** — `_OfferCaseManagerRoleActivity.target` is
-   `as_CaseParticipant` (required, not optional). A sender omitting it gets a
-   `ValidationError` at construction time. See SE-08-002.
+**Fix**: When `ActivityPattern.strict=True`, the `target_` field is now also
+matched strictly — bare URI strings do NOT match a typed target constraint.
+Patterns that discriminate by target should set `strict=True`. See SE-08-004.
 
-**Resolution (ADR-0039, Issue #1726)** — the dedicated `as_CaseParticipantRole`
-wire object type has been introduced.  New senders MUST emit
-`Offer(CaseParticipantRole, target=Actor, context=VulnerabilityCase)` using the
-`OFFER_CASE_PARTICIPANT_ROLE` semantic (factory:
-`offer_case_participant_role_activity`).  Receivers continue to handle the
-deprecated `OFFER_CASE_MANAGER_ROLE` format for interoperability with
-pre-ADR-0039 actors.  See SE-08-003, SE-08-004.
+**Full resolution (ADR-0039 + CONCERN-2322)**: The `OFFER_CASE_MANAGER_ROLE`
+format was never emitted by any supported actor; retaining it as a registry
+entry was a source of ordering fragility. It has been removed entirely.
+The canonical `OFFER_CASE_PARTICIPANT_ROLE` format uses a dedicated object
+type (`as_CaseParticipantRole`) that is self-describing without any registry
+ordering dependency. See SE-08-003, SE-08-005.
 
-**Migration checklist for senders**:
-
-1. Replace `offer_case_manager_role_activity(...)` calls with
-   `offer_case_participant_role_activity(role=CVDRole.CASE_MANAGER, ...)`.
-2. Remove `target=CaseParticipant` construction — the new format carries the
-   Actor as `target` and the case as `context`.
-3. No receiver-side change required; the registry handles both formats.
-
-**Rule for new patterns sharing `Offer(VulnerabilityCase)`** — if a new
-semantic requires `Offer(VulnerabilityCase)`, it MUST either (a) use a distinct
-object type, or (b) add a more-specific discriminator field AND be placed before
-the existing less-specific entries in `SEMANTIC_REGISTRY`.
+**Rule for new patterns that share a verb+object pair** — if a new semantic
+requires the same `(activity_, object_)` pair as an existing pattern, it MUST
+either (a) use a distinct object type (preferred — SE-08-003), or (b) add a
+more-specific discriminator field with `strict=True` AND appear before the
+less-specific entry in `SEMANTIC_REGISTRY` (SE-08-001, SE-08-004).

--- a/plan/history/2608/learning/CONCERN-2322.md
+++ b/plan/history/2608/learning/CONCERN-2322.md
@@ -1,0 +1,62 @@
+---
+source: CONCERN-2322
+timestamp: '2026-08-20T15:04:29.610858+00:00'
+title: Remove deprecated OFFER_CASE_MANAGER_ROLE and fix ActivityPattern target_ strictness
+type: learning
+---
+
+## Concern
+
+`OfferCaseManagerRolePattern` silently mis-routes when `_rehydrate_fields`
+expansion is skipped. Root cause: `ActivityPattern._match_activity_field`
+hardcodes `strict=False` for the `target_` field pair, so a bare URI string
+in `target` matches any typed target constraint. This made registry ordering
+the **sole** protection against misrouting the deprecated
+`Offer(VulnerabilityCase, target=CaseParticipant)` format as an ownership
+transfer.
+
+## Decisions
+
+1. **`strict=True` must also gate `target_` matching** — passing `self.strict`
+   to the `target_` field pair instead of hardcoded `False` ensures a bare URI
+   string cannot match a typed target constraint when `strict=True`.
+2. **`OFFER_CASE_MANAGER_ROLE` is removed** (not merely kept deprecated) — the
+   wire format was never emitted by any supported actor implementation; retaining
+   it as a registry entry was a source of ordering fragility (CONCERN-2322).
+3. **`ACCEPT_CASE_PARTICIPANT_ROLE` and `REJECT_CASE_PARTICIPANT_ROLE`** are
+   added to complete the three-way role-offer flow for the canonical
+   `OFFER_CASE_PARTICIPANT_ROLE` format.
+
+## Scope of removal
+
+~61 production code locations across ~15 files plus ~99 test locations spanning:
+wire patterns, semantic registry, BT nodes (`SendOfferCaseManagerRoleNode`,
+`AutoAcceptCaseManagerRoleNode`, `EmitRejectCaseManagerRoleNode`), BT trees,
+trigger factories, ports, adapters, FastAPI endpoint, and demo test assertions.
+
+`case_participant_role.py` (new format's received-use-case) currently borrows
+the old `offer_case_manager_role_received_tree` — a new dedicated tree must be
+built before the old one can be deleted.
+
+## Docs changes
+
+- `specs/semantic-extraction.yaml`: SE-08-001/002 rationales made generic;
+  SE-08-004 added (strict=True for target_ discriminators); SE-08-005 added
+  (documents removal, replaces old SE-08-004 deprecation entry)
+- `docs/adr/0039-offer-case-participant-role-wire-type.md`: amendment section
+  added documenting the strictness fix and removal decision
+- `notes/activitystreams-state-update.md`: Target-Field Discriminators section
+  updated to reflect removal and strict=True fix
+- `AGENTS.md`: stale ordering pitfall replaced with target_ permissiveness
+  pitfall (SE-08-004, CONCERN-2322)
+
+## Implementation issues
+
+- #2428 (size:S) — Wire strictness fix + AcceptCaseParticipantRolePattern +
+  RejectCaseParticipantRolePattern + registry entries
+- #2429 (size:L) — Full removal of OFFER_CASE_MANAGER_ROLE from all layers +
+  new received-tree for OFFER_CASE_PARTICIPANT_ROLE
+
+## Reference
+
+PR: <https://github.com/CERTCC/Vultron/pull/2427>

--- a/specs/semantic-extraction.yaml
+++ b/specs/semantic-extraction.yaml
@@ -285,11 +285,9 @@ groups:
       less-specific pattern. The more-specific pattern MUST appear before the less-specific
       one in `SEMANTIC_REGISTRY`.
     rationale: >-
-      `OFFER_CASE_MANAGER_ROLE` and `OFFER_CASE_OWNERSHIP_TRANSFER` both match
-      `Offer(VulnerabilityCase)`. `OFFER_CASE_MANAGER_ROLE` is disambiguated by the
-      presence of `target=CaseParticipant`. If the more-specific entry appeared after the
-      less-specific one, every case-manager delegation offer would be silently misrouted
-      as an ownership transfer. `_validate_registry_order()` enforces this at import time.
+      Without an additional discriminator, two patterns sharing the same verb and object
+      type are indistinguishable; the first matching entry always wins.
+      `_validate_registry_order()` enforces ordering at import time.
     relationships:
     - rel_type: refines
       spec_id: SE-03-002
@@ -301,9 +299,9 @@ groups:
       MUST declare that target field as required (not optional) so that a sender omitting it
       produces a validation error rather than a silently misrouted activity.
     rationale: >-
-      `_OfferCaseManagerRoleActivity.target` is `as_CaseParticipant` (required). This ensures
-      that any attempt to construct the activity without the discriminator field fails fast at
-      the sending side rather than reaching the receiver's registry as an ambiguous shape.
+      Declaring the discriminator field as required ensures that any attempt to construct
+      the activity without it fails fast at the sending side rather than reaching the
+      receiver's registry as an ambiguous shape.
     relationships:
     - rel_type: refines
       spec_id: SE-08-001
@@ -311,35 +309,52 @@ groups:
     priority: SHOULD
     kind: protocol
     statement: >-
-      When two semantics share `Offer(VulnerabilityCase)` and are discriminated only by a
-      target-field value, a dedicated wire object type (e.g. `as_CaseParticipantRole`)
-      SHOULD be preferred over target-field discrimination so that the wire shape is
-      unambiguously self-describing without depending on registry ordering.
+      When two semantics are discriminated only by a target-field value, a dedicated wire
+      object type (e.g. `as_CaseParticipantRole`) SHOULD be preferred over target-field
+      discrimination so that the wire shape is unambiguously self-describing without
+      depending on registry ordering.
     rationale: >-
       Target-field discrimination is a latent correctness risk: a minimally-conformant or
       buggy sender omitting the target will be silently misrouted. A distinct object type
       eliminates this risk structurally and makes the wire format self-describing.
       See also `notes/activitystreams-state-update.md` § "Target-Field Discriminators".
+      `OFFER_CASE_PARTICIPANT_ROLE` (`Offer(CaseParticipantRole, context=VulnerabilityCase)`)
+      is the canonical example of applying this principle, introduced by ADR-0039.
     relationships:
     - rel_type: refines
       spec_id: SE-08-001
   - id: SE-08-004
     priority: MUST
     kind: protocol
+    statement: >-
+      When an `ActivityPattern` uses `target_` as the sole field that distinguishes it from
+      a less-specific competing pattern, `strict=True` MUST be set on that pattern so that
+      a bare URI string in the `target` field does NOT match the typed target constraint.
+    rationale: >-
+      `ActivityPattern._match_activity_field` treats a bare string as matching in permissive
+      mode (`strict=False`). Without `strict=True`, an unresolved `target` URI would cause
+      the more-specific pattern to match every competing shape regardless of whether the
+      target is the right type, making registry ordering the sole protection against
+      misrouting and defeating the discriminator's purpose.
+      See CONCERN-2322.
+    relationships:
+    - rel_type: refines
+      spec_id: SE-08-001
+  - id: SE-08-005
+    priority: MUST
+    kind: protocol
     deprecated: true
     statement: >-
       The `OFFER_CASE_MANAGER_ROLE` semantic and its wire format
-      `Offer(VulnerabilityCase, target=CaseParticipant)` are **deprecated** in favour of
-      `OFFER_CASE_PARTICIPANT_ROLE` (`Offer(CaseParticipantRole, target=Actor,
-      context=VulnerabilityCase)`) introduced by ADR-0039. New senders MUST emit the
-      `OFFER_CASE_PARTICIPANT_ROLE` wire format. Receivers MUST continue to handle
-      `OFFER_CASE_MANAGER_ROLE` traffic for interoperability with pre-ADR-0039 actors.
+      `Offer(VulnerabilityCase, target=CaseParticipant)` have been **removed**.
+      Use `OFFER_CASE_PARTICIPANT_ROLE` (`Offer(CaseParticipantRole, target=Actor,
+      context=VulnerabilityCase)`) introduced by ADR-0039.
     rationale: >-
-      ADR-0039 resolves the wire ambiguity identified in CONCERN-1674 by introducing a
-      self-describing `as_CaseParticipantRole` object type, eliminating reliance on the
-      target-field discriminator that SE-08-001 through SE-08-003 document.
-      `OFFER_CASE_MANAGER_ROLE` is retained in the registry as a fallback-only entry
-      that appears after `OFFER_CASE_PARTICIPANT_ROLE` (SE-08-001).
+      ADR-0039 resolved the wire ambiguity identified in CONCERN-1674 by introducing a
+      self-describing `as_CaseParticipantRole` object type. The deprecated backward-compat
+      entry was removed by CONCERN-2322 since its wire format was never emitted by any
+      supported actor implementation and its presence was a source of registry-ordering
+      fragility documented in SE-08-004.
     relationships:
     - rel_type: refines
       spec_id: SE-08-003


### PR DESCRIPTION
- Closes #2322
<!-- ⚠️ MUST BE FIRST — before any ## header -->

## Summary

Plans the removal of the deprecated `OFFER_CASE_MANAGER_ROLE` wire format and
fixes the structural gap in `ActivityPattern._match_activity_field` where `target_`
was always matched permissively, making registry ordering the sole protection
against misrouting when `_rehydrate_fields` was skipped.

## Changes

- **`specs/semantic-extraction.yaml`**: Update SE-08-001/002 rationales to be
  generic (remove stale `OFFER_CASE_MANAGER_ROLE` examples); add SE-08-004
  (mandates `strict=True` for `target_`-discriminated patterns); update SE-08-005
  (documents deprecated format removal, was SE-08-004)
- **`docs/adr/0039-offer-case-participant-role-wire-type.md`**: Add amendment
  section documenting the `target_` strictness decision and the full removal of
  `OFFER_CASE_MANAGER_ROLE` (CONCERN-2322)
- **`notes/activitystreams-state-update.md`**: Update "Target-Field Discriminators"
  section to reflect the removal, the `strict=True` fix, and the new canonical rule
  for patterns sharing a verb+object pair
- **`AGENTS.md`**: Replace stale `OFFER_CASE_MANAGER_ROLE` ordering pitfall with
  the `target_` permissiveness pitfall (SE-08-004, CONCERN-2322)

## Implementation Issues

- #2428 (size:S) — Wire/registry strictness fix + accept/reject patterns for new format
- #2429 (size:L) — Full removal of deprecated OFFER_CASE_MANAGER_ROLE and supporting infrastructure