### PR TITLE
feat: introduce WireRenderPort driven port and As2WireRenderAdapter

### DIFF
--- a/test/adapters/driven/test_wire_render_adapter.py
+++ b/test/adapters/driven/test_wire_render_adapter.py
@@ -28,6 +28,7 @@ from datetime import timedelta
 import pytest
 
 from vultron.adapters.driven.wire_render import As2WireRenderAdapter
+from vultron.wire.as2.vocab.base.registry import VOCABULARY
 from vultron.core.models.actor import VultronPerson
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_actor import CaseActor
@@ -64,6 +65,12 @@ def _assert_wire_dict(result: dict, expected_type: str) -> None:
     # camelCase key present (not snake_case)
     # The 'id' field is always emitted by VultronAS2Object
     assert "id" in result, f"Missing 'id' key in wire dict for {expected_type}"
+    # AC-5 / CLP-07-001: output must be receiver-reconstitutable
+    wire_cls = VOCABULARY.get(expected_type)
+    assert (
+        wire_cls is not None
+    ), f"No VOCABULARY entry for {expected_type!r} — cannot verify reconstitutability"
+    wire_cls.model_validate(result)
 
 
 # ---------------------------------------------------------------------------

--- a/test/adapters/driven/test_wire_render_adapter.py
+++ b/test/adapters/driven/test_wire_render_adapter.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for :class:`~vultron.adapters.driven.wire_render.As2WireRenderAdapter`.
+
+Covers:
+- AC-2: round-trip test for every core type with a wire counterpart
+- AC-3: VultronValidationError raised for core types with no wire counterpart
+- AC-6: test file does NOT import from vultron.core (adapter import only)
+
+Per ``specs/architecture.yaml`` ARCH-20-001 through ARCH-20-004.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from vultron.adapters.driven.wire_render import As2WireRenderAdapter
+from vultron.core.models.actor import VultronPerson
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_actor import CaseActor
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.case_reference import CaseReference
+from vultron.core.models.case_status import CaseStatus
+from vultron.core.models.embargo_policy import EmbargoPolicy
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.report import VulnerabilityReport
+from vultron.core.models.vulnerability_record import VulnerabilityRecord
+from vultron.errors import VultronValidationError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def adapter():
+    return As2WireRenderAdapter()
+
+
+# ---------------------------------------------------------------------------
+# Helper — assert a render result looks like a wire object
+# ---------------------------------------------------------------------------
+
+
+def _assert_wire_dict(result: dict, expected_type: str) -> None:
+    assert isinstance(result, dict), f"Expected dict, got {type(result)}"
+    assert (
+        result.get("type") == expected_type
+    ), f"Expected type={expected_type!r}, got {result.get('type')!r}"
+    # camelCase key present (not snake_case)
+    # The 'id' field is always emitted by VultronAS2Object
+    assert "id" in result, f"Missing 'id' key in wire dict for {expected_type}"
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Round-trip for every core type that HAS a wire counterpart (9 types)
+# ---------------------------------------------------------------------------
+
+
+def test_render_vulnerability_case(adapter):
+    obj = VulnerabilityCase()
+    result = adapter.render(obj)
+    _assert_wire_dict(result, "VulnerabilityCase")
+
+
+def test_render_vulnerability_report(adapter):
+    obj = VulnerabilityReport()
+    result = adapter.render(obj)
+    _assert_wire_dict(result, "VulnerabilityReport")
+
+
+def test_render_case_participant(adapter):
+    obj = CaseParticipant()
+    result = adapter.render(obj)
+    _assert_wire_dict(result, "CaseParticipant")
+
+
+def test_render_case_reference(adapter):
+    obj = CaseReference(url="https://example.org/ref")
+    result = adapter.render(obj)
+    _assert_wire_dict(result, "CaseReference")
+
+
+def test_render_embargo_policy(adapter):
+    obj = EmbargoPolicy(
+        actor_id="urn:uuid:actor",
+        inbox="https://example.org/inbox",
+        preferred_duration=timedelta(days=90),
+    )
+    result = adapter.render(obj)
+    _assert_wire_dict(result, "EmbargoPolicy")
+
+
+def test_render_vulnerability_record(adapter):
+    obj = VulnerabilityRecord(name="CVE-2024-0001")
+    result = adapter.render(obj)
+    _assert_wire_dict(result, "VulnerabilityRecord")
+
+
+def test_render_case_status(adapter):
+    obj = CaseStatus(context="urn:uuid:case")
+    result = adapter.render(obj)
+    _assert_wire_dict(result, "CaseStatus")
+
+
+def test_render_participant_status(adapter):
+    obj = ParticipantStatus(context="urn:uuid:case")
+    result = adapter.render(obj)
+    _assert_wire_dict(result, "ParticipantStatus")
+
+
+def test_render_case_ledger_entry(adapter):
+    obj = CaseLedgerEntry(
+        case_id="urn:uuid:case",
+        log_object_id="urn:uuid:obj",
+        event_type="V",
+    )
+    result = adapter.render(obj)
+    _assert_wire_dict(result, "CaseLedgerEntry")
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Round-trip output uses by_alias=True, exclude_none=True
+# ---------------------------------------------------------------------------
+
+
+def test_render_returns_camel_case_keys(adapter):
+    """Output dict uses camelCase field names (by_alias=True)."""
+    obj = CaseLedgerEntry(
+        case_id="urn:uuid:case",
+        log_object_id="urn:uuid:obj",
+        event_type="V",
+    )
+    result = adapter.render(obj)
+    # Wire alias for 'case_id' is 'caseId' / 'context' depending on wire model;
+    # at minimum no snake_case keys that are known aliases should be present
+    assert (
+        "case_id" not in result
+    ), "Expected camelCase output (by_alias=True) but found snake_case key 'case_id'"
+
+
+def test_render_excludes_none_fields(adapter):
+    """Output dict omits None-valued fields (exclude_none=True)."""
+    obj = VulnerabilityCase()
+    result = adapter.render(obj)
+    for key, val in result.items():
+        assert (
+            val is not None
+        ), f"Field {key!r} should be excluded (exclude_none=True) but has value None"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: VultronValidationError for core types with no wire counterpart
+# ---------------------------------------------------------------------------
+
+
+def test_render_raises_for_case_actor(adapter):
+    """CaseActor has no VultronAS2Object wire counterpart — must raise."""
+    obj = CaseActor()
+    with pytest.raises(VultronValidationError, match="CaseActor"):
+        adapter.render(obj)
+
+
+def test_render_raises_for_vultron_person(adapter):
+    """VultronPerson wire class is NOT VultronAS2Object — must raise."""
+    obj = VultronPerson()
+    with pytest.raises(VultronValidationError, match="VultronPerson"):
+        adapter.render(obj)
+
+
+def test_render_raises_for_unknown_type(adapter):
+    """Arbitrary non-vocabulary object raises VultronValidationError."""
+
+    class _NotACoreType:
+        pass
+
+    with pytest.raises(VultronValidationError):
+        adapter.render(_NotACoreType())
+
+
+# ---------------------------------------------------------------------------
+# AC-6: Protocol structural compliance — adapter satisfies WireRenderPort
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_satisfies_wire_render_port():
+    """As2WireRenderAdapter is structurally compatible with WireRenderPort."""
+    from vultron.core.ports.wire_render import WireRenderPort
+
+    assert isinstance(As2WireRenderAdapter(), WireRenderPort)

