### PR TITLE
refactor: extract 16 universal invariant tests into shared factory

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -259,6 +259,9 @@ jobs:
       needs.scenarios.result == 'success'
     strategy:
       fail-fast: false
+      # Intentionally identical to the `demo` job matrix: both jobs must fan
+      # out over the same scenario set.  GitHub Actions does not support YAML
+      # anchors, so the `include:` stanza cannot be deduplicated further.
       matrix:
         include: ${{ fromJSON(needs.scenarios.outputs.matrix) }}
 

--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -167,13 +167,36 @@ existing nine:
    "Artifact Availability on Failure" above.
 3. Declare `_CHAIN_ACTORS` (scenario-role names, not docker service names) and
    `_<SCENARIO>_EXPECTED_EVENT_TYPES`.
-4. Call the shared check functions from `common.py`; keep scenario-specific
-   assertions in the scenario file.
-5. Include `test_invariant_per_actor_replica_divergence` calling
-   `check_per_actor_replica_divergence(replicas)`.  Pass
-   `check_fix_ready=False` for scenarios where no Vendor ever becomes a case
-   participant (currently only `fcv-reject`), mirroring the canonical
+4. Define the module-scoped fixture (e.g. `fv_replicas`) that calls
+   `load_devlogs(demo_name=_DEMO_NAME)`.
+5. Inject the 16 universal invariant tests by calling:
+
+   ```python
+   from test.ci.invariants.universal_harness import make_universal_invariant_tests
+
+   globals().update(
+       make_universal_invariant_tests(
+           replicas_fixture="<scenario>_replicas",
+           chain_actors=_CHAIN_ACTORS,
+           expected_event_types=_<SCENARIO>_EXPECTED_EVENT_TYPES,
+       )
+   )
+   ```
+
+   Pass `check_fix_ready=False` for scenarios where no Vendor ever becomes a
+   case participant (currently only `fcv-reject`), mirroring the canonical
    `test_invariant_15_cs_state_transitions_observed` rule (ISSUE-2411 Gap 1).
