### PR TITLE
impl: enforce ledger_payload_object_override producer/consumer contract (RSH-05-010 to RSH-05-014)

### DIFF
--- a/test/core/behaviors/case/nodes/test_lifecycle.py
+++ b/test/core/behaviors/case/nodes/test_lifecycle.py
@@ -24,6 +24,9 @@ from py_trees.common import Status
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge, BTExecutionResult
 from vultron.core.behaviors.case.nodes import CommitCaseLedgerEntryNode
+from vultron.core.behaviors.case.nodes.lifecycle import (
+    BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE,
+)
 from vultron.core.models.events.base import MessageSemantics
 from vultron.core.models.vultron_types import VultronCaseActor
 from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
@@ -347,3 +350,107 @@ def test_inner_commit_bt_failure_propagates(bridge):
 # (e.g., SvcAddNoteToCaseUseCase) after the activity is successfully
 # enqueued, and cleared in AnnounceLedgerEntryReceivedUseCase when the
 # matching Announce(CaseLedgerEntry) arrives — see SYNC-11-002/003.
+
+
+# ---------------------------------------------------------------------------
+# AC-2, AC-3, AC-4: ledger_payload_object_override producer/consumer contract
+# ---------------------------------------------------------------------------
+
+
+def _run_with_override(
+    bridge: BTBridge,
+    fields: dict,
+    producer_type: str | None,
+    object_id: str = "https://example.org/statuses/status-001",
+) -> Status:
+    """Run CommitCaseLedgerEntryNode with a pre-written ledger override on the blackboard."""
+
+    class _WriteOverride(py_trees.behaviour.Behaviour):
+        def __init__(self):
+            super().__init__(name="_WriteOverride")
+
+        def setup(self, **kwargs):
+            self.bb = self.attach_blackboard_client(name="_WriteOverride")
+            self.bb.register_key(
+                key=BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE,
+                access=py_trees.common.Access.WRITE,
+            )
+
+        def update(self) -> Status:
+            override = {"object_id": object_id, "fields": fields}
+            if producer_type is not None:
+                override["producer_type"] = producer_type
+            self.bb.set(
+                BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE, override, overwrite=True
+            )
+            return Status.SUCCESS
+
+    node = CommitCaseLedgerEntryNode(case_id=CASE_ID)
+    activity = _FakeActivity(
+        activity_id=object_id,
+        semantic_type=MessageSemantics.CREATE_CASE,
+        activity=_FakeWireActivityWithPayload(
+            {
+                "id": object_id,
+                "type": "Add",
+                "context": CASE_ID,
+                "object": {
+                    "id": object_id,
+                    "type": "ParticipantStatus",
+                    "rmState": "RECEIVED",
+                },
+            }
+        ),
+    )
+    seq = py_trees.composites.Sequence(
+        name="TestOverrideSeq",
+        memory=False,
+        children=[_WriteOverride(), node],
+    )
+    with patch(_INNER_BRIDGE_PATH) as mock_bridge_cls:
+        mock_bridge_cls.return_value.execute_with_setup.return_value = (
+            BTExecutionResult(status=Status.SUCCESS)
+        )
+        result = bridge.execute_with_setup(
+            tree=seq, actor_id=ACTOR_ID, activity=activity
+        )
+    return result.status
+
+
+class TestPayloadObjectOverrideContract:
+    """AC-2, AC-3, AC-4: producer/consumer contract for ledger_payload_object_override."""
+
+    def test_hard_fail_on_unrecognized_alias(self, bridge):
+        """AC-2/AC-4a: FAILURE when fields contains a key not in _SNAKE_TWINS (RSH-05-013)."""
+        status = _run_with_override(
+            bridge,
+            fields={"rmState": "VALID", "unknownAlias": "oops"},
+            producer_type="FilterParticipantStatusDimensionsNode",
+        )
+        assert status == Status.FAILURE
+
+    def test_warning_on_unknown_producer_type(self, bridge, caplog):
+        """AC-3/AC-4b: WARNING logged but commit proceeds when producer_type is unrecognized (RSH-05-014)."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            status = _run_with_override(
+                bridge,
+                fields={"rmState": "VALID"},
+                producer_type="SomeUnknownProducerNode",
+            )
+        assert status == Status.SUCCESS
+        assert any(
+            "unrecognized" in rec.message
+            and "SomeUnknownProducerNode" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_successful_commit_with_valid_fields(self, bridge):
+        """AC-4c: Commit succeeds when both fields and producer_type are valid."""
+        status = _run_with_override(
+            bridge,
+            fields={"rmState": "VALID", "vfdState": "VFd"},
+            producer_type="FilterParticipantStatusDimensionsNode",
+        )
+        assert status == Status.SUCCESS

--- a/test/core/behaviors/status/test_partial_accept_participant_status.py
+++ b/test/core/behaviors/status/test_partial_accept_participant_status.py
@@ -1023,3 +1023,36 @@ class TestRMGapAnomalyFlag:
         assert anomaly["anomaly_type"] == "regression"
         assert anomaly["from_rm"] == RM.ACCEPTED
         assert anomaly["to_rm"] == RM.RECEIVED
+
+
+# ---------------------------------------------------------------------------
+# RSH-05-011: producer_type in ledger_payload_object_override
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideIncludesProducerType:
+    """AC-1: FilterParticipantStatusDimensionsNode publishes producer_type (RSH-05-011)."""
+
+    def test_published_override_includes_producer_type(self, dl, make_payload):
+        """The override dict written to BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE must carry producer_type."""
+        current = _current_status(RM.VALID, CS_vfd.Vfd, CS_pxa.pxa)
+        asserted = _asserted_status(RM.RECEIVED, CS_vfd.VFd, CS_pxa.Pxa)
+        _seed_case(dl, current, asserted)
+
+        reader = py_trees.blackboard.Client(name="override-shape-reader")
+        reader.register_key(
+            key=BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE,
+            access=py_trees.common.Access.READ,
+        )
+
+        result = _run_tree(dl, asserted, ACTOR_ID, make_payload)
+        assert result.status == Status.SUCCESS
+
+        override = reader.get(BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE)
+        assert isinstance(
+            override, dict
+        ), "override must be a dict after partial accept"
+        assert (
+            override.get("producer_type")
+            == "FilterParticipantStatusDimensionsNode"
+        ), "RSH-05-011: producer_type must identify the producing node"

--- a/vultron/core/behaviors/case/nodes/lifecycle.py
+++ b/vultron/core/behaviors/case/nodes/lifecycle.py
@@ -37,6 +37,7 @@ from vultron.core.ports.case_persistence import (
     CasePersistence,
 )
 from vultron.core.use_cases._helpers import build_activity_payload_snapshot
+from vultron.errors import VultronValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,13 @@ _SNAKE_TWINS: dict[str, str] = {
     "emConsentState": "em_consent_state",
     "caseStatus": "case_status",
 }
+
+#: Producer class names recognized by the override consumer.  An override with
+#: an unrecognized ``producer_type`` still applies (RSH-05-014 is a warning,
+#: not a block); this set is an audit allowlist, not a security gate.
+_RECOGNIZED_OVERRIDE_PRODUCERS: frozenset[str] = frozenset(
+    {"FilterParticipantStatusDimensionsNode"}
+)
 
 
 def _merge_snapshot_object_fields(
@@ -244,6 +252,25 @@ class CommitCaseLedgerEntryNode(DataLayerAction):
         fields = override.get("fields")
         if not isinstance(fields, dict) or not fields:
             return None
+        # RSH-05-014: warn when producer_type is present but unrecognized.
+        producer_type = override.get("producer_type")
+        if (
+            producer_type is not None
+            and producer_type not in _RECOGNIZED_OVERRIDE_PRODUCERS
+        ):
+            self.logger.warning(
+                "%s: ledger_payload_object_override from unrecognized"
+                " producer '%s' — applying override (RSH-05-014)",
+                self.name,
+                producer_type,
+            )
+        # RSH-05-013: hard-fail on any unrecognized wire alias in fields.
+        unknown = set(fields) - set(_SNAKE_TWINS)
+        if unknown:
+            raise VultronValidationError(
+                f"ledger_payload_object_override contains unrecognized wire"
+                f" alias(es) {unknown!r} — fix the producer (RSH-05-013)"
+            )
         current = payload_snapshot.get("object")
         if not isinstance(current, dict):
             return None
@@ -306,9 +333,19 @@ class CommitCaseLedgerEntryNode(DataLayerAction):
         # Record the portion of the assertion the receiver accepts, when a
         # preceding guard adjudicated it (RSH-05).
         if payload_snapshot:
-            replacement = self._resolve_payload_object_override(
-                payload_snapshot
-            )
+            try:
+                replacement = self._resolve_payload_object_override(
+                    payload_snapshot
+                )
+            except VultronValidationError as exc:
+                self.logger.error(
+                    "%s: refusing ledger commit for case '%s':"
+                    " override validation failed: %s",
+                    self.name,
+                    case_id,
+                    exc,
+                )
+                return Status.FAILURE
             if replacement is not None:
                 payload_snapshot = dict(payload_snapshot)
                 payload_snapshot["object"] = replacement

--- a/vultron/core/behaviors/status/nodes/dimension_filter.py
+++ b/vultron/core/behaviors/status/nodes/dimension_filter.py
@@ -266,6 +266,7 @@ class FilterParticipantStatusDimensionsNode(DataLayerCondition):
             BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE,
             {
                 "object_id": self.status_id,
+                "producer_type": self.__class__.__name__,
                 "fields": _accepted_wire_patch(filtered),
             },
             overwrite=True,


### PR DESCRIPTION
- Closes #2432

## Summary

Implements the producer/consumer contract for `ledger_payload_object_override` (RSH-05-010 to RSH-05-014).

## Changes

- **`vultron/core/behaviors/status/nodes/dimension_filter.py`**: `FilterParticipantStatusDimensionsNode._publish()` now adds `"producer_type": self.__class__.__name__` to the `BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE` dict (AC-1 / RSH-05-011).
- **`vultron/core/behaviors/case/nodes/lifecycle.py`**: `_resolve_payload_object_override()` hard-fails (`raise VultronValidationError` → `Status.FAILURE`) when `fields` contains any key not in the `_SNAKE_TWINS` wire-alias allowlist (AC-2 / RSH-05-013); emits `WARNING` when `producer_type` is present but not in `_RECOGNIZED_OVERRIDE_PRODUCERS` without blocking the commit (AC-3 / RSH-05-014). Adds `_RECOGNIZED_OVERRIDE_PRODUCERS: frozenset[str]`.
- **`test/core/behaviors/case/nodes/test_lifecycle.py`**: `TestPayloadObjectOverrideContract` — (a) FAILURE on unrecognized alias, (b) SUCCESS + WARNING log on unknown `producer_type`, (c) SUCCESS on valid fields + valid `producer_type` (AC-4a/b/c).
- **`test/core/behaviors/status/test_partial_accept_participant_status.py`**: `TestOverrideIncludesProducerType` — end-to-end check that the live BT publishes `producer_type == "FilterParticipantStatusDimensionsNode"` (AC-1 end-to-end).

## Verification

- 7161 unit tests pass, 1167 integration tests pass
- Black, flake8, mypy, pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)