### PR TITLE
docs: plan CONCERN-2326 — specify ledger_payload_object_override producer/consumer contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -766,6 +766,19 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   > /tmp/unit.log 2>&1; echo $?`. The spec-lint test
   (`test_real_specs_lint_no_hard_errors`) is particularly load-sensitive at ~3s
   against the 5s budget. *Source: ISSUE-2232*
+- **`ledger_payload_object_override` Producers MUST Clear the Key on Every No-Op Tick** —
+  the override key is process-global on the py_trees blackboard.  A producer node
+  that only writes on its active path leaves a stale patch for `CommitCaseLedgerEntryNode`
+  to apply to an unrelated payload snapshot on the next call.  Write `None` (or
+  equivalent `self._publish((), None)`) as the *first* statement in `update()`,
+  before any conditional branch (BT-17-003).  The override dict shape is
+  `{"object_id": …, "producer_type": <node class name>, "fields": {<wire alias>: …}}`
+  (RSH-05-010 through RSH-05-012).  The consumer hard-fails on unrecognized aliases
+  and warns on unknown `producer_type` (RSH-05-013, RSH-05-014).  Once the node is
+  migrated to the typed-Ports base class (ISSUE-1808), the base class SHOULD
+  auto-clear declared output ports in `initialise()`, making the clear structural.
+  See [notes/received-status-authorization.md](notes/received-status-authorization.md)
+  § "Per-dimension partial accept".  *Source: CONCERN-2326*
 - **Never Restate Counts in Cross-References or Long-Lived Docs** — when a
   spec entry, notes file, or AGENTS.md pitfall cross-references another spec,
   omit the count: write "the universal types (DEMOMA-16-001)" not "the five

--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -105,10 +105,20 @@ only `datalayer` and `trigger_activity_factory` between runs:
 | `ledger_payload_object_override` | `FilterParticipantStatusDimensionsNode` | `CommitCaseLedgerEntryNode` |
 
 `ledger_payload_object_override` is defined in
-`vultron/core/behaviors/case/nodes/lifecycle.py` next to its consumer and is
-deliberately generic (`{"object_id", "fields"}`): any receive tree may patch the
-`object` entry of the ledger payload snapshot, and the other receive trees are
-unaffected because the override is opt-in and ID-matched.
+`vultron/core/behaviors/case/nodes/lifecycle.py` next to its consumer. The
+required shape is `{"object_id": <id>, "producer_type": <str>, "fields": {…}}`
+(RSH-05-011). Any receive tree may patch the `object` entry of the ledger
+payload snapshot; the other receive trees are unaffected because the override is
+opt-in and ID-matched.
+
+**Producer contract** (RSH-05-010 through RSH-05-012): every producer MUST (a)
+write `None` to the key unconditionally at the start of every tick before any
+early return (BT-17-003), (b) include `producer_type` identifying the source
+node, and (c) use only wire alias keys recognized by the consumer.
+
+**Consumer validation** (RSH-05-013, RSH-05-014): `CommitCaseLedgerEntryNode`
+hard-fails on any unrecognized wire alias in `fields` (data integrity) and
+warns on an unrecognized `producer_type` (audit hint, not a commit blocker).
 
 It carries a **field patch, not a replacement object** (RSH-05-009). The
 snapshot's `object` is the sender's wire-shaped `ParticipantStatus` — flat
@@ -122,8 +132,9 @@ merging them onto the existing snapshot makes shape preservation structural
 rather than something the guard has to remember:
 
 ```python
