### PR TITLE
docs: plan issue #2415 — CI failure notification design notes

### DIFF
--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -4,6 +4,7 @@ status: active
 related_specs:
   - specs/demo-ci.yaml
   - specs/multi-actor-demo.yaml
+  - specs/ci-security.yaml
 ---
 
 # Demo CI Invariant Harness Design
@@ -423,8 +424,8 @@ workflow-status-detection logic lives inside the action:
     run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 ```
 
-Every qualifying workflow MUST declare `issues: write` permission (CISEC-05-001,
-CISEC-05-002). Workflows with a root-level `permissions: contents: read` block MUST
+Every qualifying workflow MUST declare `issues: write` permission (CISEC-02-002,
+CISEC-05-001, CISEC-05-002). Workflows with a root-level `permissions: contents: read` block MUST
 expand it to a map that explicitly includes `issues: write`.
 
 ### Qualifying Workflows and Their Labels

--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -384,6 +384,76 @@ follow-up Idea; DEMOCI-05 only adds the post-merge baseline signal.
 
 ---
 
+## CI Failure Notification — `notify-failure` Composite Action (CISEC-05)
+
+Design decisions and implementation guidance for `.github/actions/notify-failure`,
+the shared composite action wired into every qualifying workflow (push to `main`
+or `schedule` trigger). See ADR-0055 and `specs/ci-security.yaml` CISEC-05.
+
+### Composite Action Interface
+
+The action accepts three inputs:
+
+- `mode`: `notify` (file/update issue on failure) or `close` (close open issue on
+  recovery).
+- `workflow-label`: the workflow-specific label, e.g. `ci:workflow-demo-integration`.
+  Combined with the shared `ci:main-failure` label, the pair uniquely identifies the
+  open failure issue for this workflow — enabling update-not-duplicate semantics.
+- `run-url`: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`.
+  Included in the issue body so the failing run is one click away.
+
+Each qualifying workflow wires **two** steps using `if:` conditions so no
+workflow-status-detection logic lives inside the action:
+
+```yaml
+- name: Notify CI failure
+  if: failure()
+  uses: ./.github/actions/notify-failure
+  with:
+    mode: notify
+    workflow-label: ci:workflow-<name>
+    run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+- name: Close CI failure issue
+  if: success()
+  uses: ./.github/actions/notify-failure
+  with:
+    mode: close
+    workflow-label: ci:workflow-<name>
+    run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+```
+
+Every qualifying workflow MUST declare `issues: write` permission (CISEC-05-001,
+CISEC-05-002). Workflows with a root-level `permissions: contents: read` block MUST
+expand it to a map that explicitly includes `issues: write`.
+
+### Qualifying Workflows and Their Labels
+
+| Workflow file                 | Trigger            | Workflow-specific label              |
+|-------------------------------|--------------------|-----------------------------------------|
+| `demo-integration.yml`        | push to main       | `ci:workflow-demo-integration`          |
+| `python-app.yml`              | push to main       | `ci:workflow-python-app`                |
+| `lint_md_all.yml`             | push to main       | `ci:workflow-lint-markdown`             |
+| `spec-check.yml`              | push to main       | `ci:workflow-spec-check`                |
+| `actions-lint.yml`            | push to main       | `ci:workflow-actions-lint`              |
+| `quarterly_tag.yml`           | schedule           | `ci:workflow-quarterly-tag`             |
+| `stale_claim_sweeper.yml`     | schedule           | `ci:workflow-stale-claim-sweeper`       |
+
+### Deduplication Model
+
+The composite action searches for any open issue with **both** `ci:main-failure`
+and the workflow-specific label using `gh issue list --label`. If one exists,
+`notify` appends a comment (avoids alert flooding across repeated failures without
+a fix). If none exists, `notify` creates a new issue. `close` searches the same
+label combination and closes any open match.
+
+The `ci:main-failure` label is bot-managed; CISEC-05-005 enforces this via a
+separate `issues: labeled` workflow that strips the label if `github.actor !=
+github-actions[bot]`. This prevents label spoofing that could suppress a
+legitimate failure notification.
+
+---
+
 ## Invariant Scoping: Per-Scenario Participant Set Audit
 
 Invariants in the harness are only invariant *within their scenario's protocol

--- a/plan/history/2608/learning/CONCERN-2415.md
+++ b/plan/history/2608/learning/CONCERN-2415.md
@@ -1,0 +1,35 @@
+---
+source: CONCERN-2415
+timestamp: '2026-08-20T15:59:03.144634+00:00'
+title: No post-merge CI protection on main — failures are silent
+type: learning
+---
+
+## Summary
+
+The CI pipeline validates PRs before merge but has no post-merge protection
+for `main`. When Demo Integration or Invariant Harness jobs break on `main`,
+no alert fires, no issue is filed, and no notification reaches the team.
+Breakage sits undetected until someone manually checks the Actions tab.
+
+## Surface Symptom vs. Underlying Problem
+
+**Surface symptom:** `main` is occasionally found broken by someone trying to
+branch from it or cut a release.
+
+**Underlying problem:** The CI pipeline was designed as a merge gate
+(one-directional: block bad PRs). There is no scheduled or push-triggered run
+of Demo Integration or Invariant Harness on `main`, and no failure-notification
+mechanism. The feedback loop is structurally asymmetric: CI blocks bad PRs but
+does not protect `main` from the cumulative effect of edge cases that
+individually passed PR CI. Issues #1859 and #2132 documented this gap; both
+were closed without a follow-on issue or implementation.
+
+## Resolution
+
+**Resolved**: 2026-08-20 — implementation tracked in #2438 (composite action +
+workflow wiring), #2439 (verification test), #2440 (bot-managed label guard).
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2437>.
+Notes: `notes/demo-ci-invariants.md` § "CI Failure Notification".
+Spec: `specs/ci-security.yaml` CISEC-05-001 through CISEC-05-005.


### PR DESCRIPTION
- Closes #2415

## Summary

Adds implementation guidance for the `notify-failure` composite action to
`notes/demo-ci-invariants.md`, covering the composite action interface, the
qualifying workflow table with workflow-specific labels, and the deduplication
model for CISEC-05-001 through CISEC-05-005.

## Changes

- **`notes/demo-ci-invariants.md`**: new section "CI Failure Notification —
  `notify-failure` Composite Action (CISEC-05)" documenting the action inputs
  (`mode`, `workflow-label`, `run-url`), the two-step wiring pattern for
  qualifying workflows, the table of all 7 qualifying workflows and their
  workflow-specific labels, the `issues: write` permission requirement, and the
  deduplication model for bot-managed `ci:main-failure` label enforcement.
- **`plan/history/2608/learning/CONCERN-2415.md`**: archives the resolved
  CONCERN-2415 learning with resolution details and PR reference.

## Implementation Issues

- #2438
- #2439
- #2440