### PR TITLE
task: verify DEMOCI-06-004 — 4 scenarios on PRs, 9 on push-to-main

### DIFF
--- a/plan/incoming/learnings/20260821-democi-06-004-verified.md
+++ b/plan/incoming/learnings/20260821-democi-06-004-verified.md
@@ -1,0 +1,23 @@
+---
+title: DEMOCI-06-004 scenario filter verified — 4 on PR, 9 on push
+type: learning
+timestamp: 2026-08-21
+source: ISSUE-2460
+signal: verification
+---
+
+Verified that the `scenarios` pre-filter job (DEMOCI-06-004, PR #2118) is
+working correctly.
+
+**PR run** (run ID 32416027725, PR #2448):
+
+- fv, fvcv-handoff, fcvcv, fcv-reject — exactly 4 scenarios (minimum PR set,
+  DEMOCI-06-002). The `jq 'select(.full_suite_only == false)'` filter correctly
+  handles JSON booleans from `.github/demo-scenarios.json`.
+
+**Push-to-main run** (run ID 32482959828, post #2448 merge):
+
+- All 9 scenarios ran. `full_suite_only: true` entries included as expected.
+
+Boolean coercion concern (CONCERN-2327) confirmed as not applicable to the
+current `jq`-based implementation. AGENTS.md pitfall added (PR #2459).


### PR DESCRIPTION
- Closes #2460

## Summary

Verifies that the `scenarios` pre-filter job (DEMOCI-06-004, PR #2118) is
working correctly by inspecting recent GitHub Actions workflow runs.

## Changes

- **`plan/incoming/learnings/20260821-democi-06-004-verified.md`**: Verification
  evidence — PR run 32416027725 shows exactly 4 scenarios (`fv`, `fvcv-handoff`,
  `fcvcv`, `fcv-reject`); push-to-main run 32482959828 shows all 9 scenarios.
  Confirms `jq 'select(.full_suite_only == false)'` handles JSON booleans
  correctly and the boolean coercion concern (CONCERN-2327) does not apply to
  the current implementation.