### PR TITLE
fix(pec): remove apply_pec_trigger and migrate tests to PecDimension.transition()

### DIFF
--- a/test/core/behaviors/case/test_accept_invite_tree.py
+++ b/test/core/behaviors/case/test_accept_invite_tree.py
@@ -62,9 +62,9 @@ class TestSignEmbargoConsentLeafNode:
     ) -> None:
         """Regression: invitee starting at NO_EMBARGO must reach SIGNATORY.
 
-        Before the ADR-0048 fix, apply_pec_trigger(NO_EMBARGO, ACCEPT)
-        returned NO_EMBARGO unchanged and the node logged success while
-        leaving consent unrecorded — CM-10-001 violated.
+        Before the ADR-0048 fix the consent write was fail-open, returning
+        NO_EMBARGO unchanged while the node logged success — CM-10-001
+        violated.
         """
         status, participant = _run_sign_node(
             bt_scenario, starting_pec=PEC.NO_EMBARGO
@@ -97,11 +97,9 @@ class TestSignEmbargoConsentLeafNode:
     ) -> None:
         """Participant already SIGNATORY: ACCEPT is an illegal trigger → FAILURE.
 
-        With the fail-closed apply_pec_transition(), ACCEPT from SIGNATORY
-        raises VultronInvalidStateTransitionError; the BTBridge catches it and
+        apply_pec_transition() is fail-closed: ACCEPT from SIGNATORY raises
+        VultronInvalidStateTransitionError; the BTBridge catches it and
         returns FAILURE with the error in feedback_message (AC-5, CM-18-005).
-        The old soft-fail apply_pec_trigger() silently returned the state
-        unchanged — that silent no-op is the bug this test pins down.
         """
         node = _SignEmbargoConsentLeafNode(invitee_id=_ACTOR_ID)
         participant = CaseParticipant(

--- a/test/core/models/test_case_participant.py
+++ b/test/core/models/test_case_participant.py
@@ -429,8 +429,7 @@ class TestApplyPecTransition:
         """AC-5: illegal trigger raises VultronInvalidStateTransitionError.
 
         ACCEPT from SIGNATORY is not a valid PEC transition; it must raise
-        rather than silently returning the current state (old apply_pec_trigger
-        soft-fail behaviour was the bug).
+        rather than silently returning the current state.
         """
         from vultron.core.states.participant_embargo_consent import PEC_Trigger
         from vultron.errors import VultronInvalidStateTransitionError

--- a/test/core/services/test_embargo_lifecycle.py
+++ b/test/core/services/test_embargo_lifecycle.py
@@ -856,9 +856,8 @@ def test_record_participant_consent_illegal_trigger_raises(
 ) -> None:
     """AC-5: illegal trigger raises VultronInvalidStateTransitionError.
 
-    ACCEPT from SIGNATORY is not a valid PEC transition. The old
-    apply_pec_trigger() soft-fail silently returned state unchanged; the
-    new fail-closed apply_pec_transition() raises — this test pins that
+    ACCEPT from SIGNATORY is not a valid PEC transition.
+    apply_pec_transition() is fail-closed and raises; this test pins that
     behavior and confirms record_participant_consent propagates it.
     """
     owner, dl = owner_and_dl

--- a/test/core/states/test_participant_embargo_consent.py
+++ b/test/core/states/test_participant_embargo_consent.py
@@ -2,12 +2,13 @@
 
 import pytest
 
+from vultron.core.models.dimensions import PecDimension
 from vultron.core.states.participant_embargo_consent import (
     PEC,
     PEC_Trigger,
-    apply_pec_trigger,
     create_pec_machine,
 )
+from vultron.errors import VultronInvalidStateTransitionError
 
 
 class TestPECEnum:
@@ -40,42 +41,50 @@ class TestPECMachineCreation:
         assert isinstance(machine, Machine)
 
 
-class TestApplyPecTrigger:
+class TestPecDimensionTransition:
     # --- INVITE transitions ---
     def test_invite_from_no_embargo(self) -> None:
-        result = apply_pec_trigger(PEC.NO_EMBARGO, PEC_Trigger.INVITE)
-        assert result == PEC.INVITED
+        result = PecDimension(state=PEC.NO_EMBARGO).transition(
+            PEC_Trigger.INVITE
+        )
+        assert result.state == PEC.INVITED
 
     def test_invite_from_lapsed(self) -> None:
-        result = apply_pec_trigger(PEC.LAPSED, PEC_Trigger.INVITE)
-        assert result == PEC.INVITED
+        result = PecDimension(state=PEC.LAPSED).transition(PEC_Trigger.INVITE)
+        assert result.state == PEC.INVITED
 
     def test_invite_from_declined(self) -> None:
-        result = apply_pec_trigger(PEC.DECLINED, PEC_Trigger.INVITE)
-        assert result == PEC.INVITED
+        result = PecDimension(state=PEC.DECLINED).transition(
+            PEC_Trigger.INVITE
+        )
+        assert result.state == PEC.INVITED
 
     # --- ACCEPT transitions ---
     def test_accept_from_invited(self) -> None:
-        result = apply_pec_trigger(PEC.INVITED, PEC_Trigger.ACCEPT)
-        assert result == PEC.SIGNATORY
+        result = PecDimension(state=PEC.INVITED).transition(PEC_Trigger.ACCEPT)
+        assert result.state == PEC.SIGNATORY
 
     def test_accept_from_lapsed(self) -> None:
-        result = apply_pec_trigger(PEC.LAPSED, PEC_Trigger.ACCEPT)
-        assert result == PEC.SIGNATORY
+        result = PecDimension(state=PEC.LAPSED).transition(PEC_Trigger.ACCEPT)
+        assert result.state == PEC.SIGNATORY
 
     # --- DECLINE transitions ---
     def test_decline_from_invited(self) -> None:
-        result = apply_pec_trigger(PEC.INVITED, PEC_Trigger.DECLINE)
-        assert result == PEC.DECLINED
+        result = PecDimension(state=PEC.INVITED).transition(
+            PEC_Trigger.DECLINE
+        )
+        assert result.state == PEC.DECLINED
 
     def test_decline_from_lapsed(self) -> None:
-        result = apply_pec_trigger(PEC.LAPSED, PEC_Trigger.DECLINE)
-        assert result == PEC.DECLINED
+        result = PecDimension(state=PEC.LAPSED).transition(PEC_Trigger.DECLINE)
+        assert result.state == PEC.DECLINED
 
     # --- REVISE transition ---
     def test_revise_from_signatory(self) -> None:
-        result = apply_pec_trigger(PEC.SIGNATORY, PEC_Trigger.REVISE)
-        assert result == PEC.LAPSED
+        result = PecDimension(state=PEC.SIGNATORY).transition(
+            PEC_Trigger.REVISE
+        )
+        assert result.state == PEC.LAPSED
 
     # --- RESET transitions (wildcard) ---
     @pytest.mark.parametrize(
@@ -83,36 +92,40 @@ class TestApplyPecTrigger:
         [PEC.NO_EMBARGO, PEC.INVITED, PEC.SIGNATORY, PEC.DECLINED, PEC.LAPSED],
     )
     def test_reset_from_any_state(self, state: PEC) -> None:
-        result = apply_pec_trigger(state, PEC_Trigger.RESET)
-        assert result == PEC.NO_EMBARGO
+        result = PecDimension(state=state).transition(PEC_Trigger.RESET)
+        assert result.state == PEC.NO_EMBARGO
 
     # --- ADR-0048: ACCEPT and DECLINE directly from NO_EMBARGO ---
     def test_accept_from_no_embargo(self) -> None:
-        result = apply_pec_trigger(PEC.NO_EMBARGO, PEC_Trigger.ACCEPT)
-        assert result == PEC.SIGNATORY
+        result = PecDimension(state=PEC.NO_EMBARGO).transition(
+            PEC_Trigger.ACCEPT
+        )
+        assert result.state == PEC.SIGNATORY
 
     def test_decline_from_no_embargo(self) -> None:
-        result = apply_pec_trigger(PEC.NO_EMBARGO, PEC_Trigger.DECLINE)
-        assert result == PEC.DECLINED
+        result = PecDimension(state=PEC.NO_EMBARGO).transition(
+            PEC_Trigger.DECLINE
+        )
+        assert result.state == PEC.DECLINED
 
     # --- CM-18-004: SIGNATORY → INVITED must remain invalid ---
-    def test_invite_from_signatory_is_invalid(self) -> None:
-        result = apply_pec_trigger(PEC.SIGNATORY, PEC_Trigger.INVITE)
-        assert result == PEC.SIGNATORY  # unchanged
+    def test_invite_from_signatory_raises(self) -> None:
+        with pytest.raises(VultronInvalidStateTransitionError):
+            PecDimension(state=PEC.SIGNATORY).transition(PEC_Trigger.INVITE)
 
-    # --- Other invalid transitions return current state (no raise) ---
-    def test_accept_from_declined_is_invalid(self) -> None:
-        result = apply_pec_trigger(PEC.DECLINED, PEC_Trigger.ACCEPT)
-        assert result == PEC.DECLINED  # unchanged
+    # --- Other invalid transitions raise VultronInvalidStateTransitionError ---
+    def test_accept_from_declined_raises(self) -> None:
+        with pytest.raises(VultronInvalidStateTransitionError):
+            PecDimension(state=PEC.DECLINED).transition(PEC_Trigger.ACCEPT)
 
-    def test_decline_from_declined_is_invalid(self) -> None:
-        result = apply_pec_trigger(PEC.DECLINED, PEC_Trigger.DECLINE)
-        assert result == PEC.DECLINED  # unchanged
+    def test_decline_from_declined_raises(self) -> None:
+        with pytest.raises(VultronInvalidStateTransitionError):
+            PecDimension(state=PEC.DECLINED).transition(PEC_Trigger.DECLINE)
 
-    def test_revise_from_invited_is_invalid(self) -> None:
-        result = apply_pec_trigger(PEC.INVITED, PEC_Trigger.REVISE)
-        assert result == PEC.INVITED  # unchanged
+    def test_revise_from_invited_raises(self) -> None:
+        with pytest.raises(VultronInvalidStateTransitionError):
+            PecDimension(state=PEC.INVITED).transition(PEC_Trigger.REVISE)
 
-    def test_revise_from_no_embargo_is_invalid(self) -> None:
-        result = apply_pec_trigger(PEC.NO_EMBARGO, PEC_Trigger.REVISE)
-        assert result == PEC.NO_EMBARGO  # unchanged
+    def test_revise_from_no_embargo_raises(self) -> None:
+        with pytest.raises(VultronInvalidStateTransitionError):
+            PecDimension(state=PEC.NO_EMBARGO).transition(PEC_Trigger.REVISE)

--- a/vultron/core/models/case_participant.py
+++ b/vultron/core/models/case_participant.py
@@ -197,8 +197,7 @@ class CaseParticipant(CoreObject):
 
         This is the single authoritative consent-write path (CM-18-005,
         CM-18-006, ADR-0048).  All sites that record a PEC change MUST call
-        this method instead of assigning ``embargo_consent_state`` directly or
-        using the ``apply_pec_trigger()`` helper.
+        this method instead of assigning ``embargo_consent_state`` directly.
         """
         current_pec = coerce_em_consent_state(self.embargo_consent_state)
         if current_pec is None:

--- a/vultron/core/states/participant_embargo_consent.py
+++ b/vultron/core/states/participant_embargo_consent.py
@@ -41,14 +41,11 @@ for self-determined embargoes and implicit-consent cases (CM-14-005).
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-import logging
 from enum import StrEnum, auto
 
-from transitions import Machine, MachineError
+from transitions import Machine
 
 from vultron.core.states.common import TransitionBase, mermaid_machine
-
-logger = logging.getLogger(__name__)
 
 
 class PEC(StrEnum):
@@ -121,13 +118,6 @@ _transitions: list[dict] = [
 ]
 
 
-class PECAdapter:
-    """Adapter for applying PEC transitions to a plain ``.state`` attribute."""
-
-    def __init__(self, initial: PEC) -> None:
-        self.state = initial
-
-
 def create_pec_machine() -> Machine:
     """Create a new Participant Embargo Consent state machine instance."""
     return Machine(
@@ -137,27 +127,6 @@ def create_pec_machine() -> Machine:
         auto_transitions=False,
         name="PEC FSM",
     )
-
-
-def apply_pec_trigger(current_state: PEC, trigger: PEC_Trigger) -> PEC:
-    """Apply a PEC trigger to a state and return the resulting state.
-
-    Returns the unchanged state when the transition is not valid (logs a
-    warning instead of raising).
-    """
-    adapter = PECAdapter(current_state)
-    machine = create_pec_machine()
-    machine.add_model(adapter, initial=current_state)
-    try:
-        getattr(adapter, trigger)()
-        return PEC(adapter.state)
-    except MachineError:
-        logger.warning(
-            "Invalid PEC transition: state='%s' trigger='%s' — ignored",
-            current_state,
-            trigger,
-        )
-        return current_state
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Closes #2472

## Summary

Removes `apply_pec_trigger` (the fail-open soft-fail helper in
`vultron/core/states/participant_embargo_consent.py`) and migrates its
tests to use `PecDimension.transition()` directly. Also removes the
now-dead `PECAdapter` class and cleans up unused `logging`/`MachineError`
imports.

All production consent-write sites were already migrated to
`CaseParticipant.apply_pec_transition()` in #1866; the only remaining
consumer was the unit-test suite itself.

## Changes

- **`vultron/core/states/participant_embargo_consent.py`**: remove
  `apply_pec_trigger`, `PECAdapter`, and now-unused `logging` /
  `MachineError` imports (AC-1)
- **`test/core/states/test_participant_embargo_consent.py`**: replace
  `TestApplyPecTrigger` with `TestPecDimensionTransition`; valid
  transitions now call `PecDimension(state=…).transition(trigger)` and
  assert `result.state`; invalid transitions assert
  `VultronInvalidStateTransitionError` is raised (AC-2)
- **`vultron/core/models/case_participant.py`**: remove stale
  `apply_pec_trigger()` reference from docstring
- **`test/core/behaviors/case/test_accept_invite_tree.py`**,
  **`test/core/services/test_embargo_lifecycle.py`**,
  **`test/core/models/test_case_participant.py`**: update docstrings to
  remove historical `apply_pec_trigger` references (AC-3)

## Verification

- `grep -r "apply_pec_trigger" vultron/ test/` returns no results
- 24 PEC state machine tests pass (`TestPecDimensionTransition`)
- 7181 unit tests pass; 1167 integration tests pass
- Black, flake8, mypy, pyright all clean