### PR TITLE
fix: accept non-adjacent forward RM jumps and notify; refuse backward regressions non-silently

### DIFF
--- a/docs/adr/0067-rm-nonadj-accept-and-notify.md
+++ b/docs/adr/0067-rm-nonadj-accept-and-notify.md
@@ -1,0 +1,148 @@
+---
+status: accepted
+date: 2026-08-20
+deciders: Allen D. Householder
+consulted: Vultron protocol maintainers
+informed: Vultron contributors
+---
+
+# Accept Non-Adjacent Forward RM Jumps and Notify; Refuse Backward Regressions Non-Silently
+
+## Context and Problem Statement
+
+When a CaseActor receives `Add(ParticipantStatus, CaseParticipant)` and
+compares the reported `rm` state against its local replica, three cases arise:
+
+1. **Adjacent valid transition** — no anomaly; accept silently.
+2. **Non-adjacent forward jump** — the sender skipped intermediate states
+   (e.g. `RECEIVED → ACCEPTED` without passing through `VALID`). The existing
+   `FilterParticipantStatusDimensionsNode._rm_is_acceptable()` already accepts
+   these and documents the rationale (*"sender is authoritative about own RM
+   progress"*), but acceptance is silent.
+3. **Backward regression** — the sender reports a state earlier on the RM
+   progress scale than what the receiver has already observed (e.g.
+   `ACCEPTED → VALID`). `ValidateRMTransitionNode` refuses these, which is
+   correct, but the refusal is also silent.
+
+Two independent bugs arise from the silent treatment:
+
+- Forward jumps are accepted without any log entry at WARNING level or any
+  protocol-level notification. An anomaly that should trigger a clarification
+  request passes through as if nothing unusual happened (ISSUE-2258).
+- Backward regressions are refused without emitting a protocol-level note.
+  A remote actor's replica is now permanently diverged from the receiver's, with
+  no signal to either party.
+
+The broader principle: CVD is inherently asynchronous. Events happen at time t₀
+but are only recognised as anomalous at time t₁ > t₀. When a protocol-level
+anomaly is detected on receipt, the receiver must both act correctly *and* act
+non-silently. Silence on anomalies breaks the protocol's observability and makes
+diagnosis impossible.
+
+## Decision Drivers
+
+- **Liberal accept / Postel's law** (ISSUE-2229): accept everything acceptable;
+  refuse only what must be refused.
+- **Sender is authoritative about its own RM progress**: refusing a
+  non-adjacent forward jump would leave the receiver's replica permanently wrong,
+  because the sender will not resend the intermediate transitions it never
+  reported.
+- **RM is monotonic**: backward regressions indicate either a protocol error or
+  a divergent replica state. Neither is acceptable; both warrant correction.
+- **Non-silence principle**: anomalies detected asynchronously must produce an
+  observable effect — at minimum a WARNING log, and on the production path an
+  `Add(Note, VulnerabilityCase)` addressed to the sender.
+- **ADR-0049**: core does not model inbound protocol error message types
+  (`RE` from the original BT protocol design). The pragmatic substitute is
+  `Add(Note, VulnerabilityCase)` via the existing note-emission infrastructure.
+- **Consistency across call paths**: `FilterParticipantStatusDimensionsNode`
+  (production path, `add_participant_status_tree`) and
+  `ValidateRMTransitionNode` (standalone path, `append_participant_status_tree`)
+  must implement the same acceptance policy. The standalone path is test-only;
+  it has no case context and therefore cannot emit a note, but it must still log
+  at WARNING level.
+
+## Considered Options
+
+- **Refuse non-adjacent forward jumps** — reject the `rm` dimension and carry
+  the receiver's current value forward (as RSH-05 does for other refusals).
+- **Accept silently** — current behaviour; no log, no notification.
+- **Accept and notify** — accept the forward jump (honouring sender authority),
+  log at WARNING level, and on the production path emit
+  `Add(Note, VulnerabilityCase)` describing the anomaly and requesting
+  clarification.
+
+## Decision Outcome
+
+Chosen option: **accept and notify**.
+
+### Forward jumps (non-adjacent, monotonically forward)
+
+The receiver MUST accept the reported RM state. Refusing would leave the
+replica permanently wrong. The receiver MUST:
+
+1. Log a WARNING naming the sender, the observed gap (`before → after`), and
+   the fact that the jump is non-adjacent.
+2. On the production `add_participant_status_tree` path, emit
+   `Add(Note, VulnerabilityCase)` requesting the sender to clarify the
+   intermediate path it took.
+
+### Backward regressions
+
+The receiver MUST refuse the `rm` update (current behaviour, preserved). In
+addition it MUST:
+
+1. Log a WARNING (already done; confirmed correct).
+2. On the production `add_participant_status_tree` path, emit
+   `Add(Note, VulnerabilityCase)` describing the refused regression.
+
+### Implementation shape
+
+A blackboard flag key `rm_transition_anomaly` is set by
+`FilterParticipantStatusDimensionsNode` (forward gap) and by
+`ValidateRMTransitionNode` (backward regression on the standalone path) when
+an anomaly is detected. A new `EmitRMGapNoteNode` in
+`effect_nodes` of `add_participant_status_tree` reads this flag and emits the
+note when set. The `append_participant_status_tree` standalone path only logs
+— it has no `case_id` and no caller in production.
+
+### Consequences
+
+- Good, because replica correctness is preserved (forward jumps accepted).
+- Good, because anomalies become observable at the protocol level.
+- Good, because both call paths now agree: forward jumps are always accepted.
+- Good, because the asynchronous non-silence principle is encoded as a spec
+  requirement, not just a one-off fix.
+- Neutral, because `Add(Note, VulnerabilityCase)` is a pragmatic substitute
+  for the `RE` (Report Management Error) message type from the original BT
+  protocol. A future ADR may formalise `RE` in `MessageSemantics` and replace
+  the note; that change would be backward-compatible with this decision.
+- Bad, because note emission adds a new effect to the `add_participant_status_tree`
+  path; tests must cover the case where no anomaly is present so that the
+  node is a no-op in the happy path.
+
+## Validation
+
+- `ValidateRMTransitionNode`: unit tests assert WARNING log + anomaly flag on
+  forward gap; WARNING log + FAILURE on backward regression.
+- `FilterParticipantStatusDimensionsNode`: unit tests assert anomaly flag is
+  set when a non-adjacent forward jump is accepted.
+- `add_participant_status_tree` integration tests: note emitted on forward gap;
+  note emitted on backward rejection; no note on adjacent transition.
+- `append_participant_status_tree` unit tests: WARNING log on forward gap; no
+  note (standalone path has no case context).
+
+## More Information
+
+- Original protocol `RE` message type: `vultron.bt.messaging.states`; not yet
+  in core `MessageSemantics`. ADR-0049 explains why core does not model
+  inbound error types.
+- RSH-05 (ADR-0061): per-dimension partial accept — the complement of this
+  decision. This ADR governs the `rm` dimension's anomaly notification policy
+  while RSH-05 governs the per-dimension filter and snapshot shape.
+- ISSUE-2258: the concrete bug; `ValidateRMTransitionNode` accepted forward
+  gaps at INFO level with no notification.
+- ISSUE-2229: liberal-accept epic (Postel's law).
+
+Generated spec requirements: `specs/received-status-handling.yaml` RSH-06-001
+through RSH-06-005.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -136,6 +136,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0064 Enforce Post-Construction Type Safety on the Core Branch Only, in Three Ratcheted Steps](0064-core-branch-validate-assignment.md)
 - [ADR-0065 Carry the Embargo Invite RSVP Deadline on `Invite.end_time`](0065-embargo-invite-rsvp-deadline.md) *(provisional)*
 - [ADR-0066 Outbox Terminal State: Per-Activity Attempt Counter, 4xx Classification, and Dead-Letter Store](0066-outbox-terminal-state.md)
+- [ADR-0067 Accept Non-Adjacent Forward RM Jumps and Notify; Refuse Backward Regressions Non-Silently](0067-rm-nonadj-accept-and-notify.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -284,6 +284,7 @@ nav:
       - Enforce Post-Construction Type Safety on the Core Branch Only: 'adr/0064-core-branch-validate-assignment.md'
       - Embargo Invite RSVP Deadline on Invite.end_time: 'adr/0065-embargo-invite-rsvp-deadline.md'
       - 'Outbox Terminal State: Per-Activity Attempt Counter, 4xx Classification, and Dead-Letter Store': 'adr/0066-outbox-terminal-state.md'
+      - 'Accept Non-Adjacent Forward RM Jumps and Notify; Refuse Backward Regressions Non-Silently': 'adr/0067-rm-nonadj-accept-and-notify.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -73,7 +73,7 @@ AddParticipantStatusBT (Sequence)
 │   ├─ CheckIsCaseOwnerNode             ← hard bypass: CASE_OWNER = gospel
 │   └─ CaseOwnerApprovesStatusUpdate    ← Evaluator call-out (AlwaysSucceed)
 ├─ EmitAddCaseStatusToSelfNode          ← NEW: triggers canonicalization
-└─ AutoCloseIfCaseManager               ← unchanged
+└─ EmitRMGapNoteNode                    ← NEW: Add(Note,Case) on RM anomaly (RSH-06-004, ADR-0067)
 ```
 
 ### Per-dimension partial accept (RSH-05, ADR-0061)

--- a/plan/incoming/learnings/20260820-bb-anomaly-bridge-and-should-level-emission.md
+++ b/plan/incoming/learnings/20260820-bb-anomaly-bridge-and-should-level-emission.md
@@ -1,0 +1,54 @@
+---
+title: "BB_RM_ANOMALY bridge pattern: blackboard key as guard-to-effect channel; SHOULD-level emission nodes always return SUCCESS"
+type: learning
+timestamp: 2026-08-20
+source: ISSUE-2258
+signal: design-question
+---
+
+## Blackboard bridge pattern
+
+When a guard node detects an anomaly that needs a downstream effect but does
+not own the emit responsibility (e.g. it returns FAILURE and the Sequence
+aborts), the pattern is:
+
+1. Define a named blackboard key (e.g. `BB_RM_ANOMALY = "rm_transition_anomaly"`).
+2. The guard node **always** writes to this key on every tick — clearing it to
+   `None` on normal paths and setting a typed dict on anomaly paths (including
+   the FAILURE path).
+3. A separate effect node later in the Sequence reads the key and acts on it.
+
+The guard and effect nodes share only the key name (defined as a module-level
+constant in `dimension_filter.py`). Neither imports the other. This preserves
+the single-responsibility principle and the BT node independence invariant.
+
+**Critical detail**: the guard must write the anomaly even on the FAILURE path,
+because the Sequence aborts after a FAILURE and the effect node never runs on
+that path. The effect node is a best-effort emit placed after other effect
+nodes — it will run only on the SUCCESS path (normal or partial-accept). For
+the FAILURE path (backward regression on a fully-refused assertion), the anomaly
+write in the guard is the only record on the blackboard; it is available to any
+node that runs before the next tick clears it.
+
+## SHOULD-level emission nodes always return SUCCESS
+
+Per ADR-0067 and RSH-06-004, `EmitRMGapNoteNode` always returns `SUCCESS`
+even when it cannot emit the note (no datalayer, no factory, exception).
+
+Reasoning: the note is advisory — a human-readable record for the operator.
+Its absence does not compromise protocol correctness. Returning `FAILURE` would
+abort the enclosing Sequence and undo the status adoption that already succeeded,
+which would be worse than a missing note.
+
+Rule: any node that emits a SHOULD-level side effect (notes, audit records,
+non-critical notifications) must return `SUCCESS` in all cases and degrade
+gracefully with a WARNING log. The enclosing tree's correctness must not depend
+on it.
+
+## Base class selection for blackboard access in emission nodes
+
+Use `DataLayerAction` (not `DataLayerActionWithPorts`) for nodes that need both
+`self.blackboard` (standard py_trees blackboard) and DataLayer access.
+`DataLayerActionWithPorts` uses the typed ports interface and does not expose
+`self.blackboard`; attempting to call `self.blackboard.get(...)` on it raises
+`AttributeError`.

--- a/plan/incoming/learnings/20260820-spec-kind-enum-constraint.md
+++ b/plan/incoming/learnings/20260820-spec-kind-enum-constraint.md
@@ -1,0 +1,22 @@
+---
+title: "spec kind: field has a constrained enum — implementation is not valid"
+type: learning
+timestamp: 2026-08-20
+source: ISSUE-2258
+signal: spec-ambiguity
+---
+
+When adding a spec entry to a `specs/*.yaml` file, the `kind:` field accepts
+only: `protocol`, `architecture`, `project`, `process`.
+
+`implementation` is NOT a valid value and causes the spec registry linter to
+reject the file at commit time. The error surfaced as a pre-commit hook failure
+(`Spec registry linter`) that is easy to misread as a YAML syntax error.
+
+The closest substitute for "this is an implementation constraint" is
+`kind: protocol` (if the requirement is a protocol obligation) or
+`kind: architecture` (if it is a structural constraint on the system).
+
+**How to apply**: whenever writing a new spec entry, verify `kind:` is one of
+the four valid values before committing. Check existing entries in the same
+spec file for context.

--- a/specs/received-status-handling.yaml
+++ b/specs/received-status-handling.yaml
@@ -356,3 +356,93 @@ groups:
       nested object's own `id` and remaining fields. A patched alias also drops
       any stale snake_case twin of the same field, so a consumer that prefers
       the snake_case spelling cannot read the value the receiver refused.
+
+- id: RSH-06
+  title: RM Anomaly Notification Policy (non-adjacent jumps and backward regressions)
+  description: >
+    When the receiver detects an RM transition anomaly — either a non-adjacent
+    forward jump (sender skipped intermediate states) or a backward regression
+    (sender reports a state earlier on the RM progress scale than the receiver
+    has already observed) — it must act correctly *and* non-silently.  Because
+    CVD is inherently asynchronous, anomalies are detected at receipt time
+    (t₁ > t₀ when the event occurred), and silence at that point breaks
+    observability for both parties.
+    Derived from ISSUE-2258 and ADR-0067.
+  specs:
+  - id: RSH-06-001
+    priority: MUST
+    kind: protocol
+    statement: >
+      A CaseActor receiving an `Add(ParticipantStatus, CaseParticipant)` that
+      carries a non-adjacent forward RM jump (i.e. `is_monotonic_rm_forward` is
+      True but `is_valid_rm_transition` is False) MUST accept the reported `rm`
+      state.
+    rationale: >
+      The sender is authoritative about its own RM progress. Refusing a
+      non-adjacent forward jump would leave the receiver's replica permanently
+      wrong, because the sender will not resend intermediate transitions it
+      never reported. Liberal accept (ISSUE-2229): accept everything acceptable.
+    note: >
+      Implemented by `FilterParticipantStatusDimensionsNode._rm_is_acceptable()`
+      in the production path and by `ValidateRMTransitionNode` in the standalone
+      path. Both paths MUST accept with the same policy.
+  - id: RSH-06-002
+    priority: MUST
+    kind: protocol
+    statement: >
+      A CaseActor receiving an `Add(ParticipantStatus, CaseParticipant)` that
+      carries a backward RM regression (i.e. the reported `rm` state is earlier
+      on the RM progress scale than the receiver's current value) MUST refuse
+      the `rm` dimension and carry the current value forward (RSH-05-002).
+    rationale: >
+      RM is monotonic: a sender cannot un-validate, un-accept, or un-close a
+      report. A backward assertion indicates either a protocol error or a
+      divergent replica state; neither should update the receiver's record.
+    note: >
+      The refusal is per-dimension only (RSH-05-001). Other dimensions of the
+      same status snapshot are still adjudicated and accepted if valid.
+  - id: RSH-06-003
+    priority: MUST
+    kind: protocol
+    statement: >
+      Neither a non-adjacent forward jump acceptance nor a backward regression
+      refusal MUST be silent. In both cases the receiver MUST log a WARNING
+      that names the sender, the observed `rm` state before and after, and
+      identifies the anomaly type (gap or regression).
+    rationale: >
+      Because CVD is inherently asynchronous, protocol anomalies are detected
+      at receipt time (t₁ > t₀ when the event occurred). Silent handling makes
+      diagnosis impossible for both parties and breaks protocol observability.
+  - id: RSH-06-004
+    priority: SHOULD
+    kind: protocol
+    statement: >
+      On the production `add_participant_status_tree` path (where a case context
+      is available), the receiver SHOULD emit `Add(Note, VulnerabilityCase)`
+      when an RM anomaly is detected, requesting the sender to clarify the
+      path it took between the two observed states.
+    rationale: >
+      The original BT protocol design included an `RE` (Report Management Error)
+      message type for exactly this scenario. Until `RE` is formalised in
+      `MessageSemantics` (ADR-0049), `Add(Note, VulnerabilityCase)` is the
+      pragmatic substitute. The note makes the anomaly visible at the protocol
+      level, not just in local logs.
+    note: >
+      Implemented by `EmitRMGapNoteNode` in `effect_nodes` of
+      `add_participant_status_tree`. The standalone `append_participant_status_tree`
+      path (test-only, no production callers) has no case context; it MUST log
+      (RSH-06-003) but MUST NOT attempt to emit a note.
+  - id: RSH-06-005
+    priority: MUST
+    kind: protocol
+    statement: >
+      The `Add(Note, VulnerabilityCase)` emitted under RSH-06-004 MUST include:
+      the sending actor's identifier, the `rm` state before the anomaly, the
+      `rm` state after the anomaly, and a human-readable description identifying
+      whether the anomaly was a non-adjacent forward jump or a backward
+      regression.
+    rationale: >
+      Without these fields the note cannot be acted on by a human or an
+      automated remediation process. The request for clarification is only
+      meaningful if the recipient can identify what they are being asked to
+      clarify.

--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -82,10 +82,10 @@ AUDITED_SITES: list[tuple[str, str]] = sorted(
         ("report/nodes/rm_transitions.py", "RmDimension"),
         ("report/nodes/rm_transitions.py", "RmDimension"),
         ("report/nodes/rm_transitions.py", "RmDimension"),
-        # FILTER — FilterParticipantStatusDimensionsNode carry-forward
-        ("status/nodes/dimension_filter.py", "PxaDimension"),
-        ("status/nodes/dimension_filter.py", "RmDimension"),
-        ("status/nodes/dimension_filter.py", "VfdDimension"),
+        # FILTER — _adjudicate_dimensions carry-forward (extracted from dimension_filter.py)
+        ("status/nodes/_adjudication.py", "PxaDimension"),
+        ("status/nodes/_adjudication.py", "RmDimension"),
+        ("status/nodes/_adjudication.py", "VfdDimension"),
         # REPLICATE — participant_status_effect.py: monotonic RM ratchet
         ("sync/nodes/participant_status_effect.py", "RmDimension"),
     ]

--- a/test/core/behaviors/status/nodes/append/test_conditions.py
+++ b/test/core/behaviors/status/nodes/append/test_conditions.py
@@ -23,6 +23,8 @@ ValidateRMTransitionNode from ``nodes.rm_validation``.
 Per DEMOMA-07-003 step 2.
 """
 
+import logging
+
 import py_trees
 from py_trees.common import Status
 
@@ -34,6 +36,7 @@ from vultron.core.behaviors.status.nodes.append import (
     ResolveAndPersistStatusObjectNode,
     SkipIfIdempotentNode,
 )
+from vultron.core.behaviors.status.nodes.dimension_filter import BB_RM_ANOMALY
 from vultron.core.behaviors.status.nodes.rm_validation import (
     ValidateRMTransitionNode,
 )
@@ -191,6 +194,146 @@ class TestValidateRMTransitionNode:
         )
         result = bridge.execute_with_setup(tree=seq, actor_id=ACTOR_ID)
         assert result.status == Status.FAILURE
+
+    def test_forward_gap_succeeds_with_warning_and_anomaly(
+        self, populated_dl, caplog
+    ):
+        """Non-adjacent forward RM jump: SUCCESS + WARNING log + anomaly flag (RSH-06-001, RSH-06-003)."""
+        received_status = as_ParticipantStatus(
+            id_="https://example.org/cases/case-01/statuses/received",
+            context=CASE_ID,
+            rm_state=RM.RECEIVED,
+        )
+        populated_dl.create(received_status)
+        p = populated_dl.read(PARTICIPANT_ID)
+        p.participant_statuses.append(received_status)
+        populated_dl.save(p)
+
+        # RECEIVED → ACCEPTED is a non-adjacent forward jump (skips VALID)
+        accepted_status = as_ParticipantStatus(
+            id_="https://example.org/cases/case-01/statuses/accepted",
+            context=CASE_ID,
+            rm_state=RM.ACCEPTED,
+        )
+        populated_dl.create(accepted_status)
+
+        bridge = BTBridge(datalayer=populated_dl)
+        load = LoadParticipantNode(participant_id=PARTICIPANT_ID)
+        resolve = ResolveAndPersistStatusObjectNode(
+            status_id=accepted_status.id_, status_obj_fallback=None
+        )
+        validate = ValidateRMTransitionNode(
+            participant_id=PARTICIPANT_ID, status_id=accepted_status.id_
+        )
+        seq = py_trees.composites.Sequence(
+            name="TestSeq",
+            memory=False,
+            children=[load, resolve, validate],
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = bridge.execute_with_setup(tree=seq, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        # RSH-06-003: must log at WARNING level
+        assert any(
+            r.levelno == logging.WARNING for r in caplog.records
+        ), "Expected WARNING log for non-adjacent forward RM jump"
+        # RSH-06: anomaly flag must be set on blackboard
+        anomaly = py_trees.blackboard.Blackboard.storage.get(
+            "/" + BB_RM_ANOMALY
+        )
+        assert anomaly is not None, "BB_RM_ANOMALY not set for forward gap"
+        assert anomaly["anomaly_type"] == "gap"
+        assert anomaly["from_rm"] == RM.RECEIVED
+        assert anomaly["to_rm"] == RM.ACCEPTED
+
+    def test_backward_regression_sets_anomaly(self, populated_dl):
+        """Backward RM regression: FAILURE + anomaly flag set (RSH-06-002, RSH-06-003)."""
+        accepted_status = as_ParticipantStatus(
+            id_="https://example.org/cases/case-01/statuses/accepted",
+            context=CASE_ID,
+            rm_state=RM.ACCEPTED,
+        )
+        populated_dl.create(accepted_status)
+        p = populated_dl.read(PARTICIPANT_ID)
+        p.participant_statuses.append(accepted_status)
+        populated_dl.save(p)
+
+        # ACCEPTED → RECEIVED is a backward regression
+        regression_status = as_ParticipantStatus(
+            id_="https://example.org/cases/case-01/statuses/regression",
+            context=CASE_ID,
+            rm_state=RM.RECEIVED,
+        )
+        populated_dl.create(regression_status)
+
+        bridge = BTBridge(datalayer=populated_dl)
+        load = LoadParticipantNode(participant_id=PARTICIPANT_ID)
+        resolve = ResolveAndPersistStatusObjectNode(
+            status_id=regression_status.id_, status_obj_fallback=None
+        )
+        validate = ValidateRMTransitionNode(
+            participant_id=PARTICIPANT_ID, status_id=regression_status.id_
+        )
+        seq = py_trees.composites.Sequence(
+            name="TestSeq",
+            memory=False,
+            children=[load, resolve, validate],
+        )
+        result = bridge.execute_with_setup(tree=seq, actor_id=ACTOR_ID)
+
+        assert result.status == Status.FAILURE
+        anomaly = py_trees.blackboard.Blackboard.storage.get(
+            "/" + BB_RM_ANOMALY
+        )
+        assert anomaly is not None, "BB_RM_ANOMALY not set for regression"
+        assert anomaly["anomaly_type"] == "regression"
+        assert anomaly["from_rm"] == RM.ACCEPTED
+        assert anomaly["to_rm"] == RM.RECEIVED
+
+    def test_adjacent_transition_clears_anomaly_flag(self, populated_dl):
+        """Valid adjacent RM transition: no anomaly flag set (happy path)."""
+        received_status = as_ParticipantStatus(
+            id_="https://example.org/cases/case-01/statuses/received",
+            context=CASE_ID,
+            rm_state=RM.RECEIVED,
+        )
+        populated_dl.create(received_status)
+        p = populated_dl.read(PARTICIPANT_ID)
+        p.participant_statuses.append(received_status)
+        populated_dl.save(p)
+
+        # RECEIVED → VALID is a valid adjacent transition
+        valid_status = as_ParticipantStatus(
+            id_="https://example.org/cases/case-01/statuses/valid",
+            context=CASE_ID,
+            rm_state=RM.VALID,
+        )
+        populated_dl.create(valid_status)
+
+        bridge = BTBridge(datalayer=populated_dl)
+        load = LoadParticipantNode(participant_id=PARTICIPANT_ID)
+        resolve = ResolveAndPersistStatusObjectNode(
+            status_id=valid_status.id_, status_obj_fallback=None
+        )
+        validate = ValidateRMTransitionNode(
+            participant_id=PARTICIPANT_ID, status_id=valid_status.id_
+        )
+        seq = py_trees.composites.Sequence(
+            name="TestSeq",
+            memory=False,
+            children=[load, resolve, validate],
+        )
+        result = bridge.execute_with_setup(tree=seq, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        anomaly = py_trees.blackboard.Blackboard.storage.get(
+            "/" + BB_RM_ANOMALY
+        )
+        assert (
+            anomaly is None
+        ), f"Expected no anomaly for adjacent transition, got {anomaly}"
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -60,12 +60,14 @@ from vultron.core.behaviors.status.nodes import (
     CheckStatusNotAlreadyAppendedNode,
     CloseNotYetEmittedConditionNode,
     EmitAddCaseStatusToSelfNode,
+    EmitRMGapNoteNode,
     LoadParticipantNode,
     PublicDisclosureBranchNode,
     ResolveAndPersistStatusObjectNode,
     ValidateRMTransitionNode,
     VerifySenderIsParticipantNode,
 )
+from vultron.core.behaviors.status.nodes.dimension_filter import BB_RM_ANOMALY
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories import add_status_to_participant_activity
@@ -1547,3 +1549,102 @@ class TestRejectionValidatorBeforeCommit:
             "A fully rejected update must produce zero CaseLedgerEntries"
             " (CLP-10-009)"
         )
+
+
+# ---------------------------------------------------------------------------
+# EmitRMGapNoteNode (RSH-06)
+# ---------------------------------------------------------------------------
+
+
+class TestEmitRMGapNoteNode:
+    """EmitRMGapNoteNode emits Add(Note,Case) on RM anomaly (RSH-06-004)."""
+
+    def _bridge_with_factory(self, dl: SqliteDataLayer) -> BTBridge:
+        return BTBridge(
+            datalayer=dl,
+            trigger_activity=TriggerActivityAdapter(dl),
+        )
+
+    def _set_anomaly(self, anomaly_type: str, from_rm: RM, to_rm: RM) -> None:
+        """Write BB_RM_ANOMALY directly to blackboard storage for the test."""
+        import py_trees
+
+        py_trees.blackboard.Blackboard.storage["/" + BB_RM_ANOMALY] = {
+            "anomaly_type": anomaly_type,
+            "from_rm": from_rm,
+            "to_rm": to_rm,
+        }
+
+    def test_no_anomaly_is_noop_success(self, populated_dl):
+        """BB_RM_ANOMALY=None → SUCCESS with no outbox entry (happy path)."""
+        bridge = self._bridge_with_factory(populated_dl)
+        node = EmitRMGapNoteNode(
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
+        outbox = populated_dl.outbox_list_for_actor(CASE_MANAGER_ID)
+        assert len(outbox) == 0, "No anomaly → no outbox entry expected"
+
+    def test_gap_anomaly_emits_note(self, populated_dl):
+        """BB_RM_ANOMALY=gap → SUCCESS + Add(Note,Case) queued (RSH-06-004)."""
+        bridge = self._bridge_with_factory(populated_dl)
+        node = EmitRMGapNoteNode(
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        # Pre-populate anomaly flag as if FilterParticipantStatusDimensionsNode ran
+        self._set_anomaly("gap", RM.RECEIVED, RM.ACCEPTED)
+
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
+
+        outbox = populated_dl.outbox_list_for_actor(CASE_MANAGER_ID)
+        assert (
+            len(outbox) == 1
+        ), "Gap anomaly should emit exactly one Add(Note,Case)"
+
+    def test_regression_anomaly_emits_note(self, populated_dl):
+        """BB_RM_ANOMALY=regression → SUCCESS + Add(Note,Case) queued (RSH-06-004)."""
+        bridge = self._bridge_with_factory(populated_dl)
+        node = EmitRMGapNoteNode(
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        self._set_anomaly("regression", RM.ACCEPTED, RM.RECEIVED)
+
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
+
+        outbox = populated_dl.outbox_list_for_actor(CASE_MANAGER_ID)
+        assert (
+            len(outbox) == 1
+        ), "Regression anomaly should emit exactly one Add(Note,Case)"
+
+    def test_no_case_id_is_noop_success(self, populated_dl):
+        """case_id=None → SUCCESS with no outbox entry (no case context)."""
+        bridge = self._bridge_with_factory(populated_dl)
+        node = EmitRMGapNoteNode(
+            sender_actor_id=ACTOR_ID,
+            case_id=None,
+        )
+        self._set_anomaly("gap", RM.RECEIVED, RM.ACCEPTED)
+
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
+        outbox = populated_dl.outbox_list_for_actor(CASE_MANAGER_ID)
+        assert len(outbox) == 0, "No case_id → no outbox entry expected"
+
+    def test_no_factory_is_success_noop(self, populated_bridge):
+        """No TriggerActivityPort → SUCCESS (degrades gracefully — SHOULD not MUST)."""
+        node = EmitRMGapNoteNode(
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        self._set_anomaly("gap", RM.RECEIVED, RM.ACCEPTED)
+        # populated_bridge has no trigger_activity_factory
+        result = populated_bridge.execute_with_setup(
+            tree=node, actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.SUCCESS

--- a/test/core/behaviors/status/test_partial_accept_participant_status.py
+++ b/test/core/behaviors/status/test_partial_accept_participant_status.py
@@ -959,3 +959,67 @@ class TestMergeSnapshotObjectFields:
         )
         assert merged["caseStatus"] == f"{ASSERTED_STATUS_ID}/cs"
         assert merged["rmState"] == "VALID"
+
+
+# ---------------------------------------------------------------------------
+# RSH-06: RM anomaly detection (BB_RM_ANOMALY)
+# ---------------------------------------------------------------------------
+
+
+class TestRMGapAnomalyFlag:
+    """FilterParticipantStatusDimensionsNode publishes BB_RM_ANOMALY (RSH-06)."""
+
+    def _read_anomaly(self) -> Any:
+        from vultron.core.behaviors.status.nodes.dimension_filter import (
+            BB_RM_ANOMALY,
+        )
+
+        return py_trees.blackboard.Blackboard.storage.get("/" + BB_RM_ANOMALY)
+
+    def test_nonadjacent_forward_jump_sets_gap_anomaly(self, dl, make_payload):
+        """RECEIVED → ACCEPTED (non-adjacent) sets BB_RM_ANOMALY='gap' (RSH-06-001)."""
+        current = _current_status(RM.RECEIVED, CS_vfd.vfd, CS_pxa.pxa)
+        asserted = _asserted_status(RM.ACCEPTED, CS_vfd.vfd, None)
+        _seed_case(dl, current, asserted)
+
+        result = _run_tree(dl, asserted, ACTOR_ID, make_payload)
+
+        assert result.status == Status.SUCCESS
+        anomaly = self._read_anomaly()
+        assert (
+            anomaly is not None
+        ), "BB_RM_ANOMALY not set for non-adjacent RM gap"
+        assert anomaly["anomaly_type"] == "gap"
+        assert anomaly["from_rm"] == RM.RECEIVED
+        assert anomaly["to_rm"] == RM.ACCEPTED
+
+    def test_adjacent_forward_transition_no_anomaly(self, dl, make_payload):
+        """RECEIVED → VALID (adjacent) sets no BB_RM_ANOMALY (happy path)."""
+        current = _current_status(RM.RECEIVED, CS_vfd.vfd, CS_pxa.pxa)
+        asserted = _asserted_status(RM.VALID, CS_vfd.vfd, None)
+        _seed_case(dl, current, asserted)
+
+        _run_tree(dl, asserted, ACTOR_ID, make_payload)
+
+        anomaly = self._read_anomaly()
+        assert (
+            anomaly is None
+        ), f"Expected no anomaly for adjacent transition, got {anomaly}"
+
+    def test_backward_regression_refused_sets_regression_anomaly(
+        self, dl, make_payload
+    ):
+        """ACCEPTED → RECEIVED (backward) sets BB_RM_ANOMALY='regression' (RSH-06-002)."""
+        current = _current_status(RM.ACCEPTED, CS_vfd.vfd, CS_pxa.pxa)
+        asserted = _asserted_status(RM.RECEIVED, CS_vfd.vfd, None)
+        _seed_case(dl, current, asserted)
+
+        _run_tree(dl, asserted, ACTOR_ID, make_payload)
+
+        anomaly = self._read_anomaly()
+        assert (
+            anomaly is not None
+        ), "BB_RM_ANOMALY not set for backward regression"
+        assert anomaly["anomaly_type"] == "regression"
+        assert anomaly["from_rm"] == RM.ACCEPTED
+        assert anomaly["to_rm"] == RM.RECEIVED

--- a/vultron/core/behaviors/status/add_participant_status_tree.py
+++ b/vultron/core/behaviors/status/add_participant_status_tree.py
@@ -39,7 +39,8 @@ EmbargoTeardownAuthorizationGate; ``add_participant_status_tree`` does not execu
     ├─ StatusAdoptionGate (Selector)           # StatusAdoptionGate authorization (RSH-01-002)
     │   ├─ CheckIsCaseOwnerNode               # Hard bypass: CASE_OWNER gospel (RSH-01-002)
     │   └─ CaseOwnerApprovesStatusUpdate      # Call-out: non-owners need approval
-    └─ EmitAddCaseStatusToSelfNode            # StatusAdoptionGate emit → triggers EmbargoTeardownAuthorizationGate (RSH-01-003)
+    ├─ EmitAddCaseStatusToSelfNode            # StatusAdoptionGate emit → triggers EmbargoTeardownAuthorizationGate (RSH-01-003)
+    └─ EmitRMGapNoteNode                      # Emit Add(Note,Case) on RM anomaly (RSH-06-004)
 
 ``FilterParticipantStatusDimensionsNode`` adjudicates ``rm``, ``vfd`` and
 ``pxa`` independently before the commit, so an unacceptable value in one
@@ -74,6 +75,7 @@ from vultron.core.behaviors.status.append_participant_status_tree import (
 )
 from vultron.core.behaviors.status.nodes import (
     EmitAddCaseStatusToSelfNode,
+    EmitRMGapNoteNode,
     FilterParticipantStatusDimensionsNode,
     VerifySenderIsParticipantNode,
 )
@@ -193,6 +195,11 @@ def add_participant_status_tree(
                 participant_status_id=status_id,
                 case_id=tree_case_id,
                 name="EmitAddCaseStatusToSelf",
+            ),
+            EmitRMGapNoteNode(
+                sender_actor_id=actor_id,
+                case_id=tree_case_id,
+                name="EmitRMGapNote",
             ),
         ],
     )

--- a/vultron/core/behaviors/status/nodes/__init__.py
+++ b/vultron/core/behaviors/status/nodes/__init__.py
@@ -36,6 +36,7 @@ Submodules:
 - ``lifecycle``: Public disclosure and auto-close emit lifecycle nodes
   (_PublicDisclosureSkipConditionNode, PublicDisclosureBranchNode,
   ThreatTerminationBranchNode, EmitAddCaseStatusToSelfNode, EmitCloseCaseNode)
+- ``rm_anomaly``: RM transition anomaly notification (EmitRMGapNoteNode)
 - ``case_status``: Idempotency guard, EM/PXA transition validation, and
   append nodes for the AddCaseStatusToCase workflow
 """
@@ -73,6 +74,9 @@ from vultron.core.behaviors.status.nodes.lifecycle import (
     ThreatTerminationBranchNode,
     _PublicDisclosureSkipConditionNode,
 )
+from vultron.core.behaviors.status.nodes.rm_anomaly import (
+    EmitRMGapNoteNode,
+)
 
 __all__ = [
     # conditions
@@ -97,6 +101,7 @@ __all__ = [
     "ThreatTerminationBranchNode",
     "EmitAddCaseStatusToSelfNode",
     "EmitCloseCaseNode",
+    "EmitRMGapNoteNode",
     # case_status
     "CASE_STATUS_ALREADY_PRESENT",
     "CheckCaseStatusIdempotencyNode",

--- a/vultron/core/behaviors/status/nodes/_adjudication.py
+++ b/vultron/core/behaviors/status/nodes/_adjudication.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Per-dimension adjudication helpers for received ParticipantStatus.
+
+Extracted from ``dimension_filter`` to keep that module under the 500-line
+BTND-07-004 limit.  All public names are re-exported from ``dimension_filter``
+and should be imported from there, not from this module directly.
+"""
+
+from typing import Any
+
+from vultron.core.models.dimensions import (
+    PxaDimension,
+    RmDimension,
+    VfdDimension,
+)
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.states.cs import (
+    is_monotonic_pxa_forward,
+    is_monotonic_vfd_forward,
+)
+from vultron.core.states.rm import (
+    RM,
+    is_monotonic_rm_forward,
+    is_valid_rm_transition,
+)
+
+
+def _rm_is_acceptable(current: RM, asserted: RM) -> bool:
+    """Return True if *asserted* is an acceptable RM value given *current*.
+
+    ``RM.CLOSED`` is terminal (DEMOMA-07-003): once a participant has closed,
+    no further RM value — not even ``CLOSED`` again — is acceptable.  Otherwise
+    a status confirmation (no change), a valid adjacent transition, or a
+    non-adjacent but monotone forward jump are all acceptable; the sender is
+    authoritative about its own RM progress.
+    """
+    if current == RM.CLOSED:
+        return False
+    if asserted == current:
+        return True
+    return is_valid_rm_transition(
+        current, asserted
+    ) or is_monotonic_rm_forward(current, asserted)
+
+
+def _adjudicate_dimensions(
+    current: ParticipantStatus, asserted: ParticipantStatus
+) -> tuple[list[str], dict[str, Any]]:
+    """Adjudicate ``rm``, ``vfd`` and ``pxa`` independently.
+
+    Returns the names of the refused dimensions and the ``model_copy`` update
+    that carries the current value forward for each of them.  ``em``,
+    ``consent``, ``case_engagement``, ``embargo_adherence``, ``cvd_role`` and
+    ``tracking_id`` are not adjudicated here — ``em`` in particular belongs to
+    EmbargoTeardownAuthorizationGate (ADR-0046, ISSUE-2256).
+
+    The two return values are deliberately not the same set.  ``refused`` names
+    the dimensions whose *asserted* value was rejected; ``update_fields`` also
+    carries dimensions the sender said nothing about, which must be preserved
+    rather than dropped.  An inbound status with no ``case_status`` at all is
+    the common case: it asserts nothing about ``pxa``/``em``, so the
+    participant's current ``case_status`` is carried forward instead of letting
+    the omission erase state the receiver already holds (RSH-05-002).
+    """
+    refused: list[str] = []
+    update_fields: dict[str, Any] = {}
+
+    if not _rm_is_acceptable(current.rm.state, asserted.rm.state):
+        refused.append("rm")
+        update_fields["rm"] = RmDimension(state=current.rm.state)
+
+    current_vfd = current.vfd.state
+    asserted_vfd = asserted.vfd.state
+    if asserted_vfd != current_vfd and not is_monotonic_vfd_forward(
+        current_vfd, asserted_vfd
+    ):
+        refused.append("vfd")
+        update_fields["vfd"] = VfdDimension(state=current_vfd)
+
+    asserted_cs = asserted.case_status
+    current_cs = current.case_status
+    if asserted_cs is None and current_cs is not None:
+        # Nothing asserted about pxa/em — carry the receiver's own view
+        # forward.  Persisting the assertion as-is would blank both.
+        update_fields["case_status"] = current_cs.model_copy(deep=True)
+    elif asserted_cs is not None and current_cs is not None:
+        current_pxa = current_cs.pxa.state
+        asserted_pxa = asserted_cs.pxa.state
+        if asserted_pxa != current_pxa and not is_monotonic_pxa_forward(
+            current_pxa, asserted_pxa
+        ):
+            refused.append("pxa")
+            update_fields["case_status"] = asserted_cs.model_copy(
+                update={"pxa": PxaDimension(state=current_pxa)}
+            )
+
+    return refused, update_fields

--- a/vultron/core/behaviors/status/nodes/dimension_filter.py
+++ b/vultron/core/behaviors/status/nodes/dimension_filter.py
@@ -49,16 +49,10 @@ from vultron.core.behaviors.case.nodes.lifecycle import (
 from vultron.core.behaviors.helpers import DataLayerCondition
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case_participant import CaseParticipant
-from vultron.core.models.dimensions import (
-    PxaDimension,
-    RmDimension,
-    VfdDimension,
-)
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.protocols import PersistableModel
-from vultron.core.states.cs import (
-    is_monotonic_pxa_forward,
-    is_monotonic_vfd_forward,
+from vultron.core.behaviors.status.nodes._adjudication import (
+    _adjudicate_dimensions,
 )
 from vultron.core.states.rm import (
     RM,
@@ -72,6 +66,13 @@ logger = logging.getLogger(__name__)
 #: nodes downstream (``ResolveAndPersistStatusObjectNode``,
 #: ``ValidateRMTransitionNode``).  ``None`` when nothing was filtered.
 BB_DIMENSION_FILTER = "append_status_dimension_filter"
+
+#: Blackboard key for RM transition anomaly info published by
+#: :class:`FilterParticipantStatusDimensionsNode` (non-adjacent forward jump)
+#: and :class:`~vultron.core.behaviors.status.nodes.rm_validation.ValidateRMTransitionNode`
+#: (backward regression on the standalone path).  ``None`` when no anomaly.
+#: When set: ``{"anomaly_type": "gap"|"regression", "from_rm": RM, "to_rm": RM}``.
+BB_RM_ANOMALY = "rm_transition_anomaly"
 
 
 def _accepted_wire_patch(filtered: ParticipantStatus) -> dict[str, Any]:
@@ -175,78 +176,6 @@ def _dimension_state(status: ParticipantStatus, dimension: str) -> Any:
     return None
 
 
-def _rm_is_acceptable(current: RM, asserted: RM) -> bool:
-    """Return True if *asserted* is an acceptable RM value given *current*.
-
-    ``RM.CLOSED`` is terminal (DEMOMA-07-003): once a participant has closed,
-    no further RM value — not even ``CLOSED`` again — is acceptable.  Otherwise
-    a status confirmation (no change), a valid adjacent transition, or a
-    non-adjacent but monotone forward jump are all acceptable; the sender is
-    authoritative about its own RM progress.
-    """
-    if current == RM.CLOSED:
-        return False
-    if asserted == current:
-        return True
-    return is_valid_rm_transition(
-        current, asserted
-    ) or is_monotonic_rm_forward(current, asserted)
-
-
-def _adjudicate_dimensions(
-    current: ParticipantStatus, asserted: ParticipantStatus
-) -> tuple[list[str], dict[str, Any]]:
-    """Adjudicate ``rm``, ``vfd`` and ``pxa`` independently.
-
-    Returns the names of the refused dimensions and the ``model_copy`` update
-    that carries the current value forward for each of them.  ``em``,
-    ``consent``, ``case_engagement``, ``embargo_adherence``, ``cvd_role`` and
-    ``tracking_id`` are not adjudicated here — ``em`` in particular belongs to
-    EmbargoTeardownAuthorizationGate (ADR-0046, ISSUE-2256).
-
-    The two return values are deliberately not the same set.  ``refused`` names
-    the dimensions whose *asserted* value was rejected; ``update_fields`` also
-    carries dimensions the sender said nothing about, which must be preserved
-    rather than dropped.  An inbound status with no ``case_status`` at all is
-    the common case: it asserts nothing about ``pxa``/``em``, so the
-    participant's current ``case_status`` is carried forward instead of letting
-    the omission erase state the receiver already holds (RSH-05-002).
-    """
-    refused: list[str] = []
-    update_fields: dict[str, Any] = {}
-
-    if not _rm_is_acceptable(current.rm.state, asserted.rm.state):
-        refused.append("rm")
-        update_fields["rm"] = RmDimension(state=current.rm.state)
-
-    current_vfd = current.vfd.state
-    asserted_vfd = asserted.vfd.state
-    if asserted_vfd != current_vfd and not is_monotonic_vfd_forward(
-        current_vfd, asserted_vfd
-    ):
-        refused.append("vfd")
-        update_fields["vfd"] = VfdDimension(state=current_vfd)
-
-    asserted_cs = asserted.case_status
-    current_cs = current.case_status
-    if asserted_cs is None and current_cs is not None:
-        # Nothing asserted about pxa/em — carry the receiver's own view
-        # forward.  Persisting the assertion as-is would blank both.
-        update_fields["case_status"] = current_cs.model_copy(deep=True)
-    elif asserted_cs is not None and current_cs is not None:
-        current_pxa = current_cs.pxa.state
-        asserted_pxa = asserted_cs.pxa.state
-        if asserted_pxa != current_pxa and not is_monotonic_pxa_forward(
-            current_pxa, asserted_pxa
-        ):
-            refused.append("pxa")
-            update_fields["case_status"] = asserted_cs.model_copy(
-                update={"pxa": PxaDimension(state=current_pxa)}
-            )
-
-    return refused, update_fields
-
-
 class FilterParticipantStatusDimensionsNode(DataLayerCondition):
     """Adjudicate each dimension of an inbound ParticipantStatus separately.
 
@@ -297,16 +226,21 @@ class FilterParticipantStatusDimensionsNode(DataLayerCondition):
             key=BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE,
             access=py_trees.common.Access.WRITE,
         )
+        self.blackboard.register_key(
+            key=BB_RM_ANOMALY,
+            access=py_trees.common.Access.WRITE,
+        )
 
     def _publish(
         self,
         refused: tuple[str, ...],
         filtered: ParticipantStatus | None,
+        rm_anomaly: dict | None = None,
     ) -> None:
         """Publish (or clear) the filter outcome on the blackboard.
 
         The py_trees blackboard is process-global and is not cleared between
-        executions, so both keys are written on *every* tick — including with
+        executions, so all keys are written on *every* tick — including with
         ``None`` when no filtering applies — to prevent a previous run's
         override from leaking into this one.
         """
@@ -315,6 +249,7 @@ class FilterParticipantStatusDimensionsNode(DataLayerCondition):
             self.blackboard.set(
                 BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE, None, overwrite=True
             )
+            self.blackboard.set(BB_RM_ANOMALY, None, overwrite=True)
             return
 
         self.blackboard.set(
@@ -335,6 +270,44 @@ class FilterParticipantStatusDimensionsNode(DataLayerCondition):
             },
             overwrite=True,
         )
+        self.blackboard.set(BB_RM_ANOMALY, rm_anomaly, overwrite=True)
+
+    def _detect_rm_anomaly(
+        self,
+        refused: list[str],
+        current_rm: RM,
+        asserted_rm: RM,
+    ) -> dict | None:
+        """Return an anomaly dict when an RM transition anomaly is detected.
+
+        Returns ``None`` when there is nothing anomalous to record.
+        """
+        if "rm" in refused:
+            return {
+                "anomaly_type": "regression",
+                "from_rm": current_rm,
+                "to_rm": asserted_rm,
+            }
+        if (
+            current_rm != RM.CLOSED
+            and asserted_rm != current_rm
+            and not is_valid_rm_transition(current_rm, asserted_rm)
+            and is_monotonic_rm_forward(current_rm, asserted_rm)
+        ):
+            self.logger.warning(
+                "%s: non-adjacent forward RM jump %s → %s for participant"
+                " '%s'; accepting sender-authoritative state (RSH-06-001)",
+                self.name,
+                current_rm,
+                asserted_rm,
+                self.participant_id,
+            )
+            return {
+                "anomaly_type": "gap",
+                "from_rm": current_rm,
+                "to_rm": asserted_rm,
+            }
+        return None
 
     def _resolve_asserted(self) -> ParticipantStatus | None:
         """Return the asserted status as a core model, DataLayer first."""
@@ -379,7 +352,14 @@ class FilterParticipantStatusDimensionsNode(DataLayerCondition):
             return Status.SUCCESS
 
         refused, update_fields = _adjudicate_dimensions(current, asserted)
+        rm_anomaly = self._detect_rm_anomaly(
+            refused, current.rm.state, asserted.rm.state
+        )
+
         if not update_fields:
+            # No dimension filtering needed; publish the anomaly flag only.
+            if rm_anomaly is not None:
+                self.blackboard.set(BB_RM_ANOMALY, rm_anomaly, overwrite=True)
             return Status.SUCCESS
 
         # ``name`` on a ParticipantStatus is a derived state summary (the wire
@@ -403,9 +383,13 @@ class FilterParticipantStatusDimensionsNode(DataLayerCondition):
             )
             self.logger.info("%s: %s", self.name, self.feedback_message)
             self._publish((), None)
+            # Still publish the anomaly even on a wholly-refused assertion:
+            # the receiver detected an anomaly and must emit a note (RSH-06).
+            if rm_anomaly is not None:
+                self.blackboard.set(BB_RM_ANOMALY, rm_anomaly, overwrite=True)
             return Status.FAILURE
 
-        self._publish(tuple(refused), filtered)
+        self._publish(tuple(refused), filtered, rm_anomaly=rm_anomaly)
         self.feedback_message = (
             f"Partially accepted status '{self.status_id}' for participant"
             f" '{self.participant_id}': {self._carry_summary(refused)}"

--- a/vultron/core/behaviors/status/nodes/rm_anomaly.py
+++ b/vultron/core/behaviors/status/nodes/rm_anomaly.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""RM transition anomaly notification node.
+
+Extracted from ``lifecycle.py`` to keep that module under the 500-line
+BTND-07-004 limit.  Re-exported from ``nodes/__init__.py`` so existing import
+paths continue to work.
+
+Per specs/received-status-handling.yaml RSH-06-004, RSH-06-005.
+"""
+
+import logging
+from typing import cast
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.behaviors.status.nodes.dimension_filter import BB_RM_ANOMALY
+
+logger = logging.getLogger(__name__)
+
+
+class EmitRMGapNoteNode(DataLayerAction):
+    """Emit ``Add(Note, VulnerabilityCase)`` when an RM transition anomaly is detected.
+
+    Reads the ``rm_transition_anomaly`` blackboard key written by
+    :class:`~vultron.core.behaviors.status.nodes.dimension_filter.FilterParticipantStatusDimensionsNode`
+    (non-adjacent forward jump) or
+    :class:`~vultron.core.behaviors.status.nodes.rm_validation.ValidateRMTransitionNode`
+    (backward regression on the standalone path).  When the key is ``None``
+    (no anomaly), returns SUCCESS without doing anything.
+
+    When an anomaly is present, creates a note describing the anomaly and
+    queues an ``Add(Note, VulnerabilityCase)`` addressed to the sender.
+    Returns SUCCESS in all cases — note emission is SHOULD-level (RSH-06-004);
+    failures degrade gracefully so the enclosing Sequence is not aborted.
+
+    Per specs/received-status-handling.yaml RSH-06-004, RSH-06-005.
+    """
+
+    def __init__(
+        self,
+        sender_actor_id: str,
+        case_id: str | None,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.sender_actor_id = sender_actor_id
+        self.case_id = case_id
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key=BB_RM_ANOMALY,
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        if not self.case_id:
+            return Status.SUCCESS
+
+        try:
+            anomaly = self.blackboard.get(BB_RM_ANOMALY)
+        except KeyError:
+            anomaly = None
+        if anomaly is None:
+            return Status.SUCCESS
+
+        if self._require_datalayer_and_actor() is not None:
+            self.logger.warning(
+                "EmitRMGapNoteNode: no datalayer/actor — cannot emit note"
+                " for RM anomaly in case '%s'",
+                self.case_id,
+            )
+            return Status.SUCCESS
+
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "EmitRMGapNoteNode: no TriggerActivityPort — cannot emit"
+                " Add(Note,Case) for RM anomaly in case '%s'",
+                self.case_id,
+            )
+            return Status.SUCCESS
+
+        anomaly_type = anomaly.get("anomaly_type", "unknown")
+        from_rm = anomaly.get("from_rm", "?")
+        to_rm = anomaly.get("to_rm", "?")
+
+        if anomaly_type == "gap":
+            note_name = f"RM state gap reported by {self.sender_actor_id}"
+            note_content = (
+                f"Actor '{self.sender_actor_id}' reported a non-adjacent forward"
+                f" RM state jump from {from_rm} to {to_rm}."
+                f" Intermediate transitions were not reported."
+                f" Please clarify the path taken between these states (RSH-06-001)."
+            )
+        else:
+            note_name = (
+                f"RM state regression reported by {self.sender_actor_id}"
+            )
+            note_content = (
+                f"Actor '{self.sender_actor_id}' reported a backward RM"
+                f" state transition from {from_rm} to {to_rm}."
+                f" RM is monotonic; this transition was refused (RSH-06-002)."
+                f" Please clarify or resync your RM state."
+            )
+
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+        assert self.trigger_activity_factory is not None
+        try:
+            note_id, _ = self.trigger_activity_factory.create_note(
+                name=note_name,
+                content=note_content,
+                context_id=self.case_id,
+                attributed_to=self.actor_id,
+            )
+            activity_id, _ = self.trigger_activity_factory.add_note_to_case(
+                note_id=note_id,
+                case_id=self.case_id,
+                actor=self.actor_id,
+                to=[self.sender_actor_id],
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity_id
+            )
+            self.logger.info(
+                "EmitRMGapNoteNode: queued Add(Note,Case) '%s' for RM %s"
+                " anomaly (%s → %s) in case '%s' (RSH-06-004)",
+                activity_id,
+                anomaly_type,
+                from_rm,
+                to_rm,
+                self.case_id,
+            )
+        except Exception as e:
+            self.logger.warning(
+                "EmitRMGapNoteNode: failed to emit note for RM anomaly"
+                " in case '%s': %s",
+                self.case_id,
+                e,
+            )
+
+        return Status.SUCCESS

--- a/vultron/core/behaviors/status/nodes/rm_validation.py
+++ b/vultron/core/behaviors/status/nodes/rm_validation.py
@@ -30,6 +30,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerCondition, read_rm_states
+from vultron.core.behaviors.status.nodes.dimension_filter import BB_RM_ANOMALY
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.states.rm import (
@@ -84,8 +85,15 @@ class ValidateRMTransitionNode(DataLayerCondition):
             key="append_status_status_obj",
             access=py_trees.common.Access.READ,
         )
+        self.blackboard.register_key(
+            key=BB_RM_ANOMALY,
+            access=py_trees.common.Access.WRITE,
+        )
 
     def update(self) -> Status:
+        # Clear on every tick so a previous run's flag never leaks forward.
+        self.blackboard.set(BB_RM_ANOMALY, None, overwrite=True)
+
         participant = self.blackboard.get("append_status_participant")
         status_obj = self.blackboard.get("append_status_status_obj")
 
@@ -135,23 +143,43 @@ class ValidateRMTransitionNode(DataLayerCondition):
             return Status.SUCCESS
 
         if is_monotonic_rm_forward(current_rm, new_rm_state):
-            self.logger.info(
+            # RSH-06-001: accept; RSH-06-003: must not be silent.
+            self.logger.warning(
                 "ValidateRMTransitionNode: non-adjacent forward RM"
                 " transition %s → %s for participant '%s';"
-                " accepting sender-authoritative state",
+                " accepting sender-authoritative state (RSH-06-001)",
                 current_rm,
                 new_rm_state,
                 self.participant_id,
             )
+            self.blackboard.set(
+                BB_RM_ANOMALY,
+                {
+                    "anomaly_type": "gap",
+                    "from_rm": current_rm,
+                    "to_rm": new_rm_state,
+                },
+                overwrite=True,
+            )
             return Status.SUCCESS
 
+        # RSH-06-002: backward regression — refuse; RSH-06-003: not silent.
         self.feedback_message = (
             f"Backwards RM transition {current_rm} → {new_rm_state}"
             f" for participant '{self.participant_id}'"
         )
         self.logger.warning(
-            "ValidateRMTransitionNode: %s — rejecting",
+            "ValidateRMTransitionNode: %s — rejecting (RSH-06-002)",
             self.feedback_message,
+        )
+        self.blackboard.set(
+            BB_RM_ANOMALY,
+            {
+                "anomaly_type": "regression",
+                "from_rm": current_rm,
+                "to_rm": new_rm_state,
+            },
+            overwrite=True,
         )
         return Status.FAILURE
 


### PR DESCRIPTION
- Closes #2258
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Implements ADR-0067 and spec group RSH-06: non-adjacent forward RM jumps are accepted (sender-authoritative) with WARNING log and `Add(Note,Case)` notification; backward RM regressions are refused with WARNING log and `Add(Note,Case)` notification. Neither path is silent.

## Changes

- **`docs/adr/0067-rm-nonadj-accept-and-notify.md`**: New ADR capturing the acceptance policy decision, consequences, and validation approach.
- **`docs/adr/index.md`**, **`mkdocs.yml`**: Register ADR-0067.
- **`specs/received-status-handling.yaml`**: New spec group RSH-06 (RSH-06-001 through RSH-06-005) for RM anomaly notification policy.
- **`vultron/core/behaviors/status/nodes/dimension_filter.py`**: Add `BB_RM_ANOMALY` blackboard key constant; `FilterParticipantStatusDimensionsNode` detects non-adjacent forward jumps and regressions, sets `BB_RM_ANOMALY`; extract anomaly detection to `_detect_rm_anomaly` helper to stay within McCabe complexity limit.
- **`vultron/core/behaviors/status/nodes/rm_validation.py`**: `ValidateRMTransitionNode` upgraded from INFO to WARNING for forward gaps; sets `BB_RM_ANOMALY` on both accept-with-gap and refuse-with-regression paths; clears it on clean transitions.
- **`vultron/core/behaviors/status/nodes/rm_anomaly.py`** *(new)*: `EmitRMGapNoteNode` — reads `BB_RM_ANOMALY` and queues `Add(Note,VulnerabilityCase)` to the sender; always returns SUCCESS (SHOULD-level per RSH-06-004).
- **`vultron/core/behaviors/status/nodes/_adjudication.py`** *(new)*: `_rm_is_acceptable` and `_adjudicate_dimensions` extracted from `dimension_filter.py` to keep both modules under the BTND-07-004 500-line limit.
- **`vultron/core/behaviors/status/nodes/__init__.py`**: Re-export `EmitRMGapNoteNode` from new `rm_anomaly` module.
- **`vultron/core/behaviors/status/add_participant_status_tree.py`**: Wire `EmitRMGapNoteNode` as the final effect node in `AddParticipantStatusBT`.
- **`test/core/behaviors/status/nodes/append/test_conditions.py`**: 3 new tests for `ValidateRMTransitionNode` (forward gap accepts with WARNING + anomaly set, backward regression sets anomaly, adjacent transition clears anomaly).
- **`test/core/behaviors/status/test_partial_accept_participant_status.py`**: 3 new tests for `FilterParticipantStatusDimensionsNode` RM anomaly flag behavior.
- **`test/core/behaviors/status/test_add_participant_status_bt.py`**: 5 new tests for `EmitRMGapNoteNode`.

## Verification

- 286 unit tests pass (11 new)
- Black, flake8, mypy, pyright all clean
- BTND-07-004 line-count tests pass: `lifecycle.py` 447 lines, `dimension_filter.py` 463 lines