### PR TITLE
docs: plan concerns #2382 and #2388 — spec corpus quality gates

### DIFF
--- a/notes/specs-vs-adrs.md
+++ b/notes/specs-vs-adrs.md
@@ -49,6 +49,55 @@ Use this self-check before committing a change:
 
 ---
 
+## The Externally-Observable Behavior Test
+
+Before writing a new `specs/` requirement for any behavior observed during
+implementation, apply this gate:
+
+> **Would a participant running a different implementation of the Vultron
+> protocol notice if this requirement were violated?**
+
+| Answer | Route to | Examples |
+|---|---|---|
+| **Yes** — the behavior is externally-observable or protocol-visible | `specs/` | Message semantics, state-machine invariants, wire format constraints, compliance-visible output |
+| **No** — the behavior is an internal implementation convention | `AGENTS.md` | File paths, naming conventions, agent guidance, demo step ordering, coding practices |
+
+This gate operationalizes two existing rules:
+
+- **MS-05-004**: Requirements must be declarative — describing *what* the
+  system must do, not *how* it is implemented internally.
+- **MS-12** (four-tier taxonomy): A requirement that cannot pass the
+  `protocol` or `architecture` tier tests is `project` or `process` kind.
+  If it also fails the externally-visible test — i.e., only this codebase
+  cares about it — it belongs in `AGENTS.md` rather than `specs/` entirely.
+
+### Common Misrouted Requirements
+
+These patterns commonly appear in `specs/` but belong in `AGENTS.md`:
+
+- **File/module paths**: "Factory functions MUST live in
+  `vultron/wire/as2/factories/`" — only this codebase has this layout.
+- **Demo step ordering**: "Step 3 MUST follow step 2 in the demo script" —
+  a different implementation would have no demo, let alone this step order.
+- **Agent instructions**: "The agent MUST confirm the selected bug with the
+  user before fixing it" — describes agent workflow, not protocol compliance.
+- **Naming conventions**: "Test files MUST be named `test_*.py`" — already
+  enforced by pytest discovery config; not protocol-relevant.
+- **Ambiguous `project`/`process` kind requirements**: If a requirement would
+  be kind `project` (MS-12-002) *and* only an internal convention, it belongs
+  in `AGENTS.md`. The `specs/` corpus should capture what an independent
+  conformance checker would verify; internal conventions belong in agent guidance.
+
+### How This Relates to the `learn` Skill
+
+The `learn` skill's `signal: spec-gap` path must apply this test before
+promoting an observation to `specs/`. If the behavior is not externally
+observable, the correct destination is `AGENTS.md` (recurring pitfall) or
+`notes/` (design decision), not a new MUST requirement in `specs/`. See also
+`notes/specs-vs-adrs.md` and the anti-pattern list in `specs/AGENTS.md`.
+
+---
+
 ## Worked Examples
 
 ### ADR only

--- a/notes/specs-vs-adrs.md
+++ b/notes/specs-vs-adrs.md
@@ -94,7 +94,7 @@ The `learn` skill's `signal: spec-gap` path must apply this test before
 promoting an observation to `specs/`. If the behavior is not externally
 observable, the correct destination is `AGENTS.md` (recurring pitfall) or
 `notes/` (design decision), not a new MUST requirement in `specs/`. See also
-`notes/specs-vs-adrs.md` and the anti-pattern list in `specs/AGENTS.md`.
+the anti-pattern list in `specs/AGENTS.md`.
 
 ---
 

