### PR TITLE
feat(spec-dump): add --kind filter for protocol-only and project-only loading

### DIFF
--- a/plan/incoming/learnings/20260820-spec-dump-kind-filter-spec-gap.md
+++ b/plan/incoming/learnings/20260820-spec-dump-kind-filter-spec-gap.md
@@ -1,0 +1,21 @@
+---
+title: spec-dump --kind filter has no SR-07 spec entry
+type: learning
+timestamp: 2026-08-20
+source: ISSUE-2389
+signal: spec-gap
+---
+
+SR-07-005 requires that "the JSON exporter SHOULD support filtering by `kind`,
+`scope`, `tags`, or `priority`". This covers `export_json` (the generic JSON
+exporter in `render.py`), but the `spec-dump` / `main_llm_json` / `to_llm_json`
+LLM-optimized path has no corresponding spec entry.
+
+ISSUE-2389 implemented `--kind` CLI support for `spec-dump`, but no spec entry
+was added to `specs/spec-registry.yaml` covering this requirement.
+
+A follow-up should add an SR-07 entry such as:
+> The `spec-dump` CLI entry point SHOULD support a `--kind` flag accepting one
+> or more comma-separated `SpecKind` values, filtering the LLM-optimized JSON
+> output to matching requirements. An unknown kind value MUST produce a clear
+> error and exit 2.

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -380,6 +380,14 @@ groups:
     kind: project
     statement: The JSON exporter SHOULD support filtering by `kind`, `scope`, `tags`, or `priority` to allow agents to request
       only relevant subsets.
+  - id: SR-07-006
+    priority: SHOULD
+    kind: project
+    statement: >-
+      The `spec-dump` CLI entry point SHOULD support a `--kind` flag accepting one or more
+      comma-separated `SpecKind` values, filtering the LLM-optimized JSON output to matching
+      requirements. An unknown kind value MUST produce a clear error message listing valid values
+      and exit with code 2.
 - id: SR-09
   title: Docs Renderer Kind Routing
   specs:

--- a/test/metadata/specs/test_llm_export.py
+++ b/test/metadata/specs/test_llm_export.py
@@ -1,6 +1,7 @@
 """Tests for SpecRegistry graph integration and llm_export module."""
 
 import json
+import sys
 
 import pytest
 import yaml
@@ -234,9 +235,21 @@ class TestLlmExport:
         assert "GA-01-002" not in ids
 
     def test_kind_filter(self, graph_registry):
-        data = json.loads(to_llm_json(graph_registry, kind="project"))
+        data = json.loads(to_llm_json(graph_registry, kinds=["project"]))
         assert len(data["requirements"]) == 1
         assert data["requirements"][0]["id"] == "GA-02-001"
+
+    def test_kinds_multi_filter(self, graph_registry):
+        data = json.loads(
+            to_llm_json(graph_registry, kinds=["protocol", "project"])
+        )
+        ids = {r["id"] for r in data["requirements"]}
+        assert ids == {"GA-01-001", "GA-01-002", "GA-02-001", "GB-01-001"}
+
+    def test_kinds_none_returns_all(self, graph_registry):
+        data_all = json.loads(to_llm_json(graph_registry))
+        data_none = json.loads(to_llm_json(graph_registry, kinds=None))
+        assert data_all["requirements"] == data_none["requirements"]
 
     def test_scope_filter(self, graph_registry):
         data = json.loads(to_llm_json(graph_registry, scope="prototype"))
@@ -331,3 +344,137 @@ class TestLlmExport:
         data = json.loads(to_llm_json(registry, topic="VV"))
         req = data["requirements"][0]
         assert req["verification"] == "A test in `test/foo.py` asserts this."
