### PR TITLE
docs: plan concern #2323 — test-infra config footguns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -706,15 +706,28 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   (recoverable) or `INFO`, not `ERROR`. `ERROR` is for conditions with no recovery
   path. Ask: is there a wired fallback that guarantees convergence? If yes,
   downgrade and name the recovery in the message. *Source: ISSUE-2169*
-- **`reload_config()` MUST Come After `monkeypatch.undo()`, Not Before** —
-  `vultron/config/app.py` holds a module-level `_config_cache`. `reload_config()`
-  re-reads the environment, but `monkeypatch` undoes env changes in fixture
-  teardown **after** its own fixture's body runs. Calling `reload_config()` in
-  the fixture teardown body re-caches the still-patched value; the undo then
-  runs too late. Result: a session-wide config leak that surfaces as flakiness
-  (test ordering matters). Fix: `monkeypatch.undo(); reload_config()`. The
-  autouse guard in `test/demo/conftest.py` contains this, but new demo fixtures
-  must follow the same order. *Source: ISSUE-2086*
+- **Prefer `config_override()` Over `monkeypatch` + `reload_config()` for Config Overrides** —
+  `vultron/config/app.py` exports a `config_override(**env_updates)` context manager that
+  atomically patches env vars, reloads the cache, yields the updated `AppConfig`, and restores
+  env and cache on exit — even on exception. Prefer it over the raw `monkeypatch.setenv()` +
+  `reload_config()` pattern, which is order-sensitive: calling `reload_config()` in fixture
+  teardown before `monkeypatch.undo()` re-caches stale values that leak into subsequent tests
+  as CI flakiness (`pytest-randomly`-dependent). When `config_override()` cannot be used
+  (e.g., session-scoped fixtures that hold `monkeypatch` open), the MUST-follow order is
+  `monkeypatch.undo()` first, then `reload_config()`. The autouse guard
+  `restore_case_actor_url_after_each_test` in `test/demo/conftest.py` detects function-scoped
+  leaks but is NOT a substitute for correct ordering in higher-scoped fixtures.
+  See [notes/configuration.md](notes/configuration.md) § "Testing Pattern". CFG-06-006,
+  CFG-06-007. *Source: ISSUE-2086, CONCERN-2323*
+- **`_TestClientRouter` WARNING for Unregistered Hosts Is a Bug Signal** —
+  `_TestClientRouter.emit` in `test/demo/conftest.py` drops deliveries when no client is
+  registered for the recipient's base URL. Drops to hosts in `_KNOWN_FICTIONAL_HOSTS`
+  (e.g. `vultron.example`) log at `DEBUG` — those are intentionally unreachable. Drops to
+  any *other* unregistered host (e.g. a `.test` host) log at `WARNING` — that is almost
+  always a config leak or fixture bug. A WARNING in the demo-test output means a `Create(
+  CaseProposal)` or similar activity was misaddressed; look for a stale-config leak upstream.
+  See [notes/configuration.md](notes/configuration.md) § "_TestClientRouter WARNING".
+  *Source: CONCERN-2323*
 - **`claim-issue.sh` Requires the Current Branch to Be Up to Date with `origin/main`** —
   the script checks that your branch is ancestor-or-equal to `origin/main`. If
   `main` has moved since you last synced, the check fails with a confusing error.

--- a/notes/configuration.md
+++ b/notes/configuration.md
@@ -293,6 +293,82 @@ async def info(config: AppConfig = Depends(get_config)):
 
 ## Testing Pattern
 
