### PR TITLE
docs: retire Coordination Agent; introduce capability-shape taxonomy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,7 +29,7 @@ engagement: participants, embargo status, report management state, and the canon
 A participant in the Vultron protocol — a person, organization, or automated service that sends
 and receives protocol messages. Actors have persistent identities (URIs) and maintain their own
 DataLayer.
-*Avoid*: user, agent (in the protocol-participant sense; see Coordination Agent below)
+*Avoid*: user, agent (in the protocol-participant sense; see Capability Shapes below)
 
 **Case Actor**:
 A special-purpose service actor that owns the canonical ledger for a case, coordinates
@@ -43,49 +43,66 @@ vulnerability until a specified date or condition.
 
 ---
 
-## Coordination Agents
+## Capability Shapes
 
 Vultron's Behavior Trees include **call-out points** — locations where the protocol cannot
-proceed automatically and must request input from an external party. Coordination agents are
-the capabilities that answer those call-out points.
+proceed automatically and must request input from an external party. Capability shapes are
+abstract interface contracts that characterise how those call-out points interact with the
+protocol.
 
 **Call-out point**:
 A location in a Vultron workflow where the protocol cannot determine the correct next action
 on its own and must request input — a fact, a decision, or content — from an external party
-(a human, an agent, or an external system) before it can continue.
+(a human, a function, or an external system) before it can continue.
 *Avoid*: decision point (reserved for SSVC scoring trees), touchpoint, integration point
 
-**Coordination agent**:
-An external capability — a skill, a set of skills with light orchestration, or a human — that
-answers a call-out point. A coordination agent has a narrow responsibility, explicit inputs,
-and explicit outputs. No single coordination agent is responsible for managing an entire case.
-*Avoid*: agent (alone; too broad), uber-agent
+**Capability shape**:
+One of the five abstract interface contracts (Sentinel, Evaluator, Retriever, Composer,
+Actuator) that characterises the interaction pattern between a call-out point and the protocol.
+A capability shape does not prescribe the implementation — the implementation (function, human
+workflow, LLM agent) is a deployment-time decision.
+*Avoid*: Coordination Agent (retired; see ADR-0024)
 
-The four canonical shapes a coordination agent can take:
+**Capability**:
+A specific named call-out point with its own blackboard contract (e.g., `EvaluateReportCredibility`).
+A capability implements one capability shape for a particular domain context.
+
+**Capability implementation**:
+The factory backend fulfilling a capability at runtime. May be a Python function, a human
+workflow, a rules engine, or an LLM agent — any callable that honours the blackboard contract.
+
+The five canonical capability shapes:
 
 **Sentinel**:
-A coordination agent that monitors a condition and, when the condition is met, calls a Vultron
+A capability shape that monitors a condition and, when the condition is met, calls a Vultron
 trigger endpoint to initiate a protocol action. Sentinels are proactive — they loop or watch;
-they are not called by the protocol.
-*Avoid*: watcher, monitor (as standalone agent names)
+they are not called by the protocol. A Sentinel has no BT call-out point.
+*Avoid*: watcher, monitor (as standalone shape names)
 
 **Evaluator**:
-A coordination agent that is called by the protocol (or by an orchestrator) with a described
-situation and a set of options, and returns a structured recommendation or decision. The output
-shapes what the Behavior Tree does next.
-*Avoid*: advisor, scorer (these are valid sub-types but not the canonical type name)
+A capability shape that is called by the protocol with a described situation and a set of
+options, and returns a structured recommendation or decision. The output shapes what the
+Behavior Tree does next.
+*Avoid*: advisor, scorer (these are valid sub-types but not the canonical shape name)
 
 **Retriever**:
-A coordination agent that is called with a query and returns structured facts from an external
+A capability shape that is called with a query and returns structured facts from an external
 source — vendor records, CPE entries, EPSS scores, threat intel, asset inventory, or similar.
-The Retriever fetches what already exists; it does not generate new content.
+Boolean/binary results (yes/no queries) are also Retriever capabilities. The Retriever fetches
+what already exists; it does not generate new content.
 *Avoid*: lookup, fetcher
 
 **Composer**:
-A coordination agent that is called with context (case state, participants, prior decisions)
+A capability shape that is called with context (case state, participants, prior decisions)
 and generates a new content artifact — a notification draft, an advisory, a case summary, a
 participant invitation. The Composer produces something that did not exist before.
 *Avoid*: drafter, writer
+
+**Actuator**:
+A capability shape that receives a trigger and context, invokes an external system to cause a
+side effect (notification dispatch, state write, queue mutation, API call), and returns SUCCESS
+when the side effect is confirmed. Does not produce a content artifact on the blackboard.
+*Avoid*: executor, dispatcher (these are valid sub-types but not the canonical shape name)
 
 ---
 

--- a/docs/adr/0024-coordination-agent-taxonomy.md
+++ b/docs/adr/0024-coordination-agent-taxonomy.md
@@ -4,11 +4,11 @@ date: 2026-07-07
 deciders: [adh]
 ---
 
-# Coordination Agent Taxonomy
+# Capability Shape Taxonomy
 
 Vultron's Behavior Trees contain **call-out points** — locations where the
 protocol cannot determine the correct next action autonomously and must request
-input from an external party. We established a canonical taxonomy of agent
+input from an external party. We established a canonical taxonomy of capability
 shapes that answer those call-out points, and chose "call-out point" as the
 term for those locations. The taxonomy began with four shapes and was extended
 to five by the Actuator amendment (2026-07-07).
@@ -24,7 +24,7 @@ explicit (protocol → external party → protocol), implies the workflow pauses
 and waits for a response, and cleanly contrasts with *trigger endpoint* (the
 call-*in* surface where external parties invoke the protocol).
 
-### Canonical agent shapes
+### Canonical capability shapes
 
 | Shape | Role |
 | --- | --- |