--- a/test/core/behaviors/test_bridge.py
+++ b/test/core/behaviors/test_bridge.py
@@ -562,3 +562,75 @@ def test_only_one_completion_record_per_failure(bridge, test_actor_id, caplog):
         bridge.execute_with_setup(tree=AlwaysFail(), actor_id=test_actor_id)
 
     assert len(_completion_records(caplog)) == 1
+
+
+# ---------------------------------------------------------------------------
+# wire_render_port injection tests (AC-4)
+# ---------------------------------------------------------------------------
+
+
+class _StubWireRenderPort:
+    """Minimal stub that satisfies the WireRenderPort Protocol."""
+
+    def render(self, obj):
+        return {"type": "stub"}
+
+
+class CheckWireRenderPort(py_trees.behaviour.Behaviour):
+    """BT node that verifies wire_render_port is on the blackboard."""
+
+    def setup(self, **kwargs) -> None:
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(
+            key="wire_render_port", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        try:
+            port = self.blackboard.wire_render_port
+            if port is None:
+                self.feedback_message = "wire_render_port is None"
+                return Status.FAILURE
+            self.feedback_message = "wire_render_port present"
+            return Status.SUCCESS
+        except KeyError as e:
+            self.feedback_message = f"Missing key: {e}"
+            return Status.FAILURE
+
+
+def test_bridge_wire_render_port_published_to_blackboard(
+    datalayer, test_actor_id
+):
+    """AC-4: wire_render_port is placed on the blackboard when provided."""
+    stub = _StubWireRenderPort()
+    bridge = BTBridge(datalayer=datalayer, wire_render_port=stub)
+
+    tree = CheckWireRenderPort(name="CheckWireRenderPort")
+    result = bridge.execute_with_setup(tree=tree, actor_id=test_actor_id)
+
+    assert result.status == Status.SUCCESS, result.feedback_message
+
+
+def test_bridge_wire_render_port_not_on_blackboard_when_absent(
+    bridge, test_actor_id
+):
+    """AC-4: wire_render_port key is absent from the blackboard when not provided."""
+    storage = py_trees.blackboard.Blackboard.storage
+    # Run without wire_render_port
+    bridge.execute_with_setup(tree=AlwaysSucceed(), actor_id=test_actor_id)
+    assert "/wire_render_port" not in storage
+
+
+def test_bridge_wire_render_port_is_correct_object(datalayer, test_actor_id):
+    """The blackboard receives the exact port object passed to BTBridge."""
+    stub = _StubWireRenderPort()
+    bridge = BTBridge(datalayer=datalayer, wire_render_port=stub)
+
+    bt = bridge.setup_tree(tree=AlwaysSucceed(), actor_id=test_actor_id)
+    bt.setup()
+
+    blackboard = py_trees.blackboard.Client(name="test-wire-render")
+    blackboard.register_key(
+        key="wire_render_port", access=py_trees.common.Access.READ
+    )
+    assert blackboard.wire_render_port is stub

--- a/vultron/adapters/driven/wire_render/__init__.py
+++ b/vultron/adapters/driven/wire_render/__init__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Adapter implementing
+:class:`~vultron.core.ports.wire_render.WireRenderPort`.
+
+Renders a core domain object to wire-shaped (camelCase) JSON without
+the core layer importing from the wire layer (ARCH-01-001).
+
+See also:
+    - ``vultron/core/ports/wire_render.py`` — port Protocol
+    - ``docs/adr/0063-wire-rendering-port-for-core-objects.md`` — ADR
+"""
+
+from .as2 import As2WireRenderAdapter
+
+__all__ = ["As2WireRenderAdapter"]

--- a/vultron/adapters/driven/wire_render/as2.py
+++ b/vultron/adapters/driven/wire_render/as2.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""AS2 adapter implementing
+:class:`~vultron.core.ports.wire_render.WireRenderPort`.
+
+Translates a core domain object to its wire-layer counterpart via:
+
+1. Vocabulary lookup — ``VOCABULARY.get(type(obj).__name__)``
+2. Wire-counterpart guard — ``issubclass(wire_cls, VultronAS2Object)``
+3. ``wire_cls.from_core(obj)``
+4. ``model_dump(by_alias=True, exclude_none=True)``
+
+Raises :exc:`~vultron.errors.VultronValidationError` when the core type
+has no wire counterpart or the counterpart does not extend
+:class:`~vultron.wire.as2.vocab.objects.base.VultronAS2Object`
+(ARCH-20-003).
+
+This module lives under ``vultron/adapters/`` so that ``vultron/core/``
+never imports from the wire layer (ARCH-01-001, ARCH-01-004).
+
+See also:
+    - ``vultron/core/ports/wire_render.py`` — port Protocol
+    - ``docs/adr/0063-wire-rendering-port-for-core-objects.md`` — ADR
+    - ``notes/core-wire-rendering-port.md`` — design rationale
+
+Per ``specs/architecture.yaml`` ARCH-20-001 through ARCH-20-004.
+"""
+
+from typing import Any
+
+from vultron.errors import VultronValidationError
+from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.objects.base import VultronAS2Object
+
+
+class As2WireRenderAdapter:
+    """Driven adapter that renders core domain objects as wire-shaped JSON.
+
+    Implements :class:`~vultron.core.ports.wire_render.WireRenderPort`
+    structurally (duck-typed via the Protocol).
+
+    Stateless — instantiate once and reuse freely.
+    """
+
+    def render(self, obj: Any) -> dict[str, Any]:
+        """Render a core domain object as wire-shaped JSON.
+
+        Looks up the wire counterpart in the AS2 vocabulary registry by
+        ``type(obj).__name__``, verifies it is a
+        :class:`~vultron.wire.as2.vocab.objects.base.VultronAS2Object`
+        (the only class with ``from_core()``), then returns the camelCase
+        dict.
+
+        Args:
+            obj: A core domain model instance.
+
+        Returns:
+            ``wire_cls.from_core(obj).model_dump(by_alias=True,
+            exclude_none=True)`` — camelCase keys, ``None`` fields omitted.
+
+        Raises:
+            :exc:`~vultron.errors.VultronValidationError`: When ``obj``'s
+                type is not in the wire vocabulary or the wire counterpart
+                does not extend ``VultronAS2Object`` (ARCH-20-003).
+        """
+        type_name = type(obj).__name__
+        wire_cls = VOCABULARY.get(type_name)
+
+        if wire_cls is None or not issubclass(wire_cls, VultronAS2Object):
+            raise VultronValidationError(
+                f"No wire counterpart for core type {type_name!r}."
+            )
+
+        return wire_cls.from_core(obj).model_dump(
+            by_alias=True, exclude_none=True
+        )

--- a/vultron/core/behaviors/bridge.py
+++ b/vultron/core/behaviors/bridge.py
@@ -50,6 +50,7 @@ from vultron.core.ports.case_persistence import CasePersistence
 if TYPE_CHECKING:
     from vultron.core.ports.sync_activity import SyncActivityPort
     from vultron.core.ports.trigger_activity import TriggerActivityPort
+    from vultron.core.ports.wire_render import WireRenderPort
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,7 @@ class BTBridge:
         is_leader: Callable[[], bool] = _default_is_leader,
         trigger_activity: "TriggerActivityPort | None" = None,
         sync_port: "SyncActivityPort | None" = None,
+        wire_render_port: "WireRenderPort | None" = None,
     ):
         """
         Initialize BT bridge with DataLayer access and optional leadership guard.
@@ -126,11 +128,17 @@ class BTBridge:
                 ``Announce(CaseLedgerEntry)`` activities to participants.
                 Without this, ledger entries committed inside BTs are
                 persisted locally but not replicated.
+            wire_render_port: Optional port for rendering core domain objects
+                to wire-shaped (camelCase) JSON (ARCH-20-001).  When provided
+                it is placed on the py_trees blackboard under the key
+                ``wire_render_port`` so that BT nodes can call it without
+                importing from the wire layer (ARCH-01-001, ARCH-01-004).
         """
         self.datalayer = datalayer
         self.is_leader = is_leader
         self.trigger_activity = trigger_activity
         self.sync_port = sync_port
