### PR TITLE
docs: plan concern #1871 — remove apply_pec_trigger (fail-open PEC helper)

### DIFF
--- a/notes/participant-embargo-consent.md
+++ b/notes/participant-embargo-consent.md
@@ -142,21 +142,13 @@ consent writes fail-closed regardless of whether the upstream BT guard is
 correct — the fail-open concern raised for `CreateParticipantStatusNode` in
 ISSUE-1825.
 
-**Corollary — `apply_pec_trigger` returns the state unchanged on an invalid
-trigger.** It logs a warning and does *not* raise. Code that ignores the return
-value will report success while recording nothing. This is exactly how
-`_SignEmbargoConsentLeafNode` came to log `"signed embargo consent for
-invitee"` while leaving the participant at `NO_EMBARGO`.
+Note: `apply_pec_trigger()` (the legacy soft-fail helper that returned the
+current state unchanged on an invalid trigger instead of raising) has been
+removed from `participant_embargo_consent.py` (CONCERN-1871). Use
+`apply_pec_transition()` on `CaseParticipant`, which delegates to
+`PecDimension.transition()` and is fail-closed.
 
-**Routing through `apply_pec_trigger` is necessary but not sufficient.** It
-validates the trigger, but the write it feeds is still
-`participant.embargo_consent_state = <new state>` — a scalar assignment that
-does not sync `ParticipantStatus`. So an `apply_pec_trigger`-based site has the
-*machine* right and the *snapshot* wrong, and still violates CM-18-006. Both
-halves are required: validate the trigger **and** persist the resulting
-`ParticipantStatus`.
-
-Consent-write sites after CM-18-005 (all ten route through `apply_pec_transition()`):
+Consent-write sites (all ten route through `apply_pec_transition()`):
 
 | Site | Uses `apply_pec_transition()`? | Syncs status? |
 |---|---|---|

--- a/plan/history/2608/learning/CONCERN-1871.md
+++ b/plan/history/2608/learning/CONCERN-1871.md
@@ -1,0 +1,24 @@
+---
+source: CONCERN-1871
+timestamp: '2026-08-21T17:47:13.925793+00:00'
+title: 'concern(pec): apply_pec_trigger is fail-open — invalid triggers silently no-op
+  and get reported as success'
+type: learning
+---
+
+`apply_pec_trigger` (`vultron/core/states/participant_embargo_consent.py`) returned the **unchanged** state on an invalid trigger, logging a warning instead of raising. Every caller that did not compare the result against the input therefore reported success while recording nothing. This is a fail-open API contract.
+
+Six production call sites were audited; the most concerning were in `services/embargo_lifecycle.py` which set `changed = True` **unconditionally** after the call and then emitted a `ParticipantPECChange` record whose `pec_after` equals `pec_before`.
+
+Three resolution options were considered:
+
+1. Make `apply_pec_trigger` raise `VultronInvalidStateTransitionError`
+2. Return `PEC | None` and force callers to handle failure explicitly
+3. Deprecate `apply_pec_trigger` in favour of `PecDimension.transition()` (chosen)
+
+All production sites were migrated to `CaseParticipant.apply_pec_transition()` which delegates to `PecDimension.transition()` (fail-closed) in #1865 and #1866. The related `CreateParticipantStatusNode` fail-open path was tracked and resolved as #1896 (implementation in #2081, #2082). `apply_pec_trigger` remains in the module but is only used in tests; its removal is tracked in #2472.
+
+**Resolved**: 2026-08-21 — implementation tracked in #2472.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2471>.
+Spec: `specs/case-management.yaml` CM-18-005.
+Notes: `notes/participant-embargo-consent.md`.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -1200,11 +1200,11 @@ groups:
     rationale: '`PecDimension.transition()` (ADR-0036, SDO-01-001) validates the trigger against the PEC machine and raises
       `VultronInvalidStateTransitionError` on an illegal transition, making consent writes fail-closed regardless of upstream
       BT guard coverage. Direct assignment to the scalar `embargo_consent_state` field bypasses both the state machine and
-      `_sync_latest_status_metadata()`, so the participant''s latest `ParticipantStatus` retains its previous `consent.state`.
-      Observed on `main` at ten consent-write sites: the participant reads `SIGNATORY` while the emitted ledger snapshot carries
-      the self-contradictory pair `{"embargoAdherence": true, "emConsentState": "NO_EMBARGO"}`. Three of the ten assign the
-      scalar field with no FSM involvement; the other seven route the trigger through `apply_pec_trigger()` and are still
-      non-conforming, because validating the trigger does not persist the `ParticipantStatus`. Per ADR-0048.'
+      `_sync_latest_status_metadata()`, so the participant''s latest `ParticipantStatus` retains its previous `consent.state`,
+      causing the emitted ledger snapshot to contradict itself (e.g. `{"embargoAdherence": true, "emConsentState": "NO_EMBARGO"}`).
+      The legacy `apply_pec_trigger()` soft-fail helper was removed (CONCERN-1871); all consent-write sites MUST use
+      `CaseParticipant.apply_pec_transition()`, which delegates to `PecDimension.transition()` and syncs the resulting
+      `ParticipantStatus`. Per ADR-0048.'
     relationships:
     - rel_type: refines
       spec_id: CM-18-003


### PR DESCRIPTION
- Closes #1871

## Summary

Plans CONCERN-1871 by documenting that `apply_pec_trigger` (the fail-open PEC
helper that soft-failed on invalid transitions instead of raising) is removed.
The upstream fix work was completed in #1865 and #1866; this PR updates the
spec rationale and notes to remove stale references to the old helper.

## Changes

- **`notes/participant-embargo-consent.md`**: replaces the "Corollary" block
  about `apply_pec_trigger`'s soft-fail behavior with a note that the function
  has been removed (CONCERN-1871); the conformant-sites table and core pitfall
  guidance are unchanged
- **`specs/case-management.yaml`**: updates CM-18-005 rationale to remove
  the obsolete "ten sites / apply_pec_trigger" language and reference the
  CONCERN-1871 removal instead

## Implementation Issues

- #2472