@@ -33,9 +33,25 @@ call-*in* surface where external parties invoke the protocol).
 | **Retriever** | Receives a query; returns structured facts from an external source (including boolean/binary results — see below) |
 | **Composer** | Receives context; generates a new content artifact |
 
-These are a typology, not exactly singleton agents. A real coordination
-agent may embody one shape or combine shapes (e.g., a Participant Discovery
-agent composes Retriever + Evaluator).
+These are a typology of interface contracts, not implementations. A concrete
+capability may embody one shape or combine shapes (e.g., a Participant
+Discovery capability composes Retriever + Evaluator).
+
+### Three-level taxonomy
+
+The taxonomy operates at three levels of specificity:
+
+| Level | Term | Definition |
+| --- | --- | --- |
+| 1 | **Capability shape** | One of the five abstract interface contracts (Sentinel, Evaluator, Retriever, Composer, Actuator); characterises the interaction pattern without prescribing the implementation |
+| 2 | **Capability** | A specific named call-out point with its own blackboard contract (e.g., `EvaluateReportCredibility`); implements a capability shape for a particular domain context |
+| 3 | **Capability implementation** | The factory backend fulfilling a capability at runtime; may be a Python function, a human workflow, a rules engine, or an LLM agent |
+
+**"Coordination Agent" is retired.** The term implied a specific kind of
+implementor (an autonomous AI entity) when the shapes are actually abstract
+interface contracts. A capability implementation may be anything that honours
+the blackboard contract. The implementation choice is made at deployment time,
+not at design time.
 
 ### Amendment (2026-07-07): Fifth canonical shape — Actuator
 