+
+
+# ---------------------------------------------------------------------------
+# CLI tests for main_llm_json --kind flag
+# ---------------------------------------------------------------------------
+
+
+class TestMainLlmJsonKindFlag:
+    """Tests for the --kind flag in the main_llm_json CLI entry point."""
+
+    @pytest.fixture
+    def kind_spec_dir(self, tmp_path):
+        """Spec dir with both protocol and project kind specs."""
+        spec_data = {
+            "id": "KF",
+            "title": "Kind Filter Test",
+            "description": "Tests --kind flag",
+            "version": "0.1",
+            "scope": ["production"],
+            "groups": [
+                {
+                    "id": "KF-01",
+                    "title": "Protocol group",
+                    "specs": [
+                        {
+                            "id": "KF-01-001",
+                            "priority": "MUST",
+                            "kind": "protocol",
+                            "statement": "KF-01-001 MUST be protocol",
+                        },
+                    ],
+                },
+                {
+                    "id": "KF-02",
+                    "title": "Project group",
+                    "specs": [
+                        {
+                            "id": "KF-02-001",
+                            "priority": "SHOULD",
+                            "kind": "project",
+                            "statement": "KF-02-001 SHOULD be project",
+                        },
+                    ],
+                },
+            ],
+        }
+        (tmp_path / "kf.yaml").write_text(yaml.dump(spec_data))
+        return tmp_path
+
+    def test_kind_flag_single(self, kind_spec_dir, monkeypatch, capsys):
+        from vultron.metadata.specs.render import main_llm_json
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["spec-dump", "--kind", "protocol", str(kind_spec_dir)],
+        )
+        main_llm_json()
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        ids = {r["id"] for r in data["requirements"]}
+        assert ids == {"KF-01-001"}
+        assert "KF-02-001" not in ids
+
+    def test_kind_flag_multi(self, kind_spec_dir, monkeypatch, capsys):
+        from vultron.metadata.specs.render import main_llm_json
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["spec-dump", "--kind", "protocol,project", str(kind_spec_dir)],
+        )
+        main_llm_json()
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        ids = {r["id"] for r in data["requirements"]}
+        assert ids == {"KF-01-001", "KF-02-001"}
+
+    def test_no_kind_flag_returns_all(
+        self, kind_spec_dir, monkeypatch, capsys
+    ):
+        from vultron.metadata.specs.render import main_llm_json
+
+        monkeypatch.setattr(sys, "argv", ["spec-dump", str(kind_spec_dir)])
+        main_llm_json()
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        ids = {r["id"] for r in data["requirements"]}
+        assert ids == {"KF-01-001", "KF-02-001"}
+
+    def test_invalid_kind_exits_with_error(
+        self, kind_spec_dir, monkeypatch, capsys
+    ):
+        from vultron.metadata.specs.render import main_llm_json
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["spec-dump", "--kind", "unknown", str(kind_spec_dir)],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main_llm_json()
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "unknown kind value(s)" in err
+        assert "unknown" in err
+        assert "protocol" in err
+
+    def test_kind_with_spaces_stripped(
+        self, kind_spec_dir, monkeypatch, capsys
+    ):
+        from vultron.metadata.specs.render import main_llm_json
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["spec-dump", "--kind", "protocol, project", str(kind_spec_dir)],
+        )
+        main_llm_json()
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        ids = {r["id"] for r in data["requirements"]}
+        assert ids == {"KF-01-001", "KF-02-001"}
+
+    def test_kind_flag_missing_value_exits_with_error(
+        self, kind_spec_dir, monkeypatch, capsys
+    ):
+        from vultron.metadata.specs.render import main_llm_json
+
+        monkeypatch.setattr(sys, "argv", ["spec-dump", "--kind"])
+        with pytest.raises(SystemExit) as exc_info:
+            main_llm_json()
+        assert exc_info.value.code == 2
+        assert "--kind requires a value" in capsys.readouterr().err

