### PR TITLE
chore(dev): cap graphify AST workers at 4 by default

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -104,6 +104,7 @@ DOCKER_ARGS=(
     -e VULTRON_MAIN_NAME="$MAIN_NAME"
     -e WIP_NOTES=/app/wip_notes
     -e WIP_OUTPUTS=/app/wip_outputs
+    -e GRAPHIFY_MAX_WORKERS=4
     -v "${MAIN_NAME}-data:/home/vscode/.data"
     # NOTE: .devcontainer is NOT mounted. It is baked into the image and belongs
     # to the container's own working tree. Mounting the host copy over it made


### PR DESCRIPTION
## Summary

Sets `GRAPHIFY_MAX_WORKERS=4` in `start-dev.sh` so every slot container
limits parallel AST extraction to 4 cores instead of saturating all available
CPUs during multi-minute graphify runs.

## Changes

- **`start-dev.sh`**: adds `-e GRAPHIFY_MAX_WORKERS=4` to the `DOCKER_ARGS`
  array so the env var is injected at container creation time; no `setup.sh`
  re-run required on existing machines