--- a/plan/history/2608/learning/CONCERN-2382.md
+++ b/plan/history/2608/learning/CONCERN-2382.md
@@ -1,0 +1,26 @@
+---
+source: CONCERN-2382
+timestamp: '2026-08-21T16:41:00.376427+00:00'
+title: 'concern: 98% of MUST requirements have no verification criteria — MS-05-003
+  is self-violating'
+type: learning
+---
+
+2,392 of 2,439 requirements (98%) in `specs/` have no `verification:` field populated. This violates the project's own MS-05-003 meta-requirement ("measurable acceptance criteria MUST be provided where applicable"). There is no documented method to confirm any MUST requirement has been satisfied after implementation.
+
+**Surface symptom:** `verification: null` on 2,392/2,439 requirements across all spec YAML files. Raw YAML check: only 47 requirements have any verification criteria.
+
+**Underlying problem:** The `lint.py` linter does not enforce MS-05-003 for `priority: MUST` requirements, so this gap is invisible and grows unnoticed with every new requirement added. Neither implementers nor reviewers have a testability contract — they know what to build but not how to confirm it is correct. The meta-spec is in self-violating state.
+
+**Evidence:**
+
+- Python analysis of compiled spec corpus (2,439 requirements): `Missing verification: 2439/2439 (100%)` in the rendered export.
+- Raw YAML check across `specs/*.yaml`: `Have verification criteria: 47` out of 2,439 requirements.
+- `specs/meta-specifications.yaml` MS-05-003: "Requirements MUST be testable; measurable acceptance criteria MUST be provided where applicable."
+- `vultron/metadata/specs/lint.py` does not currently check for the presence of `verification:` on MUST requirements.
+- Surfaced during NASA system design process requirements validation review (2026-08-19).
+
+**Resolved**: 2026-08-21 — implementation tracked in #2466, #2467.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2465>.
+Spec: `specs/meta-specifications.yaml` (MS-10-003, MS-10-005).
+Notes: `notes/specs-vs-adrs.md`.

--- a/plan/history/2608/learning/CONCERN-2388.md
+++ b/plan/history/2608/learning/CONCERN-2388.md
@@ -1,0 +1,30 @@
+---
+source: CONCERN-2388
+timestamp: '2026-08-21T16:41:57.775935+00:00'
+title: 'concern: build→learn→specs pipeline has no gate for ''is this a system requirement?'''
+type: learning
+---
+
+The `build` → `learn` → `specs/` pipeline has no gate for "does this qualify as a system requirement?", causing implementation details (file paths, demo scripts, agent guidance) to accumulate as `priority: MUST` requirements in `specs/`. Five targeted changes to `upward-reflection.md`, the `learn` skill, the linter, the meta-spec, and `specs/AGENTS.md` close the gap.
+
+**Surface symptom vs. Underlying problem:**
+
+Surface symptom: ~1,000 `project`/`process`-kind MUST requirements describing file locations, demo step ordering, and agent instructions rather than observable system behavior.
+
+Underlying problem: Three absent quality gates, each independently sufficient to cause the problem:
+
+1. `upward-reflection.md` spec-gap signal is too broad — "Was any behaviour implemented or fixed that has no existing spec entry?" fires on any implementation action. No qualifier for "externally-observable" or "protocol-visible" behavior.
+2. `learn` skill has a completion imperative with no filter — "A lesson is not complete until it has been promoted to `specs/`, `notes/`, or `AGENTS.md`." For `signal: spec-gap`, the instruction is "Write the missing spec requirement" with no gate question.
+3. Linter enforces structure, not substance — MS-05-003 is a hard MUST in `meta-specifications.yaml` but has no linter check. Implementation-detail requirements pass all linter checks perfectly.
+
+**Evidence:**
+
+- 949 `project`/`process` MUST requirements identified by corpus analysis (2026-08-19).
+- Signal-word breakdown: 208 organization/path, 113 demo/script, 34 agent guidance, 24 naming convention, 24 coding practice, 467 ambiguous.
+- All 70+ spec files share creation date 2026-04-27 (git log `--diff-filter=A`).
+- Related: #2382 (missing verification criteria — the downstream symptom of the same root cause).
+
+**Resolved**: 2026-08-21 — implementation tracked in #2466.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2465>.
+Spec: `specs/meta-specifications.yaml` (MS-10-003, MS-10-005).
+Notes: `notes/specs-vs-adrs.md`.

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -80,6 +80,25 @@ When updating specs per LEARN_prompt instructions:
 - **Maintain verification criteria**: Every requirement needs a test
 - **Follow existing conventions**: Match style and structure of other specs
 