+### Preferred: `config_override()` context manager (CFG-06-006)
+
+Use `config_override()` when a test needs to override `AppConfig` values.  It
+atomically patches `os.environ`, reloads the cache, and restores both on exit —
+even when the body raises.  This makes the incorrect reload-before-undo ordering
+impossible by construction (CONCERN-2323):
+
+```python
+from vultron.config import config_override
+
+def test_env_override():
+    with config_override(VULTRON_SERVER__BASE_URL="http://myserver:8080") as cfg:
+        assert cfg.server.base_url == "http://myserver:8080"
+    # env and cache are restored here, regardless of exception
+```
+
+For tests that only need to reset the cache (no env override), null
+`_config_cache` directly in teardown rather than calling `reload_config()`:
+
+```python
+import vultron.config.app as _cfg_module
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    yield
+    # Null the cache directly — calling reload_config() would re-read the env
+    # while monkeypatch patches are still active, baking stale values in.
+    _cfg_module._config_cache = None
+```
+
+### The `reload_config()` ordering footgun
+
+`_config_cache` is a module-level singleton.  `reload_config()` clears it and
+immediately calls `get_config()`, which re-reads `os.environ` at that instant.
+`pytest`'s `monkeypatch` undoes env changes in fixture **teardown**, *after* the
+teardown body runs.
+
+```text
+BAD teardown order:
+    reload_config()      ← re-reads env while patches are still active
+    monkeypatch.undo()   ← too late: stale value is already cached
+
+CORRECT teardown order:
+    monkeypatch.undo()   ← patches gone before reload
+    reload_config()      ← re-reads clean env
+
+BEST: use config_override() — ordering is correct by construction
+```
+
+A leaked stale value causes every subsequent test that reads `get_config()` to
+see the wrong host.  In the demo suite this surfaces as "no routable recipients"
+failures whose order dependency looks random under `pytest-randomly` (ISSUE-2086).
+
+The session-scoped `restore_case_actor_url_after_each_test` autouse fixture in
+`test/demo/conftest.py` detects and repairs function-scoped leaks, but
+module/class/session-scoped fixtures must still use correct ordering themselves.
+
+### `_TestClientRouter` WARNING for unexpected drops
+
+`_TestClientRouter.emit` (in `test/demo/conftest.py`) drops deliveries when no
+client is registered for the recipient's base URL.  This is intentional for
+known-fictional external URLs such as `vultron.example` — those MUST NOT become
+real HTTP requests.
+
+However, the same silence swallows *unintentional* misrouting.  A stale-config
+leak that causes `Create(CaseProposal)` to be addressed to an unregistered
+`.test` host vanishes without any WARNING.  The failure surfaces several steps
+downstream ("no routable recipients") with no pointer to the real cause.
+
+The fix: maintain a `_KNOWN_FICTIONAL_HOSTS` allowlist in `test/demo/conftest.py`
+(e.g. `{"vultron.example"}`).  Drops matching the allowlist keep `DEBUG` logging;
+drops outside it upgrade to `WARNING` — a `.test` host that was not registered
+is almost always a config bug.
+
+### Legacy pattern (raw monkeypatch + explicit test_config.py)
+
 ```python
 # test/test_config.py
 import pytest

--- a/plan/history/2608/learning/CONCERN-2323.md
+++ b/plan/history/2608/learning/CONCERN-2323.md
@@ -1,0 +1,52 @@
+---
+source: CONCERN-2323
+timestamp: '2026-08-21T18:08:35.856880+00:00'
+title: test infra config management footguns — _config_cache order sensitivity and
+  _TestClientRouter silent drops
+type: learning
+---
+
+## Two related test-infrastructure fragilities that obscure config leaks
+
+### 1) `reload_config()` before `monkeypatch.undo()` leaks stale config
+
+`vultron/config/app.py` holds a module-level `_config_cache`. `reload_config()`
+re-reads the environment. `pytest`'s `monkeypatch` undoes environment changes in
+fixture teardown **after** the requesting fixture's teardown body runs.
+
+Calling `reload_config()` in a fixture teardown before `monkeypatch.undo()` fires
+re-caches the still-patched fake values. The undo then runs too late. The re-cached
+stale value persists into later tests, surfacing as flakiness that depends on test
+execution order (and therefore looks random under `pytest-randomly`).
+
+Four demo fixtures in `test/demo/` had this buggy order (issue #2086). An autouse
+guard in `test/demo/conftest.py` contains the blast radius, but any **new** demo
+fixture must explicitly follow `monkeypatch.undo(); reload_config()` order or it
+will re-introduce the leak.
+
+**Long-term fix**: expose config via a `config_override()` context manager in
+`vultron/config/app.py` that owns both the env patch and cache invalidation
+atomically. Specified as CFG-06-006, CFG-06-007.
+
+### 2) `_TestClientRouter` silent drops mask unintentional misrouting
+
+`_TestClientRouter.emit` in `test/demo/conftest.py` drops deliveries when no client
+is registered for the recipient's base URL, logging only at `DEBUG`. This is
+intentional for fictional external URLs (`https://vultron.example/...`) that must
+not become real HTTP requests.
+
+However, the same silence swallows *unintentional* misrouting. When a config leak
+causes `Create(CaseProposal)` to be addressed to `http://coordinator-otc.test` — a
+host no router registered — the delivery vanishes without a WARNING, the CaseActor
+never creates the canonical case, and the failure surfaces three steps downstream as
+`SvcValidateReportUseCase: no routable recipients`. Nothing in the output names the
+actual cause.
+
+**Suggested fix**: maintain a `_KNOWN_FICTIONAL_HOSTS` allowlist (e.g. `vultron.example`)
+that keeps `DEBUG` logging. Anything outside the allowlist that is dropped should
+log at `WARNING` — a `.test` host that was not registered is almost always a bug.
+
+**Resolved**: 2026-08-21 — implementation tracked in #2475, #2476.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2474>.
+Spec: `specs/configuration.yaml` CFG-06-006, CFG-06-007.
+Notes: `notes/configuration.md`.