@@ -51,7 +67,7 @@ considered and rejected — it would obscure the seam and complicate the
 abstraction layer design (ADR-0025 / issue #1151), which needs an invocation
 interface for Actuators, not a content-generation interface.
 
-A fifth shape is added:
+A fifth capability shape is added:
 
 | Shape | Role |
 | --- | --- |
@@ -69,30 +85,30 @@ The updated five-shape taxonomy:
 
 ### Message-Driven Responses excluded from the taxonomy
 
-An earlier draft included "message-driven responses" as an additional category of
-agent touchpoint. This was rejected: receiving a protocol message is handled
-by the protocol's inbox BT, not by a coordination agent. The relevant
-call-out point — if any — is the evaluation or decision node that fires
-*after* message receipt, which already falls under Evaluator or Retriever.
+An earlier draft included "message-driven responses" as an additional category.
+This was rejected: receiving a protocol message is handled by the protocol's
+inbox BT, not by a call-out point. The relevant call-out point — if any — is
+the evaluation or decision node that fires *after* message receipt, which
+already falls under Evaluator or Retriever.
 
-### Orchestrator deferred
+### Orchestrator deferred (moved to Agentic Participants epic)
 
-Whether **Orchestrator** constitutes an additional agent shape (an agent that
-sequences other agents toward a bounded goal) is unresolved. No concrete
-multi-agent sequencing requirement exists yet. The question is tracked in
-GitHub issue #1141 and will be revisited when two or more concrete agent
-instances exist and a workflow clearly needs to sequence them.
+Whether **Orchestrator** constitutes an additional capability shape (a
+capability that sequences other capabilities toward a bounded goal) is
+unresolved. However, an Orchestrator is more like an autonomous Actor with
+judgment than a narrow call-out point fulfiller — its design is tracked in
+the Agentic Participants epic (#2450, GitHub issue #1141) rather than here.
 
-### Boolean external queries are Retrievers, not Sentinels
+### Boolean external queries are Retriever capabilities, not Sentinels
 
 A Retriever returns structured facts from an external source in response to
 an on-demand query. A Sentinel monitors a condition over time and fires a
 trigger endpoint when that condition is met.
 
-A node that queries an external system synchronously and returns only a
-binary (yes/no) result is still a **Retriever**: a boolean is the simplest
-possible structured fact. The defining characteristic is the synchronous
-on-demand query pattern, not the richness of the returned data.
+A capability that queries an external system synchronously and returns only a
+binary (yes/no) result is still a **Retriever** capability: a boolean is the
+simplest possible structured fact. The defining characteristic is the
+synchronous on-demand query pattern, not the richness of the returned data.
 
 Nodes such as `MitigationDeployed`, `MitigationAvailable`, and `HaveExploit`
 fit the Retriever shape: they receive a query (implicitly, "is X the case?"),
@@ -108,6 +124,6 @@ protocol → query → external system.
 ### "Retriever" over "Data Retriever"
 
 The qualifier "Data" was dropped to achieve parallel naming with the other
-single-word role nouns (Sentinel, Evaluator, Composer). The definition in
+single-word shape nouns (Sentinel, Evaluator, Composer). The definition in
 `CONTEXT.md` makes clear that a Retriever returns structured external facts,
 not generated content — the qualifier is redundant.

--- a/docs/adr/0025-call-out-point-abstraction-layer.md
+++ b/docs/adr/0025-call-out-point-abstraction-layer.md
@@ -10,11 +10,11 @@ deciders: [adh]
 
 Vultron's Behavior Trees contain **call-out points** — nodes where the
 protocol cannot proceed autonomously and must request input from an external
-party (see ADR-0024 for the taxonomy of agent shapes). After FUZZ-01 through
+party (see ADR-0024 for the taxonomy of capability shapes). After FUZZ-01 through
 FUZZ-07 (#860–#866), each call-out point has a probabilistic fuzzer node as
 its stand-in. The fuzzer is not a permanent implementation: it is an adapter
 that will be replaced over time by real data lookups, policy evaluations, or
-coordination agents.
+capability implementations.
 
 Before those replacements can happen, the call-out points must be expressed
 as proper injection seams: the BT tree must be built so that the fuzzer is
@@ -37,9 +37,9 @@ pattern, factory-function conventions, and blackboard contract model?**
   or a real implementation — downstream nodes must be unaffected by the swap
 - Must keep simulation artifacts (`vultron/demo/fuzzer/`) out of
   `vultron/core/behaviors/` (BT-16-001)
-- Must be compatible with the four agent shapes from ADR-0024 (Sentinel,
-  Evaluator, Retriever, Composer), each of which has different input/output
-  semantics
+- Must be compatible with the five capability shapes from ADR-0024 (Sentinel,
+  Evaluator, Retriever, Composer, Actuator), each of which has different
+  input/output semantics
 - Must support partial replacement: a scenario can use real implementations
   for some call-out points and fuzzer backends for others in the same run
 
@@ -95,8 +95,8 @@ The concrete form:
    (or a mapping of factories) as a parameter with the fuzzer factory as
    the default. This is the canonical swap mechanism.
 
-5. The four agent shapes (Evaluator, Retriever, Sentinel, Composer from
-   ADR-0024) each define a **lifecycle pattern** — how the node reads
+5. The five capability shapes (Evaluator, Retriever, Sentinel, Composer, Actuator
+   from ADR-0024) each define a **lifecycle pattern** — how the node reads
    input from the blackboard, dispatches to the backend, and writes output
    back. Concrete call-out point nodes subclass the appropriate shape base
    class and declare their specific I/O keys and types. The shape base
@@ -112,7 +112,7 @@ The concrete form:
 - Good, because fuzzer backends maintain the same blackboard contract as
   real backends, making swap transparent to downstream nodes
 - Good, because the shape base classes document the lifecycle pattern for
-  each agent shape, making the code self-explanatory
+  each capability shape, making the code self-explanatory
 - Neutral, because tree builders gain new parameters (one per call-out
   point or a single registry mapping); this is a small API surface increase
 - Bad/uncertain, because the exact factory signature (positional args,
@@ -169,7 +169,7 @@ The concrete form:
 
 ## Validation
 
-- #1151 implemented one exemplar per agent shape (PR closed).  The factory
+- #1151 implemented one exemplar per capability shape (PR closed).  The factory
   injection pattern, shape mixin classes, and blackboard contract approach
   proved sound across all five ADR-0024 shapes.  ADR status advanced from
   `proposed` to `accepted`.
@@ -290,13 +290,13 @@ design question tracked as a separate type:Idea issue.
 
 ## More Information
 
-- ADR-0024: Coordination Agent Taxonomy (call-out point concept and the four
-  agent shapes)
-- `notes/coordination-agents.md`: design notes for coordination agents
+- ADR-0024: Capability Shape Taxonomy (call-out point concept and the five
+  capability shapes; three-level taxonomy: shape / capability / capability implementation)
+- `notes/coordination-agents.md`: design notes for the capability shapes model
   including the two integration surfaces (call-in vs. call-out)
 - `notes/call-out-configuration.md`: bundle/mode design decisions (2026-07-23)
 - `notes/bt-fuzzer-nodes.md` and sub-files: per-node catalog with automation
-  potential ratings and agent-shape classifications (completed by #1150)
+  potential ratings and capability-shape classifications (completed by #1150)
 - Implementation chain: #1150 (catalog update) → #1151 (exemplars) →
   #1152 (demo scenario wiring) → FUZZ-08d–08g (shape rollout)
 

--- a/docs/adr/0047-report-to-others-sentinel-over-inline-bt.md
+++ b/docs/adr/0047-report-to-others-sentinel-over-inline-bt.md
@@ -24,7 +24,7 @@ STOCHASTIC fuzzer stub provides.
 
 The design question is: **should party discovery and invitation be an inline
 tick-driven BT subtree, or should it be driven by an external Sentinel
-coordination agent?**
+capability?**
 
 ## Decision Drivers
 
@@ -35,7 +35,7 @@ coordination agent?**
   lookups or LLM evaluation is an inherently external, latency-variable
   operation — poorly suited to a tick-driven inline BT that must return
   quickly
-- The Sentinel coordination agent pattern (ADR-0024, issue #1143) explicitly
+- The Sentinel capability shape pattern (ADR-0024, issue #1143) explicitly
   covers "monitors a condition; when met, calls a trigger endpoint"; this is
   exactly the party-discovery model
 - The existing `create_report_to_others_tree` module (from #1311) has no
@@ -48,7 +48,7 @@ coordination agent?**
    Retriever implementations (CPE/NVD lookups) for `IdentifyX` factories so
    the loop executes against real data on every tick
 2. **External Sentinel** — replace the inline loop entirely; a Sentinel
-   coordination agent that runs periodically or event-triggered, inspects
+   capability that runs periodically or event-triggered, inspects
    the case, and calls `suggest-actor-to-case` for each uninvited candidate
 3. **Hybrid** — inline BT provides a single-pass Retriever seam (one
    call-out that returns all candidates at once); Sentinel calls this subtree;
@@ -57,7 +57,7 @@ coordination agent?**
 ## Decision Outcome
 
 Chosen option: **Option 2 — External Sentinel**, because it matches the
-coordination agent taxonomy (ADR-0024), avoids coupling external I/O latency
+capability shape taxonomy (ADR-0024), avoids coupling external I/O latency
 into the BT tick loop, and the downstream trigger cascade already handles the
 rest. No inline BT loop is needed.
 
@@ -67,7 +67,7 @@ removal (see `notes/bt-fuzzer-rm-reporting.md` § "Sentinel supersession note").
 
 ### Consequences
 
-- Good, because party discovery becomes a proper coordination agent — observable,
+- Good, because party discovery becomes a proper Sentinel capability — observable,
   auditable, and independently replaceable without changing the BT tree structure
 - Good, because the downstream suggest-actor-to-case cascade already works; no
   new BT machinery is required
@@ -81,11 +81,11 @@ removal (see `notes/bt-fuzzer-rm-reporting.md` § "Sentinel supersession note").
 
 ## More Information
 
-- ADR-0024: Coordination Agent Taxonomy (Sentinel pattern)
+- ADR-0024: Capability Shape Taxonomy (Sentinel pattern)
 - ADR-0026: CaseActor-Routed Actor Suggestion and Invitation Flow
 - ADR-0029: Notification Loop Collapse (Production Collapse 3)
-- Issue #1143: Sentinel coordination agent design (open)
-- Issue #1147: Coordination Agents epic
+- Issue #1143: Sentinel capability shape design (open)
+- Issue #1147: Capability Shapes epic
 - Issue #1252: Idea planning session that surfaced this decision (closed)
 - `notes/bt-fuzzer-rm-reporting.md` § "Sentinel supersession note"
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -93,7 +93,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0021 CaseActor Inbox Routing as the Sole Path to Canonical Ledger Entries](0021-caseactor-inbox-routing-canonical-ledger.md)
 - [ADR-0022 Single BT Execution Per Inbox Delivery for Received-Side CaseActor Routing](0022-single-bt-execution-for-received-side-case-actor-routing.md)
 - [ADR-0023 Introduce `CaseProposal` for Distributed Case Actor Initialization](0023-case-proposal-protocol.md)
-- [ADR-0024 Coordination Agent Taxonomy](0024-coordination-agent-taxonomy.md)
+- [ADR-0024 Capability Shape Taxonomy](0024-coordination-agent-taxonomy.md)
 - [ADR-0025 Call-Out Point Abstraction Layer: Factory-Based Injection with Typed Backends](0025-call-out-point-abstraction-layer.md)
 - [ADR-0026 CaseActor-Routed Actor Suggestion and Invitation Flow](0026-caseactor-routed-actor-suggestion.md)
 - [ADR-0027 Exploit-Strategy Subtree Collapse: Five Simulator Nodes → EvaluateExploitStrategy](0027-exploit-strategy-bt-collapse.md)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -196,13 +196,15 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 | **Protocol-Significant Behavior** | Any action that affects protocol-observable state (emitting an **Activity**, transitioning RM/EM/CS, cascading consequences); MUST be implemented as BT nodes/subtrees, never as procedural code outside the tree | Domain logic, tree-resident behavior |
 | **Cascading Consequences** | Automated downstream behaviors triggered by primary protocol events via BT subtrees; examples include submit-report → case creation → participant setup → embargo initialization → notifications (anti-pattern: post-BT procedural calls) | Event cascade, automation chain |
 | **Call-Out Point** | A BT node location where automated protocol execution cannot proceed without external input from a human, skill, or LLM agent; implemented as a **Fuzzer Node** stub in the simulator layer | Decision point, human-in-the-loop seam |
-| **Fuzzer Node** | A stub BT node in the legacy simulation (`vultron/bt/`) that stands in for unimplemented real-world decision logic by returning probabilistic SUCCESS/FAILURE; each represents a **Call-Out Point** awaiting a real **Coordination Agent** | Stub node, random node |
-| **Coordination Agent** | An external capability (human, skill, or LLM agent) that fulfills a **Call-Out Point** by providing a decision, data, or content; five subtypes: **Sentinel**, **Evaluator**, **Retriever**, **Composer**, **Actuator** | External agent, decision agent |
-| **Sentinel** | A **Coordination Agent** subtype that checks external state and returns SUCCESS/FAILURE without side effects; used as a BT precondition guard | Guard agent, check agent |
-| **Evaluator** | A **Coordination Agent** subtype that makes a domain decision and records it (e.g., `ReviewAdvisoryDraft`); its `update()` method gates downstream BT execution | Decision agent, reviewer agent |
-| **Retriever** | A **Coordination Agent** subtype that fetches external data needed by the BT (e.g., CVE ID lookup, SSVC scoring) | Fetch agent, lookup agent |
-| **Composer** | A **Coordination Agent** subtype that assembles content from domain state (e.g., drafting advisory text) | Generator agent, authoring agent |
-| **Actuator** | A **Coordination Agent** subtype that invokes an external system to cause a side effect (notification dispatch, state write, queue mutation, API call); returns SUCCESS when the side effect is confirmed, FAILURE otherwise; produces no content artifact | Side-effect agent, executor |
+| **Fuzzer Node** | A stub BT node in the legacy simulation (`vultron/bt/`) that stands in for unimplemented real-world decision logic by returning probabilistic SUCCESS/FAILURE; each represents a **Call-Out Point** awaiting a real **capability** | Stub node, random node |
+| **Capability shape** | One of five abstract interface contracts that characterise how a **Call-Out Point** interacts with the protocol; describes the interaction pattern without prescribing the implementation. A concrete **capability** may be a function, a human workflow, or an LLM agent. The five shapes are **Sentinel**, **Evaluator**, **Retriever**, **Composer**, and **Actuator**. See ADR-0024. | Coordination Agent (deprecated) |
+| **Capability** | A specific named call-out point with its own blackboard contract (input keys, output keys, and types); implements a **capability shape** for a particular domain context. Example: `EvaluateReportCredibility` is an Evaluator capability. | Call-out node, capability instance |
+| **Capability implementation** | The factory backend fulfilling a **capability** at runtime; may be a Python function, a human workflow, a rules engine, or an LLM agent. The implementation choice is made at deployment time, not at design time. | Backend, factory backend |
+| **Sentinel** | A **capability shape** that monitors a condition over time; when the condition is met, calls a Vultron trigger endpoint. Operates on the call-in surface — it has no BT call-out point. | Guard agent, check agent |
+| **Evaluator** | A **capability shape** that receives a situation and returns a structured recommendation or decision (e.g., `ReviewAdvisoryDraft`); its output gates downstream BT execution | Decision agent, reviewer agent |
+| **Retriever** | A **capability shape** that receives a query and returns structured external facts (e.g., CVE ID lookup, SSVC scoring); also used for binary yes/no external queries | Fetch agent, lookup agent |
+| **Composer** | A **capability shape** that receives context and generates a new content artifact (e.g., drafting advisory text); output is written to the blackboard | Generator agent, authoring agent |
+| **Actuator** | A **capability shape** that receives a trigger and invokes an external system to cause a side effect (notification dispatch, state write, queue mutation, API call); returns SUCCESS when the side effect is confirmed, FAILURE otherwise; produces no content artifact | Side-effect agent, executor |
 | **StatusAdoptionGate** | A BT authorization gate that determines whether a received **CaseStatus** update should be adopted by the receiving actor; guards the `add_participant_status_tree` path for received-side status canonicalization (ADR-0046). | Seam 1, StatusUpdateGuard |
 | **EmbargoTeardownAuthorizationGate** | A BT authorization gate that determines whether an incoming status update should trigger **Embargo** teardown; guards the `add_case_status_tree` path alongside `ThreatTerminationBranchNode` for received-side CaseStatus canonicalization (ADR-0046). | Seam 2, SideEffectsGuard |
 | **GuardedCommit** | A Behavior Tree subtree pattern that gates case ledger entry persistence on a CASE_MANAGER role check, ensuring only the actor holding the CASE_MANAGER role commits entries to the canonical log. | — |
@@ -227,7 +229,7 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 | **Observer** | A **CVDRole** value (`CVDRole.OBSERVER`) representing a case participant with no vendor-fix-deployment obligations; the base role — lowest non-null privilege set — admitted via standard Invite/Accept (CM-25). Formerly `CVDRole.OTHER`; renamed in ADR-0057. A participant holding OBSERVER alongside VENDOR or DEPLOYER retains VFD obligations from those roles (CM-26). | Watcher, monitor, OTHER (deprecated) |
 | **Dimension Object** | A small immutable `BaseModel` capturing the state of exactly one state machine (RM, EM, VFD, or PXA) at a point in time; replaces flat fields in `CaseStatus`/`ParticipantStatus` per ADR-0036 | Status sub-object, state fragment |
 | **Advisory** | A public disclosure document summarizing a vulnerability's details, remediation, and affected parties; produced by the publication pipeline via a Draft → Review → Submit sequence | Security advisory, disclosure document, bulletin |
-| **Advisory Review Decision** | A record produced by a **Reviewer** (Evaluator-type **Coordination Agent**) capturing whether an **Advisory** draft needs revision; the `needs_revision` flag gates the BT pipeline; to block submission for any reason, the Evaluator MUST return `Status.FAILURE` (BT-18-007) | Review result, review outcome |
+| **Advisory Review Decision** | A record produced by a **Reviewer** (Evaluator **capability**) capturing whether an **Advisory** draft needs revision; the `needs_revision` flag gates the BT pipeline; to block submission for any reason, the Evaluator MUST return `Status.FAILURE` (BT-18-007) | Review result, review outcome |
 | **Publication Intent** | A domain object recording a participant's decision about *how* and *when* to disclose a vulnerability (e.g., which advisory platform, embargo exit condition); gates the BT publish pipeline | Disclosure intent, publish intent |
 | **CVDRolesFlag** | Legacy bitmask-based Flag enum using bitwise arithmetic to represent combined roles; retained for backward compatibility with the `vultron.bt` simulator layer only; **do not use in new code** — use `list[CVDRole]` instead | Bitmask roles, legacy roles |
 | **CASE_OWNER** | A **CVDRole** value marking a participant as the human decision-maker who owns and administers the VulnerabilityCase (BTND-05-001); distinct from CASE_MANAGER which is the service actor | Owner role |
@@ -421,12 +423,12 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 - A **Participant** has zero or more **CVDRoles** (represented as `list[CVDRole]`).
 - A **BT Node** reads from and writes to the **Blackboard** and may emit **Outbound Activities**.
 
-**Call-Out Points and Coordination:**
+**Call-Out Points and Capability Shapes:**
 
 - A **Fuzzer Node** in the simulator is the placeholder form of a **Call-Out Point**.
-- A **Call-Out Point** is fulfilled in production by a **Coordination Agent** of the appropriate subtype.
-- A **Sentinel** answers a yes/no check; an **Evaluator** records a domain decision; a **Retriever** fetches external data; a **Composer** generates content; an **Actuator** fires a side effect in an external system.
-- An **Advisory Review Decision** is produced by a **Reviewer** (an **Evaluator** subtype) and determines whether an **Advisory** draft requires revision before the BT submits it.
+- A **Call-Out Point** is fulfilled in production by a **capability** of the appropriate **capability shape**.
+- A **Sentinel** monitors a condition and fires a trigger; an **Evaluator** records a domain decision; a **Retriever** fetches external data; a **Composer** generates content; an **Actuator** fires a side effect in an external system.
+- An **Advisory Review Decision** is produced by a **Reviewer** (an Evaluator **capability**) and determines whether an **Advisory** draft requires revision before the BT submits it.
 
 **Status and Dimensions:**
 
@@ -513,14 +515,14 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 
 16. **"Call-Out Point" vs. "Fuzzer Node"**:
      - A **Call-Out Point** is the abstract concept — a BT location requiring external input.
-     - A **Fuzzer Node** is the concrete simulator-layer stub that occupies that location until a real **Coordination Agent** is wired in.
+     - A **Fuzzer Node** is the concrete simulator-layer stub that occupies that location until a real **capability** is wired in.
      - **Recommendation**: Use "**Call-Out Point**" when discussing design or integration seams; use "**Fuzzer Node**" only when discussing the simulator implementation.
 
-17. **"Composer" vs. "Actuator"**:
+17. **"Composer" vs. "Actuator"** (capability shape classification):
      - A **Composer** reads context, runs a generation process, and writes a content artifact to the blackboard (e.g., advisory draft text).
      - An **Actuator** receives a trigger, calls an external system, and confirms the side effect; no artifact is placed on the blackboard.
-     - Misclassification risk: nodes that "do something" to an external system look like Composers if you only notice they dispatch outbound calls. The discriminator is whether a content artifact lands on the blackboard. If not, it is an **Actuator**.
-     - **Recommendation**: Before classifying a node as Composer, verify it writes a content artifact to the blackboard. If the only output is a SUCCESS/FAILURE confirming an external side effect, it is an **Actuator**.
+     - Misclassification risk: nodes that "do something" to an external system look like Composers if you only notice they dispatch outbound calls. The discriminator is whether a content artifact lands on the blackboard. If not, it is an **Actuator** capability shape.
+     - **Recommendation**: Before classifying a node as Composer, verify it writes a content artifact to the blackboard. If the only output is a SUCCESS/FAILURE confirming an external side effect, it is an **Actuator** capability shape.
 
 18. **"Dimension Object" vs. "status field"**:
      - A **Dimension Object** (per ADR-0036) is an immutable `BaseModel` containing the state of one machine; it is a first-class structured type, not a flat field.
@@ -618,27 +620,27 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 > organization deployed the fix. You update your model of the **Case State** and potentially make your
 > own decisions based on that new information."
 
-### Call-Out Points and Coordination Agents Example
+### Call-Out Points and Capability Shapes Example
 
 > **Developer:** "The BT has a `ReviewAdvisoryDraft` node — what actually runs there?"
 >
 > **Domain Expert:** "That's a **Call-Out Point**. In the simulator it's a **Fuzzer Node** that
-> returns SUCCESS or FAILURE probabilistically. In production you wire in a **Coordination Agent** —
-> an **Evaluator** subtype — that reviews the draft and records an **Advisory Review Decision**."
+> returns SUCCESS or FAILURE probabilistically. In production you wire in an Evaluator
+> **capability** — that reviews the draft and records an **Advisory Review Decision**."
 >
 > **Developer:** "What does the BT read from that decision? Just `needs_revision`?"
 >
 > **Domain Expert:** "Yes. If `needs_revision=True`, the pipeline routes to the revision arm before
 > submit. If you want to block outright without requesting edits — say, a legal hold — your
-> **Evaluator** returns `FAILURE` directly from `update()`. That's the universal BT blocking idiom
+> Evaluator returns `FAILURE` directly from `update()`. That's the universal BT blocking idiom
 > (BT-18-007)."
 >
 > **Developer:** "And if there's no human reviewer yet, we just leave the **Fuzzer Node** in place?"
 >
 > **Domain Expert:** "Right. The **Fuzzer Node** is the stub — it keeps the BT runnable without a
-> real **Coordination Agent**. When you're ready, you replace it with a **Retriever** that fetches
-> reviewer feedback, or an **Evaluator** backed by an LLM, or a **Sentinel** that checks an
-> external approval queue."
+> real capability wired in. When you're ready, you replace it with a Retriever capability that
+> fetches reviewer feedback, or an Evaluator backed by an LLM, or a Sentinel capability that
+> checks an external approval queue."
 
 ### Dimension Objects and Status Example
 

--- a/notes/README.md
+++ b/notes/README.md
@@ -354,7 +354,7 @@ needs external input (data, a decision, or content). This file explains the
 entry format, automation potential categories, and the fuzzer base-type
 probability table, then indexes the per-domain sub-files.
 **Load when**: understanding what fuzzer nodes are and why they exist; mapping
-fuzzer nodes to coordination agent types; jump directly to a sub-file for the
+fuzzer nodes to capability shapes; jump directly to a sub-file for the
 actual catalog entries.
 
 **`bt-fuzzer-nodes-vul-discovery.md`**
@@ -747,15 +747,15 @@ CM-21-006, CM-21-007), auditing transfer routing in demos, or understanding
 why the CaseActor must be the intermediary for ownership transfers.
 
 **`coordination-agents.md`**
-Design guidance for coordination agents — external capabilities (human, skill,
-or LLM agent) that answer Vultron call-out points. Covers the two-surface
-integration model (trigger endpoints = call-in; call-out points = call-out),
-the four agent type patterns (Sentinel, Evaluator, Retriever, Composer), the
-trust/execution-authority axis, composite agent design, and the fuzzer-node
-discovery methodology.
-**Load when**: designing a new coordination agent or call-out point integration,
-working on the fuzzer-to-agent replacement roadmap, or explaining the
-coordination agent concept to new contributors.
+Design guidance for capability shapes — the five abstract interface contracts
+(Sentinel, Evaluator, Retriever, Composer, Actuator) that answer Vultron
+call-out points. Covers the two-surface integration model (trigger endpoints =
+call-in; call-out points = call-out), the three-level taxonomy (shape /
+capability / capability implementation), the trust/execution-authority axis,
+composite capability design, and the fuzzer-node discovery methodology.
+**Load when**: designing a new capability or call-out point integration,
+working on the fuzzer-to-capability replacement roadmap, or explaining the
+capability shape concept to new contributors.
 
 **`agents-md-structure.md`**
 Routing policy for `AGENTS.md` content: the decision tree for whether new

--- a/notes/bt-fuzzer-nodes.md
+++ b/notes/bt-fuzzer-nodes.md
@@ -62,7 +62,7 @@ Each fuzzer node entry in the sub-files has these fields:
   in the py_trees-based prototype (added in FUZZ-08a / PR #1179); N/A for
   simulation-only nodes not ported to the new architecture
 - **Call-out point shape**: Evaluator, Retriever, Sentinel, Composer, or
-  ProtocolInternal — per the agent shape taxonomy in
+  ProtocolInternal — per the capability shape taxonomy in
   `docs/adr/0024-coordination-agent-taxonomy.md` (added in FUZZ-08a / PR
   #1179; reclassified in issue #1188). Use `ProtocolInternal` only for
   nodes that are terminal placeholders or structural composites with no

--- a/notes/bt-fuzzer-rm-closure.md
+++ b/notes/bt-fuzzer-rm-closure.md
@@ -132,7 +132,7 @@ type. No vocabulary change is needed.
 
 ### Close Readiness Monitoring (future — epic #1147 / #1143)
 
-When a future Sentinel coordination agent is implemented, the intended pattern
+When a future Sentinel capability is implemented, the intended pattern
 is:
 
 1. A Sentinel observes protocol state for objective preconditions (e.g.,
@@ -149,8 +149,8 @@ The Sentinel fires into `OtherCloseCriteriaMet` seam in
 `create_close_report_tree`; the Case Owner's subsequent `Leave` flows through
 `create_close_case_trigger_tree` as usual.
 
-Track under epic #1147 (Coordination Agents), linked to #1143 (Sentinel
-agent type).
+Track under epic #1147 (Capability Shapes), linked to #1143 (Sentinel
+capability shape).
 
 ---
 

--- a/notes/bt-fuzzer-rm-reporting.md
+++ b/notes/bt-fuzzer-rm-reporting.md
@@ -541,7 +541,7 @@ no real implementation path. The `SuggestXTrigger` factories fire
 only the stub provides in STOCHASTIC mode.
 
 **The correct production model** (resolved during #1252 planning): the party
-identification and invitation step belongs in a **Sentinel coordination agent**
+identification and invitation step belongs in a **Sentinel capability**
 (see #1147 / #1143) that:
 
 1. Periodically or event-triggered inspects the case for actors who are known

--- a/notes/coordination-agents.md
+++ b/notes/coordination-agents.md
@@ -1,10 +1,11 @@
 ---
-title: Coordination Agents Design Notes
+title: Capability Shapes Design Notes
 status: active
 description: >
-  Design guidance for coordination agents — external capabilities (human, skill, or
-  LLM agent) that answer Vultron call-out points. Covers the two-surface integration
-  model, agent type patterns, trust/execution authority, and composite agent design.
+  Design guidance for capability shapes — the five abstract interface contracts that
+  characterise how call-out points interact with the protocol. Covers the three-level
+  taxonomy (shape / capability / capability implementation), the two-surface integration
+  model, shape patterns, trust/execution authority, and composite capability design.
 related_notes:
   - notes/bt-fuzzer-nodes.md
   - notes/bt-integration.md
@@ -17,16 +18,17 @@ relevant_packages:
   - vultron/core/behaviors
 ---
 
-# Coordination Agents Design Notes
+# Capability Shapes Design Notes
 
 Vultron's Behavior Trees contain **call-out points** — nodes where the protocol
 cannot determine the correct next action autonomously and must request external
-input before it can continue. Coordination agents are the capabilities that
-answer those call-out points.
+input before it can continue. The five **capability shapes** characterise the
+interface contracts that answer those call-out points.
 
-See `CONTEXT.md` § Coordination Agents for the canonical definitions of
-*call-out point*, *Sentinel*, *Evaluator*, *Retriever*, *Composer*, and *Actuator*.
-See ADR-0024 for the decisions behind that taxonomy.
+See `CONTEXT.md` § Capability Shapes for the canonical definitions of
+*call-out point*, *capability shape*, *Sentinel*, *Evaluator*, *Retriever*,
+*Composer*, and *Actuator*.
+See ADR-0024 for the decisions behind the taxonomy.
 
 ---
 
@@ -34,7 +36,7 @@ See ADR-0024 for the decisions behind that taxonomy.
 
 Vultron has two distinct surfaces where external capabilities connect to the
 protocol. Understanding which surface you are working with is the first step
-in any coordination agent design.
+in any capability shape design.
 
 ### Trigger endpoints (call-in surface)
 
@@ -76,7 +78,7 @@ called from the call-out surface.
 
 Every fuzzer node in `vultron/demo/fuzzer/` is a **known call-out point
 candidate**. Fuzzer nodes make randomized choices precisely because the real
-decision logic has not been identified or implemented. Each one represents
+capability logic has not been identified or implemented. Each one represents
 an open question: "What information should actually drive this choice?"
 
 ### Discovery methodology
@@ -85,7 +87,7 @@ For each fuzzer node, ask:
 
 1. What decision or fact is actually needed here?
 2. Is the answer deterministic given data already in the case (no external call)?
-   → ProtocolInternal (no coordination agent required)
+   → ProtocolInternal (no capability needed)
 3. Does it require data from an external system (including binary queries)?
    → **Retriever** call-out point
 4. Does it require judgment/evaluation? → **Evaluator** call-out point
@@ -99,13 +101,13 @@ For each fuzzer node, ask:
 The fuzzer node's `Input category` docstring annotation
 (`Human decision`, `Environmental check`, `System integration`, etc.) and
 `Automation potential` rating (`High` / `Medium` / `Low`) give a starting
-assessment. `High` automation potential with `Environmental check` = no agent
-needed. `Low` automation potential with `Human decision` = Evaluator (or
-human) call-out point.
+assessment. `High` automation potential with `Environmental check` = no
+capability needed. `Low` automation potential with `Human decision` = Evaluator
+(or human) call-out point.
 
 ---
 
-## Agent Type Integration Patterns
+## Capability Shape Integration Patterns
 
 ### Sentinel
 
@@ -196,9 +198,9 @@ integration hooks when protocol state transitions occur.
 ## Trust / Execution Authority
 
 Whether an Evaluator's recommendation is immediately acted on (auto-execute)
-or presented for human confirmation (advisory mode) is **orthogonal to agent
-type**. The same Evaluator implementation can run in either mode depending on
-deployment configuration.
+or presented for human confirmation (advisory mode) is **orthogonal to
+capability shape**. The same Evaluator implementation can run in either mode
+depending on deployment configuration.
 
 This means the BT call-out point should be designed to handle both modes:
 
@@ -216,10 +218,10 @@ recommendation accepted as-is / overridden) enables this trust-building.
 
 ---
 
-## Composite Agent Pattern
+## Composite Capability Pattern
 
-Some coordination tasks require more than one agent type. The worked example
-from the session design is **Participant Discovery** (issue #1142):
+Some coordination tasks require more than one capability shape. The worked
+example from the session design is **Participant Discovery** (issue #1142):
 
 1. **Retriever** phase — search CPE data, supply chain graphs, product
    documentation, web sources, and GitHub for indicators that a vendor or
@@ -230,14 +232,15 @@ from the session design is **Participant Discovery** (issue #1142):
    for similar past cases so future cases can bootstrap from prior experience.
    Bias toward overnotification; adds are more important than deletes.
 
-A composite agent coordinates these steps internally. Its external interface
-remains a single call-out point: input is case context, output is a
+A composite capability coordinates these steps internally. Its external
+interface remains a single call-out point: input is case context, output is a
 recommended participant set. The internal Retriever + Evaluator structure is
 an implementation detail.
 
 This pattern — a bounded, single-purpose workflow that composes two or more
-agent types — is the appropriate scope for a coordination agent. It is NOT
-the same as an "uber-agent" that manages an entire case.
+capability shapes — is the appropriate scope for a composite capability. It is
+NOT the same as an autonomous Actor that manages an entire case (see the
+Agentic Participants epic, #2450).
 
 ---
 
@@ -288,7 +291,7 @@ Blackboard contract requirements are specified in
 
 ### Shape base classes
 
-Each of the five agent shapes (Evaluator, Retriever, Sentinel, Composer, Actuator)
+Each of the five capability shapes (Evaluator, Retriever, Sentinel, Composer, Actuator)
 defines a **lifecycle pattern** for how the node reads input, dispatches, and
 writes output. Concrete call-out point nodes subclass the appropriate shape
 base class. The shape base class is NOT a generic reusable class; it
@@ -316,7 +319,7 @@ four shapes that appear at call-out points.
 
 ```text
 #1150 — Update catalog: add cross-refs (vultron/bt/ → demo/fuzzer/) +
-         agent-shape classification per node [DONE]
+         capability-shape classification per node [DONE]
 
 #1151 — Design exemplar: one call-out point per shape [DONE]
          Delivered:

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -745,7 +745,7 @@ groups:
   - id: BT-20-003
     priority: SHOULD
     kind: project
-    statement: The production report-to-others workflow SHOULD be driven by a Sentinel coordination agent that proactively
+    statement: The production report-to-others workflow SHOULD be driven by a Sentinel capability that proactively
       queries the case for actors who are not yet participants but should be (party discovery), then fires `suggest-actor-to-case`
       for each candidate. The `suggest-actor-to-case` protocol (Offer → CaseActor → CaseOwner → Invite → Accept → Record
       cascade) handles the downstream flow; no inline tick-driven BT loop is needed at the outer level. If an inline subtree
@@ -756,7 +756,7 @@ groups:
       The original Production Collapse 3 design (#1311, ADR-0029) retained a three-typed-sub-loop BT structure whose
       inner blackboard queues (identified_vendors, identified_coordinators, identified_others) had no production
       mechanism to populate them. Planning of #1252 surfaced that the identification step belongs in a Sentinel
-      coordination agent (see #1147/#1143) that periodically or event-triggered inspects the case and asynchronously
+      capability (see #1147/#1143) that periodically or event-triggered inspects the case and asynchronously
       fires suggest-actor-to-case for each uninvited candidate. The downstream accept/invite/bootstrap cascade already
       works; no inline BT loop is required. The tick-driven `create_report_to_others_tree` module from #1311 is an
       implementation artifact of the intermediate design and is tracked for removal in a follow-on Task (see
@@ -992,7 +992,7 @@ groups:
     statement: The domain bundle dataclass and its DETERMINISTIC singleton (e.g., `VALIDATION_DETERMINISTIC`) MUST be
       defined in the core layer (`vultron/core/behaviors/call_out/bundles/<domain>.py`).
     rationale: The DETERMINISTIC bundle is the production-usable happy-path backend a real actor uses before a
-      coordination agent is wired in, so a core tree builder must resolve its default without reaching into the
+      capability implementation is wired in, so a core tree builder must resolve its default without reaching into the
       simulation layer. Locating it in vultron/demo/ inverts the core→demo dependency (corrects the original
       2026-07-23 amendment).
   - id: BT-23-009


### PR DESCRIPTION
- Closes #2449

## Summary

Retires the term **Coordination Agent** and introduces a three-level capability
taxonomy (capability shape → capability → capability implementation) across all
docs, notes, and specs.

## Changes

- **`CONTEXT.md`**: § "Coordination Agents" renamed to § "Capability Shapes"; adds
  `Capability`, `Capability implementation`, and `Actuator` entries; retires
  `Coordination Agent`
- **`docs/adr/0024-coordination-agent-taxonomy.md`**: retitled to "Capability Shape
  Taxonomy"; three-level taxonomy added; `Coordination Agent` retired with rationale
- **`docs/adr/0025-call-out-point-abstraction-layer.md`**: vocabulary updated to
  "capability shapes" throughout; Actuator added to shape count
- **`docs/adr/0047-report-to-others-sentinel-over-inline-bt.md`**: "coordination
  agent" → "Sentinel capability" / "capability shape"
- **`docs/adr/index.md`**: ADR-0024 entry title updated
- **`docs/reference/glossary.md`**: `Coordination Agent` entry removed; `Capability
  shape`, `Capability`, `Capability implementation` entries added; shape entries
  revised to "A capability shape that…"
- **`notes/coordination-agents.md`**: retitled to "Capability Shapes Design Notes";
  three-level taxonomy documented throughout
- **`notes/bt-fuzzer-rm-closure.md`**: "Sentinel coordination agent" → "Sentinel
  capability"
- **`notes/bt-fuzzer-rm-reporting.md`**: "Sentinel coordination agent" → "Sentinel
  capability"
- **`notes/bt-fuzzer-nodes.md`**: "agent shape taxonomy" → "capability shape taxonomy"
- **`notes/README.md`**: description of `coordination-agents.md` updated
- **`specs/behavior-tree-integration.yaml`**: "Sentinel coordination agent" →
  "Sentinel capability"; "coordination agent" → "capability implementation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)