+        self.wire_render_port = wire_render_port
         self.logger = logging.getLogger(
             f"{__name__}.{self.__class__.__name__}"
         )
@@ -188,6 +196,13 @@ class BTBridge:
                 access=py_trees.common.Access.WRITE,
             )
             blackboard.sync_port = self.sync_port
+
+        if self.wire_render_port is not None:
+            blackboard.register_key(
+                key="wire_render_port",
+                access=py_trees.common.Access.WRITE,
+            )
+            blackboard.wire_render_port = self.wire_render_port
 
         if activity is not None:
             blackboard.register_key(

--- a/vultron/core/ports/wire_render.py
+++ b/vultron/core/ports/wire_render.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Driven port for rendering core domain objects as wire-shaped JSON.
+
+Core code that needs wire-shaped (AS2 camelCase) JSON for a domain
+object calls this port.  The adapter translates the core object to its
+wire counterpart and returns the result of
+``model_dump(by_alias=True, exclude_none=True)``.
+
+Raises :exc:`~vultron.errors.VultronValidationError` when no wire
+counterpart exists (ARCH-20-003).
+
+See also:
+    - ``vultron/adapters/driven/wire_render/as2.py`` — adapter
+    - ``docs/adr/0063-wire-rendering-port-for-core-objects.md`` — ADR
+    - ``notes/core-wire-rendering-port.md`` — design rationale
+
+Per ``specs/architecture.yaml`` ARCH-20-001 through ARCH-20-004.
+"""
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class WireRenderPort(Protocol):
+    """Driven port for rendering core domain objects as wire-shaped JSON.
+
+    A single-method port (matching the ``SyncActivityPort`` /
+    ``ActivityEmitter`` style).  The adapter is the sole owner of
+    wire-spelling knowledge; core code calls this port without importing
+    from the wire layer (ARCH-01-001, ARCH-20-001).
+
+    Per ``specs/architecture.yaml`` ARCH-20-001 through ARCH-20-004.
+    """
+
+    def render(self, obj: Any) -> dict[str, Any]:
+        """Render a core domain object as wire-shaped JSON.
+
+        Args:
+            obj: A core domain model instance.
+
+        Returns:
+            A ``dict`` equivalent to
+            ``as_X.from_core(obj).model_dump(by_alias=True, exclude_none=True)``
+            — camelCase keys, ``None`` fields omitted.
+
+        Raises:
+            :exc:`~vultron.errors.VultronValidationError`: When ``obj``'s
+                core type has no wire counterpart registered in the wire
+                vocabulary, or when the wire counterpart does not implement
+                ``from_core()`` (ARCH-20-003).
+        """
+        ...


### PR DESCRIPTION
- Closes #2286
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Introduces `WireRenderPort` as a `typing.Protocol` in `vultron/core/ports/` and `As2WireRenderAdapter` in `vultron/adapters/driven/wire_render/` that implements it. `BTBridge` now accepts `wire_render_port` and publishes it to the py_trees blackboard under `"wire_render_port"`, exactly as `sync_port` is handled.

## Changes

- **`vultron/core/ports/wire_render.py`**: New `WireRenderPort` Protocol with `render(obj) -> dict[str, Any]`, `@runtime_checkable` (AC-1, ARCH-20-001)
- **`vultron/adapters/driven/wire_render/as2.py`**: `As2WireRenderAdapter.render()` — vocabulary lookup → `issubclass(wire_cls, VultronAS2Object)` guard → `from_core()` → `model_dump(by_alias=True, exclude_none=True)`; raises `VultronValidationError` when no wire counterpart exists (AC-2, AC-3)
- **`vultron/adapters/driven/wire_render/__init__.py`**: Package init exporting `As2WireRenderAdapter`
- **`vultron/core/behaviors/bridge.py`**: `wire_render_port` parameter added to `BTBridge.__init__`, published to blackboard in `setup_tree()` after `sync_port` block (AC-4)
- **`test/adapters/driven/test_wire_render_adapter.py`**: 13 new tests — round-trip for all 9 core types with wire counterparts, camelCase/exclude_none checks, 3 negative tests (AC-2, AC-3, AC-6)
- **`test/core/behaviors/test_bridge.py`**: 3 new tests — `wire_render_port` published, absent when not provided, correct object identity (AC-4)

## Verification

- All 7199 unit tests pass (16 new)
- All 1167 integration tests pass
- Black, flake8, mypy, pyright clean