-{"object_id": status_id, "fields": {"rmState": "VALID", "vfdState": "VFd",
-                                    "caseStatus": {"pxaState": "Pxa", ...}}}
+{"object_id": status_id, "producer_type": "FilterParticipantStatusDimensionsNode",
+ "fields": {"rmState": "VALID", "vfdState": "VFd",
+            "caseStatus": {"pxaState": "Pxa", ...}}}
 ```
 
 `CommitCaseLedgerEntryNode._resolve_payload_object_override` merges one level

--- a/plan/history/2608/learning/CONCERN-2326.md
+++ b/plan/history/2608/learning/CONCERN-2326.md
@@ -1,0 +1,53 @@
+---
+source: CONCERN-2326
+timestamp: '2026-08-20T15:45:07.755488+00:00'
+title: ledger_payload_object_override producer/consumer contract
+type: learning
+---
+
+## What the concern identified
+
+`ledger_payload_object_override` had no explicit spec contract. Any BT node
+could publish an arbitrary dict and `CommitCaseLedgerEntryNode` would apply
+it to the canonical hash-chained ledger entry without validating field names
+or knowing where the patch came from. ISSUE-2256 (EM adjudication) would add
+a second producer before any contract existed.
+
+## Decisions made
+
+**Override shape** (RSH-05-011): `{"object_id": …, "producer_type": <str>, "fields": {…}}`.
+`producer_type` was added to enable per-producer audit logging and diagnostics;
+multiple producers are anticipated.
+
+**No-op clear** (RSH-05-010): producers MUST write `None` unconditionally at
+the start of every tick before any early return. The py_trees blackboard is
+process-global and `BTBridge.execute_with_setup` does not reset
+application-level keys between runs. A producer that only writes on active
+paths leaves stale values for `CommitCaseLedgerEntryNode` to apply to a
+different payload snapshot on the next call. BT-17-003.
+
+**Field-name allowlist** (RSH-05-012, RSH-05-013): producers MUST use only
+recognized wire aliases; `CommitCaseLedgerEntryNode` MUST hard-fail (not warn)
+on any unrecognized key. An unknown alias applied to the canonical snapshot
+would silently corrupt the ledger entry replicated to all participants.
+
+**producer_type validation** (RSH-05-014): consumer SHOULD warn on unknown
+`producer_type` but MUST NOT fail the commit. Field-name validation is the
+data-integrity guard; `producer_type` is an audit hint.
+
+**ADR determination**: spec entries only — RSH-05-009 already captures the
+field-patch-not-replacement rationale; no new ADR needed.
+
+**Typed Ports forward pointer**: ISSUE-1808 (typed-Ports base class for BT
+nodes) could make the no-op clear structural if the base class auto-clears
+declared output ports in `initialise()`. This connection is captured in
+RSH-05-010 and the AGENTS.md pitfall; ISSUE-1808 authors should consider it.
+
+## What was produced
+
+- RSH-05-010 through RSH-05-014 added to `specs/received-status-handling.yaml`
+- `notes/received-status-authorization.md` updated with new override shape and
+  producer/consumer contract summary
+- `AGENTS.md` pitfall added: `ledger_payload_object_override` producer contract
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/2431>
+- Impl tasks: #2432 (enforce contract in code, size:M), #2433 (update ISSUE-2256 with contract reference, size:S)

--- a/specs/received-status-handling.yaml
+++ b/specs/received-status-handling.yaml
@@ -356,3 +356,77 @@ groups:
       nested object's own `id` and remaining fields. A patched alias also drops
       any stale snake_case twin of the same field, so a consumer that prefers
       the snake_case spelling cannot read the value the receiver refused.
+  - id: RSH-05-010
+    priority: MUST
+    kind: protocol
+    statement: >
+      A producer of `ledger_payload_object_override` MUST write `None` to the
+      key unconditionally at the start of every tick — before any early return
+      — so that a stale value from a previous execution cannot bleed into the
+      current one.
+    rationale: >
+      The py_trees blackboard is process-global. `BTBridge.execute_with_setup`
+      does not reset application-level keys between runs, so a producer that
+      only writes on its active path leaves the key at its previous value on
+      every no-op tick. `CommitCaseLedgerEntryNode` would then apply that stale
+      patch to a different payload snapshot. BT-17-003.
+    note: >
+      Pattern: call the unconditional clear (e.g. `self._publish((), None)`) as
+      the first statement in `update()`, before any conditional branch. Once
+      the producer node is migrated to the typed-Ports base class (ISSUE-1808),
+      the base class SHOULD auto-clear declared output ports in `initialise()`,
+      making this obligation structural.
+  - id: RSH-05-011
+    priority: MUST
+    kind: protocol
+    statement: >
+      A producer of `ledger_payload_object_override` MUST include a
+      `producer_type` field in the override dict. The required shape is
+      `{"object_id": <id>, "producer_type": <str>, "fields": {<wire alias>: <value>}}`.
+    rationale: >
+      Multiple producers are anticipated (ISSUE-2256 adds EM adjudication in
+      `EmbargoTeardownAuthorizationGate` as a second producer). Naming the
+      source node in the dict enables targeted audit logging and per-producer
+      diagnostics without out-of-band context. RSH-05-014 uses `producer_type`
+      to emit a warning on unrecognized producers without failing the commit.
+  - id: RSH-05-012
+    priority: MUST
+    kind: protocol
+    statement: >
+      The `fields` value of `ledger_payload_object_override` MUST contain only
+      wire alias keys recognized by `CommitCaseLedgerEntryNode`. Publishing an
+      unrecognized key is a protocol error.
+    rationale: >
+      The consumer hard-fails on any unrecognized alias (RSH-05-013). An unknown
+      alias applied to the canonical snapshot would abort the commit, blocking
+      the receive-side BT. Declaring this as a producer obligation means callers
+      can validate at construction time rather than catching a runtime failure.
+    note: >
+      The recognized aliases are those present in the `_migrate_flat_fields` /
+      `_SNAKE_TWINS` mechanism in `CommitCaseLedgerEntryNode`
+      (`vultron/core/behaviors/case/nodes/lifecycle.py`).
+  - id: RSH-05-013
+    priority: MUST
+    kind: protocol
+    statement: >
+      `CommitCaseLedgerEntryNode` MUST raise a hard failure — not a warning —
+      if the `fields` dict of `ledger_payload_object_override` contains a key
+      that is not a recognized wire alias for the snapshot object type.
+    rationale: >
+      An unrecognized alias applied to the canonical snapshot would silently add
+      unexpected content to the hash-chained ledger entry, which every replica
+      and the invariant harness would then apply. Data integrity requires a hard
+      stop; the correct response is to fix the producer (RSH-05-012), not to log
+      and continue.
+  - id: RSH-05-014
+    priority: SHOULD
+    kind: protocol
+    statement: >
+      `CommitCaseLedgerEntryNode` SHOULD emit a WARNING when
+      `ledger_payload_object_override` carries an unrecognized `producer_type`
+      value, and MUST NOT fail the commit on that basis alone.
+    rationale: >
+      An unrecognized `producer_type` may indicate a newer node type operating
+      against an older consumer. Logging preserves auditability without
+      blocking a structurally valid override. Field-name validation (RSH-05-013)
+      is the data-integrity guard; `producer_type` is an audit hint only.

--- a/specs/received-status-handling.yaml
+++ b/specs/received-status-handling.yaml
@@ -402,9 +402,10 @@ groups:
       the receive-side BT. Declaring this as a producer obligation means callers
       can validate at construction time rather than catching a runtime failure.
     note: >
-      The recognized aliases are those present in the `_migrate_flat_fields` /
-      `_SNAKE_TWINS` mechanism in `CommitCaseLedgerEntryNode`
-      (`vultron/core/behaviors/case/nodes/lifecycle.py`).
+      The recognized aliases are those defined in `_SNAKE_TWINS` in
+      `vultron/core/behaviors/case/nodes/lifecycle.py` — the module-level dict
+      that maps each camelCase wire alias to its snake_case twin for
+      `CommitCaseLedgerEntryNode`.
   - id: RSH-05-013
     priority: MUST
     kind: protocol


### PR DESCRIPTION
- Closes #2326
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Specifies the explicit producer/consumer contract for the
`ledger_payload_object_override` blackboard seam, closing the spec gap
identified in CONCERN-2326 before a second producer (ISSUE-2256 EM
adjudication) is added.

## Changes

- **`specs/received-status-handling.yaml`**: Add RSH-05-010 through
  RSH-05-014 — producer must clear the key unconditionally on no-op ticks
  (BT-17-003), must include `producer_type`, must use only recognized wire
  aliases; consumer must hard-fail on unknown alias (RSH-05-013), should
  warn on unknown `producer_type` (RSH-05-014). Forward pointer to
  ISSUE-1808 typed-Ports base class as the path to structural enforcement.
- **`notes/received-status-authorization.md`**: Update override shape to
  `{"object_id", "producer_type", "fields"}`, add producer/consumer
  contract summary paragraph, update example dict.
- **`AGENTS.md`**: Add pitfall entry for `ledger_payload_object_override`
  producers covering the no-op clear rule, required dict shape, and the
  ISSUE-1808 structural enforcement path.

## Implementation Issues

- #2432 (size:M) — enforce producer/consumer contract in code
- #2433 (size:S) — update ISSUE-2256 with producer contract reference