### PR TITLE
docs: wire ISSUE-2256 to RSH-05-010–014 producer contract

### DIFF
--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -92,7 +92,9 @@ DataLayer (CLP-10-006), so it can run before `GuardedCommitOrSkip` and the
 canonical entry snapshots the accepted portion rather than the raw claim.
 
 `em` is deliberately **not** adjudicated here — embargo state belongs to EmbargoTeardownAuthorizationGate
-(ISSUE-2256).
+(ISSUE-2256). The EM adjudication node introduced by ISSUE-2256 will be a second producer of
+`ledger_payload_object_override`; ISSUE-2256's body documents the required producer contract
+(RSH-05-010 through RSH-05-014).
 
 Two blackboard keys carry the handoff. Both are written on *every* tick (with
 `None` when nothing was filtered) and matched by object ID on read, because the


### PR DESCRIPTION
- Closes #2433

## Summary

Updates `notes/received-status-authorization.md` to explicitly note that
the EM adjudication node introduced by ISSUE-2256 will be a second producer
of `ledger_payload_object_override`, and that ISSUE-2256's body carries the
required producer contract (RSH-05-010 through RSH-05-014).

Also updates ISSUE-2256's body directly (via GitHub API) to add an
"Implementation note" section that enumerates RSH-05-010 through RSH-05-014
with their obligations, satisfying AC-1.

## Changes

- **`notes/received-status-authorization.md`**: extends the sentence
  at the `em` adjudication paragraph to cross-reference ISSUE-2256 as the
  second `ledger_payload_object_override` producer and point implementers
  to RSH-05-010–014 in the issue body.