--- a/specs/configuration.yaml
+++ b/specs/configuration.yaml
@@ -182,6 +182,36 @@ groups:
     priority: MUST
     kind: project
     statement: Tests MUST verify that the application starts successfully with all defaults (no file, no env vars set).
+  - id: CFG-06-006
+    priority: MUST
+    kind: project
+    statement: >-
+      `vultron/config/app.py` MUST export a `config_override(**env_updates)` context manager that
+      atomically sets the given environment variables, calls `reload_config()`, yields the updated
+      `AppConfig`, and then restores the original environment values and calls `reload_config()`
+      again — including when the body raises an exception (i.e., the restore MUST happen in a
+      `finally` block).
+    rationale: >-
+      Calling `reload_config()` in fixture teardown while env patches are still active bakes
+      stale values into the module-level `_config_cache` for subsequent tests (ISSUE-2086,
+      CONCERN-2323). `config_override()` owns both the env mutation and the cache lifecycle, making
+      the incorrect reload-before-undo ordering impossible by construction.
+  - id: CFG-06-007
+    priority: SHOULD
+    kind: project
+    statement: >-
+      Test fixtures that need to override `AppConfig` values SHOULD use `config_override()`
+      instead of combining `monkeypatch.setenv()` with explicit `reload_config()` calls. Where
+      `monkeypatch` is used directly (e.g., in session-scoped fixtures), `monkeypatch.undo()` MUST
+      precede any `reload_config()` call in teardown (CFG-06-003).
+    rationale: >-
+      `config_override()` (CFG-06-006) eliminates the ordering footgun: the correct
+      undo-then-reload sequence is impossible to get wrong. The explicit ordering rule
+      is still required for code that cannot adopt `config_override()`.
+    relationships:
+    - rel_type: refines
+      spec_id: CFG-06-003
+      note: config_override() is the preferred mechanism; CFG-06-003 applies when it cannot be used
 - id: CFG-07
   title: Actor Configuration
   specs:


### PR DESCRIPTION
- Closes #2323

## Summary

Documents and specifies the two test-infrastructure footguns from concern
#2323: the `reload_config()` / `monkeypatch` ordering hazard and the
`_TestClientRouter` silent-drop problem. Adds the `config_override()` API
contract to specs and notes so implementation issues can reference it.

## Changes

- **`specs/configuration.yaml`**: add CFG-06-006 (`config_override()`
  context manager MUST exist in `vultron/config/app.py` with atomic
  env-patch + cache lifecycle) and CFG-06-007 (SHOULD use it over raw
  `monkeypatch` + `reload_config()`)
- **`notes/configuration.md`**: document the `config_override()` pattern
  and the ordering footgun side-by-side; add `_TestClientRouter` WARNING
  behaviour section explaining the allowlist approach
- **`AGENTS.md`**: upgrade `reload_config()` ordering pitfall to reference
  `config_override()`; add new `_TestClientRouter` WARNING pitfall entry

## Implementation Issues

- #2475
- #2476