--- a/vultron/metadata/specs/llm_export.py
+++ b/vultron/metadata/specs/llm_export.py
@@ -140,7 +140,7 @@ def _matches_filters(
     topic: str | None,
     selected_ids: set[str] | None,
     spec_id: str,
-    kind: str | None,
+    kinds: list[str] | None,
     scope: str | None,
     tags: list[str] | None,
     priority: str | None,
@@ -155,7 +155,7 @@ def _matches_filters(
     }
     eff_tag_values = {item.value for item in effective_tags(spec, file)}
 
-    if kind and spec.kind.value != kind:
+    if kinds and spec.kind.value not in kinds:
         return False
     if scope and scope not in eff_scope_values:
         return False
@@ -183,7 +183,7 @@ def to_llm_json(
     topic: str | None = None,
     spec_ids: list[str] | None = None,
     include_deps: bool = False,
-    kind: str | None = None,
+    kinds: list[str] | None = None,
     scope: str | None = None,
     tags: list[str] | None = None,
     priority: str | None = None,
@@ -196,7 +196,8 @@ def to_llm_json(
         spec_ids: Filter to these specific spec IDs.
         include_deps: When True and *spec_ids* is given, expand to include
             transitive dependencies via the requirements graph.
-        kind: Filter to specs with this effective kind value.
+        kinds: Filter to specs whose kind value is in this list (e.g.
+            ``["protocol", "architecture"]``).  *None* means no filter.
         scope: Filter to specs whose effective scope contains this value.
         tags: Filter to specs that have ALL of the given tags.
         priority: Filter to specs with this priority value.
@@ -220,7 +221,7 @@ def to_llm_json(
             topic=topic,
             selected_ids=selected_ids,
             spec_id=spec_id,
-            kind=kind,
+            kinds=kinds,
             scope=scope,
             tags=tags,
             priority=priority,

--- a/vultron/metadata/specs/render.py
+++ b/vultron/metadata/specs/render.py
@@ -375,6 +375,8 @@ def main_llm_json() -> None:
 
         spec-dump
         spec-dump specs/
+        spec-dump --kind protocol
+        spec-dump --kind protocol,architecture
         spec-dump-llm-json
 
     Agents should run this at the start of any implementation or design task
@@ -382,7 +384,30 @@ def main_llm_json() -> None:
     """
     import sys
 
+    from vultron.metadata.specs.schema import SpecKind
+
+    _valid_kinds = {k.value for k in SpecKind}
+
     args = sys.argv[1:]
+    kinds_filter: list[str] | None = None
+
+    if "--kind" in args:
+        idx = args.index("--kind")
+        if idx + 1 >= len(args):
+            print("Error: --kind requires a value", file=sys.stderr)
+            sys.exit(2)
+        raw_kind = args[idx + 1]
+        args = args[:idx] + args[idx + 2 :]
+        kinds_filter = [k.strip() for k in raw_kind.split(",")]
+        invalid = [k for k in kinds_filter if k not in _valid_kinds]
+        if invalid:
+            print(
+                f"Error: unknown kind value(s): {', '.join(sorted(invalid))}."
+                f" Valid values: {', '.join(sorted(_valid_kinds))}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
     spec_dir = Path(args[0]) if args else Path("specs")
 
     if not spec_dir.is_dir():
@@ -395,7 +420,7 @@ def main_llm_json() -> None:
     from vultron.metadata.specs.llm_export import to_llm_json
 
     registry = load_registry(spec_dir)
-    print(to_llm_json(registry))
+    print(to_llm_json(registry, kinds=kinds_filter))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Closes #2389

## Summary

Adds a `--kind` flag to `uv run spec-dump` that filters the flat JSON output to one or more `kind:` values (`protocol`, `architecture`, `project`, `process`). Comma-separated values return the union of matching requirements.

## Changes

- **`vultron/metadata/specs/llm_export.py`**: Changed `kind: str | None` to `kinds: list[str] | None` in `to_llm_json()` and `_matches_filters()`. Single-value filtering becomes `spec.kind.value not in kinds` instead of `!= kind`.
- **`vultron/metadata/specs/render.py`**: Added `--kind` flag parsing to `main_llm_json` with comma-split, whitespace-strip, and validation against `SpecKind` enum values. Guards against missing value (`--kind` with no argument) with a clean error + exit 2.
- **`test/metadata/specs/test_llm_export.py`**: Updated `test_kind_filter` to use `kinds=["project"]`. Added `test_kinds_multi_filter`, `test_kinds_none_returns_all`, and a full `TestMainLlmJsonKindFlag` class covering single-kind, multi-kind, no-flag, invalid-kind, space-stripping, and missing-value edge cases.

## Verification

- 37 tests in `test/metadata/specs/test_llm_export.py` pass (9 new)
- 7172 unit tests pass, 1167 integration tests pass
- Black, flake8, mypy, pyright all clean