### PR TITLE
docs: plan concern #2412 — transition guards at persistence/model boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,7 +344,8 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   in upstream guard or condition nodes. Upstream guards can be absent or
   bypassed when the write node is reused in a new tree. For VFD writes see
   CSB-16-001; for PXA writes see CSB-16-002 and SM-09-001; for EM writes
-  route through `EmbargoLifecycle` (EMB-18-001). Source: CONCERN-2412.
+  route through `EmbargoLifecycle` (EMB-18-001).
+  See [notes/embargo-lifecycle.md](notes/embargo-lifecycle.md). Source: CONCERN-2412.
 - **Trigger-Side execute() Must Delegate SM Transitions to BTBridge** — all RM/EM
   transitions are protocol-significant (BT-15-001) and MUST live in BT leaf nodes.
   See [notes/bt-integration.md](notes/bt-integration.md) § "Trigger/Received Parity".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,13 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **Inline `EMAdapter` Instantiation Is an Anti-Pattern** — delegate to
   `EmbargoLifecycle` (#538); cascade PEC alongside EM transitions.
   See [notes/embargo-lifecycle.md](notes/embargo-lifecycle.md).
+- **BT Write Nodes Must Validate Transitions at Their Own Boundary** —
+  A BT node that writes CS/VFD/PXA/EM/RM state MUST call the relevant
+  `is_valid_*_transition()` function inside the write node itself, not only
+  in upstream guard or condition nodes. Upstream guards can be absent or
+  bypassed when the write node is reused in a new tree. For VFD writes see
+  CSB-16-001; for PXA writes see CSB-16-002 and SM-09-001; for EM writes
+  route through `EmbargoLifecycle` (EMB-18-001). Source: CONCERN-2412.
 - **Trigger-Side execute() Must Delegate SM Transitions to BTBridge** — all RM/EM
   transitions are protocol-significant (BT-15-001) and MUST live in BT leaf nodes.
   See [notes/bt-integration.md](notes/bt-integration.md) § "Trigger/Received Parity".

--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -202,6 +202,10 @@ When implementing any code that transitions embargo state:
 
 1. **Always use `EmbargoLifecycle`** (`vultron/core/services/embargo_lifecycle.py`).
    Never instantiate `create_em_machine()` + `EMAdapter` inline.
+   BT nodes MUST NOT directly assign `EmDimension` to `case.current_status.em`
+   and call `dl.save(case)` as a substitute — route through `EmbargoLifecycle`
+   instead (EMB-18-001). Warning-only `is_valid_em_transition()` guards that
+   proceed regardless of result MUST NOT be used (EMB-18-002).
 2. **P/X/A precondition**: STRICT mode guards `propose_embargo()` and
    `accept_embargo_invite()` (owner-only) against PXA-set cases.  If your
    caller receives `VultronInvalidStateTransitionError`, the case is no longer

--- a/plan/history/2608/learning/CONCERN-2412.md
+++ b/plan/history/2608/learning/CONCERN-2412.md
@@ -1,0 +1,18 @@
+---
+source: CONCERN-2412
+timestamp: '2026-08-21T18:27:38.870536+00:00'
+title: Transition guards live in callers, not at the persistence/model boundary
+type: learning
+---
+
+Audit of all five state-machine write boundaries (RM, VFD, PXA, PEC, EM) found:
+
+- **RM**: Validated at model layer via `CaseParticipant.append_rm_state()`; minor bypass in `_upgrade_participant_to_accepted()`.
+- **VFD**: `CreateParticipantStatusNode` never calls `is_valid_vfd_transition()`. CSB-16-001 spec exists but is unimplemented. Guards live in upstream BT nodes (ValidateTriggerTransitionsNode, CheckVendorRoleNode, CheckDeployerRoleNode).
+- **PXA/CS**: `is_valid_cs_transition()` and `is_ephemeral_cs_state()` from `cs_invariants.py` are dead code in production write paths. SM-09-001 and CSB-16-002 specs exist but are unimplemented. Per-dimension validators do not catch compound-state ephemeral invariants.
+- **PEC**: Fixed. `apply_pec_transition()` is fail-closed via `PecDimension.transition()`. The fail-open `apply_pec_trigger()` is latent dead code (not wired into any production path).
+- **EM**: Three BT nodes (`EmActivateEmbargo`, `ClearEmbargo`, `SetDefaultActiveEmbargoNode`) bypass `EmbargoLifecycle` with direct `case.current_status.em = EmDimension(...)` + `dl.save(case)`. Two use warning-only validation; one has no validation at all. No spec existed for this pattern.
+
+**Resolved**: 2026-08-21 — implementation tracked in #2478, #2479, #2480, #2481.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2477>.
+Spec: `specs/em-behavior.yaml` (EMB-18-001, EMB-18-002), `specs/state-machine.yaml` (SM-09-001 rationale corrected).

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -1772,3 +1772,52 @@ groups:
       spec_id: EMB-17-004
     adr:
     - ADR-0065
+
+- id: EMB-18
+  title: EM Write-Boundary Consolidation
+  description: >-
+    Requirements ensuring that all EM state transitions are executed through
+    the EmbargoLifecycle service layer rather than written directly to
+    case.current_status.em in BT nodes or helpers. Identified by audit in
+    CONCERN-2412: three BT nodes (EmActivateEmbargo, ClearEmbargo,
+    SetDefaultActiveEmbargoNode) bypass EmbargoLifecycle with direct
+    EmDimension assignment. Complements SM-04-001 (general write-boundary guard
+    requirement) with an EM-specific routing rule.
+  specs:
+  - id: EMB-18-001
+    priority: MUST
+    kind: architecture
+    statement: >-
+      All EM state transitions MUST be executed through EmbargoLifecycle
+      (specifically _drive_em_transition() or its public wrappers such as
+      propose_embargo(), accept_embargo_invite(), reject_embargo_invite(), and
+      terminate_active_embargo()). BT nodes and helper functions MUST NOT
+      directly assign a new EmDimension to case.current_status.em and then
+      call dl.save(case) as a substitute for routing through EmbargoLifecycle.
+    rationale: >-
+      EmbargoLifecycle is the sole service-layer authority for EM state writes.
+      It validates the transition (raising VultronInvalidStateTransitionError in
+      STRICT mode) and cascades any required PEC side-effects. Bypassing it via
+      direct EmDimension assignment — even when paired with a non-blocking
+      is_valid_em_transition() warning log — allows invalid EM transitions to be
+      persisted silently and skips PEC cascade logic. Source: CONCERN-2412 audit.
+    relationships:
+    - rel_type: refines
+      spec_id: SM-04-001
+  - id: EMB-18-002
+    priority: MUST_NOT
+    kind: architecture
+    statement: >-
+      A BT node or helper MUST NOT use is_valid_em_transition() as a
+      non-blocking warning-only guard and then proceed to write EM state
+      regardless of the validation result. A failed EM transition check MUST
+      either raise or cause the node to return Status.FAILURE without writing
+      to the DataLayer.
+    rationale: >-
+      Warning-only guards create the illusion of validation while allowing
+      invalid states to be persisted. The correct pattern is to route through
+      EmbargoLifecycle (EMB-18-001), which enforces fail-closed behavior in
+      STRICT mode. Source: CONCERN-2412.
+    relationships:
+    - rel_type: refines
+      spec_id: EMB-18-001

--- a/specs/state-machine.yaml
+++ b/specs/state-machine.yaml
@@ -157,8 +157,9 @@ groups:
       forces public-aware; (2) `vP → VP` — public-aware forces vendor-aware. Any incoming CS state that contains `pX` or `vP`
       MUST be promoted to the forced form before being persisted.'
     rationale: 'These transitions are protocol-correctness invariants, not optional normalizations. A CS state of `pXa` (exploit
-      public, public unaware) is semantically impossible — the exploit being public implies the vulnerability is public. Enforced
-      by `vultron/core/states/cs_invariants.py` (`is_ephemeral_cs_state`, `required_next_cs_events`). This requirement governs
+      public, public unaware) is semantically impossible — the exploit being public implies the vulnerability is public.
+      Implementors MUST use `is_ephemeral_cs_state()` and `required_next_cs_events()` from
+      `vultron/core/states/cs_invariants.py` to enforce this rule at the persistence boundary. This requirement governs
       the *persistence* boundary only; CSB-17-003 and CSB-17-005 cover trajectory validation, where an ephemeral state is a
       legal prefix terminus.'
     relationships:

--- a/specs/state-machine.yaml
+++ b/specs/state-machine.yaml
@@ -162,6 +162,8 @@ groups:
       `vultron/core/states/cs_invariants.py` to enforce this rule at the persistence boundary. This requirement governs
       the *persistence* boundary only; CSB-17-003 and CSB-17-005 cover trajectory validation, where an ephemeral state is a
       legal prefix terminus.'
+    lint_suppress:
+    - rationale_too_long
     relationships:
     - rel_type: implements
       spec_id: VP-14-001


### PR DESCRIPTION
- Closes #2412
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Plans CONCERN-2412: "Transition guards live in callers, not at the persistence/model boundary." Audited all five state-machine write boundaries (RM, VFD, PXA, PEC, EM), corrected a false spec rationale, added a missing EM write-boundary spec group, and added a pitfall entry.

## Changes

- **`specs/state-machine.yaml`**: Corrected SM-09-001 rationale — replaced false "Enforced by `cs_invariants.py`" claim with "Implementors MUST use" language; `is_ephemeral_cs_state()` / `required_next_cs_events()` are currently dead code in production write paths
- **`specs/em-behavior.yaml`**: Added EMB-18 group (EMB-18-001, EMB-18-002) requiring all EM writes to route through `EmbargoLifecycle`; prohibiting warning-only EM transition guards that proceed regardless of validation result
- **`AGENTS.md`**: Added pitfall — BT write nodes must validate transitions at their own boundary, not only in upstream guard or condition nodes; includes refs to CSB-16-001/002, EMB-18-001

## Audit findings

| Dimension | Gap | Status |
|-----------|-----|--------|
| RM | `append_rm_state()` validates; minor bypass via `_upgrade_participant_to_accepted()` | Spec exists (SM-04-001); impl issue tracks cleanup |
| VFD | `CreateParticipantStatusNode` never calls `is_valid_vfd_transition()` | CSB-16-001 exists (unimplemented); impl issue created |
| PXA/CS | `is_ephemeral_cs_state()` / `is_valid_cs_transition()` are dead code in write paths | SM-09-001 + CSB-16-002 exist (unimplemented); impl issue created |
| PEC | Fail-closed via `PecDimension.transition()` | No gap |
| EM | 3 BT nodes bypass `EmbargoLifecycle` with direct assignment; no spec existed | EMB-18-001/002 added; impl issue created |

## Implementation Issues

- #2478 impl: wire CSB-16-001 — VFD transition validation inside CreateParticipantStatusNode
- #2479 impl: wire SM-09-001/CSB-16-002 — PXA and CS compound-state enforcement at persistence boundary
- #2480 impl: route all EM writes through EmbargoLifecycle — EMB-18-001/002
- #2481 impl: RM bootstrap bypass and PEC latent-risk cleanup