+
+6. Add only the **scenario-specific** assertions below the injection call —
+   count checks, late-joiner checks, and any protocol-path constraints unique
+   to this scenario.
+
+`test/ci/invariants/universal_harness.py` defines `make_universal_invariant_tests()`.
+It generates the 16 standard test functions (Invariants 1–15, clp13, per_actor)
+as closures that retrieve the scenario's replicas fixture at runtime via
+`request.getfixturevalue(replicas_fixture)`. Each function has its `__module__`
+set to the calling harness so pytest's fixture lookup resolves to the harness
+module's own fixtures (ISSUE-2007, AC-1).
 
 **The scenario→harness registry is the CI matrix**, not a Python module. The
 `demo:` / `test_file:` pairs in `.github/demo-scenarios.json` (read by the
@@ -191,11 +214,6 @@ and must be kept in step.
 > holds synthetic in-memory JSONL fixtures for unit-testing the check functions
 > in `common.py` — it carries no scenario mapping. Do not bolt scenario routing
 > onto it.
-
-Known duplication: all nine harnesses re-implement the same ~14 universal
-invariant tests as near-identical thin wrappers over `common.py`. Extracting
-them is tracked separately; the per-file `_DEMO_NAME` + `load_devlogs` idiom is
-not the duplication worth fixing.
 
 ---
 

--- a/test/ci/invariants/test_fccv_extension_invariants.py
+++ b/test/ci/invariants/test_fccv_extension_invariants.py
@@ -35,26 +35,12 @@ from __future__ import annotations
 import pytest
 
 from test.ci.invariants.common import (
-    check_cross_actor_hash_agreement,
-    check_cross_actor_payload_actor_agreement,
-    check_cs_state_transitions_observed,
     check_event_type_count,
     check_event_type_present,
-    check_genesis_entry_present,
-    check_hash_chain,
     check_late_joiner_has_full_history,
-    check_log_starts_at_genesis,
-    check_nested_objects_inlined,
-    check_no_gaps_in_log_indices,
-    check_no_rejected_invite_entries,
-    check_no_rm_state_oscillation,
-    check_non_empty_payload_snapshots,
-    check_participant_status_schema_completeness,
-    check_payload_context_uses_case_uri,
-    check_per_actor_replica_divergence,
-    check_rm_closed_termination,
     load_devlogs,
 )
+from test.ci.invariants.universal_harness import make_universal_invariant_tests
 
 _DEMO_NAME = "fccv-extension"
 
@@ -107,212 +93,16 @@ def fccv_extension_replicas() -> dict[str, list[dict]]:
 
 
 # ---------------------------------------------------------------------------
-# Universal invariants
+# Universal invariants (injected from universal_harness)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_1_local_hash_chain_consistent(
-    actor_name: str,
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Within each contiguous logIndex fragment, hashes chain correctly."""
-    entries = fccv_extension_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fccv-extension/"
-        )
-    violations = check_hash_chain(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_2_cross_actor_hash_agreement(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on entryHash for every shared logIndex."""
-    violations = check_cross_actor_hash_agreement(fccv_extension_replicas)
-    assert not violations, (
-        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
-        + "\n".join(violations[:20])
+globals().update(
+    make_universal_invariant_tests(
+        replicas_fixture="fccv_extension_replicas",
+        chain_actors=_CHAIN_ACTORS,
+        expected_event_types=_FCCV_EXTENSION_EXPECTED_EVENT_TYPES,
     )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_3_cross_actor_payload_actor_agreement(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
-    violations = check_cross_actor_payload_actor_agreement(
-        fccv_extension_replicas
-    )
-    assert (
-        not violations
-    ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
-        violations[:20]
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_4_non_empty_payload_snapshot(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Every recorded canonical entry has a non-empty payloadSnapshot."""
-    violations = check_non_empty_payload_snapshots(fccv_extension_replicas)
-    assert not violations, (
-        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize(
-    "event_type_val", _FCCV_EXTENSION_EXPECTED_EVENT_TYPES
 )
-def test_invariant_5_expected_event_types_present(
-    event_type_val: str,
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Each expected protocol eventType appears at least once."""
-    violations = check_event_type_present(
-        fccv_extension_replicas, event_type_val
-    )
-    assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_6_no_rm_state_oscillation(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """No participant changes RM state after first reaching CLOSED."""
-    violations = check_no_rm_state_oscillation(fccv_extension_replicas)
-    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_7_log_terminates_all_rm_closed(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """The log terminates with every participant in RM=CLOSED."""
-    violations = check_rm_closed_termination(fccv_extension_replicas)
-    assert not violations, f"Participants not in RM=CLOSED: {violations}"
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_9_participant_status_schema_completeness(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
-    violations = check_participant_status_schema_completeness(
-        fccv_extension_replicas
-    )
-    assert not violations, (
-        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_10_nested_objects_inlined_in_payload(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.object is an inline dict, not a bare ID string."""
-    violations = check_nested_objects_inlined(fccv_extension_replicas)
-    assert not violations, (
-        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_11_payload_context_uses_case_uri(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
-    violations = check_payload_context_uses_case_uri(fccv_extension_replicas)
-    assert not violations, (
-        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_12_genesis_entry_present(
-    actor_name: str,
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """logIndex=0 is present in the actor's log."""
-    entries = fccv_extension_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fccv-extension/"
-        )
-    violations = check_genesis_entry_present(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_13_log_starts_at_genesis(
-    actor_name: str,
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """The first entry in the actor's sorted log has logIndex=0."""
-    entries = fccv_extension_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fccv-extension/"
-        )
-    violations = check_log_starts_at_genesis(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_14_no_gaps_in_log_indices(
-    actor_name: str,
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """No gaps within the actor's present logIndex range."""
-    entries = fccv_extension_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fccv-extension/"
-        )
-    violations = check_no_gaps_in_log_indices(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_15_cs_state_transitions_observed(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """All three key CS transitions observed in the authoritative log."""
-    violations = check_cs_state_transitions_observed(fccv_extension_replicas)
-    assert not violations, "Missing CS-transition observations:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_clp13_no_rejected_invite_entries(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
-
-    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
-    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
-    called create_commit_log_entry_tree.
-    """
-    violations = check_no_rejected_invite_entries(fccv_extension_replicas)
-    assert not violations, (
-        f"Found {len(violations)} spurious rejected invite_actor_to_case"
-        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -408,16 +198,3 @@ def test_fccv_extension_accept_invite_at_least_twice(
         fccv_extension_replicas, "accept_invite_actor_to_case", min_count=2
     )
     assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_per_actor_replica_divergence(
-    fccv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
-    violations = check_per_actor_replica_divergence(fccv_extension_replicas)
-    assert (
-        not violations
-    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
-        violations
-    )

--- a/test/ci/invariants/test_fccv_handoff_invariants.py
+++ b/test/ci/invariants/test_fccv_handoff_invariants.py
@@ -32,26 +32,11 @@ from __future__ import annotations
 import pytest
 
 from test.ci.invariants.common import (
-    check_cross_actor_hash_agreement,
-    check_cross_actor_payload_actor_agreement,
-    check_cs_state_transitions_observed,
     check_event_type_count,
-    check_event_type_present,
-    check_genesis_entry_present,
-    check_hash_chain,
     check_late_joiner_has_full_history,
-    check_log_starts_at_genesis,
-    check_nested_objects_inlined,
-    check_no_gaps_in_log_indices,
-    check_no_rejected_invite_entries,
-    check_no_rm_state_oscillation,
-    check_non_empty_payload_snapshots,
-    check_participant_status_schema_completeness,
-    check_payload_context_uses_case_uri,
-    check_per_actor_replica_divergence,
-    check_rm_closed_termination,
     load_devlogs,
 )
+from test.ci.invariants.universal_harness import make_universal_invariant_tests
 
 _DEMO_NAME = "fccv-handoff"
 
@@ -104,210 +89,16 @@ def fccv_handoff_replicas() -> dict[str, list[dict]]:
 
 
 # ---------------------------------------------------------------------------
-# Universal invariants
+# Universal invariants (injected from universal_harness)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_1_local_hash_chain_consistent(
-    actor_name: str,
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Within each contiguous logIndex fragment, hashes chain correctly."""
-    entries = fccv_handoff_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fccv-handoff/"
-        )
-    violations = check_hash_chain(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_2_cross_actor_hash_agreement(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on entryHash for every shared logIndex."""
-    violations = check_cross_actor_hash_agreement(fccv_handoff_replicas)
-    assert not violations, (
-        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
-        + "\n".join(violations[:20])
+globals().update(
+    make_universal_invariant_tests(
+        replicas_fixture="fccv_handoff_replicas",
+        chain_actors=_CHAIN_ACTORS,
+        expected_event_types=_FCCV_HANDOFF_EXPECTED_EVENT_TYPES,
     )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_3_cross_actor_payload_actor_agreement(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
-    violations = check_cross_actor_payload_actor_agreement(
-        fccv_handoff_replicas
-    )
-    assert (
-        not violations
-    ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
-        violations[:20]
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_4_non_empty_payload_snapshot(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Every recorded canonical entry has a non-empty payloadSnapshot."""
-    violations = check_non_empty_payload_snapshots(fccv_handoff_replicas)
-    assert not violations, (
-        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("event_type_val", _FCCV_HANDOFF_EXPECTED_EVENT_TYPES)
-def test_invariant_5_expected_event_types_present(
-    event_type_val: str,
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Each expected protocol eventType appears at least once."""
-    violations = check_event_type_present(
-        fccv_handoff_replicas, event_type_val
-    )
-    assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_6_no_rm_state_oscillation(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """No participant changes RM state after first reaching CLOSED."""
-    violations = check_no_rm_state_oscillation(fccv_handoff_replicas)
-    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_7_log_terminates_all_rm_closed(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """The log terminates with every participant in RM=CLOSED."""
-    violations = check_rm_closed_termination(fccv_handoff_replicas)
-    assert not violations, f"Participants not in RM=CLOSED: {violations}"
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_9_participant_status_schema_completeness(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
-    violations = check_participant_status_schema_completeness(
-        fccv_handoff_replicas
-    )
-    assert not violations, (
-        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_10_nested_objects_inlined_in_payload(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.object is an inline dict, not a bare ID string."""
-    violations = check_nested_objects_inlined(fccv_handoff_replicas)
-    assert not violations, (
-        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_11_payload_context_uses_case_uri(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
-    violations = check_payload_context_uses_case_uri(fccv_handoff_replicas)
-    assert not violations, (
-        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_12_genesis_entry_present(
-    actor_name: str,
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """logIndex=0 is present in the actor's log."""
-    entries = fccv_handoff_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fccv-handoff/"
-        )
-    violations = check_genesis_entry_present(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_13_log_starts_at_genesis(
-    actor_name: str,
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """The first entry in the actor's sorted log has logIndex=0."""
-    entries = fccv_handoff_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fccv-handoff/"
-        )
-    violations = check_log_starts_at_genesis(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_14_no_gaps_in_log_indices(
-    actor_name: str,
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """No gaps within the actor's present logIndex range."""
-    entries = fccv_handoff_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fccv-handoff/"
-        )
-    violations = check_no_gaps_in_log_indices(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_15_cs_state_transitions_observed(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """All three key CS transitions observed in the authoritative log."""
-    violations = check_cs_state_transitions_observed(fccv_handoff_replicas)
-    assert not violations, "Missing CS-transition observations:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_clp13_no_rejected_invite_entries(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
-
-    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
-    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
-    called create_commit_log_entry_tree.
-    """
-    violations = check_no_rejected_invite_entries(fccv_handoff_replicas)
-    assert not violations, (
-        f"Found {len(violations)} spurious rejected invite_actor_to_case"
-        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
-    )
+)
 
 
 # ---------------------------------------------------------------------------
@@ -410,16 +201,3 @@ def test_fccv_handoff_vendor_late_joiner_has_full_history(
         fccv_handoff_replicas, early_actor="vendor", late_actor="vendor2"
     )
     assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_per_actor_replica_divergence(
-    fccv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
-    violations = check_per_actor_replica_divergence(fccv_handoff_replicas)
-    assert (
-        not violations
-    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
-        violations
-    )

--- a/test/ci/invariants/test_fcv_invariants.py
+++ b/test/ci/invariants/test_fcv_invariants.py
@@ -26,29 +26,15 @@ from __future__ import annotations
 import pytest
 
 from test.ci.invariants.common import (
-    check_cross_actor_hash_agreement,
-    check_cross_actor_payload_actor_agreement,
-    check_cs_state_transitions_observed,
     check_event_type_count,
     check_event_type_present,
-    check_genesis_entry_present,
-    check_hash_chain,
     check_late_joiner_has_full_history,
-    check_log_starts_at_genesis,
-    check_nested_objects_inlined,
-    check_no_gaps_in_log_indices,
-    check_no_rejected_invite_entries,
-    check_no_rm_state_oscillation,
-    check_non_empty_payload_snapshots,
-    check_participant_status_schema_completeness,
-    check_payload_context_uses_case_uri,
-    check_per_actor_replica_divergence,
-    check_rm_closed_termination,
     cs_observations_from_snap,
     event_type,
     load_devlogs,
     payload,
 )
+from test.ci.invariants.universal_harness import make_universal_invariant_tests
 
 _DEMO_NAME = "fcv"
 
@@ -92,196 +78,16 @@ def fcv_replicas() -> dict[str, list[dict]]:
 
 
 # ---------------------------------------------------------------------------
-# Universal invariants
+# Universal invariants (injected from universal_harness)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_1_local_hash_chain_consistent(
-    actor_name: str,
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Within each contiguous logIndex fragment, hashes chain correctly."""
-    entries = fcv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcv/")
-    violations = check_hash_chain(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_2_cross_actor_hash_agreement(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on entryHash for every shared logIndex."""
-    violations = check_cross_actor_hash_agreement(fcv_replicas)
-    assert not violations, (
-        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
-        + "\n".join(violations[:20])
+globals().update(
+    make_universal_invariant_tests(
+        replicas_fixture="fcv_replicas",
+        chain_actors=_CHAIN_ACTORS,
+        expected_event_types=_FCV_EXPECTED_EVENT_TYPES,
     )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_3_cross_actor_payload_actor_agreement(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
-    violations = check_cross_actor_payload_actor_agreement(fcv_replicas)
-    assert (
-        not violations
-    ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
-        violations[:20]
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_4_non_empty_payload_snapshot(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Every recorded canonical entry has a non-empty payloadSnapshot."""
-    violations = check_non_empty_payload_snapshots(fcv_replicas)
-    assert not violations, (
-        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("event_type_val", _FCV_EXPECTED_EVENT_TYPES)
-def test_invariant_5_expected_event_types_present(
-    event_type_val: str,
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Each expected protocol eventType appears at least once."""
-    violations = check_event_type_present(fcv_replicas, event_type_val)
-    assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_6_no_rm_state_oscillation(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """No participant changes RM state after first reaching CLOSED."""
-    violations = check_no_rm_state_oscillation(fcv_replicas)
-    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_7_log_terminates_all_rm_closed(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """The log terminates with every participant in RM=CLOSED."""
-    violations = check_rm_closed_termination(fcv_replicas)
-    assert not violations, f"Participants not in RM=CLOSED: {violations}"
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_9_participant_status_schema_completeness(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
-    violations = check_participant_status_schema_completeness(fcv_replicas)
-    assert not violations, (
-        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_10_nested_objects_inlined_in_payload(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.object is an inline dict, not a bare ID string."""
-    violations = check_nested_objects_inlined(fcv_replicas)
-    assert not violations, (
-        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_11_payload_context_uses_case_uri(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
-    violations = check_payload_context_uses_case_uri(fcv_replicas)
-    assert not violations, (
-        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_12_genesis_entry_present(
-    actor_name: str,
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """logIndex=0 is present in the actor's log."""
-    entries = fcv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcv/")
-    violations = check_genesis_entry_present(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_13_log_starts_at_genesis(
-    actor_name: str,
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """The first entry in the actor's sorted log has logIndex=0."""
-    entries = fcv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcv/")
-    violations = check_log_starts_at_genesis(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_14_no_gaps_in_log_indices(
-    actor_name: str,
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """No gaps within the actor's present logIndex range."""
-    entries = fcv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcv/")
-    violations = check_no_gaps_in_log_indices(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_15_cs_state_transitions_observed(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """All three key CS transitions observed in the authoritative log."""
-    violations = check_cs_state_transitions_observed(fcv_replicas)
-    assert not violations, "Missing CS-transition observations:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_clp13_no_rejected_invite_entries(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
-
-    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
-    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
-    called create_commit_log_entry_tree.
-    """
-    violations = check_no_rejected_invite_entries(fcv_replicas)
-    assert not violations, (
-        f"Found {len(violations)} spurious rejected invite_actor_to_case"
-        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
-    )
+)
 
 
 # ---------------------------------------------------------------------------
@@ -413,17 +219,4 @@ def test_fcv_coordinator_p_transition_observed(
     assert saw_published, (
         "Coordinator: pxa_state starting with 'P' (public-aware) never observed "
         "in add_participant_status_to_participant entries"
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_per_actor_replica_divergence(
-    fcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
-    violations = check_per_actor_replica_divergence(fcv_replicas)
-    assert (
-        not violations
-    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
-        violations
     )

--- a/test/ci/invariants/test_fcv_reject_invariants.py
+++ b/test/ci/invariants/test_fcv_reject_invariants.py
@@ -28,27 +28,13 @@ from __future__ import annotations
 import pytest
 
 from test.ci.invariants.common import (
-    check_cross_actor_hash_agreement,
-    check_cross_actor_payload_actor_agreement,
-    check_cs_state_transitions_observed,
     check_event_type_present,
-    check_genesis_entry_present,
-    check_hash_chain,
-    check_log_starts_at_genesis,
-    check_nested_objects_inlined,
-    check_no_gaps_in_log_indices,
-    check_no_rejected_invite_entries,
-    check_no_rm_state_oscillation,
-    check_non_empty_payload_snapshots,
-    check_participant_status_schema_completeness,
-    check_payload_context_uses_case_uri,
-    check_per_actor_replica_divergence,
-    check_rm_closed_termination,
     cs_observations_from_snap,
     event_type,
     load_devlogs,
     payload,
 )
+from test.ci.invariants.universal_harness import make_universal_invariant_tests
 
 _DEMO_NAME = "fcv-reject"
 
@@ -91,216 +77,17 @@ def fcv_reject_replicas() -> dict[str, list[dict]]:
 
 
 # ---------------------------------------------------------------------------
-# Universal invariants
+# Universal invariants (injected from universal_harness)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_1_local_hash_chain_consistent(
-    actor_name: str,
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """Within each contiguous logIndex fragment, hashes chain correctly."""
-    entries = fcv_reject_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fcv-reject/"
-        )
-    violations = check_hash_chain(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_2_cross_actor_hash_agreement(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on entryHash for every shared logIndex."""
-    violations = check_cross_actor_hash_agreement(fcv_reject_replicas)
-    assert not violations, (
-        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
-        + "\n".join(violations[:20])
+globals().update(
+    make_universal_invariant_tests(
+        replicas_fixture="fcv_reject_replicas",
+        chain_actors=_CHAIN_ACTORS,
+        expected_event_types=_FCV_REJECT_EXPECTED_EVENT_TYPES,
+        check_fix_ready=False,
     )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_3_cross_actor_payload_actor_agreement(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
-    violations = check_cross_actor_payload_actor_agreement(fcv_reject_replicas)
-    assert (
-        not violations
-    ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
-        violations[:20]
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_4_non_empty_payload_snapshot(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """Every recorded canonical entry has a non-empty payloadSnapshot."""
-    violations = check_non_empty_payload_snapshots(fcv_reject_replicas)
-    assert not violations, (
-        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("event_type_val", _FCV_REJECT_EXPECTED_EVENT_TYPES)
-def test_invariant_5_expected_event_types_present(
-    event_type_val: str,
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """Each expected protocol eventType appears at least once."""
-    violations = check_event_type_present(fcv_reject_replicas, event_type_val)
-    assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_6_no_rm_state_oscillation(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """No participant changes RM state after first reaching CLOSED."""
-    violations = check_no_rm_state_oscillation(fcv_reject_replicas)
-    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_7_log_terminates_all_rm_closed(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """The log terminates with every participant in RM=CLOSED."""
-    violations = check_rm_closed_termination(fcv_reject_replicas)
-    assert not violations, f"Participants not in RM=CLOSED: {violations}"
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_9_participant_status_schema_completeness(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
-    violations = check_participant_status_schema_completeness(
-        fcv_reject_replicas
-    )
-    assert not violations, (
-        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_10_nested_objects_inlined_in_payload(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.object is an inline dict, not a bare ID string."""
-    violations = check_nested_objects_inlined(fcv_reject_replicas)
-    assert not violations, (
-        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_11_payload_context_uses_case_uri(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
-    violations = check_payload_context_uses_case_uri(fcv_reject_replicas)
-    assert not violations, (
-        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_12_genesis_entry_present(
-    actor_name: str,
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """logIndex=0 is present in the actor's log."""
-    entries = fcv_reject_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fcv-reject/"
-        )
-    violations = check_genesis_entry_present(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_13_log_starts_at_genesis(
-    actor_name: str,
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """The first entry in the actor's sorted log has logIndex=0."""
-    entries = fcv_reject_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fcv-reject/"
-        )
-    violations = check_log_starts_at_genesis(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_14_no_gaps_in_log_indices(
-    actor_name: str,
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """No gaps within the actor's present logIndex range."""
-    entries = fcv_reject_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fcv-reject/"
-        )
-    violations = check_no_gaps_in_log_indices(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_15_cs_state_transitions_observed(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """P-transition (public aware) observed; VFd check skipped for reject-flow.
-
-    In the fcv-reject scenario Vendor rejects the case invitation and is never
-    added as a participant, so no actor advances the VFD state machine.
-    ``vfd_state == 'VFd'`` (fix ready) is therefore unreachable and is excluded
-    from this scenario's Invariant 15.  The P-transition (pxa_state starts with
-    'P') is still required — Coordinator triggers CS.P during publication.
-    """
-    violations = check_cs_state_transitions_observed(
-        fcv_reject_replicas, check_fix_ready=False
-    )
-    assert not violations, "Missing CS-transition observations:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_clp13_no_rejected_invite_entries(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
-
-    The intentional rejection in this scenario is recorded as a
-    ``reject_invite_actor_to_case`` event, NOT as a ``invite_actor_to_case``
-    entry with disposition=rejected.  Idempotency guards MUST NOT write
-    spurious rejected invite entries for duplicate detection.
-    """
-    violations = check_no_rejected_invite_entries(fcv_reject_replicas)
-    assert not violations, (
-        f"Found {len(violations)} spurious rejected invite_actor_to_case"
-        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
-    )
+)
 
 
 # ---------------------------------------------------------------------------
@@ -431,23 +218,4 @@ def test_fcv_reject_coordinator_p_transition_observed(
     assert saw_published, (
         "Coordinator: pxa_state starting with 'P' (public-aware) never observed "
         "in add_participant_status_to_participant entries"
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_per_actor_replica_divergence(
-    fcv_reject_replicas: dict[str, list[dict]],
-) -> None:
-    """Each non-case-actor replica satisfies the same state invariants as the authoritative log.
-
-    check_fix_ready=False because Vendor rejected the invitation and never
-    advanced the VFD state machine (matching the canonical invariant 15 rule).
-    """
-    violations = check_per_actor_replica_divergence(
-        fcv_reject_replicas, check_fix_ready=False
-    )
-    assert (
-        not violations
-    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
-        violations
     )

--- a/test/ci/invariants/test_fcvcv_invariants.py
+++ b/test/ci/invariants/test_fcvcv_invariants.py
@@ -36,26 +36,12 @@ from __future__ import annotations
 import pytest
 
 from test.ci.invariants.common import (
-    check_cross_actor_hash_agreement,
-    check_cross_actor_payload_actor_agreement,
-    check_cs_state_transitions_observed,
     check_event_type_count,
     check_event_type_present,
-    check_genesis_entry_present,
-    check_hash_chain,
     check_late_joiner_has_full_history,
-    check_log_starts_at_genesis,
-    check_nested_objects_inlined,
-    check_no_gaps_in_log_indices,
-    check_no_rejected_invite_entries,
-    check_no_rm_state_oscillation,
-    check_non_empty_payload_snapshots,
-    check_participant_status_schema_completeness,
-    check_payload_context_uses_case_uri,
-    check_per_actor_replica_divergence,
-    check_rm_closed_termination,
     load_devlogs,
 )
+from test.ci.invariants.universal_harness import make_universal_invariant_tests
 
 _DEMO_NAME = "fcvcv"
 
@@ -108,196 +94,16 @@ def fcvcv_replicas() -> dict[str, list[dict]]:
 
 
 # ---------------------------------------------------------------------------
-# Universal invariants
+# Universal invariants (injected from universal_harness)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_1_local_hash_chain_consistent(
-    actor_name: str,
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Within each contiguous logIndex fragment, hashes chain correctly."""
-    entries = fcvcv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcvcv/")
-    violations = check_hash_chain(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_2_cross_actor_hash_agreement(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on entryHash for every shared logIndex."""
-    violations = check_cross_actor_hash_agreement(fcvcv_replicas)
-    assert not violations, (
-        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
-        + "\n".join(violations[:20])
+globals().update(
+    make_universal_invariant_tests(
+        replicas_fixture="fcvcv_replicas",
+        chain_actors=_CHAIN_ACTORS,
+        expected_event_types=_FCVCV_EXPECTED_EVENT_TYPES,
     )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_3_cross_actor_payload_actor_agreement(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
-    violations = check_cross_actor_payload_actor_agreement(fcvcv_replicas)
-    assert (
-        not violations
-    ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
-        violations[:20]
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_4_non_empty_payload_snapshot(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Every recorded canonical entry has a non-empty payloadSnapshot."""
-    violations = check_non_empty_payload_snapshots(fcvcv_replicas)
-    assert not violations, (
-        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("event_type_val", _FCVCV_EXPECTED_EVENT_TYPES)
-def test_invariant_5_expected_event_types_present(
-    event_type_val: str,
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Each expected protocol eventType appears at least once."""
-    violations = check_event_type_present(fcvcv_replicas, event_type_val)
-    assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_6_no_rm_state_oscillation(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """No participant changes RM state after first reaching CLOSED."""
-    violations = check_no_rm_state_oscillation(fcvcv_replicas)
-    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_7_log_terminates_all_rm_closed(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """The log terminates with every participant in RM=CLOSED."""
-    violations = check_rm_closed_termination(fcvcv_replicas)
-    assert not violations, f"Participants not in RM=CLOSED: {violations}"
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_9_participant_status_schema_completeness(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
-    violations = check_participant_status_schema_completeness(fcvcv_replicas)
-    assert not violations, (
-        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_10_nested_objects_inlined_in_payload(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.object is an inline dict, not a bare ID string."""
-    violations = check_nested_objects_inlined(fcvcv_replicas)
-    assert not violations, (
-        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_11_payload_context_uses_case_uri(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
-    violations = check_payload_context_uses_case_uri(fcvcv_replicas)
-    assert not violations, (
-        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_12_genesis_entry_present(
-    actor_name: str,
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """logIndex=0 is present in the actor's log."""
-    entries = fcvcv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcvcv/")
-    violations = check_genesis_entry_present(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_13_log_starts_at_genesis(
-    actor_name: str,
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """The first entry in the actor's sorted log has logIndex=0."""
-    entries = fcvcv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcvcv/")
-    violations = check_log_starts_at_genesis(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_14_no_gaps_in_log_indices(
-    actor_name: str,
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """No gaps within the actor's present logIndex range."""
-    entries = fcvcv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fcvcv/")
-    violations = check_no_gaps_in_log_indices(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_15_cs_state_transitions_observed(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """All three key CS transitions observed in the authoritative log."""
-    violations = check_cs_state_transitions_observed(fcvcv_replicas)
-    assert not violations, "Missing CS-transition observations:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_clp13_no_rejected_invite_entries(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
-
-    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
-    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
-    called create_commit_log_entry_tree.
-    """
-    violations = check_no_rejected_invite_entries(fcvcv_replicas)
-    assert not violations, (
-        f"Found {len(violations)} spurious rejected invite_actor_to_case"
-        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
-    )
+)
 
 
 # ---------------------------------------------------------------------------
@@ -414,16 +220,3 @@ def test_fcvcv_v1_late_joiner_has_full_history(
         fcvcv_replicas, early_actor="c1", late_actor="v1"
     )
     assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_per_actor_replica_divergence(
-    fcvcv_replicas: dict[str, list[dict]],
-) -> None:
-    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
-    violations = check_per_actor_replica_divergence(fcvcv_replicas)
-    assert (
-        not violations
-    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
-        violations
-    )

--- a/test/ci/invariants/test_fv_invariants.py
+++ b/test/ci/invariants/test_fv_invariants.py
@@ -16,25 +16,10 @@ from __future__ import annotations
 import pytest
 
 from test.ci.invariants.common import (
-    check_cross_actor_hash_agreement,
-    check_cross_actor_payload_actor_agreement,
-    check_cs_state_transitions_observed,
-    check_event_type_present,
-    check_genesis_entry_present,
-    check_hash_chain,
     check_late_joiner_has_full_history,
-    check_log_starts_at_genesis,
-    check_nested_objects_inlined,
-    check_no_gaps_in_log_indices,
-    check_no_rejected_invite_entries,
-    check_no_rm_state_oscillation,
-    check_non_empty_payload_snapshots,
-    check_participant_status_schema_completeness,
-    check_payload_context_uses_case_uri,
-    check_per_actor_replica_divergence,
-    check_rm_closed_termination,
     load_devlogs,
 )
+from test.ci.invariants.universal_harness import make_universal_invariant_tests
 
 _DEMO_NAME = "fv"
 
@@ -72,98 +57,27 @@ def fv_replicas() -> dict[str, list[dict]]:
 
 
 # ---------------------------------------------------------------------------
-# Universal invariants (shared library)
+# Universal invariants (injected from universal_harness)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_1_local_hash_chain_consistent(
-    actor_name: str,
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """Within each contiguous logIndex fragment, hashes chain correctly.
-
-    Spec: CLP-07.
-    """
-    entries = fv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/")
-    violations = check_hash_chain(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_2_cross_actor_hash_agreement(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on entryHash for every shared logIndex."""
-    violations = check_cross_actor_hash_agreement(fv_replicas)
-    assert not violations, (
-        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
-        + "\n".join(violations[:20])
+globals().update(
+    make_universal_invariant_tests(
+        replicas_fixture="fv_replicas",
+        chain_actors=_CHAIN_ACTORS,
+        expected_event_types=_FV_EXPECTED_EVENT_TYPES,
     )
+)
 
 
-@pytest.mark.case_ledger_invariants
-def test_invariant_3_cross_actor_payload_actor_agreement(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
-    violations = check_cross_actor_payload_actor_agreement(fv_replicas)
-    assert not violations, (
-        f"Cross-actor payloadSnapshot.actor mismatches at "
-        f"{len(violations)} logIndex(es):\n" + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_4_non_empty_payload_snapshot(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """Every recorded canonical entry has a non-empty payloadSnapshot."""
-    violations = check_non_empty_payload_snapshots(fv_replicas)
-    assert not violations, (
-        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("event_type_val", _FV_EXPECTED_EVENT_TYPES)
-def test_invariant_5_expected_event_types_present(
-    event_type_val: str,
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """Each expected protocol eventType appears at least once.
-
-    Note: ``ack_report`` is intentionally excluded — the FV demo uses
-    ``auto_create_case=True``, so no pre-case ACK is emitted (see #1133).
-    """
-    violations = check_event_type_present(fv_replicas, event_type_val)
-    assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_6_no_rm_state_oscillation(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """No participant changes RM state after first reaching CLOSED."""
-    violations = check_no_rm_state_oscillation(fv_replicas)
-    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_7_log_terminates_all_rm_closed(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """The log terminates with every participant in RM=CLOSED."""
-    violations = check_rm_closed_termination(fv_replicas)
-    assert (
-        not violations
-    ), f"Participants not in RM=CLOSED at log end: {violations}"
+# ---------------------------------------------------------------------------
+# FV-specific invariants
+# ---------------------------------------------------------------------------
+#
+# The FV scenario has no scenario-specific ledger invariant beyond
+# the universal set: the Finder joins by submitting a report (which creates the
+# case), never via an ``invite_actor_to_case`` activity, so no invite event is
+# expected in this ledger.  Scenarios that invite a mid-case participant (FVV,
+# FVCV-extension, FVCV-handoff) assert the invite event in their own files.
 
 
 @pytest.mark.case_ledger_invariants
@@ -183,139 +97,3 @@ def test_invariant_8_late_joiner_has_full_history(
         fv_replicas, early_actor="vendor", late_actor="finder"
     )
     assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_9_participant_status_schema_completeness(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
-    violations = check_participant_status_schema_completeness(fv_replicas)
-    assert not violations, (
-        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_10_nested_objects_inlined_in_payload(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.object is an inline dict, not a bare ID string."""
-    violations = check_nested_objects_inlined(fv_replicas)
-    assert not violations, (
-        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_11_payload_context_uses_case_uri(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
-    violations = check_payload_context_uses_case_uri(fv_replicas)
-    assert not violations, (
-        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_12_genesis_entry_present(
-    actor_name: str,
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """logIndex=0 is present in the actor's log."""
-    entries = fv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/")
-    violations = check_genesis_entry_present(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_13_log_starts_at_genesis(
-    actor_name: str,
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """The first entry in the actor's sorted log has logIndex=0."""
-    entries = fv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/")
-    violations = check_log_starts_at_genesis(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_14_no_gaps_in_log_indices(
-    actor_name: str,
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """No gaps within the actor's present logIndex range."""
-    entries = fv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/")
-    violations = check_no_gaps_in_log_indices(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_15_cs_state_transitions_observed(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """All three key CS transitions are recorded in the authoritative log.
-
-    Checks vfd_state == "VFd" (fix_ready), "VFD" (fix_deployed), and
-    pxa_state starting with "P" (public-aware).
-    """
-    violations = check_cs_state_transitions_observed(fv_replicas)
-    assert not violations, (
-        "Missing CS-transition observations in "
-        "add_participant_status_to_participant entries:\n"
-        + "\n".join(violations)
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_clp13_no_rejected_invite_entries(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
-
-    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
-    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
-    called create_commit_log_entry_tree.
-    """
-    violations = check_no_rejected_invite_entries(fv_replicas)
-    assert not violations, (
-        f"Found {len(violations)} spurious rejected invite_actor_to_case"
-        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_per_actor_replica_divergence(
-    fv_replicas: dict[str, list[dict]],
-) -> None:
-    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
-    violations = check_per_actor_replica_divergence(fv_replicas)
-    assert (
-        not violations
-    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
-        violations
-    )
-
-
-# ---------------------------------------------------------------------------
-# FV-specific invariants
-# ---------------------------------------------------------------------------
-#
-# The FV scenario has no scenario-specific ledger invariant beyond
-# the universal set: the Finder joins by submitting a report (which creates the
-# case), never via an ``invite_actor_to_case`` activity, so no invite event is
-# expected in this ledger.  Scenarios that invite a mid-case participant (FVV,
-# FVCV-extension, FVCV-handoff) assert the invite event in their own files.

--- a/test/ci/invariants/test_fvcv_extension_invariants.py
+++ b/test/ci/invariants/test_fvcv_extension_invariants.py
@@ -27,26 +27,12 @@ from __future__ import annotations
 import pytest
 
 from test.ci.invariants.common import (
-    check_cross_actor_hash_agreement,
-    check_cross_actor_payload_actor_agreement,
-    check_cs_state_transitions_observed,
     check_event_type_count,
     check_event_type_present,
-    check_genesis_entry_present,
-    check_hash_chain,
     check_late_joiner_has_full_history,
-    check_log_starts_at_genesis,
-    check_nested_objects_inlined,
-    check_no_gaps_in_log_indices,
-    check_no_rejected_invite_entries,
-    check_no_rm_state_oscillation,
-    check_non_empty_payload_snapshots,
-    check_participant_status_schema_completeness,
-    check_payload_context_uses_case_uri,
-    check_per_actor_replica_divergence,
-    check_rm_closed_termination,
     load_devlogs,
 )
+from test.ci.invariants.universal_harness import make_universal_invariant_tests
 
 _DEMO_NAME = "fvcv-extension"
 
@@ -98,210 +84,16 @@ def fvcv_extension_replicas() -> dict[str, list[dict]]:
 
 
 # ---------------------------------------------------------------------------
-# Universal invariants
+# Universal invariants (injected from universal_harness)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_1_local_hash_chain_consistent(
-    actor_name: str,
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Within each contiguous logIndex fragment, hashes chain correctly."""
-    entries = fvcv_extension_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fvcv-extension/"
-        )
-    violations = check_hash_chain(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_2_cross_actor_hash_agreement(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on entryHash for every shared logIndex."""
-    violations = check_cross_actor_hash_agreement(fvcv_extension_replicas)
-    assert not violations, (
-        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
-        + "\n".join(violations[:20])
+globals().update(
+    make_universal_invariant_tests(
+        replicas_fixture="fvcv_extension_replicas",
+        chain_actors=_CHAIN_ACTORS,
+        expected_event_types=_FVCV_EXPECTED_EVENT_TYPES,
     )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_3_cross_actor_payload_actor_agreement(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
-    violations = check_cross_actor_payload_actor_agreement(
-        fvcv_extension_replicas
-    )
-    assert (
-        not violations
-    ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
-        violations[:20]
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_4_non_empty_payload_snapshot(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Every recorded canonical entry has a non-empty payloadSnapshot."""
-    violations = check_non_empty_payload_snapshots(fvcv_extension_replicas)
-    assert not violations, (
-        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("event_type_val", _FVCV_EXPECTED_EVENT_TYPES)
-def test_invariant_5_expected_event_types_present(
-    event_type_val: str,
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Each expected protocol eventType appears at least once."""
-    violations = check_event_type_present(
-        fvcv_extension_replicas, event_type_val
-    )
-    assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_6_no_rm_state_oscillation(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """No participant changes RM state after first reaching CLOSED."""
-    violations = check_no_rm_state_oscillation(fvcv_extension_replicas)
-    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_7_log_terminates_all_rm_closed(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """The log terminates with every participant in RM=CLOSED."""
-    violations = check_rm_closed_termination(fvcv_extension_replicas)
-    assert not violations, f"Participants not in RM=CLOSED: {violations}"
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_9_participant_status_schema_completeness(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
-    violations = check_participant_status_schema_completeness(
-        fvcv_extension_replicas
-    )
-    assert not violations, (
-        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_10_nested_objects_inlined_in_payload(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.object is an inline dict, not a bare ID string."""
-    violations = check_nested_objects_inlined(fvcv_extension_replicas)
-    assert not violations, (
-        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_11_payload_context_uses_case_uri(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
-    violations = check_payload_context_uses_case_uri(fvcv_extension_replicas)
-    assert not violations, (
-        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_12_genesis_entry_present(
-    actor_name: str,
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """logIndex=0 is present in the actor's log."""
-    entries = fvcv_extension_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fvcv-extension/"
-        )
-    violations = check_genesis_entry_present(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_13_log_starts_at_genesis(
-    actor_name: str,
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """The first entry in the actor's sorted log has logIndex=0."""
-    entries = fvcv_extension_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fvcv-extension/"
-        )
-    violations = check_log_starts_at_genesis(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_14_no_gaps_in_log_indices(
-    actor_name: str,
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """No gaps within the actor's present logIndex range."""
-    entries = fvcv_extension_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fvcv-extension/"
-        )
-    violations = check_no_gaps_in_log_indices(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_15_cs_state_transitions_observed(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """All three key CS transitions observed in the authoritative log."""
-    violations = check_cs_state_transitions_observed(fvcv_extension_replicas)
-    assert not violations, "Missing CS-transition observations:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_clp13_no_rejected_invite_entries(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
-
-    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
-    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
-    called create_commit_log_entry_tree.
-    """
-    violations = check_no_rejected_invite_entries(fvcv_extension_replicas)
-    assert not violations, (
-        f"Found {len(violations)} spurious rejected invite_actor_to_case"
-        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
-    )
+)
 
 
 # ---------------------------------------------------------------------------
@@ -401,16 +193,3 @@ def test_fvcv_extension_coordinator_late_joiner_has_full_history(
         fvcv_extension_replicas, early_actor="vendor", late_actor="coordinator"
     )
     assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_per_actor_replica_divergence(
-    fvcv_extension_replicas: dict[str, list[dict]],
-) -> None:
-    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
-    violations = check_per_actor_replica_divergence(fvcv_extension_replicas)
-    assert (
-        not violations
-    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
-        violations
-    )

--- a/test/ci/invariants/test_fvcv_handoff_invariants.py
+++ b/test/ci/invariants/test_fvcv_handoff_invariants.py
@@ -32,26 +32,11 @@ from __future__ import annotations
 import pytest
 
 from test.ci.invariants.common import (
-    check_cross_actor_hash_agreement,
-    check_cross_actor_payload_actor_agreement,
-    check_cs_state_transitions_observed,
     check_event_type_count,
-    check_event_type_present,
-    check_genesis_entry_present,
-    check_hash_chain,
     check_late_joiner_has_full_history,
-    check_log_starts_at_genesis,
-    check_nested_objects_inlined,
-    check_no_gaps_in_log_indices,
-    check_no_rejected_invite_entries,
-    check_no_rm_state_oscillation,
-    check_non_empty_payload_snapshots,
-    check_participant_status_schema_completeness,
-    check_payload_context_uses_case_uri,
-    check_per_actor_replica_divergence,
-    check_rm_closed_termination,
     load_devlogs,
 )
+from test.ci.invariants.universal_harness import make_universal_invariant_tests
 
 _DEMO_NAME = "fvcv-handoff"
 
@@ -97,210 +82,16 @@ def fvcv_handoff_replicas() -> dict[str, list[dict]]:
 
 
 # ---------------------------------------------------------------------------
-# Universal invariants
+# Universal invariants (injected from universal_harness)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_1_local_hash_chain_consistent(
-    actor_name: str,
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Within each contiguous logIndex fragment, hashes chain correctly."""
-    entries = fvcv_handoff_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fvcv-handoff/"
-        )
-    violations = check_hash_chain(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_2_cross_actor_hash_agreement(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on entryHash for every shared logIndex."""
-    violations = check_cross_actor_hash_agreement(fvcv_handoff_replicas)
-    assert not violations, (
-        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
-        + "\n".join(violations[:20])
+globals().update(
+    make_universal_invariant_tests(
+        replicas_fixture="fvcv_handoff_replicas",
+        chain_actors=_CHAIN_ACTORS,
+        expected_event_types=_FVCV_HANDOFF_EXPECTED_EVENT_TYPES,
     )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_3_cross_actor_payload_actor_agreement(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
-    violations = check_cross_actor_payload_actor_agreement(
-        fvcv_handoff_replicas
-    )
-    assert (
-        not violations
-    ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
-        violations[:20]
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_4_non_empty_payload_snapshot(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Every recorded canonical entry has a non-empty payloadSnapshot."""
-    violations = check_non_empty_payload_snapshots(fvcv_handoff_replicas)
-    assert not violations, (
-        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("event_type_val", _FVCV_HANDOFF_EXPECTED_EVENT_TYPES)
-def test_invariant_5_expected_event_types_present(
-    event_type_val: str,
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Each expected protocol eventType appears at least once."""
-    violations = check_event_type_present(
-        fvcv_handoff_replicas, event_type_val
-    )
-    assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_6_no_rm_state_oscillation(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """No participant changes RM state after first reaching CLOSED."""
-    violations = check_no_rm_state_oscillation(fvcv_handoff_replicas)
-    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_7_log_terminates_all_rm_closed(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """The log terminates with every participant in RM=CLOSED."""
-    violations = check_rm_closed_termination(fvcv_handoff_replicas)
-    assert not violations, f"Participants not in RM=CLOSED: {violations}"
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_9_participant_status_schema_completeness(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
-    violations = check_participant_status_schema_completeness(
-        fvcv_handoff_replicas
-    )
-    assert not violations, (
-        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_clp13_no_rejected_invite_entries(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
-
-    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
-    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
-    called create_commit_log_entry_tree.
-    """
-    violations = check_no_rejected_invite_entries(fvcv_handoff_replicas)
-    assert not violations, (
-        f"Found {len(violations)} spurious rejected invite_actor_to_case"
-        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_10_nested_objects_inlined_in_payload(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.object is an inline dict, not a bare ID string."""
-    violations = check_nested_objects_inlined(fvcv_handoff_replicas)
-    assert not violations, (
-        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_11_payload_context_uses_case_uri(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
-    violations = check_payload_context_uses_case_uri(fvcv_handoff_replicas)
-    assert not violations, (
-        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_12_genesis_entry_present(
-    actor_name: str,
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """logIndex=0 is present in the actor's log."""
-    entries = fvcv_handoff_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fvcv-handoff/"
-        )
-    violations = check_genesis_entry_present(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_13_log_starts_at_genesis(
-    actor_name: str,
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """The first entry in the actor's sorted log has logIndex=0."""
-    entries = fvcv_handoff_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fvcv-handoff/"
-        )
-    violations = check_log_starts_at_genesis(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_14_no_gaps_in_log_indices(
-    actor_name: str,
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """No gaps within the actor's present logIndex range."""
-    entries = fvcv_handoff_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(
-            f"No log found for actor {actor_name!r} in devlogs/fvcv-handoff/"
-        )
-    violations = check_no_gaps_in_log_indices(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_15_cs_state_transitions_observed(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """All three key CS transitions observed in the authoritative log."""
-    violations = check_cs_state_transitions_observed(fvcv_handoff_replicas)
-    assert not violations, "Missing CS-transition observations:\n" + "\n".join(
-        violations
-    )
+)
 
 
 # ---------------------------------------------------------------------------
@@ -380,16 +171,3 @@ def test_fvcv_handoff_vendor2_late_joiner_has_full_history(
         fvcv_handoff_replicas, early_actor="vendor", late_actor="vendor2"
     )
     assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_per_actor_replica_divergence(
-    fvcv_handoff_replicas: dict[str, list[dict]],
-) -> None:
-    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
-    violations = check_per_actor_replica_divergence(fvcv_handoff_replicas)
-    assert (
-        not violations
-    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
-        violations
-    )

--- a/test/ci/invariants/test_fvv_invariants.py
+++ b/test/ci/invariants/test_fvv_invariants.py
@@ -25,26 +25,11 @@ from __future__ import annotations
 import pytest
 
 from test.ci.invariants.common import (
-    check_cross_actor_hash_agreement,
-    check_cross_actor_payload_actor_agreement,
-    check_cs_state_transitions_observed,
     check_event_type_count,
-    check_event_type_present,
-    check_genesis_entry_present,
-    check_hash_chain,
     check_late_joiner_has_full_history,
-    check_log_starts_at_genesis,
-    check_nested_objects_inlined,
-    check_no_gaps_in_log_indices,
-    check_no_rejected_invite_entries,
-    check_no_rm_state_oscillation,
-    check_non_empty_payload_snapshots,
-    check_participant_status_schema_completeness,
-    check_payload_context_uses_case_uri,
-    check_per_actor_replica_divergence,
-    check_rm_closed_termination,
     load_devlogs,
 )
+from test.ci.invariants.universal_harness import make_universal_invariant_tests
 
 _DEMO_NAME = "fvv"
 
@@ -88,198 +73,16 @@ def fvv_replicas() -> dict[str, list[dict]]:
 
 
 # ---------------------------------------------------------------------------
-# Universal invariants
+# Universal invariants (injected from universal_harness)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_1_local_hash_chain_consistent(
-    actor_name: str,
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """Within each contiguous logIndex fragment, hashes chain correctly."""
-    entries = fvv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fvv/")
-    violations = check_hash_chain(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_2_cross_actor_hash_agreement(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on entryHash for every shared logIndex."""
-    violations = check_cross_actor_hash_agreement(fvv_replicas)
-    assert not violations, (
-        f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
-        + "\n".join(violations[:20])
+globals().update(
+    make_universal_invariant_tests(
+        replicas_fixture="fvv_replicas",
+        chain_actors=_CHAIN_ACTORS,
+        expected_event_types=_FVV_EXPECTED_EVENT_TYPES,
     )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_3_cross_actor_payload_actor_agreement(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """All actors agree on payloadSnapshot.actor for every shared logIndex."""
-    violations = check_cross_actor_payload_actor_agreement(fvv_replicas)
-    assert (
-        not violations
-    ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
-        violations[:20]
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_4_non_empty_payload_snapshot(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """Every recorded canonical entry has a non-empty payloadSnapshot."""
-    violations = check_non_empty_payload_snapshots(fvv_replicas)
-    assert not violations, (
-        f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("event_type_val", _FVV_EXPECTED_EVENT_TYPES)
-def test_invariant_5_expected_event_types_present(
-    event_type_val: str,
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """Each expected protocol eventType appears at least once."""
-    violations = check_event_type_present(fvv_replicas, event_type_val)
-    assert not violations, violations[0] if violations else ""
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_6_no_rm_state_oscillation(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """No participant changes RM state after first reaching CLOSED."""
-    violations = check_no_rm_state_oscillation(fvv_replicas)
-    assert not violations, "RM state oscillation after CLOSED:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_7_log_terminates_all_rm_closed(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """The log terminates with every participant in RM=CLOSED."""
-    violations = check_rm_closed_termination(fvv_replicas)
-    assert (
-        not violations
-    ), f"Participants not in RM=CLOSED at log end: {violations}"
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_9_participant_status_schema_completeness(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
-    violations = check_participant_status_schema_completeness(fvv_replicas)
-    assert not violations, (
-        f"{len(violations)} ParticipantStatus entries missing required fields:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_10_nested_objects_inlined_in_payload(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.object is an inline dict, not a bare ID string."""
-    violations = check_nested_objects_inlined(fvv_replicas)
-    assert not violations, (
-        f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_11_payload_context_uses_case_uri(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """payloadSnapshot.context matches the entry's case_id for recorded entries."""
-    violations = check_payload_context_uses_case_uri(fvv_replicas)
-    assert not violations, (
-        f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
-        + "\n".join(violations[:20])
-    )
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_12_genesis_entry_present(
-    actor_name: str,
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """logIndex=0 is present in the actor's log."""
-    entries = fvv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fvv/")
-    violations = check_genesis_entry_present(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_13_log_starts_at_genesis(
-    actor_name: str,
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """The first entry in the actor's sorted log has logIndex=0."""
-    entries = fvv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fvv/")
-    violations = check_log_starts_at_genesis(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-@pytest.mark.parametrize("actor_name", _CHAIN_ACTORS)
-def test_invariant_14_no_gaps_in_log_indices(
-    actor_name: str,
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """No gaps within the actor's present logIndex range."""
-    entries = fvv_replicas.get(actor_name)
-    if entries is None:
-        pytest.skip(f"No log found for actor {actor_name!r} in devlogs/fvv/")
-    violations = check_no_gaps_in_log_indices(actor_name, entries)
-    assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_15_cs_state_transitions_observed(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """All three key CS transitions observed in the authoritative log."""
-    violations = check_cs_state_transitions_observed(fvv_replicas)
-    assert not violations, "Missing CS-transition observations:\n" + "\n".join(
-        violations
-    )
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_clp13_no_rejected_invite_entries(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001).
-
-    Idempotency guards MUST NOT write any CaseLedgerEntry when detecting a
-    duplicate.  A spurious rejected invite entry indicates the guard incorrectly
-    called create_commit_log_entry_tree.
-    """
-    violations = check_no_rejected_invite_entries(fvv_replicas)
-    assert not violations, (
-        f"Found {len(violations)} spurious rejected invite_actor_to_case"
-        f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
-    )
+)
 
 
 # ---------------------------------------------------------------------------
@@ -339,16 +142,3 @@ def test_fvv_finder_late_joiner_has_full_history(
         fvv_replicas, early_actor="vendor", late_actor="finder"
     )
     assert not violations, "\n".join(violations)
-
-
-@pytest.mark.case_ledger_invariants
-def test_invariant_per_actor_replica_divergence(
-    fvv_replicas: dict[str, list[dict]],
-) -> None:
-    """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
-    violations = check_per_actor_replica_divergence(fvv_replicas)
-    assert (
-        not violations
-    ), f"{len(violations)} per-actor invariant violation(s):\n" + "\n".join(
-        violations
-    )

--- a/test/ci/invariants/universal_harness.py
+++ b/test/ci/invariants/universal_harness.py
@@ -1,0 +1,296 @@
+"""Factory for the 16 universal case-ledger invariant test functions.
+
+Each scenario harness calls::
+
+    globals().update(
+        make_universal_invariant_tests(
+            replicas_fixture="<scenario>_replicas",
+            chain_actors=_CHAIN_ACTORS,
+            expected_event_types=_XXX_EXPECTED_EVENT_TYPES,
+        )
+    )
+
+to inject all 16 universal test functions without copying their
+implementations (ISSUE-2007, AC-1).
+
+The injected functions use ``request.getfixturevalue(replicas_fixture)``
+to retrieve the calling module's scenario-specific replicas fixture at
+pytest collection time.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from test.ci.invariants.common import (
+    check_cross_actor_hash_agreement,
+    check_cross_actor_payload_actor_agreement,
+    check_cs_state_transitions_observed,
+    check_event_type_present,
+    check_genesis_entry_present,
+    check_hash_chain,
+    check_log_starts_at_genesis,
+    check_nested_objects_inlined,
+    check_no_gaps_in_log_indices,
+    check_no_rejected_invite_entries,
+    check_no_rm_state_oscillation,
+    check_non_empty_payload_snapshots,
+    check_participant_status_schema_completeness,
+    check_payload_context_uses_case_uri,
+    check_per_actor_replica_divergence,
+    check_rm_closed_termination,
+)
+
+
+def make_universal_invariant_tests(  # noqa: C901
+    replicas_fixture: str,
+    chain_actors: list,
+    expected_event_types: list,
+    check_fix_ready: bool = True,
+) -> dict[str, Any]:
+    """Return the 16 universal invariant test functions keyed by name.
+
+    Parameters
+    ----------
+    replicas_fixture:
+        Name of the module-scoped fixture in the calling harness that
+        returns ``dict[str, list[dict]]`` — e.g. ``"fv_replicas"``.
+    chain_actors:
+        Per-scenario ``_CHAIN_ACTORS`` list (``pytest.param`` entries or
+        plain strings) passed to ``@pytest.mark.parametrize``.
+    expected_event_types:
+        Per-scenario ``_XXX_EXPECTED_EVENT_TYPES`` list passed to
+        ``@pytest.mark.parametrize``.
+    check_fix_ready:
+        Forwarded to ``check_cs_state_transitions_observed`` and
+        ``check_per_actor_replica_divergence``; set to ``False`` for the
+        ``fcv-reject`` scenario where Vendor never advances the VFD state
+        machine.
+    """
+    calling_module = sys._getframe(1).f_globals.get("__name__", __name__)
+
+    @pytest.mark.case_ledger_invariants
+    @pytest.mark.parametrize("actor_name", chain_actors)
+    def test_invariant_1_local_hash_chain_consistent(
+        actor_name: str,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """Within each contiguous logIndex fragment, hashes chain correctly."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        entries = replicas.get(actor_name)
+        if entries is None:
+            pytest.skip(f"No log found for actor {actor_name!r} in devlogs/")
+        violations = check_hash_chain(actor_name, entries)
+        assert not violations, "\n".join(violations)
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_2_cross_actor_hash_agreement(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """All actors agree on entryHash for every shared logIndex."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_cross_actor_hash_agreement(replicas)
+        assert not violations, (
+            f"Cross-actor hash mismatches at {len(violations)} logIndex(es):\n"
+            + "\n".join(violations[:20])
+        )
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_3_cross_actor_payload_actor_agreement(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """All actors agree on payloadSnapshot.actor for every shared logIndex."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_cross_actor_payload_actor_agreement(replicas)
+        assert (
+            not violations
+        ), "Cross-actor payloadSnapshot.actor mismatches:\n" + "\n".join(
+            violations[:20]
+        )
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_4_non_empty_payload_snapshot(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """Every recorded canonical entry has a non-empty payloadSnapshot."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_non_empty_payload_snapshots(replicas)
+        assert not violations, (
+            f"Found {len(violations)} recorded entries with empty payloadSnapshot:\n"
+            + "\n".join(violations[:20])
+        )
+
+    @pytest.mark.case_ledger_invariants
+    @pytest.mark.parametrize("event_type_val", expected_event_types)
+    def test_invariant_5_expected_event_types_present(
+        event_type_val: str,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """Each expected protocol eventType appears at least once."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_event_type_present(replicas, event_type_val)
+        assert not violations, violations[0] if violations else ""
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_6_no_rm_state_oscillation(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """No participant changes RM state after first reaching CLOSED."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_no_rm_state_oscillation(replicas)
+        assert (
+            not violations
+        ), "RM state oscillation after CLOSED:\n" + "\n".join(violations)
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_7_log_terminates_all_rm_closed(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """The log terminates with every participant in RM=CLOSED."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_rm_closed_termination(replicas)
+        assert (
+            not violations
+        ), f"Participants not in RM=CLOSED at log end: {violations}"
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_9_participant_status_schema_completeness(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """Every ParticipantStatus snapshot includes emConsentState and cvdRole list."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_participant_status_schema_completeness(replicas)
+        assert not violations, (
+            f"{len(violations)} ParticipantStatus entries missing required fields:\n"
+            + "\n".join(violations[:20])
+        )
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_10_nested_objects_inlined_in_payload(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """payloadSnapshot.object is an inline dict, not a bare ID string."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_nested_objects_inlined(replicas)
+        assert not violations, (
+            f"payloadSnapshot.object is a bare ID string in {len(violations)} entries:\n"
+            + "\n".join(violations[:20])
+        )
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_11_payload_context_uses_case_uri(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """payloadSnapshot.context matches the entry's case_id for recorded entries."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_payload_context_uses_case_uri(replicas)
+        assert not violations, (
+            f"payloadSnapshot.context != case_id in {len(violations)} entries:\n"
+            + "\n".join(violations[:20])
+        )
+
+    @pytest.mark.case_ledger_invariants
+    @pytest.mark.parametrize("actor_name", chain_actors)
+    def test_invariant_12_genesis_entry_present(
+        actor_name: str,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """logIndex=0 is present in the actor's log."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        entries = replicas.get(actor_name)
+        if entries is None:
+            pytest.skip(f"No log found for actor {actor_name!r} in devlogs/")
+        violations = check_genesis_entry_present(actor_name, entries)
+        assert not violations, "\n".join(violations)
+
+    @pytest.mark.case_ledger_invariants
+    @pytest.mark.parametrize("actor_name", chain_actors)
+    def test_invariant_13_log_starts_at_genesis(
+        actor_name: str,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """The first entry in the actor's sorted log has logIndex=0."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        entries = replicas.get(actor_name)
+        if entries is None:
+            pytest.skip(f"No log found for actor {actor_name!r} in devlogs/")
+        violations = check_log_starts_at_genesis(actor_name, entries)
+        assert not violations, "\n".join(violations)
+
+    @pytest.mark.case_ledger_invariants
+    @pytest.mark.parametrize("actor_name", chain_actors)
+    def test_invariant_14_no_gaps_in_log_indices(
+        actor_name: str,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """No gaps within the actor's present logIndex range."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        entries = replicas.get(actor_name)
+        if entries is None:
+            pytest.skip(f"No log found for actor {actor_name!r} in devlogs/")
+        violations = check_no_gaps_in_log_indices(actor_name, entries)
+        assert not violations, "\n".join(violations)
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_15_cs_state_transitions_observed(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """All key CS transitions are recorded in the authoritative log."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_cs_state_transitions_observed(
+            replicas, check_fix_ready=check_fix_ready
+        )
+        assert (
+            not violations
+        ), "Missing CS-transition observations:\n" + "\n".join(violations)
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_clp13_no_rejected_invite_entries(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """No invite_actor_to_case entries with disposition=rejected exist (CLP-13-001)."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_no_rejected_invite_entries(replicas)
+        assert not violations, (
+            f"Found {len(violations)} spurious rejected invite_actor_to_case"
+            f" entries (CLP-13-001 violation):\n" + "\n".join(violations)
+        )
+
+    @pytest.mark.case_ledger_invariants
+    def test_invariant_per_actor_replica_divergence(
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """Each non-case-actor replica satisfies the same state invariants as the authoritative log."""
+        replicas = request.getfixturevalue(replicas_fixture)
+        violations = check_per_actor_replica_divergence(
+            replicas, check_fix_ready=check_fix_ready
+        )
+        assert not violations, (
+            f"{len(violations)} per-actor invariant violation(s):\n"
+            + "\n".join(violations)
+        )
+
+    result = {
+        "test_invariant_1_local_hash_chain_consistent": test_invariant_1_local_hash_chain_consistent,
+        "test_invariant_2_cross_actor_hash_agreement": test_invariant_2_cross_actor_hash_agreement,
+        "test_invariant_3_cross_actor_payload_actor_agreement": test_invariant_3_cross_actor_payload_actor_agreement,
+        "test_invariant_4_non_empty_payload_snapshot": test_invariant_4_non_empty_payload_snapshot,
+        "test_invariant_5_expected_event_types_present": test_invariant_5_expected_event_types_present,
+        "test_invariant_6_no_rm_state_oscillation": test_invariant_6_no_rm_state_oscillation,
+        "test_invariant_7_log_terminates_all_rm_closed": test_invariant_7_log_terminates_all_rm_closed,
+        "test_invariant_9_participant_status_schema_completeness": test_invariant_9_participant_status_schema_completeness,
+        "test_invariant_10_nested_objects_inlined_in_payload": test_invariant_10_nested_objects_inlined_in_payload,
+        "test_invariant_11_payload_context_uses_case_uri": test_invariant_11_payload_context_uses_case_uri,
+        "test_invariant_12_genesis_entry_present": test_invariant_12_genesis_entry_present,
+        "test_invariant_13_log_starts_at_genesis": test_invariant_13_log_starts_at_genesis,
+        "test_invariant_14_no_gaps_in_log_indices": test_invariant_14_no_gaps_in_log_indices,
+        "test_invariant_15_cs_state_transitions_observed": test_invariant_15_cs_state_transitions_observed,
+        "test_invariant_clp13_no_rejected_invite_entries": test_invariant_clp13_no_rejected_invite_entries,
+        "test_invariant_per_actor_replica_divergence": test_invariant_per_actor_replica_divergence,
+    }
+    for fn in result.values():
+        fn.__module__ = calling_module
+    return result


### PR DESCRIPTION
- Closes #2007
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Eliminates ~2,050 lines of near-identical boilerplate by extracting the 16 universal case-ledger invariant test functions from all 9 scenario harnesses into a single factory in `test/ci/invariants/universal_harness.py` (ISSUE-2007, AC-1).

## Changes

- **`test/ci/invariants/universal_harness.py`** (new): `make_universal_invariant_tests(replicas_fixture, chain_actors, expected_event_types, check_fix_ready=True)` generates closures for Invariants 1–15, clp13, and per_actor. Each function uses `request.getfixturevalue(replicas_fixture)` so pytest resolves the fixture from the calling harness module. `__module__` is set on every injected function to the calling harness module, ensuring pytest fixture lookup resolves correctly (AC-1).
- **9 scenario harness files** (modified): each removes its 16 duplicated universal test functions and calls `globals().update(make_universal_invariant_tests(...))` after the fixture definition; retains only scenario-specific assertions (AC-2). `fcv-reject` passes `check_fix_ready=False`, preserving the existing invariant-15 / per-actor behaviour for that scenario (DEMOCI-06-001).
- **`notes/demo-ci-invariants.md`**: "Harness File Conventions" section rewritten to describe the factory injection pattern; removed the stale "known duplication tracked separately" note (AC-6).
- **`.github/workflows/demo-integration.yml`**: comment added to the `invariant-harness` job explaining that its `matrix: include:` stanza is intentionally identical to the `demo` job's — GitHub Actions does not support YAML anchors (AC-7).

### Acceptance criteria

| AC | Status | Evidence |
|---|---|---|
| AC-1: universal tests defined once | ✅ | 16 functions in `universal_harness.py`; 0 copies in harness files |
| AC-2: harnesses retain only scenario-specific tests + constants | ✅ | Each harness has only `_DEMO_NAME`, `_CHAIN_ACTORS`, `_XXX_EXPECTED_EVENT_TYPES`, fixture, `globals().update(...)`, scenario-specific tests |
| AC-3: test IDs traceable per scenario | ✅ | `globals().update()` injects functions with unchanged `__name__`; test IDs remain `test_XXX_invariants.py::test_invariant_N_...` |
| AC-4: no `conftest.py` scenario mapping | ✅ | `conftest.py` untouched; matrix in `demo-scenarios.json` unchanged |
| AC-5: test counts preserved | ✅ | All 9 counts match baseline exactly (verified via `pytest --collect-only`) |
| AC-6: `notes/demo-ci-invariants.md` updated | ✅ | Harness File Conventions section rewritten |
| AC-7: matrix block documented | ✅ | Comment added to `invariant-harness` job in `demo-integration.yml` |

## Verification

- All 7181 unit tests pass (0 new, 0 removed — counts preserved per AC-5)
- `pytest --collect-only` per harness: all 9 counts match baseline exactly
- black, flake8, mypy, pyright clean (`# noqa: C901` on factory for inherent cyclomatic complexity of 16 inner definitions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)