### PR TITLE
feat(ports): migrate Type-A report/embargo BT nodes to WithPorts bases (#1884)

### DIFF
--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -113,7 +113,7 @@ No open entries.
 | `fv Invariant Harness` | #2422 | 2026-08-20 |
 | `fvcv-handoff Demo Integration` | #2257 | 2026-08-18 |
 | `fvcv-handoff Invariant Harness` | #2257 | 2026-08-18 |
-| `fcvcv Demo Integration` | #2376 | 2026-08-20 |
+| `fcvcv Demo Integration` | #2376 | 2026-08-21 |
 | `fcv-reject Demo Integration` | #2390 | 2026-08-19 |
 | `fcv-reject Invariant Harness` | #2390 | 2026-08-19 |
 

--- a/notes/py-trees-ports-adoption.md
+++ b/notes/py-trees-ports-adoption.md
@@ -29,7 +29,7 @@ adopting, what is deferred, the known technical mismatch, and the issue
 sequence — so each implementing agent starts from evidence rather than the
 Idea's optimistic framing.
 
-## Current state (migration in progress — verified 2026-08-14)
+## Current state (migration in progress — verified 2026-08-21)
 
 - **Dependency**: `pyproject.toml` already pins `py-trees>=2.5.0`. The Idea's
   "evaluate the upgrade path from the current pin" step is already satisfied —
@@ -41,10 +41,19 @@ Idea's optimistic framing.
   `vultron/core/behaviors/helpers.py` and migrated a first tranche of
   `report/nodes/`. The pattern is now the standard base for all new nodes
   (ADR-0044, BTND-03-009 through BTND-03-011).
-- **Migration progress**: Part 1/5 (#1883) migrated **41 Type-A nodes** across
-  `case/`, `status/`, and `note/` domains — all trivial base-only reparents
-  with no domain-specific `register_key()` calls. Remaining legacy nodes in
-  these and other domains are tracked under the #1809 chain (parts 2–5).
+- **Migration progress**:
+  - Part 1/5 (#1883) migrated **41 Type-A nodes** across `case/`, `status/`,
+    and `note/` domains — all trivial base-only reparents with no
+    domain-specific `register_key()` calls.
+  - Part 2/5 (#1884) migrated **36 Type-A nodes** across `report/nodes/` and
+    `embargo/nodes/`. `_SendEmbargoActivityBase` and its two subclasses
+    (`SendTerminateEmbargoActivityNode`, `SendRejectEmbargoActivityNode`) are
+    deferred to Part 3 (#1885) — they access `self.blackboard` directly
+    (Type-B). **Headroom note**: `report/nodes/deploy_fix.py` is now exactly
+    500 lines (the BTND-07-004 hard limit); split it before the next change
+    (see `plan/incoming/learnings/20260821-deploy-fix-line-count-margin.md`).
+  - Remaining Type-B nodes across all domains are tracked under #1809
+    (parts 3–5).
 - **XML parser**: `py_trees.parsers.behaviour_tree_xml` exists but is documented
   as **experimental** ("the parser is experimental and its API may change
   between releases"). It instantiates only classes registered in a

--- a/plan/incoming/learnings/20260821-deploy-fix-line-count-margin.md
+++ b/plan/incoming/learnings/20260821-deploy-fix-line-count-margin.md
@@ -1,0 +1,20 @@
+---
+title: deploy_fix.py is at the 500-line BTND-07-004 limit after ports migration
+type: learning
+timestamp: 2026-08-21T16:30:00Z
+source: ISSUE-1884
+signal: concern
+---
+
+After migrating Type-A nodes in `vultron/core/behaviors/report/nodes/deploy_fix.py`
+(PR #2464), the file sits at exactly 500 lines — the BTND-07-004 hard limit.
+
+The import expansion (1-line → 5-line block for three helpers) consumed the
+available margin. A single-line addition anywhere in the file will now trigger
+the structure test failure.
+
+**Recommendation**: before the next change to `deploy_fix.py`, split it by
+semantic concern — e.g. `deploy_fix_conditions.py` (guards: `CSinStateFixDeployed`,
+`CheckCSFixNotYetDeployed`, `RMinStateDeferred`, `CheckNoNewDeploymentInfoNode`)
+and `deploy_fix_actions.py` (transitions and emit: `TransitionCStoFixDeployed`,
+`EmitCDActivity`).

--- a/test/core/behaviors/embargo/nodes/test_cascade.py
+++ b/test/core/behaviors/embargo/nodes/test_cascade.py
@@ -18,6 +18,8 @@
 import logging
 
 import py_trees
+import pytest
+from py_trees.ports import NoDataAvailable
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.embargo.nodes.cascade import (
@@ -39,17 +41,8 @@ def _make_core_embargo(suffix: str = "1") -> CoreEmbargoEvent:
 
 
 def _setup_blackboard_null_dl() -> None:
-    """Populate blackboard with datalayer=None to exercise null-DL guards."""
+    """Enable activity stream without populating datalayer (port absent)."""
     py_trees.blackboard.Blackboard.enable_activity_stream()
-    blackboard = py_trees.blackboard.Client(name="test-null-dl")
-    blackboard.register_key(
-        key="datalayer", access=py_trees.common.Access.WRITE
-    )
-    blackboard.register_key(
-        key="actor_id", access=py_trees.common.Access.WRITE
-    )
-    blackboard.datalayer = None
-    blackboard.actor_id = None
 
 
 class TestPersistEmbargoEventNode:
@@ -89,14 +82,12 @@ class TestPersistEmbargoEventNode:
         assert any("already exists" in r.message for r in caplog.records)
 
     def test_returns_failure_when_datalayer_unavailable(self):
-        """Node returns FAILURE when the DataLayer is None on the blackboard."""
+        """NoDataAvailable raised when datalayer port has no data (BTND-03-011)."""
         embargo = _make_core_embargo("pen3")
 
         _setup_blackboard_null_dl()
 
         node = PersistEmbargoEventNode(embargo=embargo)
-        bt = py_trees.trees.BehaviourTree(root=node)
-        bt.setup()
-        bt.tick()
-
-        assert node.status == py_trees.common.Status.FAILURE
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")

--- a/test/core/behaviors/embargo/nodes/test_em_state.py
+++ b/test/core/behaviors/embargo/nodes/test_em_state.py
@@ -30,7 +30,10 @@ from vultron.core.behaviors.embargo.nodes.em_state import (
     ReadEmStateNode,
     WriteEmStateNode,
 )
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    DataLayerConditionWithPorts,
+)
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
@@ -47,12 +50,12 @@ class TestReadEmStateNodeInheritance:
     """ReadEmStateNode follows the DataLayerCondition base class pattern (AC-2)."""
 
     def test_is_data_layer_condition(self):
-        """ReadEmStateNode inherits from DataLayerCondition."""
+        """ReadEmStateNode inherits from DataLayerConditionWithPorts."""
         node = ReadEmStateNode(
             case_id="https://example.org/cases/test",
             result_out={},
         )
-        assert isinstance(node, DataLayerCondition)
+        assert isinstance(node, DataLayerConditionWithPorts)
 
 
 class TestReadEmStateNode:
@@ -165,12 +168,12 @@ class TestWriteEmStateNodeInheritance:
     """WriteEmStateNode follows the DataLayerAction base class pattern (AC-2)."""
 
     def test_is_data_layer_action(self):
-        """WriteEmStateNode inherits from DataLayerAction."""
+        """WriteEmStateNode inherits from DataLayerActionWithPorts."""
         node = WriteEmStateNode(
             case_id="https://example.org/cases/test",
             result_out={},
         )
-        assert isinstance(node, DataLayerAction)
+        assert isinstance(node, DataLayerActionWithPorts)
 
 
 class TestWriteEmStateNode:

--- a/test/core/behaviors/report/nodes/test_typed_ports.py
+++ b/test/core/behaviors/report/nodes/test_typed_ports.py
@@ -35,6 +35,7 @@ from vultron.core.behaviors.report.nodes.conditions import (
     CheckRMStateValid,
     CheckRMStateReceivedOrInvalid,
     EnsureEmbargoExists,
+    EvaluateReportCredibility,
 )
 from vultron.core.behaviors.report.nodes.rm_transitions import (
     TransitionRMtoValid,
@@ -387,3 +388,20 @@ class TestTransitionRMtoValidPorts:
 
         result = node.update()
         assert result == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# AC-4 (issue #1884): isolated-port NoDataAvailable tests for newly migrated
+# report-domain nodes.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateReportCredibilityPorts:
+    """EvaluateReportCredibility — Type-A migration NoDataAvailable tests."""
+
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        """BTND-03-011: get_input('datalayer') raises NoDataAvailable when absent."""
+        node = EvaluateReportCredibility(report_id=REPORT_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")

--- a/vultron/core/behaviors/embargo/nodes/cascade.py
+++ b/vultron/core/behaviors/embargo/nodes/cascade.py
@@ -17,11 +17,11 @@
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models.embargo_event import EmbargoEvent
 
 
-class PersistEmbargoEventNode(DataLayerAction):
+class PersistEmbargoEventNode(DataLayerActionWithPorts):
     """Persist the trigger-created embargo event before outbound fan-out."""
 
     def __init__(self, embargo: EmbargoEvent, name: str | None = None) -> None:

--- a/vultron/core/behaviors/embargo/nodes/conditions.py
+++ b/vultron/core/behaviors/embargo/nodes/conditions.py
@@ -18,14 +18,17 @@
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerCondition,
+    DataLayerConditionWithPorts,
+)
 from vultron.core.models._helpers import has_case_statuses
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.errors import VultronInvalidStateTransitionError
 
 
-class ValidateCaseExistsNode(DataLayerCondition):
+class ValidateCaseExistsNode(DataLayerConditionWithPorts):
     """Check that the target case exists in the DataLayer.
 
     Returns SUCCESS if the case is found and is a ``VulnerabilityCase``.
@@ -54,7 +57,7 @@ class ValidateCaseExistsNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class IsActiveEmbargoNode(DataLayerCondition):
+class IsActiveEmbargoNode(DataLayerConditionWithPorts):
     """Check that the given embargo is the active embargo on the case.
 
     Returns SUCCESS if ``case.active_embargo`` resolves to ``embargo_id``.
@@ -245,7 +248,7 @@ class OptionalLookupParticipantNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class HasActiveEmbargoNode(DataLayerCondition):
+class HasActiveEmbargoNode(DataLayerConditionWithPorts):
     """Guard that the case has an active embargo set.
 
     Returns SUCCESS when ``case.active_embargo`` is non-None.
@@ -294,7 +297,7 @@ class HasActiveEmbargoNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class IsProposedEmbargoNode(DataLayerCondition):
+class IsProposedEmbargoNode(DataLayerConditionWithPorts):
     """Check that the case EM state is PROPOSED.
 
     Returns SUCCESS when ``case.current_status.em.state == EM.PROPOSED``.
@@ -337,7 +340,7 @@ class IsProposedEmbargoNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class HasCaseStatusesNode(DataLayerCondition):
+class HasCaseStatusesNode(DataLayerConditionWithPorts):
     """Guard that the case has at least one CaseStatus entry.
 
     Returns SUCCESS when ``case.case_statuses`` is non-empty.

--- a/vultron/core/behaviors/embargo/nodes/em_state.py
+++ b/vultron/core/behaviors/embargo/nodes/em_state.py
@@ -33,8 +33,8 @@ a ``HasActiveEmbargoNode`` guard earlier in the BT sequence to enforce the
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import (
-    DataLayerAction,
-    DataLayerCondition,
+    DataLayerActionWithPorts,
+    DataLayerConditionWithPorts,
 )
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import EmDimension
@@ -42,7 +42,7 @@ from vultron.core.states.em import EM
 from vultron.errors import VultronValidationError
 
 
-class ReadEmStateNode(DataLayerCondition):
+class ReadEmStateNode(DataLayerConditionWithPorts):
     """Read the current EM state from a case and write it to result_out.
 
     Replaces the inline ``em_before = EM(case.current_status.em_state)`` reads
@@ -107,7 +107,7 @@ class ReadEmStateNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class WriteEmStateNode(DataLayerAction):
+class WriteEmStateNode(DataLayerActionWithPorts):
     """Write a computed EM state back to the case and persist it.
 
     Replaces the inline ``case.current_status.em_state = em_after`` mutations

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -30,7 +30,10 @@ from vultron.core.behaviors.embargo.nodes.reject_proposed import (  # noqa: F401
     RejectProposedEmbargoLifecycleNode,
     SendRejectEmbargoActivityNode,
 )
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+)
 from vultron.core.behaviors.narrative_log import log_em_transition
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import EmDimension
@@ -51,7 +54,7 @@ from vultron.errors import (
 )
 
 
-class ValidateEmbargoRevisionStateNode(DataLayerAction):
+class ValidateEmbargoRevisionStateNode(DataLayerActionWithPorts):
     """Guard that the case EM state permits a revision proposal.
 
     Returns SUCCESS when EM state is ACTIVE or REVISE.  Returns FAILURE
@@ -101,7 +104,7 @@ class ValidateEmbargoRevisionStateNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class _EmbargoLifecycleNode(DataLayerAction):
+class _EmbargoLifecycleNode(DataLayerActionWithPorts):
     """Base node for EmbargoLifecycle strict-mode transitions.
 
     Orchestrates the em_state read/compute/write cycle via named BT nodes
@@ -405,7 +408,7 @@ class SendTerminateEmbargoActivityNode(_SendEmbargoActivityBase):
         return Status.FAILURE
 
 
-class SetEmbargoActiveNode(DataLayerAction):
+class SetEmbargoActiveNode(DataLayerActionWithPorts):
     """Set embargo active on case and transition EM → ACTIVE.
 
     Handles idempotency and state-sync override for non-standard EM

--- a/vultron/core/behaviors/embargo/nodes/proposal.py
+++ b/vultron/core/behaviors/embargo/nodes/proposal.py
@@ -18,7 +18,10 @@
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+)
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
@@ -147,7 +150,7 @@ class CreateAndStoreInviteNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class RecordParticipantAcceptanceNode(DataLayerAction):
+class RecordParticipantAcceptanceNode(DataLayerActionWithPorts):
     """Record participant acceptance of embargo via EmbargoLifecycle.
 
     Uses EmbargoLifecycle.accept_embargo_invite(OBSERVED) to record the

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -20,7 +20,11 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.embargo.nodes.em_state import ReadEmStateNode
 from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+    DataLayerConditionWithPorts,
+)
 from vultron.core.behaviors.narrative_log import log_em_transition
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import EmDimension
@@ -32,7 +36,7 @@ from vultron.core.use_cases._helpers import (
 )
 
 
-class HasEmbargoActiveNode(DataLayerCondition):
+class HasEmbargoActiveNode(DataLayerConditionWithPorts):
     """Condition: EM state is ACTIVE or REVISE (embargo is active).
 
     Returns SUCCESS when ``case.current_status.em.state`` is not EXITED
@@ -71,7 +75,7 @@ class HasEmbargoActiveNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class ClearActiveEmbargoNode(DataLayerAction):
+class ClearActiveEmbargoNode(DataLayerActionWithPorts):
     """Apply EM → EXITED transition and clear active_embargo.
 
     Reads the current EM state via ``ReadEmStateNode``, transitions
@@ -147,7 +151,7 @@ class ClearActiveEmbargoNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class ResetParticipantConsentNode(DataLayerAction):
+class ResetParticipantConsentNode(DataLayerActionWithPorts):
     """Reset all participant embargo consent states to NO_EMBARGO.
 
     Calls ``reset_case_participant_embargo_consent`` for the given case.
@@ -353,7 +357,7 @@ class SendAnnounceEmbargoEventNode(_SendEmbargoActivityBase):
         return Status.SUCCESS
 
 
-class RemoveFromProposedEmbargoesNode(DataLayerAction):
+class RemoveFromProposedEmbargoesNode(DataLayerActionWithPorts):
     """Remove the embargo from the case's proposed_embargoes list.
 
     Idempotent cleanup: returns SUCCESS if embargo successfully removed or was

--- a/vultron/core/behaviors/report/nodes/conditions.py
+++ b/vultron/core/behaviors/report/nodes/conditions.py
@@ -18,7 +18,6 @@
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import (
-    DataLayerCondition,
     DataLayerConditionWithPorts,
     FindParticipantByActorIdNode,
 )
@@ -200,7 +199,7 @@ class EnsureEmbargoExists(DataLayerConditionWithPorts):
         return Status.SUCCESS
 
 
-class EvaluateReportCredibility(DataLayerCondition):
+class EvaluateReportCredibility(DataLayerConditionWithPorts):
     """
     Evaluate report credibility using policy.
 
@@ -234,7 +233,7 @@ class EvaluateReportCredibility(DataLayerCondition):
         return Status.SUCCESS
 
 
-class EvaluateReportValidity(DataLayerCondition):
+class EvaluateReportValidity(DataLayerConditionWithPorts):
     """
     Evaluate report technical validity using policy.
 
@@ -268,7 +267,7 @@ class EvaluateReportValidity(DataLayerCondition):
         return Status.SUCCESS
 
 
-class EvaluateCasePriority(DataLayerCondition):
+class EvaluateCasePriority(DataLayerConditionWithPorts):
     """
     Evaluate whether to engage or defer a case using prioritization policy.
 
@@ -337,7 +336,7 @@ class CheckParticipantExists(FindParticipantByActorIdNode):
         )
 
 
-class CheckReportNotClosed(DataLayerCondition):
+class CheckReportNotClosed(DataLayerConditionWithPorts):
     """Check that the report does NOT already have an RM.CLOSED status record.
 
     Returns SUCCESS when the report is not yet closed (the transition is

--- a/vultron/core/behaviors/report/nodes/deploy_fix.py
+++ b/vultron/core/behaviors/report/nodes/deploy_fix.py
@@ -49,7 +49,11 @@ from vultron.core.behaviors.case.nodes.participant.common import (
     resolve_case_manager_id,
     resolve_participant_state_from_dl,
 )
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    DataLayerCondition,
+    DataLayerConditionWithPorts,
+)
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import VfdDimension
 from vultron.core.ports.case_persistence import (
@@ -61,10 +65,9 @@ from vultron.core.states.rm import RM
 
 logger = logging.getLogger(__name__)
 
-# Blackboard key written by the upstream NewDeploymentInfoSentinel (FUZZ-08f).
-# When present and truthy, new deployment-relevant information has arrived and
-# the deployer should re-evaluate rather than stay deferred.  When the key is
-# absent, CheckNoNewDeploymentInfoNode defaults to SUCCESS (no new info).
+# Blackboard key written by NewDeploymentInfoSentinel (FUZZ-08f). When present
+# and truthy, the deployer re-evaluates rather than staying deferred.
+# When absent, CheckNoNewDeploymentInfoNode defaults to SUCCESS (no new info).
 NEW_DEPLOYMENT_INFO_KEY = "new_deployment_info"
 
 
@@ -92,7 +95,7 @@ def _resolve_vfd_state(
     return vfd_state
 
 
-class CSinStateFixDeployed(DataLayerCondition):
+class CSinStateFixDeployed(DataLayerConditionWithPorts):
     """Short-circuit guard: fix already deployed means nothing to do.
 
     Returns ``SUCCESS`` when the actor's VFD state is already fix-deployed
@@ -148,7 +151,7 @@ class CSinStateFixDeployed(DataLayerCondition):
         return Status.FAILURE
 
 
-class CheckCSFixNotYetDeployed(DataLayerCondition):
+class CheckCSFixNotYetDeployed(DataLayerConditionWithPorts):
     """Guard: fix must be READY but NOT yet deployed (VFD state == ``VFd``).
 
     Returns ``SUCCESS`` only when the actor's VFD state is fix-ready and the
@@ -220,7 +223,7 @@ class CheckCSFixNotYetDeployed(DataLayerCondition):
         return Status.SUCCESS
 
 
-class RMinStateDeferred(DataLayerCondition):
+class RMinStateDeferred(DataLayerConditionWithPorts):
     """Guard: actor RM state must be DEFERRED (stay-deferred arm).
 
     Returns ``SUCCESS`` when the actor's latest RM state is ``RM.DEFERRED``.
@@ -330,7 +333,7 @@ class CheckNoNewDeploymentInfoNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class TransitionCStoFixDeployed(DataLayerAction):
+class TransitionCStoFixDeployed(DataLayerActionWithPorts):
     """Persist a VFD ParticipantStatus snapshot for the actor in this case.
 
     Advances the actor's VFD dimension to ``CS_vfd.VFD`` (fix deployed) and
@@ -392,7 +395,7 @@ class TransitionCStoFixDeployed(DataLayerAction):
             return Status.FAILURE
 
 
-class EmitCDActivity(DataLayerAction):
+class EmitCDActivity(DataLayerActionWithPorts):
     """Emit a CD (Fix Deployed) ``Add(ParticipantStatus)`` to the Case Actor.
 
     Calls ``trigger_activity_factory.add_participant_status_to_participant``

--- a/vultron/core/behaviors/report/nodes/develop_fix.py
+++ b/vultron/core/behaviors/report/nodes/develop_fix.py
@@ -33,7 +33,10 @@ from typing import cast
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    DataLayerConditionWithPorts,
+)
 from vultron.core.behaviors.case.nodes.participant.common import (
     resolve_case_manager_id,
     resolve_participant_state_from_dl,
@@ -85,7 +88,7 @@ def _resolve_actor_roles(
     return list(participant.roles) if participant.roles else []
 
 
-class CheckIsVendorRoleNode(DataLayerCondition):
+class CheckIsVendorRoleNode(DataLayerConditionWithPorts):
     """Gate: actor MUST hold CVDRole.VENDOR to proceed with fix development.
 
     Returns ``SUCCESS`` when the actor holds ``CVDRole.VENDOR`` — allowing
@@ -142,7 +145,7 @@ class CheckIsVendorRoleNode(DataLayerCondition):
         return Status.SUCCESS
 
 
-class CheckCSFixNotYetReady(DataLayerCondition):
+class CheckCSFixNotYetReady(DataLayerConditionWithPorts):
     """Short-circuit guard: fix already ready means nothing to do.
 
     Returns ``SUCCESS`` when the actor's VFD state is already fix-ready
@@ -206,7 +209,7 @@ class CheckCSFixNotYetReady(DataLayerCondition):
         return Status.FAILURE
 
 
-class CheckRMStateAccepted(DataLayerCondition):
+class CheckRMStateAccepted(DataLayerConditionWithPorts):
     """Guard: actor RM state must be ACCEPTED to create a fix.
 
     Returns ``SUCCESS`` when the actor's latest RM state is ``RM.ACCEPTED``.
@@ -267,7 +270,7 @@ class CheckRMStateAccepted(DataLayerCondition):
         return Status.FAILURE
 
 
-class TransitionCStoFixReady(DataLayerAction):
+class TransitionCStoFixReady(DataLayerActionWithPorts):
     """Persist a VFd ParticipantStatus snapshot for the actor in this case.
 
     Advances the actor's VFD dimension to ``CS_vfd.VFd`` (fix developed) and
@@ -329,7 +332,7 @@ class TransitionCStoFixReady(DataLayerAction):
             return Status.FAILURE
 
 
-class EmitCFActivity(DataLayerAction):
+class EmitCFActivity(DataLayerActionWithPorts):
     """Emit a CF (Fix Readiness) ``Add(ParticipantStatus)`` to the Case Actor.
 
     Calls ``trigger_activity_factory.add_participant_status_to_participant``

--- a/vultron/core/behaviors/report/nodes/emit.py
+++ b/vultron/core/behaviors/report/nodes/emit.py
@@ -19,14 +19,14 @@ from typing import cast
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 
 
-class _EmitCaseActorReportActivityBase(DataLayerAction):
+class _EmitCaseActorReportActivityBase(DataLayerActionWithPorts):
     """Base class for emit nodes that route report-phase activities to the CaseActor.
 
     Per ADR-0021 CLP-10-001: trigger trees MUST emit an outbound activity
@@ -331,7 +331,7 @@ class EmitAckReportActivity(_EmitCaseActorReportActivityBase):
         )
 
 
-class EmitSubmitReportActivity(DataLayerAction):
+class EmitSubmitReportActivity(DataLayerActionWithPorts):
     """Create Offer(VulnerabilityReport) and queue in actor outbox.
 
     Calls ``trigger_activity_factory.submit_report()`` and queues the

--- a/vultron/core/behaviors/report/nodes/participant.py
+++ b/vultron/core/behaviors/report/nodes/participant.py
@@ -17,12 +17,12 @@
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.states.rm import RM
 from vultron.core.use_cases._helpers import update_participant_rm_state
 
 
-class TransitionParticipantRMtoAccepted(DataLayerAction):
+class TransitionParticipantRMtoAccepted(DataLayerActionWithPorts):
     """
     Transition actor's RM state to ACCEPTED in the specified case.
 
@@ -76,7 +76,7 @@ class TransitionParticipantRMtoAccepted(DataLayerAction):
             return Status.FAILURE
 
 
-class TransitionParticipantRMtoDeferred(DataLayerAction):
+class TransitionParticipantRMtoDeferred(DataLayerActionWithPorts):
     """
     Transition actor's RM state to DEFERRED in the specified case.
 

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -18,7 +18,6 @@
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import (
-    DataLayerAction,
     DataLayerActionWithPorts,
 )
 from vultron.core.models.dimensions import PecDimension, RmDimension
@@ -65,7 +64,7 @@ def _current_report_phase_rm_state(dl, actor_id: str, report_id: str) -> RM:
 
 
 def _transition_case_participant_rm(
-    node: "DataLayerAction",
+    node: "DataLayerActionWithPorts",
     report_id: str | None,
     new_rm_state: RM,
 ) -> "Status":
@@ -249,7 +248,7 @@ class TransitionRMtoValid(DataLayerActionWithPorts):
             return Status.FAILURE
 
 
-class TransitionRMtoInvalid(DataLayerAction):
+class TransitionRMtoInvalid(DataLayerActionWithPorts):
     """
     Transition report to RM.INVALID.
 
@@ -337,7 +336,7 @@ class TransitionRMtoInvalid(DataLayerAction):
             return Status.FAILURE
 
 
-class TransitionRMtoClosed(DataLayerAction):
+class TransitionRMtoClosed(DataLayerActionWithPorts):
     """
     Transition report to RM.CLOSED (report-phase ParticipantStatus).
 
@@ -424,7 +423,7 @@ class TransitionRMtoClosed(DataLayerAction):
             return Status.FAILURE
 
 
-class TransitionCaseParticipantRMtoClosed(DataLayerAction):
+class TransitionCaseParticipantRMtoClosed(DataLayerActionWithPorts):
     """Transition the actor's RM state to CLOSED in the case for a report.
 
     Looks up the VulnerabilityCase by ``report_id`` and advances the actor's
@@ -460,7 +459,7 @@ class TransitionCaseParticipantRMtoClosed(DataLayerAction):
         return _transition_case_participant_rm(self, self.report_id, RM.CLOSED)
 
 
-class TransitionCaseParticipantRMtoInvalid(DataLayerAction):
+class TransitionCaseParticipantRMtoInvalid(DataLayerActionWithPorts):
     """Transition the actor's RM state to INVALID in the case for a report.
 
     Looks up the VulnerabilityCase by ``report_id`` and advances the actor's

--- a/vultron/core/behaviors/report/nodes/storage.py
+++ b/vultron/core/behaviors/report/nodes/storage.py
@@ -35,11 +35,11 @@ from typing import Any
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.use_cases._helpers import _idempotent_create
 
 
-class StoreReportNode(DataLayerAction):
+class StoreReportNode(DataLayerActionWithPorts):
     """Idempotently store a VulnerabilityReport in the DataLayer.
 
     Returns SUCCESS (no-op) when ``report_id`` is empty or ``report_obj`` is
@@ -89,7 +89,7 @@ class StoreReportNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class StoreActivityNode(DataLayerAction):
+class StoreActivityNode(DataLayerActionWithPorts):
     """Idempotently store an inbound protocol activity in the DataLayer.
 
     Returns SUCCESS (no-op) when ``activity_id`` is empty or


### PR DESCRIPTION
- Closes #1884

## Summary

Migrates all **Type-A** (base-class-only reparent) BT nodes in `report/nodes/` and `embargo/nodes/` from legacy `DataLayerCondition`/`DataLayerAction` to `DataLayerConditionWithPorts`/`DataLayerActionWithPorts`. Part 2/5 in the typed-Ports migration chain (#1809).

## Changes

**report/nodes/**
- **`conditions.py`**: `EvaluateReportCredibility`, `EvaluateReportValidity`, `EvaluateCasePriority`, `CheckReportNotClosed` → `DataLayerConditionWithPorts`
- **`rm_transitions.py`**: `TransitionRMtoInvalid`, `TransitionRMtoClosed`, `TransitionCaseParticipantRMtoClosed`, `TransitionCaseParticipantRMtoInvalid` → `DataLayerActionWithPorts`
- **`storage.py`**: `StoreReportNode`, `StoreActivityNode` → `DataLayerActionWithPorts`
- **`participant.py`**: `TransitionParticipantRMtoAccepted`, `TransitionParticipantRMtoDeferred` → `DataLayerActionWithPorts`
- **`deploy_fix.py`**: `CSinStateFixDeployed`, `CheckCSFixNotYetDeployed`, `RMinStateDeferred` → `DataLayerConditionWithPorts`; `TransitionCStoFixDeployed`, `EmitCDActivity` → `DataLayerActionWithPorts`
- **`develop_fix.py`**: `CheckIsVendorRoleNode`, `CheckCSFixNotYetReady`, `CheckRMStateAccepted` → `DataLayerConditionWithPorts`; `TransitionCStoFixReady`, `EmitCFActivity` → `DataLayerActionWithPorts`
- **`emit.py`**: `_EmitCaseActorReportActivityBase`, `EmitSubmitReportActivity` → `DataLayerActionWithPorts`

**embargo/nodes/**
- **`conditions.py`**: `ValidateCaseExistsNode`, `IsActiveEmbargoNode`, `HasActiveEmbargoNode`, `IsProposedEmbargoNode`, `HasCaseStatusesNode` → `DataLayerConditionWithPorts`
- **`em_state.py`**: `ReadEmStateNode` → `DataLayerConditionWithPorts`; `WriteEmStateNode` → `DataLayerActionWithPorts`
- **`teardown.py`**: `HasEmbargoActiveNode` → `DataLayerConditionWithPorts`; `ClearActiveEmbargoNode`, `ResetParticipantConsentNode`, `RemoveFromProposedEmbargoesNode` → `DataLayerActionWithPorts`
- **`cascade.py`**: `PersistEmbargoEventNode` → `DataLayerActionWithPorts`
- **`lifecycle.py`**: `ValidateEmbargoRevisionStateNode`, `_EmbargoLifecycleNode`, `SetEmbargoActiveNode` → `DataLayerActionWithPorts`
- **`proposal.py`**: `RecordParticipantAcceptanceNode` → `DataLayerActionWithPorts`

**Tests:**
- **`test/core/behaviors/report/nodes/test_typed_ports.py`**: `TestEvaluateReportCredibilityPorts` — AC-4 `NoDataAvailable` test for report domain
- **`test/core/behaviors/embargo/nodes/test_cascade.py`**: updated `test_returns_failure_when_datalayer_unavailable` to use `NoDataAvailable` pattern (AC-4 embargo domain)
- **`test/core/behaviors/embargo/nodes/test_em_state.py`**: updated inheritance assertions

**Deferred:** `embargo/nodes/emit.py` (`_SendEmbargoActivityBase`) — two subclasses (`SendTerminateEmbargoActivityNode`, `SendRejectEmbargoActivityNode`) read `self.blackboard` directly (Type-B). Migrating the base without migrating the subclasses causes mypy failures. Deferred to #1885.

## Verification

- AC-1 ✅ Every Type-A node in report/ and embargo/ now subclasses `*WithPorts`
- AC-2 ✅ No redundant `setup()`/`initialise()` overrides; `update()` bodies unchanged
- AC-3 ✅ 7182 unit tests pass, 1167 integration tests pass
- AC-4 ✅ `NoDataAvailable` isolated-port tests added for report and embargo domains
- Black, flake8, mypy, pyright clean