### PR TITLE
fix(rm-transitions): validate RM transitions per BTND-10-001

### DIFF
--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -166,8 +166,15 @@ def received_report(dl, actor, report):
 
 
 @pytest.fixture
-def invalid_report(report):
-    """Put the report into RM.RECEIVED state (for invalidate/reject triggers)."""
+def invalid_report(dl, report, actor):
+    """Pre-seed RM.INVALID for reject triggers (INVALID→CLOSED is valid per BTND-10-001)."""
+    status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.INVALID.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.INVALID),
+    )
+    dl.create(status)
     return report
 
 
@@ -197,8 +204,15 @@ def _seed_owner_case(dl, actor_id, report_id):
 
 @pytest.fixture
 def accepted_report(dl, report, actor):
-    """Report in an acceptable state for close-case (actor is CASE_OWNER in linked case)."""
+    """Report ready for close: actor is CASE_OWNER and RM.ACCEPTED is seeded (BTND-10-001)."""
     _seed_owner_case(dl, actor.id_, report.id_)
+    status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.ACCEPTED.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.ACCEPTED),
+    )
+    dl.create(status)
     return report
 
 

--- a/test/core/behaviors/report/nodes/test_rm_transitions.py
+++ b/test/core/behaviors/report/nodes/test_rm_transitions.py
@@ -36,6 +36,8 @@ from vultron.core.behaviors.report.nodes.rm_transitions import (
 )
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.dimensions import RmDimension
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 from vultron.core.models.activity import VultronOffer
 from vultron.core.states.rm import RM
@@ -208,6 +210,17 @@ def test_transition_rm_to_closed_context_is_case_uri(
     case: VulnerabilityCase,
 ) -> None:
     """TransitionRMtoClosed sets ParticipantStatus.context to the case URI."""
