### PR TITLE
docs: add Vultron concept taxonomy and update reference docs

### DIFF
--- a/docs/reference/draft-vultron-spec.md
+++ b/docs/reference/draft-vultron-spec.md
@@ -164,7 +164,7 @@ during implementation (see §6.4) and is fully normative.
 
 !!! note "Informative: ActivityPub roadmap"
     A future version of this specification is expected to raise the conformance
-    floor to ActivityPub at T1 and above. Implementations built against the
+    floor to ActivityPub for all participants. Implementations built against the
     current AS2-only baseline should anticipate that re-evaluation against a
     future ActivityPub-baseline version will be required. The AS2-only profile
     may become a compatibility profile at that point. (See issue #2068.)
@@ -293,6 +293,43 @@ permitted.
 - JSON-LD as the normative serialization
 - Required context declarations
 - *Source: AS2/ActivityPub standards; `specs/message-validation.yaml`*
+
+### 4.6 Transport Layer [N/I]
+
+The transport layer defines how vultron-wire messages move between participants.
+The message schema (§4.1–§4.5) is transport-agnostic: the same JSON payload is
+deliverable over any conformant transport.
+
+This specification recognizes two transport profiles.
+
+#### REST (HTTP) profile [N]
+
+- Each actor exposes an inbox endpoint for receiving inbound Activities.
+- Outbound Activities are delivered by HTTP POST to the recipient's inbox.
+- Authentication and authorization requirements are described in §8.
+- *Source: `specs/vultron-protocol-spec.yaml` VP-18-001; `specs/outbox.yaml`*
+
+#### ActivityPub federation profile [I]
+
+Full ActivityPub conformance — inbox/outbox HTTP delivery, HTTP Signatures,
+WebFinger discovery — is not currently required by this specification.
+See the informative note in §4.1 and Annex E for the ActivityPub roadmap.
+
+#### Participant discovery [I]
+
+Before two actors can exchange messages, they must locate each other.
+WebFinger is the anticipated discovery mechanism, consistent with its use
+alongside ActivityPub in federated systems such as Mastodon.
+A participant discovery specification is not yet included in this document.
+
+!!! note "Transport vs. routing topology"
+    The routing topology rule in §4.4.2 — all case-scoped messages MUST route
+    through the Case Actor — is a vultron-core protocol rule. It applies
+    regardless of which transport carries the messages. The transport layer is
+    responsible for delivery. The protocol layer is responsible for routing
+    authority.
+
+- *Source: §4.1 informative note (ActivityPub roadmap, issue #2068); Annex E*
 
 ---
 
@@ -922,8 +959,50 @@ what lets either be re-policied without touching the other.
 
 ### 6.6 Participant Lifecycle Within a Case
 
-- Invitation, acceptance, role assignment, removal
-- Case ownership and transfer
+#### 6.6.1 Role Assignment [N]
+
+Roles are assigned through a defined authority chain. They are not self-declared.
+
+1. A case starts with a **Case Owner** — the actor who initiated the case.
+2. The Case Owner MAY delegate the **Case Manager** role to another actor via
+   an `Offer(CaseParticipant)` / `Accept` handshake.
+3. The Case Manager assigns actors into process roles (Reporter, Vendor,
+   Coordinator, Deployer, Observer, CNA) via the case participant management flow.
+
+An actor MUST NOT self-assign a role to a case it did not initiate.
+This rule prevents an actor from claiming authority (for example, Coordinator)
+on a case it is not ready to coordinate.
+
+An implementation MAY verify that an actor has the capability prerequisites
+for a role (§7.3.1) before completing a role assignment.
+
+#### 6.6.2 Invitation and Acceptance [N]
+
+- An actor joins a case via `Invite(CaseStub)` from the Case Actor, answered with
+  `Accept(Invite)` or `Reject(Invite)`.
+- `Accept(Invite)` places the actor at `RM.RECEIVED` and, where an embargo is
+  active, implies consent to that embargo (§6.4.7).
+- The suggest-actor path (§4.3, §5.4) allows a Participant to recommend an actor
+  to the Case Owner. The Case Owner decides whether to issue the invitation.
+
+#### 6.6.3 Case Ownership Transfer [N]
+
+The Case Owner MAY transfer ownership to another actor via
+`Offer(VulnerabilityCase)` / `Accept` handshake routed through the Case Actor
+(ADR-0053). On acceptance, the receiving actor acquires Case Owner authority and
+the associated protocol responsibilities.
+
+!!! note "Open: Case Actor identity during ownership transfer"
+    Because the Case Actor URI is the identity anchor for the canonical ledger,
+    ownership transfer raises a re-keying question for future cryptographic
+    identity designs. See §7.3.2 and Open Questions.
+
+#### 6.6.4 Participant Removal [I]
+
+A Case Owner or Case Manager MAY remove a participant from a case.
+The protocol mechanics of removal and the effect on active embargo consent
+are not yet fully specified.
+
 - *Source: `specs/case-management.yaml`; `notes/ownership-transfer.md`*
 
 ---
@@ -932,35 +1011,41 @@ what lets either be re-policied without touching the other.
 
 ### 7.1 Conformance Model Overview
 
-Conformance is two-dimensional: a **capability tier** (what protocol machinery an
+Conformance is two-dimensional: **capability sets** (what protocol machinery an
 implementation provides) and a **role profile** (which roles it claims). A
-conformance claim takes the form:
+conformance claim names capability sets and roles directly:
 
-> `T{n} / Role [+ Role ...]`
+> `CapabilitySet [+ CapabilitySet ...] / Role [+ Role ...]`
 
-Examples: `T1 / Reporter`, `T1 / Vendor`, `T1 / Vendor + Deployer`,
-`T2 / Coordinator + CNA`, `T2 / Coordinator + Case Owner`.
+Examples: `Observer / Reporter`, `Observer / Vendor`, `Observer / Vendor + Deployer`,
+`Observer + Authority + Hosting / Coordinator + Case Owner`.
 
-Capability tiers are cumulative: T2 implies T1.
+The Observer capability set is required for all participation.
 Role obligations are additive and orthogonal: no role subsumes another.
 
-!!! warning "Tiers are not the same as conformance test layers"
-    This project uses two distinct numbered schemes, and they must not be
-    conflated:
+Capability set names and role names come from §7.2 and §7.3 respectively.
 
-    - **Capability tiers (T0–T2)**, defined here, describe *what an
-      implementation provides* — a claim an implementer makes about their
-      software.
+**Roles and capability expectations.** The relationship between roles and
+capabilities is bidirectional. An implementation must have the capability
+prerequisites for a role before it can be assigned that role (§7.3.1).
+Conversely, holding a role in a case creates an expectation that the
+implementation has those capabilities — other participants act on that
+assumption. See §6.6.1 for the role assignment gatekeeping rules.
+
+!!! warning "Capability sets are not the same as conformance test layers"
+    This project uses two distinct schemes, and they must not be conflated:
+
+    - **Capability sets**, defined here, describe *what an implementation
+      provides* — a claim an implementer makes about their software.
     - **Conformance test layers (L1–L4)**, used in the behavioral conformance
       material, describe *what a test verifies* — syntax, semantics, behavior,
-      and internal process structure. These are orthogonal to tiers: a `T1`
+      and internal process structure. These are orthogonal: an Observer
       implementation is tested at layers L1 through L3.
 
-    "T" was chosen over reusing "L" precisely to keep these separable. Earlier
-    drafts of this document used `L0`/`L1`/`L2` for tiers; those labels are
-    superseded.
+    Earlier drafts of this document used `T0`/`T1`/`T2` for capability tiers and
+    `L0`/`L1`/`L2` before that. Both sets of labels are superseded.
 
-### 7.2 Capability Tiers
+### 7.2 Capability Sets
 
 !!! note "What 'implement a state machine' means"
     Implementing a state machine has two components:
@@ -975,29 +1060,14 @@ Role obligations are additive and orthogonal: no role subsumes another.
     state changes. Driving without tracking means you are unaware of the case
     state you are acting on.
 
-#### T0 — Consumer
+#### Observer capability set
 
-- MUST be able to receive and parse all Vultron message types
-- No state machine tracking required; no send obligations
-- The minimum for a monitoring, archival, or display tool that reads case
-  traffic without participating in coordination
+The Observer capability set is the participation floor.
+**Every actor that participates in any Vultron case MUST implement it.**
 
-!!! note "T0 is not case participation"
-    A T0 implementation can consume messages but cannot be a case Participant: it
-    holds no `CaseParticipant` record, has no RM state, and no case is obliged to
-    deliver anything to it. An actor that accepts a case invitation has
-    implicitly committed to T1 behavior — from that point it must track state and
-    notify others of its own transitions.
-
-    T0 is therefore a claim about *software capability*, not a way to sit inside
-    a case passively. See §7.3.3 on why "Observer" is not a T0 concept.
-
-#### T1 — Participant
-
-Meaningful case participation requires all five state machines. An
-implementation that tracks RM but ignores EM cannot correctly gate its own
-embargo behavior; one that ignores CS cannot correctly evaluate disclosure
-timing. The machines are not independent add-ons — they are the protocol.
+There is no sub-Observer participation level. An actor that accepts a case
+invitation has committed to Observer behavior from that point. It must track
+state and notify others of its own transitions.
 
 - MUST implement all five state machines: **RM, EM, PEC, VFD, PXA**
   (track and drive, per the definition above)
@@ -1005,27 +1075,49 @@ timing. The machines are not independent add-ons — they are the protocol.
   transitions occur
 - MUST receive and update local state when notified of other participants'
   transitions
-- MUST participate in embargo negotiation as appropriate to role: responding to
-  `Invite(Event)`, and recording consent or refusal via PEC
+- MUST participate in embargo negotiation: responding to `Invite(Event)`, and
+  recording consent or refusal via PEC
 - MUST route all case-scoped messages through the Case Actor (§4.4.2)
-- Role-specific drive obligations are governed by §7.4
+- MAY report PXA observations; no VFD drive obligations unless a role extension
+  set adds them
+
+!!! note "Why there is no sub-Observer level"
+    A monitoring-only actor might seem to need only message parsing, with no
+    state tracking required. But an actor that cannot track PEC cannot know what
+    it is permitted to display. An actor that cannot track RM has no basis for
+    evaluating case status. Meaningful use of Vultron data requires the full
+    Observer set. A parse-only tool is not a case Participant: it holds no
+    `CaseParticipant` record and no case is obliged to deliver anything to it.
 
 !!! note "Role-specific drive obligations"
-    All T1 participants **track** all five machines. Which transitions a
-    participant **drives** depends on its role: a Vendor drives its own VFD
-    transitions; a Reporter drives RM; any participant may report PXA
+    All Observer participants **track** all five machines. Which transitions a
+    participant **drives** depends on its role extension set: a Vendor drives its
+    own VFD transitions; a Reporter drives RM; any participant may report PXA
     observations. See §7.3 and §7.4.
 
 - *Source: `specs/vultron-protocol-spec.yaml`; `specs/state-machine.yaml`;
   `specs/embargo-policy.yaml`; `specs/case-management.yaml` CM-18*
 
-#### T2 — Coordinator
+#### Authority capability set
 
-A T2 implementation provides multi-party case management on behalf of other
-participants. This is coordination *authority* — not an additional state machine
-requirement, since all five are already required at T1.
+The Authority capability set defines Case Owner governance capabilities.
+It is separable from the Hosting capability set.
 
-- All T1 requirements, plus:
+- Observer capability set, plus:
+- Status updates MUST be adopted without requiring an external approval gate
+  (the Case Owner's own updates are authoritative)
+- MUST be able to drive shared EM transitions
+- MUST be able to transfer case ownership via the `Offer(VulnerabilityCase)` /
+  `Accept` handshake
+
+A human Coordinator typically holds Authority while a service actor provides Hosting.
+
+#### Hosting capability set
+
+The Hosting capability set defines Case Manager infrastructure capabilities.
+It is separable from the Authority capability set.
+
+- Observer capability set, plus:
 - MUST act as or host a **Case Actor**, and therefore MUST implement the
   single-writer authority rules of §4.4.1
 - MUST maintain the authoritative canonical case ledger and replicate it to
@@ -1038,13 +1130,29 @@ requirement, since all five are already required at T1.
 
 !!! note "Ledger replication scope"
     Whether the full ledger replication protocol belongs in this specification or
-    in a companion document is unresolved (see Open Questions). The T2
+    in a companion document is unresolved (see Open Questions). The Hosting
     requirement above is stable regardless: a Case Actor host must replicate the
     ledger. What may move is the *detailed* replication mechanics — ordering,
     hash-chaining, gap recovery — not the obligation.
 
 - *Source: `specs/sync-ledger-replication.yaml`; `specs/case-management.yaml`;
   `specs/received-status-handling.yaml`; `specs/vultron-protocol-spec.yaml` VP-17-001*
+
+#### Named configurations
+
+Common combinations of capability sets have names because they appear frequently
+in real deployments. These names are informative; conformance claims use the
+full capability set list.
+
+| Configuration | Capability sets | Roles |
+|---|---|---|
+| **Hosting Coordinator** | Observer + Authority + Hosting | Coordinator + Case Owner |
+| **Self-coordinating Vendor** | Observer + Authority + Hosting | Vendor + Deployer + Case Owner |
+| **Bug Bounty Platform** | Observer + Hosting | Case Manager (Authority optional) |
+
+A Hosting Coordinator is a `type:service` actor that holds both `CASE_OWNER`
+and `CASE_MANAGER` roles. It decides and executes without a separate human
+approval step for its own status updates.
 
 ### 7.3 Role Taxonomy
 
@@ -1061,6 +1169,14 @@ transitions it is authorized to drive. An actor may hold multiple process roles.
 | Coordinator | Drives case participant management; coordinates multi-party disclosure |
 | CNA | May directly assign CVE IDs; a non-CNA delegates to an external CNA service. Orthogonal to other roles — typically co-held with Coordinator or Vendor |
 | Observer † | Holds no drive obligations for VFD; may report PXA observations (§7.4.2) |
+
+**Capability prerequisites.** Every case Participant — whatever its roles — MUST
+implement the Observer capability set (§7.2, §7.3.3). Role extension sets add
+obligations on top of that floor; they do not substitute for it. An implementation
+SHOULD verify that an actor has the capability prerequisites for a role before
+completing a role assignment (§6.6.1). The full capability prerequisites per
+role are under active specification; see `docs/reference/vultron-taxonomy.md`
+§"Open Ideas."
 
 !!! note "† Observer: decided (ADR-0057); Finder: still provisional"
     **Observer** (`CVDRole.OBSERVER`): the rename from `CVDRole.OTHER` is decided
@@ -1110,31 +1226,29 @@ the associated protocol responsibilities.
     The design for ownership transfer across cryptographic boundaries requires
     further work before this aspect can be normative.
 
-#### 7.3.3 Roles and Tiers Are Independent
+#### 7.3.3 Roles and Capability Sets Are Independent
 
-A role is a position within a case. A tier is a property of software. Mixing them
-produces contradictions, so the relationship is stated explicitly:
+A role is a position within a case. A capability set is a property of software.
+Mixing them produces contradictions, so the relationship is stated explicitly:
 
-- Every case Participant — whatever its roles — is at minimum **T1**. Holding a
-  role means having a `CaseParticipant` record, an RM state, and therefore
-  tracking obligations.
-- **T0 is not a role.** A T0 implementation consumes messages without
-  participating; it holds no role and no case owes it delivery.
-- A T2 implementation additionally hosts the Case Actor. T2 is commonly co-held
-  with Coordinator and Case Manager, but the tier is what obliges ledger
-  authority, not the role name.
+- Every case Participant — whatever its roles — MUST implement the **Observer**
+  capability set. Holding a role means having a `CaseParticipant` record, an RM
+  state, and therefore tracking obligations.
+- A parse-only actor is not a case Participant: it holds no role and no case owes
+  it delivery.
+- An implementation holding the Hosting capability set additionally hosts the
+  Case Actor. Hosting is commonly co-held with the Coordinator and Case Manager
+  roles, but it is the Hosting capability set that obliges ledger authority, not
+  the role name.
 
-!!! warning "Observer is a participant role, not a passive tier"
-    An Observer that is *in a case* is a T1 participant: it has an RM state, it is
-    subject to embargo consent, and it may report PXA observations. It is
-    distinguished by holding no VFD drive obligations — not by being exempt from
-    tracking.
+!!! note "Observer is a participant role, not a passive state"
+    An Observer role holder that is *in a case* implements the full Observer
+    capability set: it has an RM state, it is subject to embargo consent, and it
+    may report PXA observations. The Observer role is distinguished by holding no
+    VFD drive obligations — not by being exempt from state tracking.
 
-    How a role-light participant is admitted to a case, and what content it
-    receives, is not fully specified. Presumably admission is by invitation from a
-    Case Owner or Case Manager, on the same `Invite` / `Accept(Invite)` path as
-    any other participant — but the invitation flow for a participant with no
-    functional role has not been worked through. See Open Questions.
+    Observer role admission follows the standard `Invite` / `Accept(Invite)` path.
+    Role semantics are normative per ADR-0057; see the note at §7.3.1.
 
 ### 7.4 Role-Specific Normative Requirements
 
@@ -1188,18 +1302,19 @@ two-seam model in **§6.5.1**. The role rule here — *who may report* — is
 deliberately separate from the authorization rules there — *what the Case Actor
 does with a report*.
 
-!!! note "Informative: the sentinel pattern"
+!!! note "Informative: the Sentinel capability shape"
     A participant that monitors external sources (threat feeds, public
     disclosures, vulnerability databases) and reports what it finds into a case is
-    referred to as a **sentinel**. This is the anticipated mechanism for PXA
-    observations originating outside the case.
+    an instance of the **Sentinel** capability shape (§7.6).
 
-    The sentinel is currently a *design pattern* rather than a specified protocol
-    role: no spec group defines a sentinel's trust relationship to a case, and
-    nothing distinguishes a sentinel's observations from any other participant's.
-    Given that StatusAdoptionGate's default policy is to auto-adopt non-owner reports, an
-    unspecified external reporter is a trust-model question and not merely a
-    naming one. Treat this note as informative.
+    The Sentinel shape is defined as an optional, pluggable capability — not a
+    mandatory protocol role. No spec group yet defines a Sentinel's trust
+    relationship to a case, and nothing in the current protocol distinguishes a
+    Sentinel's observations from any other participant's report.
+    Given that StatusAdoptionGate's default policy is to auto-adopt non-owner
+    reports, an unspecified external reporter is a trust-model question, not
+    merely a naming one. See §7.6 and Open Questions item 16. Treat this note
+    as informative.
 
 - *Source: `specs/cs-behavior.yaml`; ADR-0047 (sentinel pattern);
   §6.5.1 for adoption authorization*
@@ -1251,6 +1366,61 @@ canonical-write-before-side-effects rule of §6.5.1 being the clearest case.
 
 - *Source: `notes/behavioral-conformance-specs.md`;
   `specs/rm-behavior.yaml`, `specs/em-behavior.yaml`, `specs/cs-behavior.yaml`*
+
+### 7.6 Capability Shapes [I]
+
+Capability shapes define optional, pluggable capabilities that connect to
+call-out points in the behavior engine. They are orthogonal to the capability
+sets of §7.2: an Observer implementation may have zero capability shapes
+implemented, and a capability that fits a given shape does not require anything
+beyond what the host behavior engine provides.
+
+A capability shape defines a **contract** — what the call-out point accepts and
+what it returns. A concrete implementation that satisfies the contract is a
+Vultron-compatible capability of that shape.
+
+!!! note "Name change"
+    This concept was previously named "agent shape" or "coordination agent
+    taxonomy." The name was changed to "capability shape" because "agent" has
+    acquired strong connotations of LLM-based autonomous systems. The intent was
+    always to describe capability contracts, not autonomous agents specifically.
+    See ADR-0024 (original decision) and `docs/reference/vultron-taxonomy.md`.
+
+#### 7.6.1 The Five Capability Shapes
+
+| Shape | Contract: accepts | Contract: returns | Notes |
+|---|---|---|---|
+| **Sentinel** | A condition to monitor | SUCCESS/FAILURE, no side effects | Operates on the call-in surface; has no call-out point node. Used as a precondition guard. |
+| **Evaluator** | A situation and a set of options | A structured recommendation | Its result gates downstream execution. |
+| **Retriever** | A query | Structured facts from an external source | — |
+| **Composer** | Context | A new content artifact written to the blackboard | The discriminator vs. Actuator: if a content artifact lands on the blackboard, it is a Composer. |
+| **Actuator** | A trigger | SUCCESS when the side effect is confirmed; FAILURE otherwise | Invokes an external system for a side effect. Produces no content artifact. |
+
+!!! warning "Distinguishing Composer from Actuator"
+    Both shapes call external systems. The discriminator is whether a content
+    artifact is written to the blackboard. If the only output is a SUCCESS/FAILURE
+    confirming an external side effect, the shape is **Actuator**, not Composer.
+
+#### 7.6.2 Relationship to Conformance
+
+Capability shapes are not part of the Observer, Authority, or Hosting
+capability set requirements. An implementation at any capability set level
+may implement any number of capability shapes. A conformance claim need not
+state which shapes are implemented.
+
+Where a capability shape is implemented, it MUST satisfy the contract defined
+above. The technology used to fulfill the contract is not specified: a shape
+may be fulfilled by a human, an automated script, an LLM, or any other mechanism.
+
+#### 7.6.3 Relationship to the Reference Implementation
+
+In the Python reference implementation, a capability shape maps to a Port
+(abstract Protocol interface) and a concrete capability maps to an Adapter.
+This mapping is specific to the hexagonal architecture of the reference
+implementation. Other implementations are not required to use this structure.
+
+- *Source: ADR-0024 (original agent shape taxonomy); ADR-0025 (call-out point
+  abstraction); `docs/reference/vultron-taxonomy.md`; `notes/coordination-agents.md`*
 
 ---
 
@@ -1334,12 +1504,12 @@ canonical-write-before-side-effects rule of §6.5.1 being the clearest case.
 1. **Namespace URI** — Is there a stable `vultron:` or `https://vultron.example/`
    namespace ready to cite?
 2. **Sync/replication** — Is the ledger replication protocol in scope for this
-   RFC, or a separate companion spec? The T2 obligation to replicate is stable
-   either way (§7.2); what may move is the detailed mechanics.
+   RFC, or a separate companion spec? The Hosting capability set obligation to
+   replicate is stable either way (§7.2); what may move is the detailed mechanics.
 3. ~~**ActivityPub vs. bare AS2**~~ — Resolved for this version. §4.1 states the
    current normative floor as AS2 vocabulary only, with an informative note that
-   a future version is expected to require full ActivityPub conformance at T1+.
-   Tracked in issue #2068.
+   a future version is expected to require full ActivityPub conformance for all
+   participants. Tracked in issue #2068.
 4. **Background material depth** — How much CVD domain background belongs here
    vs. a companion "CVD Concepts" document?
 5. **Finder removal ADR** — Decision to drop the Finder role needs an ADR before
@@ -1364,14 +1534,15 @@ canonical-write-before-side-effects rule of §6.5.1 being the clearest case.
    Operational Rules v4.1.0 criteria inline. Should the RFC cite these as
    normative external requirements, or treat the eligibility checks as
    implementation-defined?
-10. ~~**Capability tier structure**~~ — Resolved (consolidates the former items
-    10–13). All five state machines (RM, EM, PEC, VFD, PXA) are required at T1;
-    the machines are not independent add-ons. T0 = consumer (parse only, not a
-    Participant); T1 = Participant (all machines, role-appropriate drive
-    obligations); T2 = Coordinator (Case Actor hosting, ledger replication, and
-    multi-party case management as one inseparable coordination-authority tier).
-    Tiers were renamed from `L{n}` to `T{n}` to avoid collision with the L1–L4
-    conformance *test layers* (§7.1, §7.5).
+10. ~~**Capability set structure**~~ — Resolved (consolidates the former items
+    10–13, and the T-tier model previously noted here). All five state machines
+    (RM, EM, PEC, VFD, PXA) are required at the Observer level; the machines are
+    not independent add-ons. Observer = participation floor (all machines,
+    role-appropriate drive obligations); Authority = Case Owner governance (status
+    adoption, EM authority, ownership transfer); Hosting = Case Manager
+    infrastructure (Case Actor, ledger, multi-party management). Authority and
+    Hosting are separable. Earlier drafts used `T0`/`T1`/`T2` labels, and before
+    that `L0`/`L1`/`L2`; both sets are superseded by named capability sets.
 11. ~~**Ledger-based status broadcast**~~ — Resolved. `Announce(CaseStatus)` does
     not exist: there is no such `MessageSemantics` value, and
     `Announce(CaseLedgerEntry)` is the only mechanism by which participants learn

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -427,7 +427,7 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 
 - A **Fuzzer Node** in the simulator is the placeholder form of a **Call-Out Point**.
 - A **Call-Out Point** is fulfilled in production by a **capability** of the appropriate **capability shape**.
-- A **Sentinel** answers a yes/no check; an **Evaluator** records a domain decision; a **Retriever** fetches external data; a **Composer** generates content; an **Actuator** fires a side effect in an external system.
+- A **Sentinel** monitors a condition and fires a trigger when the condition is met; an **Evaluator** records a domain decision; a **Retriever** fetches external data; a **Composer** generates content; an **Actuator** fires a side effect in an external system.
 - An **Advisory Review Decision** is produced by a **Reviewer** (an Evaluator **capability**) and determines whether an **Advisory** draft requires revision before the BT submits it.
 
 **Status and Dimensions:**
@@ -643,9 +643,8 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 > **Developer:** "And if there's no human reviewer yet, we just leave the **Fuzzer Node** in place?"
 >
 > **Domain Expert:** "Right. The **Fuzzer Node** is the stub — it keeps the BT runnable without a
-> real capability of the required **Capability Shape**. When you're ready, you replace it with a **Retriever** that fetches
-> reviewer feedback, or an **Evaluator** backed by an LLM, or a **Sentinel** that checks an
-> external approval queue."
+> real capability of the required **Capability Shape**. When you're ready, you replace it with a **Retriever** that
+> fetches reviewer feedback from an external system, or an **Evaluator** backed by an LLM."
 
 ### Dimension Objects and Status Example
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -202,7 +202,7 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 | **Capability implementation** | The factory backend fulfilling a **capability** at runtime; may be a Python function, a human workflow, a rules engine, or an LLM agent. The implementation choice is made at deployment time, not at design time. | Backend, factory backend |
 | **Sentinel** | A **capability shape** that monitors a condition over time; when the condition is met, calls a Vultron trigger endpoint. Operates on the call-in surface — it has no BT call-out point. | Guard agent, check agent |
 | **Evaluator** | A **capability shape** that receives a situation and returns a structured recommendation or decision (e.g., `ReviewAdvisoryDraft`); its output gates downstream BT execution | Decision agent, reviewer agent |
-| **Retriever** | A **capability shape** that receives a query and returns structured external facts (e.g., CVE ID lookup, SSVC scoring); also used for binary yes/no external queries | Fetch agent, lookup agent |
+| **Retriever** | A **capability shape** that receives a query and returns structured facts from an external source (e.g., CVE ID lookup, SSVC scoring); also used for binary yes/no external queries | Fetch agent, lookup agent |
 | **Composer** | A **capability shape** that receives context and generates a new content artifact (e.g., drafting advisory text); output is written to the blackboard | Generator agent, authoring agent |
 | **Actuator** | A **capability shape** that receives a trigger and invokes an external system to cause a side effect (notification dispatch, state write, queue mutation, API call); returns SUCCESS when the side effect is confirmed, FAILURE otherwise; produces no content artifact | Side-effect agent, executor |
 | **StatusAdoptionGate** | A BT authorization gate that determines whether a received **CaseStatus** update should be adopted by the receiving actor; guards the `add_participant_status_tree` path for received-side status canonicalization (ADR-0046). | Seam 1, StatusUpdateGuard |
@@ -427,7 +427,7 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 
 - A **Fuzzer Node** in the simulator is the placeholder form of a **Call-Out Point**.
 - A **Call-Out Point** is fulfilled in production by a **capability** of the appropriate **capability shape**.
-- A **Sentinel** monitors a condition and fires a trigger; an **Evaluator** records a domain decision; a **Retriever** fetches external data; a **Composer** generates content; an **Actuator** fires a side effect in an external system.
+- A **Sentinel** answers a yes/no check; an **Evaluator** records a domain decision; a **Retriever** fetches external data; a **Composer** generates content; an **Actuator** fires a side effect in an external system.
 - An **Advisory Review Decision** is produced by a **Reviewer** (an Evaluator **capability**) and determines whether an **Advisory** draft requires revision before the BT submits it.
 
 **Status and Dimensions:**
@@ -524,7 +524,12 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
      - Misclassification risk: nodes that "do something" to an external system look like Composers if you only notice they dispatch outbound calls. The discriminator is whether a content artifact lands on the blackboard. If not, it is an **Actuator** capability shape.
      - **Recommendation**: Before classifying a node as Composer, verify it writes a content artifact to the blackboard. If the only output is a SUCCESS/FAILURE confirming an external side effect, it is an **Actuator** capability shape.
 
-18. **"Dimension Object" vs. "status field"**:
+18. **"Coordination Agent" vs. "Capability shape"**:
+     - A **Capability shape** is the current term for the abstract interface contract at a call-out point (Sentinel, Evaluator, Retriever, Composer, Actuator).
+     - **Coordination Agent** was the previous term. It is deprecated because "agent" has acquired connotations of LLM-based autonomous systems, which was not the original intent.
+     - **Recommendation**: Use "capability shape" in all new text. When reading older code or docs, treat "Coordination Agent" as a synonym for "capability shape."
+
+19. **"Dimension Object" vs. "status field"**:
      - A **Dimension Object** (per ADR-0036) is an immutable `BaseModel` containing the state of one machine; it is a first-class structured type, not a flat field.
      - "Status field" is informal language that may mean a flat scalar (`rmState: "ACCEPTED"`) or a **Dimension Object** (`rm: {"state": "ACCEPTED"}`); both appear in real ledger snapshots.
      - **Recommendation**: Say "**Dimension Object**" when referring to the structured sub-model; say "flat legacy field" when referring to the pre-ADR-0036 serialization. When extracting state from JSONL, probe both shapes (see 2026-07-22 learning on three nesting shapes).
@@ -625,22 +630,22 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 > **Developer:** "The BT has a `ReviewAdvisoryDraft` node — what actually runs there?"
 >
 > **Domain Expert:** "That's a **Call-Out Point**. In the simulator it's a **Fuzzer Node** that
-> returns SUCCESS or FAILURE probabilistically. In production you wire in an Evaluator
-> **capability** — that reviews the draft and records an **Advisory Review Decision**."
+> returns SUCCESS or FAILURE probabilistically. In production you wire in a **capability** —
+> an Evaluator **capability shape** — that reviews the draft and records an **Advisory Review Decision**."
 >
 > **Developer:** "What does the BT read from that decision? Just `needs_revision`?"
 >
 > **Domain Expert:** "Yes. If `needs_revision=True`, the pipeline routes to the revision arm before
 > submit. If you want to block outright without requesting edits — say, a legal hold — your
-> Evaluator returns `FAILURE` directly from `update()`. That's the universal BT blocking idiom
+> **Evaluator** returns `FAILURE` directly from `update()`. That's the universal BT blocking idiom
 > (BT-18-007)."
 >
 > **Developer:** "And if there's no human reviewer yet, we just leave the **Fuzzer Node** in place?"
 >
 > **Domain Expert:** "Right. The **Fuzzer Node** is the stub — it keeps the BT runnable without a
-> real capability wired in. When you're ready, you replace it with a Retriever capability that
-> fetches reviewer feedback, or an Evaluator backed by an LLM, or a Sentinel capability that
-> checks an external approval queue."
+> real capability of the required **Capability Shape**. When you're ready, you replace it with a **Retriever** that fetches
+> reviewer feedback, or an **Evaluator** backed by an LLM, or a **Sentinel** that checks an
+> external approval queue."
 
 ### Dimension Objects and Status Example
 
@@ -663,7 +668,7 @@ fix not ready) are structurally impossible, per SM-09-002 and CSB-17-001.
 ## Metadata
 
 - **Source:** Vultron codebase, CERT/CC CVD research publications, architecture audit, formal protocol specification
-- **Last Updated:** 2026-08-18
+- **Last Updated:** 2026-08-21
 - **Domains:** Formal MPCVD protocol, CVD process models (RM/EM/CS), communicating state machines, hexagonal architecture, activity pattern matching, persistence abstraction, behavior tree orchestration, case actor federation, participant case replicas, trust bootstrap and delegation
 - **Related References:**
   - [A State-Based Model for Multi-Party Coordinated Vulnerability Disclosure](https://resources.sei.cmu.edu/library/asset-view.cfm?assetid=735513) (CMU/SEI-2021-SR-021)

--- a/docs/reference/vultron-taxonomy.md
+++ b/docs/reference/vultron-taxonomy.md
@@ -150,7 +150,7 @@ Even a monitoring-only actor must track embargo state (PEC) to know what it is p
 
 The Observer capability set includes:
 
-- Track all five state machines (RM, EM, PEC, VFD, PXA)
+- Implement all five state machines (RM, EM, PEC, VFD, PXA) — track state and drive transitions
 - Embargo compliance: accept and decline embargo invitations; track PEC state
 - Receive and process all Vultron message types
 - Report PXA observations (public awareness, exploit public, attacks observed)
@@ -201,11 +201,11 @@ A platform can provide Hosting without holding governance authority.
 
 Common combinations of capability sets have names because they describe real deployment patterns.
 
-| Configuration | Capability sets |
-|---|---|
-| **Hosting Coordinator** (or Autonomous Coordinator) | Observer + Coordinator role + Authority + Hosting |
-| **Self-coordinating Vendor** | Observer + Vendor role + Deployer role + Authority + Hosting |
-| **Bug Bounty Platform** | Observer + Hosting (Authority is optional) |
+| Configuration | Capability sets | Roles |
+|---|---|---|
+| **Hosting Coordinator** (or Autonomous Coordinator) | Observer + Authority + Hosting | Coordinator + Case Owner |
+| **Self-coordinating Vendor** | Observer + Authority + Hosting | Vendor + Deployer + Case Owner |
+| **Bug Bounty Platform** | Observer + Hosting | Case Manager (Authority optional) |
 
 A Hosting Coordinator is a `type:service` actor that holds both `CASE_OWNER` and `CASE_MANAGER` roles.
 It decides (Authority) and executes (Hosting) without a separate human approval step.
@@ -255,7 +255,7 @@ Examples: `Observer / Vendor`, `Observer + Authority + Hosting / Coordinator + C
 
 | Shape | What it does | Connection type |
 |---|---|---|
-| **Sentinel** | Monitors a condition. Returns success or failure with no side effects. Used as a precondition guard. | Call-in surface (no call-out point node) |
+| **Sentinel** | Independently monitors an external condition; when the condition fires, calls a Vultron trigger endpoint. Not called by the behavior engine. | Call-in surface (no call-out point node) |
 | **Evaluator** | Receives a situation and a set of options. Returns a structured recommendation. Gates downstream execution. | Call-out point |
 | **Retriever** | Receives a query. Returns structured facts from an external source. | Call-out point |
 | **Composer** | Receives context. Generates and records a new content artifact. | Call-out point |

--- a/docs/reference/vultron-taxonomy.md
+++ b/docs/reference/vultron-taxonomy.md
@@ -1,0 +1,446 @@
+---
+title: "Vultron Concept Taxonomy"
+status: active
+description: >
+  Reference definitions for the distinct concepts that together constitute
+  Vultron. Use this document to understand what each named concept covers,
+  what it excludes, and how the concepts relate to each other.
+---
+
+# Vultron Concept Taxonomy
+
+The name "Vultron" covers several distinct concepts.
+Each concept has a defined scope, and each plays a different role.
+This document names each concept, defines its scope, and describes the relationships between them.
+
+!!! note "Audience"
+    This document addresses four audiences: sponsors, collaborators, independent
+    implementers, and contributors to this codebase. The concepts are the same
+    for all four audiences. The language used to describe them may vary by
+    context.
+
+---
+
+## Quick Reference
+
+| Concept | One-line definition |
+|---|---|
+| [vultron-core](#vultron-core) | The abstract protocol: state machines, transitions, and process logic |
+| [vultron-wire](#vultron-wire) | The message format: AS2 vocabulary plus semantic mapping |
+| [vultron-transport](#vultron-transport) | The delivery mechanism: how messages move between participants |
+| [Vultron capability sets](#vultron-capability-sets) | The named groups of capabilities that define participation levels and roles |
+| [Capability shapes](#capability-shapes) | The taxonomy of optional, pluggable capability patterns |
+| [Vultron roles](#vultron-roles) | Case-level participation assignments for actors |
+| [Vultron-enabled applications](#vultron-enabled-applications) | Systems and components built on top of Vultron |
+
+---
+
+## Protocol Concepts
+
+These three concepts define the protocol itself.
+They are independent of any specific implementation language.
+
+### vultron-core
+
+**Definition.** The abstract Vultron protocol: the state machines (RM, EM, PEC, VFD, PXA), the valid transitions between states, the process logic that drives those transitions, and the behavioral conformance rules that define correct observable behavior.
+
+**What is in scope.**
+
+- The five state machines and their transition tables
+- The behavioral conformance specifications (RMB, EMB, CSB) that state correct outputs for given inputs
+- The ordering and cascade rules between dimensions (for example, when an EM transition must trigger a PEC bulk update)
+- The process model: how N independent participants coordinate through message passing
+
+**What is out of scope.**
+
+- The Python module `vultron/core/` — that is the reference implementation of this concept, not the concept itself
+- The behavior trees — those are one valid mechanism for executing vultron-core, not a required part of it
+- The message format — that is vultron-wire
+- The delivery mechanism — that is vultron-transport
+
+**Relationship to other concepts.**
+
+- vultron-wire carries the semantic meaning that vultron-core defines.
+- vultron-transport moves vultron-wire messages between participants.
+- The behavioral conformance specifications (RMB, EMB, CSB) are part of the vultron-core capability set. They are not a separate layer.
+- An implementation of vultron-core is a "coordination engine" for CVD. That label describes what the implementation does, not a separate concept.
+
+!!! note "Implementation note (reference only)"
+    In the Python reference implementation, vultron-core maps to the `vultron/core/`
+    module: the hexagonal inner circle that has no imports from the wire or adapter
+    layers. This mapping is specific to the reference implementation and does not
+    constrain how vultron-core is implemented in other languages.
+
+---
+
+### vultron-wire
+
+**Definition.** The Vultron message format: the ActivityStreams 2.0 vocabulary for Vultron activities and objects, and the semantic mapping that assigns a protocol meaning to each activity type and payload combination.
+
+**What is in scope.**
+
+- The AS2 vocabulary: the set of valid activity types and object types defined by the Vultron protocol
+- The JSON schemas that define conformant message structure
+- The semantic mapping: "this activity type with this payload carries this protocol meaning"
+- The boundary is the serialized JSON output. What a conformant message looks like as JSON is vultron-wire. How that JSON is produced (for example, by Pydantic models) is not.
+
+**What is out of scope.**
+
+- The Pydantic model classes in the reference implementation — those produce vultron-wire output, but they are not vultron-wire itself
+- Valid message sequences and ordering — those are a vultron-core concern, because they emerge from the state machines
+- How messages are delivered — that is vultron-transport
+
+**Relationship to other concepts.**
+
+- vultron-wire conformance without vultron-core conformance has limited use. A system can produce well-formed messages but cannot participate meaningfully if it does not implement the state machines.
+- Partial conformance claims are possible: "I conform to these sequences in core via wire, but not those others."
+- vultron-transport carries vultron-wire messages. The message schema is transport-agnostic.
+
+!!! note "Name under review"
+    "Wire" implies delivery to some readers. Candidate renames include "vultron-messages"
+    and "vultron-vocabulary." No decision has been made. See [open ideas](#open-ideas).
+
+---
+
+### vultron-transport
+
+**Definition.** The delivery layer: the mechanisms by which vultron-wire messages move between participants.
+
+This concept is analogous to TAXII in the STIX/TAXII pairing, where STIX is the data format and TAXII is the transport protocol.
+
+**What is in scope.**
+
+- The REST (HTTP) delivery profile: how endpoints are structured, how messages are sent and received
+- The ActivityPub federation profile: inbox/outbox semantics, HTTP Signatures, actor addressing
+- Participant discovery: how a participant finds other Vultron actors (webfinger is the anticipated mechanism, consistent with its use alongside ActivityPub in systems such as Mastodon)
+
+**What is out of scope.**
+
+- Message format and semantic meaning — those are vultron-wire
+- Protocol routing rules (for example, the single-writer rule and the requirement that all case-scoped messages route through the Case Actor) — those are vultron-core rules that apply at the protocol layer, not the transport layer
+
+**Relationship to other concepts.**
+
+- vultron-transport carries vultron-wire messages. The same JSON payload is deliverable over REST or ActivityPub.
+- The routing topology rule (Participant → Case Actor → all Participants) is a vultron-core protocol rule. It governs message routing regardless of which transport is in use.
+
+!!! note "Current status"
+    The REST profile is in use in the reference implementation. The ActivityPub
+    federation profile is planned (see issue #2068). Participant discovery via
+    webfinger is anticipated but not yet specified.
+
+---
+
+## Capability Concepts
+
+These concepts describe what a Vultron implementation or component can do.
+
+### Vultron capability sets
+
+**Definition.** A capability set is a named group of capabilities that defines what an actor must be able to do for a given participation level or role.
+A capability is one specific thing a system can do within the Vultron protocol.
+
+#### The Observer capability set
+
+**The Observer capability set is the participation floor.**
+Every actor that participates in any Vultron case must implement it.
+
+There is no sub-Observer participation level.
+Even a monitoring-only actor must track embargo state (PEC) to know what it is permitted to display.
+
+The Observer capability set includes:
+
+- Track all five state machines (RM, EM, PEC, VFD, PXA)
+- Embargo compliance: accept and decline embargo invitations; track PEC state
+- Receive and process all Vultron message types
+- Report PXA observations (public awareness, exploit public, attacks observed)
+
+No VFD drive obligations are part of the Observer set.
+Those belong to role extension sets.
+
+#### Role extension sets
+
+Every CVD process role is the Observer capability set plus a role-specific extension.
+
+| Role | Extension capabilities (added to Observer) |
+|---|---|
+| Reporter | Initiate cases; drive RS (report submission) |
+| Vendor | Drive fix-ready VFD transition (f→F, CF) |
+| Deployer | Drive fix-deployed VFD transition (d→D, CD) |
+| Coordinator | Drive case participant management; coordinate multi-party disclosure |
+| CNA | Assign CVE IDs directly |
+
+Only an actor that holds both Vendor and Deployer can drive the full fix path.
+Vendor alone cannot drive fix deployment.
+Deployer alone cannot drive fix readiness.
+
+#### The Authority capability set
+
+The Authority capability set defines Case Owner governance capabilities:
+
+- Adopt status updates without an external approval gate
+- Drive shared EM transitions
+- Transfer case ownership
+
+The Authority capability set is separable from the Hosting capability set.
+A human Coordinator can hold Authority while a service actor performs Hosting.
+
+#### The Hosting capability set
+
+The Hosting capability set defines Case Manager infrastructure capabilities:
+
+- Host a Case Actor (the single-writer for the canonical ledger)
+- Maintain the authoritative append-only case ledger
+- Replicate ledger entries to participants via `Announce(CaseLedgerEntry)`
+- Manage case participants (invitation, role assignment, removal)
+
+The Hosting capability set is separable from the Authority capability set.
+A platform can provide Hosting without holding governance authority.
+
+#### Named configurations
+
+Common combinations of capability sets have names because they describe real deployment patterns.
+
+| Configuration | Capability sets |
+|---|---|
+| **Hosting Coordinator** (or Autonomous Coordinator) | Observer + Coordinator role + Authority + Hosting |
+| **Self-coordinating Vendor** | Observer + Vendor role + Deployer role + Authority + Hosting |
+| **Bug Bounty Platform** | Observer + Hosting (Authority is optional) |
+
+A Hosting Coordinator is a `type:service` actor that holds both `CASE_OWNER` and `CASE_MANAGER` roles.
+It decides (Authority) and executes (Hosting) without a separate human approval step.
+
+#### Optional domain capability sets
+
+Optional capabilities are organized by domain function.
+
+Examples of domain capability sets:
+
+- **CNA capabilities** — assign CVE IDs (typically Actuator shape, calling the CVE assignment API)
+- **Prioritization capabilities** — assess report severity or priority (typically Evaluator or Retriever shape)
+- **Exploit detection capabilities** — detect or assess exploit availability (typically Sentinel or Retriever shape)
+
+A capability set name describes business function.
+A [capability shape](#capability-shapes) describes the technical connection contract.
+These two dimensions are orthogonal: the same domain set may use multiple shapes.
+
+**A conformance claim names capability sets and roles directly.**
+Examples: `Observer / Vendor`, `Observer + Authority + Hosting / Coordinator + Case Owner`.
+
+**What is in scope.**
+
+- All protocol behaviors a system can implement, required or optional
+- Named capability sets as defined groupings of required capabilities
+- Optional domain capability sets organized by business function
+
+**What is out of scope.**
+
+- The conformance test layers (L1–L4) — those describe what a test verifies, not what a system provides.
+  Capability sets and test layers are orthogonal.
+
+**Relationship to other concepts.**
+
+- Capability shapes provide the technical contract taxonomy for optional capabilities.
+- Vultron roles use capability sets to define prerequisites for role assignment.
+
+---
+
+### Capability shapes
+
+**Definition.** The taxonomy of optional, pluggable capability patterns. Each capability shape defines a contract for a specific category of automation that can connect to the behavior engine at a call-out point.
+
+**Previous name.** This concept was previously named "agent shapes" or "coordination agent taxonomy." That name was accurate when written. It is now replaced because "agent" has acquired strong connotations of LLM-based autonomous systems, which was not the original intent. "Capability shape" describes what the concept actually covers: the pattern that a capability takes.
+
+**The five capability shapes.**
+
+| Shape | What it does | Connection type |
+|---|---|---|
+| **Sentinel** | Monitors a condition. Returns success or failure with no side effects. Used as a precondition guard. | Call-in surface (no call-out point node) |
+| **Evaluator** | Receives a situation and a set of options. Returns a structured recommendation. Gates downstream execution. | Call-out point |
+| **Retriever** | Receives a query. Returns structured facts from an external source. | Call-out point |
+| **Composer** | Receives context. Generates and records a new content artifact. | Call-out point |
+| **Actuator** | Receives a trigger. Invokes an external system for a side effect. Confirms success or failure. Produces no content artifact. | Call-out point |
+
+A capability shape defines the contract. A concrete implementation that satisfies the contract is a Vultron-compatible capability of that shape.
+
+**What is in scope.**
+
+- The five shapes and their contracts (what each shape accepts and returns)
+- The classification rule for each shape
+
+**What is out of scope.**
+
+- The specific technology used to fulfill a shape (a shape may be fulfilled by a human, an automated script, an LLM, or any other mechanism)
+- The Fuzzer Node — that is a simulator-layer stub that occupies a call-out point until a real capability is wired in; it is not a capability shape itself
+
+**Relationship to other concepts.**
+
+- Capability shapes are orthogonal to capability sets. An Observer implementation may have zero capability shapes implemented. A Sentinel capability does not require anything beyond what the host behavior engine provides.
+- Capability shapes are the taxonomy for the optional capabilities in [Vultron-compatible capabilities](#vultron-compatible-capabilities).
+- In the reference implementation, a capability shape maps to a Port (abstract interface). A concrete capability implementation maps to an Adapter. This mapping is specific to the hexagonal architecture of the Python codebase and is not required of other implementations.
+
+---
+
+## Participation Concepts
+
+### Vultron roles
+
+**Definition.** Case-level participation assignments. A role describes what an actor is doing in a specific case.
+
+Roles are not properties of systems. They are assignments within a case.
+
+**Two categories of roles.**
+
+**Process roles** define what an actor does within a case and which protocol transitions it is authorized to drive.
+
+| Role | Drive authority |
+|---|---|
+| Reporter | Initiates cases; drives RS (report submission) |
+| Vendor | Drives its own VFD fix-ready transition (CF) |
+| Deployer | Drives its own VFD fix-deployed transition (CD) |
+| Coordinator | Drives case participant management; coordinates multi-party disclosure |
+| CNA | May directly assign CVE IDs |
+| Observer | No VFD drive obligations; may report PXA observations |
+
+**Protocol authority roles** define what an actor controls in the protocol machinery.
+
+| Role | Protocol authority |
+|---|---|
+| Case Owner | Authoritative decision-maker for a case |
+| Case Manager | AS actor performing case replica synchronization on behalf of the Case Owner |
+
+**Role assignment.**
+
+Roles are assigned, not self-declared.
+
+1. A case starts with a Case Owner (the actor who initiated the case).
+2. The Case Owner may delegate the Case Manager role to another actor.
+3. The Case Manager designates other actors into process roles.
+
+Self-assignment is not permitted. This rule prevents an actor from declaring a role (for example, Coordinator) on a case it is not ready to coordinate.
+
+**Capabilities and roles.**
+
+The relationship between capabilities and roles is bidirectional.
+
+- Capabilities are a prerequisite for a role. Having the right capabilities means an actor can perform the role. It does not mean the actor automatically holds the role.
+- Holding a role in a case means other participants expect the actor to have the capabilities that role requires.
+
+**What is in scope.**
+
+- The two categories of roles and their definitions
+- The assignment chain (Case Owner → Case Manager → others)
+- The bidirectional relationship between capabilities and roles
+
+**Relationship to other concepts.**
+
+- A role claim creates capability expectations. If an actor holds the Coordinator role, other participants expect it to have the Coordinator role extension set.
+- The Observer capability set is the minimum protocol floor for case participation. Role extension sets add further expectations on top of that floor.
+
+---
+
+## Ecosystem Concepts
+
+### Vultron-enabled applications
+
+**Definition.** Systems and components built using Vultron. This concept covers the full range: end-user applications, coordination automation components, and the reference implementation itself.
+
+**Examples.**
+
+- A PSIRT portal that uses the Vultron protocol to manage vulnerability cases — this implements vultron-core, vultron-wire, and vultron-transport, and holds process roles within its cases.
+- A Sentinel component that monitors threat feeds and reports PXA observations into a case — this implements a capability shape and is a Vultron-compatible capability.
+- The Python reference implementation in this repository — this implements the full stack: vultron-core, vultron-wire, vultron-transport, and some capability shapes.
+
+**What is in scope.**
+
+- Any system that implements one or more Vultron protocol concepts
+- Coordination automation components (implementations of capability shapes)
+- Full-stack implementations that participate in CVD coordination
+
+**What is out of scope.**
+
+- The protocol itself — that is vultron-core, vultron-wire, and vultron-transport
+- Systems that merely cite or reference Vultron without implementing it
+
+**Relationship to other concepts.**
+
+- A Vultron-enabled application that implements vultron-core, vultron-wire, and vultron-transport at the Observer level or above is a "coordination engine" in the sense that it can coordinate CVD cases. That label is descriptive vocabulary for what the application does, not a separate taxonomy concept.
+
+---
+
+## Architectural Views
+
+Three architectural views are planned for this taxonomy. Each view answers a different question.
+
+### View 1 — Layered module view
+
+This view answers the question: what are the layers of Vultron, and how do they depend on each other?
+
+The layers, from lowest to highest:
+
+1. **vultron-core** — the protocol foundation. All other layers depend on vultron-core.
+2. **vultron-wire** — the message format layer. Translates vultron-core protocol meanings into serialized messages.
+3. **vultron-transport** — the delivery layer. Carries vultron-wire messages between participants.
+4. **Capability shapes** — the integration surface. Sits at the boundary between the protocol engine and optional automation. Capability shapes are defined by vultron-core (the call-out points) and implemented by Vultron-compatible capabilities.
+5. **Vultron-enabled applications** — the top layer. Uses all lower layers to participate in CVD coordination.
+
+Vultron roles and Vultron-compatible capabilities are not layers. They describe aspects of participation and implementation, respectively, that apply across the full stack.
+
+### View 2 — Peer-to-peer component-and-connector view
+
+This view answers the question: how do two Vultron participants communicate?
+
+This view is planned and not yet drawn. It will show:
+
+- How two participants exchange vultron-wire messages over vultron-transport
+- How the Case Actor mediates all case-scoped messages
+- How case state replicates from the Case Actor to participants via ledger entries
+- Where capability shapes connect to the behavior engine
+
+### View 3 — Conformance view (custom)
+
+This view answers the question: what do I need to build to claim a specific conformance level or role?
+
+This view is planned and not yet drawn. It will show:
+
+- A capability set matrix: rows are named capability sets (Observer, role extensions, Authority, Hosting, domain sets); columns are role or configuration claims; cells show required versus optional
+- Role overlays showing which capability sets each role requires
+- Named configuration profiles as pre-filled columns in the matrix
+
+---
+
+## Open Ideas
+
+These questions are noted for future resolution. They do not block use of this taxonomy.
+
+1. **vultron-wire name review.** "Wire" implies delivery to some readers. Candidate renames: "vultron-messages," "vultron-vocabulary." No decision has been made. Log as a GitHub issue when ready to decide.
+
+2. **vultron-transport: discovery scope.** Participant discovery via webfinger is anticipated as part of vultron-transport. It is not yet specified. Related to ActivityPub federation work (issue #2068).
+
+3. **Role capability prerequisites.** The full mapping of which capabilities each role extension set requires is not yet specified. The conformance view (above) will address this when drawn.
+
+4. **Named configurations: canonical name.** "Hosting Coordinator" and "Autonomous Coordinator" are both in use. A decision on the canonical name is needed.
+
+---
+
+## Dissolved Concepts
+
+These labels were candidates for this taxonomy but did not survive review.
+
+| Label | Outcome |
+|---|---|
+| vultron-behaviors | Dissolved. The behavioral conformance specifications (RMB, EMB, CSB) are part of vultron-core. "Behavior trees" are one implementation mechanism for vultron-core, not a separate taxonomy concept. |
+| coordination engine | Demoted to descriptive vocabulary. A Vultron-enabled application that implements vultron-core at the Observer level or above is a "coordination engine" for CVD. This label describes what the application does, not a separate concept. |
+| T0 / Consumer | Dropped. A parse-only entity has nothing useful to do with Vultron data if it cannot honor embargoes. Observer is the participation floor. |
+| T1 / Participant | Collapsed into the Observer capability set. |
+| T2 / Coordinator | Split into three separable concepts: Coordinator role extension set, Authority capability set, and Hosting capability set. |
+| T0/T1/T2 tier notation | Eradicated. Conformance claims name capability sets and roles directly. Example: `Observer / Vendor` replaces `T1 / Vendor`. |
+
+---
+
+## Related Documents
+
+- [Glossary](glossary.md) — domain terminology for the Vultron protocol and reference implementation
+- [Draft Vultron Protocol Specification](draft-vultron-spec.md) — normative protocol specification including capability sets and role taxonomy
+- ADR-0024 — Coordination Agent Taxonomy (original "agent shapes" decision; capability shapes is the updated name)
+- ADR-0038 — Four-Tier Specification Taxonomy (how specification files are classified)

--- a/docs/reference/vultron-taxonomy.md
+++ b/docs/reference/vultron-taxonomy.md
@@ -276,7 +276,7 @@ A capability shape defines the contract. A concrete implementation that satisfie
 **Relationship to other concepts.**
 
 - Capability shapes are orthogonal to capability sets. An Observer implementation may have zero capability shapes implemented. A Sentinel capability does not require anything beyond what the host behavior engine provides.
-- Capability shapes are the taxonomy for the optional capabilities in [Vultron-compatible capabilities](#vultron-compatible-capabilities).
+- Capability shapes are the taxonomy for the optional capabilities in [Vultron capability sets](#vultron-capability-sets).
 - In the reference implementation, a capability shape maps to a Port (abstract interface). A concrete capability implementation maps to an Adapter. This mapping is specific to the hexagonal architecture of the Python codebase and is not required of other implementations.
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,10 @@ nav:
           - FVV Demo: 'howto/demos/fvv-demo.md'
   - Reference:
     - 'reference/index.md'
-    - Ubiquitous Language: 'reference/glossary.md'
+    - Protocol Architecture:
+      - Concept Taxonomy: 'reference/vultron-taxonomy.md'
+      - Ubiquitous Language: 'reference/glossary.md'
+      - Draft Protocol Specification: 'reference/draft-vultron-spec.md'
     - Terms and Definitions: 'reference/terms.md'
     - Notation: 'reference/notation.md'
     - Versioning: 'reference/versioning.md'
@@ -315,6 +318,7 @@ validation:
     omitted_files: warn
 draft_docs: |
   draft-*.md
+  !reference/draft-vultron-spec.md
   docs/developer/
 theme:
   logo: 'assets/Software_Engineering_Institute_Unitmark_White.svg'


### PR DESCRIPTION
## Summary

Adds a Vultron concept taxonomy reference document that draws clear circles around seven distinct concepts that were previously conflated under the name "Vultron." Updates the glossary and draft spec to reflect the taxonomy, including a full replacement of the T0/T1/T2 capability tier model with named capability sets.

## Changes

- **`docs/reference/vultron-taxonomy.md`** (new): Diataxis reference document covering vultron-core, vultron-wire, vultron-transport, Vultron capability sets (Observer floor + role extension sets + Authority + Hosting + named configurations + domain optional sets), capability shapes (5-shape table), Vultron roles, and vultron-enabled applications. Three architectural views outlined. Dissolved concepts table includes T0/T1/T2.
- **`docs/reference/glossary.md`**: "Coordination Agent" → "Capability Shape" (renamed row); all five subtype entries updated; new ambiguity entry #18.
- **`docs/reference/draft-vultron-spec.md`**: New §4.6 Transport Layer, new §6.6 Participant Lifecycle, §7.6 Capability Shapes, §7.1–§7.2 replaced T0/T1/T2 tiers with Observer/Authority/Hosting capability sets, named configurations, eradicated T-tier notation throughout.