### PR TITLE
docs: plan issue #1930 — wire→core import boundary enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,13 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **`as_VulnerabilityCase` (wire) vs `VulnerabilityCase` (core)** — all classes
   in `vultron/wire/as2/vocab/objects/` use `as_` prefix. Bare name = core type.
   See ARCH-14-001.
+- **Never add a new `from vultron.core.models import …` inside `vultron/wire/`** —
+  wire code that needs to convert a core object to wire form MUST use the
+  `as_Foo.from_core(core_obj)` class method already present on every wire vocab
+  object (e.g. `as_VulnerabilityCase.from_core(vc)`). Adding a raw core-model
+  import in wire code expands the KNOWN_VIOLATIONS set in
+  `test/architecture/test_wire_no_core_model_imports.py` and fails CI. See
+  ARCH-22-001 and ARCH-22-002.
 - **Never Reach for `alias_generator` or `by_alias=True` in Core to Get camelCase**
   — core needs wire-shaped JSON only for `CaseLedgerEntry.payloadSnapshot`, and it
   MUST get it from the `WireRenderPort` driven port, not from the domain model.

--- a/plan/history/2608/learning/CONCERN-1930.md
+++ b/plan/history/2608/learning/CONCERN-1930.md
@@ -1,0 +1,48 @@
+---
+source: CONCERN-1930
+timestamp: '2026-08-21T20:09:30.120441+00:00'
+title: VulnerabilityCase is an unguarded cross-layer coupling point — wire, domain,
+  and persistence share the same aggregate with no translation boundary
+type: learning
+---
+
+## Concern
+
+Issue #1930 identified that `VulnerabilityCase` functions as a god node
+(364 edges, betweenness centrality 0.119) shared directly across wire,
+domain, and persistence layers with no translation boundary.  Wire-layer
+modules were importing core model types directly rather than using the
+`as_Foo.from_core()` seam already present on every wire vocab object.
+
+## Resolution
+
+Added ARCH-22 spec group (ARCH-22-001 through ARCH-22-003) to
+`specs/architecture.yaml` requiring a wire→core import ratchet test, and
+added an AGENTS.md pitfall directing agents to use `as_Foo.from_core()`
+instead of direct core-model imports in wire code.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2485>
+
+## Implementation Issues (children of epic #2222)
+
+- #2486 Add wire→core import ratchet test (size:S) — blocked-by #1930
+- #2487 Split CaseOutboxPersistence into its own port file (size:S) — blocked-by #1930
+- #2488 Resolve annotation-time import cycles in vultron/core/models/ (size:S) — blocked-by #1930
+- #2489 Introduce per-semantic domain event subclasses P65-3 / CS-10-002 (size:L) — blocked-by #1930
+- #2490 Make DataLayer.read() the single VulnerabilityCase rehydration point (size:M) — blocked-by #1930
+- #2491 Update extract_intent() to return a discriminated union of VultronEvent subclasses (size:M) — blocked-by #2489
+
+## Key Learnings
+
+- The wire→core import direction was unguarded: 32 wire-layer files import
+  `vultron.core.models` directly.  The ratchet test (#2486) starts with 32
+  KNOWN_VIOLATIONS and prevents the set from growing.
+- All 9 apparent import cycles in `vultron/core/models/` are annotation-only
+  (`TYPE_CHECKING` guards), not runtime cycles — a static AST scan that
+  ignores `if TYPE_CHECKING:` blocks will report false positives.
+- The `as_Foo.from_core()` seam is already present on every wire vocab
+  object; the missing piece is enforcement (the ratchet test) and
+  documentation (ARCH-22-001, the AGENTS.md pitfall).
+- Spec YAML schema must be verified before writing — the `id`/`specs`
+  key names differ from the natural `group`/`statements` reading; the
+  Pydantic model is the authoritative source.

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -905,3 +905,64 @@ groups:
       impossible to miss.
     adr:
     - ADR-0064
+
+- id: ARCH-22
+  title: Wire→Core Import Boundary Enforcement
+  specs:
+  - id: ARCH-22-001
+    priority: MUST
+    kind: project
+    statement: >-
+      Wire-layer code MUST NOT introduce new direct imports of
+      `vultron.core.models.*` types beyond those enumerated in the
+      wire→core ratchet test's KNOWN_VIOLATIONS set.  Translation from a
+      core object to a wire object MUST go through an explicit translation
+      seam — for example, `as_Foo.from_core(core_obj)` class methods on
+      wire vocab objects — and not by importing the core type into arbitrary
+      wire modules.
+    rationale: >-
+      `VulnerabilityCase` and its siblings are the core domain model; direct
+      import into wire-layer code couples the wire schema to the domain model
+      in ways that bypass the ports-and-adapters boundary.  Each new
+      unmediated import is a ratchet-set expansion that increases the blast
+      radius of future domain-model refactors.  The from_core() class-method
+      seam already exists on every wire vocab object; using it keeps
+      translation localized.
+    adr:
+    - ADR-0017
+    - ADR-0032
+    - ADR-0063
+  - id: ARCH-22-002
+    priority: MUST
+    kind: project
+    statement: >-
+      An architecture test MUST exist that scans all `vultron/wire/` source
+      files for imports of `vultron.core.models`, enumerates the current
+      known violations as an exact frozen set, and fails both when the set
+      grows (new violation) and when a listed violation is resolved without
+      being removed from the set.
+    rationale: >-
+      A ratchet test with an exact set gives a two-sided signal: new
+      violations fail CI immediately, and a resolved violation that was
+      accidentally kept in the set also fails CI — forcing the known set to
+      track the true state of the codebase.  This mirrors the pattern already
+      used in `test/architecture/test_core_no_wire_imports.py` and
+      `test_core_no_adapter_imports.py`.
+    adr:
+    - ADR-0017
+  - id: ARCH-22-003
+    priority: SHOULD
+    kind: project
+    statement: >-
+      The KNOWN_VIOLATIONS set in the wire→core ratchet test SHOULD shrink
+      toward empty over successive releases.  A companion
+      `xfail(strict=True)` goal test SHOULD be added so that fully clearing
+      the violations set fails the build and forces the xfail marker to be
+      deleted, signalling completion.
+    rationale: >-
+      Without a strict goal test the ratchet can reach zero violations
+      silently, and the xfail marker stays forever — the completion signal
+      never fires.  The same pattern is mandated for ARCH-21 violations by
+      ARCH-21-005.
+    adr:
+    - ADR-0017


### PR DESCRIPTION
- Closes #1930

## Summary

Adds ARCH-22 spec group and an AGENTS.md pitfall to document the wire→core
import boundary requirement surfaced by concern #1930.

## Changes

- **`specs/architecture.yaml`**: new ARCH-22 group (ARCH-22-001 through
  ARCH-22-003) specifying that wire-layer code MUST NOT add direct
  `vultron.core.models` imports beyond the ratchet test's KNOWN_VIOLATIONS
  set, that a ratchet test MUST enumerate the set, and that the set SHOULD
  shrink toward empty with a `strict=True` goal test.
- **`AGENTS.md`**: new pitfall after the existing `as_VulnerabilityCase` vs
  `VulnerabilityCase` entry — never add a raw core-model import in wire code;
  use `as_Foo.from_core(core_obj)` instead.

## Implementation Issues

- #2486 Add wire→core import ratchet test (size:S)
- #2487 Split CaseOutboxPersistence into its own port file (size:S)
- #2488 Resolve annotation-time import cycles in vultron/core/models/ (size:S)
- #2489 Introduce per-semantic domain event subclasses P65-3 / CS-10-002 (size:L)
- #2490 Make DataLayer.read() the single VulnerabilityCase rehydration point (size:M)
- #2491 Update extract_intent() to return a discriminated union of VultronEvent subclasses (size:M)