+    # Pre-seed RM.INVALID so INVALID→CLOSED is a valid transition (BTND-10-001).
+    bt_scenario.seed(
+        ParticipantStatus(
+            id_=_report_phase_status_id(
+                actor.id_, report.id_, RM.INVALID.value
+            ),
+            context=case.id_,
+            attributed_to=actor.id_,
+            rm=RmDimension(state=RM.INVALID),
+        )
+    )
     result = bt_scenario.run(
         TransitionRMtoClosed(report_id=report.id_, offer_id=offer.id_),
         actor_id=actor.id_,

--- a/test/core/behaviors/report/test_nodes.py
+++ b/test/core/behaviors/report/test_nodes.py
@@ -45,6 +45,7 @@ from vultron.core.behaviors.report.nodes import (
     CreateCaseNode,
     EvaluateReportCredibility,
     EvaluateReportValidity,
+    TransitionRMtoClosed,
     TransitionRMtoInvalid,
     TransitionRMtoValid,
     UpdateActorOutbox,
@@ -242,6 +243,222 @@ def test_transition_rm_to_invalid(
     )
     bt_scenario.assert_success(result)
     bt_scenario.assert_rm_state(report.id_, RM.INVALID, actor_id=actor.id_)
+
+
+def test_transition_rm_to_valid_same_state(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoValid succeeds on a same-state write (AC-3)."""
+    valid_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.VALID.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.VALID),
+    )
+    bt_scenario.seed(valid_status)
+
+    result = bt_scenario.run(
+        TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+
+
+def test_transition_rm_to_valid_invalid_jump(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoValid returns FAILURE for an illegal RM jump (AC-2)."""
+    closed_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.CLOSED.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.CLOSED),
+    )
+    bt_scenario.seed(closed_status)
+
+    result = bt_scenario.run(
+        TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_failure(result)
+
+
+def test_transition_rm_to_invalid_same_state(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoInvalid succeeds on a same-state write (AC-3)."""
+    invalid_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.INVALID.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.INVALID),
+    )
+    bt_scenario.seed(invalid_status)
+
+    result = bt_scenario.run(
+        TransitionRMtoInvalid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+
+
+def test_transition_rm_to_invalid_invalid_jump(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoInvalid returns FAILURE for an illegal RM jump (AC-2)."""
+    closed_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.CLOSED.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.CLOSED),
+    )
+    bt_scenario.seed(closed_status)
+
+    result = bt_scenario.run(
+        TransitionRMtoInvalid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_failure(result)
+
+
+def test_transition_rm_to_valid_from_invalid(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoValid succeeds from RM.INVALID (re-validation path)."""
+    invalid_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.INVALID.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.INVALID),
+    )
+    bt_scenario.seed(invalid_status)
+
+    result = bt_scenario.run(
+        TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+    bt_scenario.assert_rm_state(report.id_, RM.VALID, actor_id=actor.id_)
+
+
+def test_transition_rm_to_closed_valid_from_invalid(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoClosed succeeds from RM.INVALID (valid adjacent step)."""
+    invalid_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.INVALID.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.INVALID),
+    )
+    bt_scenario.seed(invalid_status)
+
+    result = bt_scenario.run(
+        TransitionRMtoClosed(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+    bt_scenario.assert_rm_state(report.id_, RM.CLOSED, actor_id=actor.id_)
+
+
+def test_transition_rm_to_closed_same_state(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoClosed succeeds on a same-state write (AC-3)."""
+    closed_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.CLOSED.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.CLOSED),
+    )
+    bt_scenario.seed(closed_status)
+
+    result = bt_scenario.run(
+        TransitionRMtoClosed(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+
+
+def test_transition_rm_to_closed_valid_from_accepted(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoClosed succeeds from RM.ACCEPTED (valid adjacent step)."""
+    accepted_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.ACCEPTED.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.ACCEPTED),
+    )
+    bt_scenario.seed(accepted_status)
+
+    result = bt_scenario.run(
+        TransitionRMtoClosed(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+    bt_scenario.assert_rm_state(report.id_, RM.CLOSED, actor_id=actor.id_)
+
+
+def test_transition_rm_to_closed_valid_from_deferred(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoClosed succeeds from RM.DEFERRED (valid adjacent step)."""
+    deferred_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.DEFERRED.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.DEFERRED),
+    )
+    bt_scenario.seed(deferred_status)
+
+    result = bt_scenario.run(
+        TransitionRMtoClosed(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+    bt_scenario.assert_rm_state(report.id_, RM.CLOSED, actor_id=actor.id_)
+
+
+def test_transition_rm_to_closed_invalid_jump_from_received(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoClosed returns FAILURE for RECEIVED→CLOSED (AC-2)."""
+    result = bt_scenario.run(
+        TransitionRMtoClosed(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_failure(result)
 
 
 def test_create_case_node(

--- a/test/core/behaviors/report/test_trigger_report_trees.py
+++ b/test/core/behaviors/report/test_trigger_report_trees.py
@@ -113,6 +113,36 @@ def closed_status(
 
 
 @pytest.fixture
+def invalid_status(
+    scenario: BTTestScenario, report: VultronReport
+) -> ParticipantStatus:
+    """Pre-seed RM.INVALID — valid predecessor for INVALID→CLOSED."""
+    status = ParticipantStatus(
+        id_=_report_phase_status_id(ACTOR_ID, report.id_, RM.INVALID.value),
+        context=report.id_,
+        attributed_to=ACTOR_ID,
+        rm=RmDimension(state=RM.INVALID),
+    )
+    scenario.dl.create(status)
+    return status
+
+
+@pytest.fixture
+def accepted_status(
+    scenario: BTTestScenario, report: VultronReport
+) -> ParticipantStatus:
+    """Pre-seed RM.ACCEPTED — valid predecessor for ACCEPTED→CLOSED."""
+    status = ParticipantStatus(
+        id_=_report_phase_status_id(ACTOR_ID, report.id_, RM.ACCEPTED.value),
+        context=report.id_,
+        attributed_to=ACTOR_ID,
+        rm=RmDimension(state=RM.ACCEPTED),
+    )
+    scenario.dl.create(status)
+    return status
+
+
+@pytest.fixture
 def case_with_owner(
     scenario: BTTestScenario, report: VultronReport
 ) -> VulnerabilityCase:
@@ -230,9 +260,18 @@ class TestInvalidateReportTriggerTree:
 
 class TestRejectReportTriggerTree:
     def test_success_emits_activity_and_sets_rm_closed(
-        self, scenario: BTTestScenario, actor, report, offer
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        invalid_status: ParticipantStatus,
     ):
-        """SUCCESS: emits activity and persists RM.CLOSED ParticipantStatus."""
+        """SUCCESS: emits activity and persists RM.CLOSED ParticipantStatus.
+
+        Requires RM.INVALID to be pre-seeded — BTND-10-001 forbids
+        RECEIVED→CLOSED; the shortest valid path is RECEIVED→INVALID→CLOSED.
+        """
         tree = create_reject_report_trigger_tree(
             offer_id=offer.id_, report_id=report.id_
         )
@@ -241,7 +280,12 @@ class TestRejectReportTriggerTree:
         scenario.assert_rm_state(report.id_, RM.CLOSED)
 
     def test_success_adds_to_outbox(
-        self, scenario: BTTestScenario, actor, report, offer
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        invalid_status: ParticipantStatus,
     ):
         """SUCCESS: activity is added to the actor's outbox."""
         before = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
@@ -298,8 +342,13 @@ class TestCloseCaseTriggerTree:
         report,
         offer,
         case_with_owner: VulnerabilityCase,
+        accepted_status: ParticipantStatus,
     ):
-        """SUCCESS: emits activity and persists RM.CLOSED ParticipantStatus."""
+        """SUCCESS: emits activity and persists RM.CLOSED ParticipantStatus.
+
+        Requires RM.ACCEPTED to be pre-seeded — BTND-10-001 forbids
+        RECEIVED→CLOSED; close-case follows ACCEPTED→CLOSED.
+        """
         result_out: dict = {}
         tree = create_close_case_trigger_tree(
             actor_id=ACTOR_ID,
@@ -320,6 +369,7 @@ class TestCloseCaseTriggerTree:
         report,
         offer,
         case_with_owner: VulnerabilityCase,
+        accepted_status: ParticipantStatus,
     ):
         """SUCCESS: activity is added to the actor's outbox."""
         before = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
@@ -438,6 +488,7 @@ class TestCloseCaseTriggerTree:
         report,
         offer,
         case_with_owner: VulnerabilityCase,
+        accepted_status: ParticipantStatus,
     ):
         """SUCCESS: a custom call_out bundle's pre_close_action_factory is invoked."""
         from vultron.core.behaviors.call_out.bundles.close_report import (

--- a/test/core/use_cases/triggers/test_close_case_trigger.py
+++ b/test/core/use_cases/triggers/test_close_case_trigger.py
@@ -38,12 +38,16 @@ from vultron.adapters.driven.trigger_activity_adapter import (
 )
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.offer_record import VultronOfferRecord
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models._helpers import _report_phase_status_id
 from vultron.core.use_cases.triggers.report import (
     SvcCloseCaseUseCase,
     SvcCloseReportUseCase,
 )
 from vultron.core.use_cases.triggers.requests import CloseReportTriggerRequest
+from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.errors import VultronNotFoundError
 from vultron.wire.as2.factories import rm_submit_report_activity
@@ -162,8 +166,21 @@ class TestSvcCloseCaseUseCase:
         reset_datalayer(self.finder.id_)
         reset_datalayer(self.case_actor.id_)
 
+    def _seed_accepted(self):
+        """Pre-seed RM.ACCEPTED so ACCEPTED→CLOSED is a valid transition (BTND-10-001)."""
+        status = ParticipantStatus(
+            id_=_report_phase_status_id(
+                self.vendor.id_, self.report.id_, RM.ACCEPTED.value
+            ),
+            context=self.report.id_,
+            attributed_to=self.vendor.id_,
+            rm=RmDimension(state=RM.ACCEPTED),
+        )
+        self.dl.create(status)
+
     def test_close_case_returns_activity_dict(self):
         """execute() returns result['activity'] as Reject(Offer) dict (DL-06-001)."""
+        self._seed_accepted()
         request = CloseReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
@@ -178,6 +195,7 @@ class TestSvcCloseCaseUseCase:
 
     def test_close_case_queues_activity_in_outbox(self):
         """execute() enqueues at least one activity in the actor's outbox."""
+        self._seed_accepted()
         request = CloseReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,

--- a/test/core/use_cases/triggers/test_report_triggers.py
+++ b/test/core/use_cases/triggers/test_report_triggers.py
@@ -496,8 +496,24 @@ class TestSvcInvalidateReportUseCase(_ReportTriggerBase):
 class TestSvcRejectReportUseCase(_ReportTriggerBase):
     """execute() path tests for SvcRejectReportUseCase."""
 
+    def _seed_invalid(self):
+        """Pre-seed RM.INVALID so INVALID→CLOSED is a valid transition (BTND-10-001)."""
+        from vultron.core.models.dimensions import RmDimension
+        from vultron.core.models.participant_status import ParticipantStatus
+
+        status = ParticipantStatus(
+            id_=_report_phase_status_id(
+                self.vendor.id_, self.report.id_, RM.INVALID.value
+            ),
+            context=self.report.id_,
+            attributed_to=self.vendor.id_,
+            rm=RmDimension(state=RM.INVALID),
+        )
+        self.dl.create(status)
+
     def test_reject_report_returns_activity_dict(self):
         """execute() returns result['activity'] with type 'Reject' (DL-06-001)."""
+        self._seed_invalid()
         request = RejectReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
@@ -513,6 +529,7 @@ class TestSvcRejectReportUseCase(_ReportTriggerBase):
 
     def test_reject_report_queues_activity_in_outbox(self):
         """execute() enqueues at least one activity in the actor's outbox."""
+        self._seed_invalid()
         request = RejectReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -172,7 +172,7 @@ def received_report(dl, actor, report):
 
 @pytest.fixture
 def accepted_report(dl, report, actor):
-    """Seed the report as ready for close: actor holds CASE_OWNER in linked case."""
+    """Seed the report as ready for close: actor holds CASE_OWNER and RM.ACCEPTED."""
     from vultron.core.models.case import VulnerabilityCase
     from vultron.core.models.case_participant import CaseParticipant
 
@@ -185,6 +185,37 @@ def accepted_report(dl, report, actor):
     case_obj.actor_participant_index[actor.id_] = owner_p.id_
     dl.create(owner_p)
     _add_case_manager(case_obj, dl)
+    # Pre-seed RM.ACCEPTED so ACCEPTED→CLOSED is a valid transition (BTND-10-001).
+    accepted_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.ACCEPTED.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.ACCEPTED),
+    )
+    dl.create(accepted_status)
+    return report
+
+
+@pytest.fixture
+def rejected_report(dl, report, actor):
+    """Seed the report at RM.INVALID — valid predecessor for INVALID→CLOSED."""
+    from vultron.core.models.case import VulnerabilityCase
+
+    case_obj = VulnerabilityCase(
+        id_=f"{actor.id_}/cases/test-case-reject",
+        name="Test Case for Reject",
+        attributed_to=actor.id_,
+        vulnerability_reports=[report.id_],
+    )
+    dl.create(case_obj)
+    _add_case_manager(case_obj, dl)
+    invalid_status = ParticipantStatus(
+        id_=_report_phase_status_id(actor.id_, report.id_, RM.INVALID.value),
+        context=report.id_,
+        attributed_to=actor.id_,
+        rm=RmDimension(state=RM.INVALID),
+    )
+    dl.create(invalid_status)
     return report
 
 
@@ -426,7 +457,7 @@ def test_invalidate_report_trigger_non_report_offer_raises_404(
 
 
 def test_reject_report_trigger_returns_activity_dict(
-    dl, actor, offer, received_report
+    dl, actor, offer, rejected_report
 ):
     """reject_report_trigger returns dict with non-None 'activity'."""
     result = TriggerService(
@@ -453,7 +484,7 @@ def test_reject_report_trigger_unknown_offer_raises_404(dl, actor):
 
 
 def test_reject_report_trigger_adds_activity_to_outbox(
-    dl, actor, offer, received_report
+    dl, actor, offer, rejected_report
 ):
     """reject_report_trigger adds a new activity to the actor's outbox."""
     before = set(dl.outbox_list_for_actor(actor.id_))

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -28,8 +28,12 @@ from vultron.adapters.driven.datalayer_sqlite import (
     SqliteDataLayer,
     reset_datalayer,
 )
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.offer_record import VultronOfferRecord
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models._helpers import _report_phase_status_id
 from vultron.core.states.em import EM
+from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.errors import VultronValidationError
 from vultron.core.use_cases.triggers.case import (
@@ -625,6 +629,17 @@ class TestReportTriggerToField:
 
     def test_reject_report_to_field_falls_back_to_offer_actor(self):
         """SvcRejectReportUseCase uses offer actor as to when no case exists."""
+        # Pre-seed RM.INVALID so INVALID→CLOSED is a valid transition (BTND-10-001).
+        self.dl.create(
+            ParticipantStatus(
+                id_=_report_phase_status_id(
+                    self.vendor.id_, self.report.id_, RM.INVALID.value
+                ),
+                context=self.report.id_,
+                attributed_to=self.vendor.id_,
+                rm=RmDimension(state=RM.INVALID),
+            )
+        )
         request = RejectReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
@@ -655,6 +670,17 @@ class TestReportTriggerToField:
         )
         case.vulnerability_reports.append(self.report.id_)
         self.dl.save(case)
+        # Pre-seed RM.ACCEPTED so ACCEPTED→CLOSED is a valid transition (BTND-10-001).
+        self.dl.create(
+            ParticipantStatus(
+                id_=_report_phase_status_id(
+                    self.vendor.id_, self.report.id_, RM.ACCEPTED.value
+                ),
+                context=self.report.id_,
+                attributed_to=self.vendor.id_,
+                rm=RmDimension(state=RM.ACCEPTED),
+            )
+        )
 
         request = CloseReportTriggerRequest(
             actor_id=self.vendor.id_,
@@ -710,6 +736,17 @@ class TestReportTriggerToField:
         )
         case.vulnerability_reports.append(self.report.id_)
         self.dl.save(case)
+        # Pre-seed RM.INVALID so INVALID→CLOSED is a valid transition (BTND-10-001).
+        self.dl.create(
+            ParticipantStatus(
+                id_=_report_phase_status_id(
+                    self.vendor.id_, self.report.id_, RM.INVALID.value
+                ),
+                context=self.report.id_,
+                attributed_to=self.vendor.id_,
+                rm=RmDimension(state=RM.INVALID),
+            )
+        )
 
         request = RejectReportTriggerRequest(
             actor_id=self.vendor.id_,

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -25,13 +25,43 @@ from vultron.core.models.dimensions import PecDimension, RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.core.states.rm import RM
+from vultron.core.states.rm import RM, is_valid_rm_transition
 from vultron.enums.roles import CVDRole
 from vultron.core.models._helpers import _report_phase_status_id
 from vultron.core.use_cases._helpers import (
     _idempotent_create,
     update_participant_rm_state,
 )
+
+
+def _current_report_phase_rm_state(dl, actor_id: str, report_id: str) -> RM:
+    """Return the current report-phase RM state for actor/report.
+
+    Checks the DataLayer for existing report-phase ParticipantStatus records in
+    descending-progress order (CLOSED first) and returns the highest-progress
+    state found.  Returns ``RM.RECEIVED`` as the implicit default when no
+    records exist — consistent with ``CheckRMStateReceivedOrInvalid`` semantics
+    (absence of a status record means the report was received but not yet
+    processed).
+
+    Per BTND-10-001: callers use this to establish the *current_state* side of
+    the (current_state → target_state) validity check before writing a new
+    report-phase ParticipantStatus.
+    """
+    for rm_state in (
+        RM.CLOSED,
+        RM.ACCEPTED,
+        RM.DEFERRED,
+        RM.VALID,
+        RM.INVALID,
+        RM.RECEIVED,
+    ):
+        status_id = _report_phase_status_id(
+            actor_id, report_id, rm_state.value
+        )
+        if dl.read(status_id) is not None:
+            return rm_state
+    return RM.RECEIVED
 
 
 def _transition_case_participant_rm(
@@ -170,6 +200,18 @@ class TransitionRMtoValid(DataLayerActionWithPorts):
                 else self.report_id
             )
 
+            current_rm = _current_report_phase_rm_state(
+                self.datalayer, actor_id, self.report_id
+            )
+            if current_rm != RM.VALID and not is_valid_rm_transition(
+                current_rm, RM.VALID
+            ):
+                self.feedback_message = (
+                    f"Invalid RM transition {current_rm!r} → {RM.VALID!r}"
+                )
+                self.logger.info("%s: %s", self.name, self.feedback_message)
+                return Status.FAILURE
+
             status = ParticipantStatus(
                 id_=_report_phase_status_id(
                     actor_id, self.report_id, RM.VALID.value
@@ -251,6 +293,18 @@ class TransitionRMtoInvalid(DataLayerAction):
                 else self.report_id
             )
 
+            current_rm = _current_report_phase_rm_state(
+                self.datalayer, self.actor_id, self.report_id
+            )
+            if current_rm != RM.INVALID and not is_valid_rm_transition(
+                current_rm, RM.INVALID
+            ):
+                self.feedback_message = (
+                    f"Invalid RM transition {current_rm!r} → {RM.INVALID!r}"
+                )
+                self.logger.info("%s: %s", self.name, self.feedback_message)
+                return Status.FAILURE
+
             status = ParticipantStatus(
                 id_=_report_phase_status_id(
                     self.actor_id, self.report_id, RM.INVALID.value
@@ -326,6 +380,18 @@ class TransitionRMtoClosed(DataLayerAction):
                 if isinstance(case, VulnerabilityCase)
                 else self.report_id
             )
+
+            current_rm = _current_report_phase_rm_state(
+                self.datalayer, self.actor_id, self.report_id
+            )
+            if current_rm != RM.CLOSED and not is_valid_rm_transition(
+                current_rm, RM.CLOSED
+            ):
+                self.feedback_message = (
+                    f"Invalid RM transition {current_rm!r} → {RM.CLOSED!r}"
+                )
+                self.logger.info("%s: %s", self.name, self.feedback_message)
+                return Status.FAILURE
 
             status = ParticipantStatus(
                 id_=_report_phase_status_id(


### PR DESCRIPTION
- Closes #2082

## Summary

- Adds fail-closed RM transition validation to `TransitionRMtoValid`, `TransitionRMtoInvalid`, and `TransitionRMtoClosed` per BTND-10-001 MUST requirement
- New `_current_report_phase_rm_state()` helper resolves current report-phase RM state from the DataLayer (defaults to `RM.RECEIVED` when no records exist, matching `CheckRMStateReceivedOrInvalid` semantics)
- An illegal jump (e.g. `RECEIVED→CLOSED`) returns `Status.FAILURE` with a descriptive `feedback_message`; no record is persisted (AC-2)
- Same-state writes succeed as status confirmations (AC-3)
- All existing tests that assumed unguarded CLOSED transitions updated to pre-seed valid predecessor states (`RM.INVALID` for reject flows, `RM.ACCEPTED` for close-case flows)

## Changes

- **`vultron/core/behaviors/report/nodes/rm_transitions.py`**: Added `_current_report_phase_rm_state()` helper to read the highest-progress RM state from the DataLayer. Added transition validation guard to `TransitionRMtoValid`, `TransitionRMtoInvalid`, and `TransitionRMtoClosed` — each checks `(current_rm → target_rm)` via `is_valid_rm_transition` before persisting any `ParticipantStatus` record. Illegal jumps return `Status.FAILURE` with a descriptive `feedback_message`.
- **`test/core/behaviors/report/test_nodes.py`**: 10 new tests covering AC-2 (invalid jump → FAILURE) and AC-3 (same-state → SUCCESS) for all three transition nodes.
- **`test/core/behaviors/report/nodes/test_rm_transitions.py`**: Pre-seeds `RM.INVALID` predecessor state for the existing CLOSED-context test.
- **`test/core/behaviors/report/test_trigger_report_trees.py`**: Pre-seeds valid predecessor states for reject-report and close-case trigger tree tests.
- **`test/core/use_cases/triggers/test_close_case_trigger.py`**: Pre-seeds `RM.ACCEPTED` for close-case trigger use-case tests.
- **`test/core/use_cases/triggers/test_report_triggers.py`**: Pre-seeds `RM.INVALID` for reject-report trigger use-case tests.
- **`test/core/use_cases/triggers/test_service.py`**: Pre-seeds `RM.ACCEPTED` for close-case service tests.
- **`test/core/use_cases/triggers/test_trignotify.py`**: Pre-seeds valid predecessor states for trigger notification tests.
- **`test/adapters/driving/fastapi/routers/test_trigger_report.py`**: Updated `invalid_report` and `accepted_report` fixtures to seed valid predecessor states.

## Verification

- [x] `test_transition_rm_to_valid_same_state` — AC-3: VALID→VALID succeeds
- [x] `test_transition_rm_to_valid_invalid_jump` — AC-2: CLOSED→VALID fails
- [x] `test_transition_rm_to_valid_from_invalid` — INVALID→VALID (re-validation) succeeds
- [x] `test_transition_rm_to_invalid_same_state` — AC-3: INVALID→INVALID succeeds
- [x] `test_transition_rm_to_invalid_invalid_jump` — AC-2: CLOSED→INVALID fails
- [x] `test_transition_rm_to_closed_valid_from_invalid` — INVALID→CLOSED succeeds
- [x] `test_transition_rm_to_closed_valid_from_accepted` — ACCEPTED→CLOSED succeeds
- [x] `test_transition_rm_to_closed_valid_from_deferred` — DEFERRED→CLOSED succeeds
- [x] `test_transition_rm_to_closed_same_state` — AC-3: CLOSED→CLOSED succeeds
- [x] `test_transition_rm_to_closed_invalid_jump_from_received` — AC-2: RECEIVED→CLOSED fails
- [x] All 7162 unit tests pass, 1167 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)