### PR TITLE
docs: plan concern #2327 — GHA matrix boolean coercion pitfall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -789,6 +789,27 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   "there are 4 unimplemented nodes" or "15 xfails" — these are stale snapshots.
   See MS-16-001 and [notes/specs-vs-adrs.md](notes/specs-vs-adrs.md).
   *Source: CONCERN-2277*
+- **GHA Matrix Boolean Fields Fail Differently at Job-Level vs. Step-Level `if:`**
+  — two distinct failure modes when a boolean field from the matrix (e.g.
+  `full_suite_only: false`) is referenced in a GitHub Actions `if:` expression:
+  (1) **Job-level `if:`**: the `matrix` context does not exist yet — GitHub
+  evaluates job-level `if:` conditions *before* expanding the matrix. The
+  workflow is rejected with a startup failure: zero jobs scheduled, no logs, no
+  per-job status, and the run name is reported as the file path. The failure
+  reads as noise, not a regression (DEMOCI-06-004, ISSUE-2118).
+  (2) **Step-level `if:`**: the `matrix` context IS available, but GitHub
+  coerces JSON boolean `false` to the string `"false"`. The comparison
+  `matrix.full_suite_only == false` then always evaluates to `false` because a
+  string never equals a boolean, silently defeating the intended filter
+  (CONCERN-2327).
+  Fix for both: resolve the boolean filter *before* matrix expansion using a
+  dedicated `scenarios` job that calls `jq 'select(.full_suite_only == false)'`
+  on the JSON source and exposes a filtered matrix as a job output. Both
+  downstream jobs expand `fromJSON()` of that output — the boolean comparison
+  lives in `jq`, which understands JSON natively. See DEMOCI-06-004,
+  DEMOCI-06-007, DEMOCI-06-008 and
+  [notes/demo-ci-scenario-coverage.md](notes/demo-ci-scenario-coverage.md).
+  *Source: CONCERN-2327, ISSUE-2118*
 
 ---
 

--- a/plan/history/2608/learning/CONCERN-2327.md
+++ b/plan/history/2608/learning/CONCERN-2327.md
@@ -1,0 +1,31 @@
+---
+source: CONCERN-2327
+timestamp: '2026-08-21T16:11:40.487834+00:00'
+title: 'GHA matrix boolean coercion — two distinct if: failure modes'
+type: learning
+---
+
+In `.github/workflows/demo-integration.yml`, the matrix field `full_suite_only`
+was declared as a YAML boolean (`false`/`true`) and referenced in job `if:`
+conditions: `if: github.event_name != 'pull_request' || matrix.full_suite_only == false`.
+
+Two distinct failure modes exist when a boolean matrix field is referenced in a
+GitHub Actions `if:` expression:
+
+(1) **Job-level `if:`**: the `matrix` context does not exist before matrix
+expansion — GitHub rejects the entire workflow with a silent startup failure,
+zero jobs scheduled, no logs. This broke demo-integration.yml for 116
+consecutive runs (DEMOCI-06-004, ISSUE-2118).
+
+(2) **Step-level `if:`**: the `matrix` context IS available, but GitHub coerces
+JSON boolean `false` to the string `"false"`, making `matrix.full_suite_only ==
+false` always evaluate to `false`. The minimum-PR-set split would be silently
+defeated.
+
+The fix (PR #2118) moved filtering into a `scenarios` pre-filter job using
+`jq 'select(.full_suite_only == false)'`. `jq` handles JSON booleans natively —
+no coercion issue. DEMOCI-06-004, DEMOCI-06-007, DEMOCI-06-008 document the
+current approach.
+
+**Resolved**: 2026-08-21 — implementation tracked in #2460.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2459>.


### PR DESCRIPTION
- Closes #2327

## Summary

Adds an AGENTS.md pitfall documenting two distinct failure modes that arise
when a boolean matrix field (e.g. `full_suite_only`) is referenced in a
GitHub Actions `if:` expression.

## Changes

- **`AGENTS.md`**: New pitfall entry "GHA Matrix Boolean Fields Fail
  Differently at Job-Level vs. Step-Level `if:`" covering: (1) job-level
  `if:` rejects the entire workflow because `matrix` context is unavailable
  before matrix expansion (DEMOCI-06-004, ISSUE-2118); (2) step-level `if:`
  silently coerces JSON boolean `false` to the string `"false"`, defeating
  the intended filter (CONCERN-2327). Fix: pre-filter via a `scenarios` job
  using `jq`, where JSON booleans are handled natively.

## Implementation Issues

- #2460