+**Do NOT add spec entries for** (route to `AGENTS.md` instead):
+
+- File paths, module locations, or package layouts (e.g., "factory functions
+  MUST live in `vultron/wire/as2/factories/`")
+- Demo scenario step ordering, file layout, or script structure
+- Agent or skill behavior instructions (e.g., "the agent MUST confirm the
+  selected bug with the user")
+- Naming conventions already enforced by `code-style.yaml`
+- Coding practices or conventions internal to this Python codebase
+
+**Gate test before adding to `specs/`**: Ask "Would a participant running a
+different implementation of the Vultron protocol notice if this requirement
+were violated?" If **no**, the requirement is an internal convention — route
+it to `AGENTS.md`, not `specs/`. This test operationalizes MS-05-004
+(declarative requirements) and the four-tier taxonomy (MS-12): if it fails
+the protocol or architecture tier tests, it belongs in `project` or `process`
+kind — and if it also fails the externally-visible test, it belongs in
+`AGENTS.md` rather than specs at all.
+
 ---
 
 ### Valid `rel_type` Values in Spec Relationships

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -232,12 +232,46 @@ groups:
     tags:
     - documentation
   - id: MS-10-003
-    priority: SHOULD
+    priority: MUST
     kind: process
-    statement: Spec files SHOULD be testable with verifiable acceptance criteria per requirement.
-    rationale: Untestable specs cannot be reliably implemented.
+    statement: >-
+      Spec files MUST be testable with verifiable acceptance criteria per
+      requirement; every `priority: MUST` requirement MUST include a
+      `verification:` field.
+    rationale: >-
+      Untestable specs cannot be reliably implemented; a MUST requirement with no
+      verification field provides no contract for reviewers or agents. Upgraded
+      from SHOULD to MUST (CONCERN-2382) to align with MS-05-003 and enable
+      progressive linter enforcement. See MS-10-005 for the current enforcement
+      mechanism.
+    relationships:
+    - rel_type: refines
+      spec_id: MS-05-003
     tags:
     - documentation
+    - tooling
+  - id: MS-10-005
+    priority: MUST
+    kind: process
+    statement: >-
+      spec-lint MUST emit an advisory warning ([WARN]) for any `priority: MUST`
+      requirement whose `verification:` field is null or absent, until that
+      requirement has been backfilled.
+    rationale: >-
+      MS-05-003 and MS-10-003 require MUST requirements to carry measurable
+      acceptance criteria. The linter cannot impose a hard error on the existing
+      backlog immediately, but a visible advisory signal (a) prevents the
+      backlog from growing, (b) makes the gap visible in CI output without
+      blocking merges, and (c) provides the foundation for a future hard-error
+      upgrade once the backlog is addressed. Tracked by CONCERN-2382.
+    relationships:
+    - rel_type: implements
+      spec_id: MS-05-003
+    - rel_type: implements
+      spec_id: MS-10-003
+    tags:
+    - documentation
+    - tooling
   - id: MS-10-004
     priority: SHOULD
     kind: process


### PR DESCRIPTION
- Closes #2382

## Summary

Introduces three documentation changes that close the spec corpus quality
gap identified in #2382 and #2388: upgrades the meta-spec verification
requirement to MUST, adds the externally-observable behavior gate to the
routing guide, and documents the anti-pattern list in `specs/AGENTS.md`.

## Changes

- **`specs/meta-specifications.yaml`**: upgrade MS-10-003 from `SHOULD` to
  `MUST` ("every `priority: MUST` requirement MUST include a `verification:`
  field"); add MS-10-005 specifying the advisory linter warning as the
  progressive enforcement mechanism
- **`notes/specs-vs-adrs.md`**: add "The Externally-Observable Behavior Test"
  section with the gate question ("Would a participant running a different
  implementation notice?"), a misrouted-requirements table, and a note linking
  to the `learn` skill's promotion path
- **`specs/AGENTS.md`**: add an explicit anti-pattern list under "Updating
  Specifications" — file paths, demo step ordering, agent guidance, and naming
  conventions route to `AGENTS.md`, not `specs/`; add the gate test that
  operationalizes the rule

## Implementation Issues

- #2466
- #2467