### PR TITLE
docs: plan issue #2106 — ledger replication scope (RFC vs companion spec)

### DIFF
--- a/notes/sync-ledger-replication.md
+++ b/notes/sync-ledger-replication.md
@@ -604,7 +604,7 @@ implementation references for the ledger replication protocol.
 A separate **external-facing companion document** (suitable for reviewers
 outside the project alongside the main Vultron protocol RFC) covers the same
 protocol mechanics — see `docs/reference/draft-vultron-replication-spec.md`
-(tracked in issue #2107).
+(tracked in issue #2495).
 
 The external companion and the internal SYNC spec cover the same protocol but
 serve different audiences. When the SYNC spec requirements change, the companion
@@ -614,7 +614,7 @@ reader-friendly rendering, not an independent source of truth.
 
 The document-boundary decision — why the replication mechanics live in a
 companion document rather than the main RFC — is recorded in
-`docs/adr/0069-ledger-replication-companion-spec.md` (tracked in issue #2107).
+`docs/adr/0069-ledger-replication-companion-spec.md` (tracked in issue #2494).
 
 ## Related
 

--- a/notes/sync-ledger-replication.md
+++ b/notes/sync-ledger-replication.md
@@ -596,6 +596,26 @@ Spec: SYNC-15-003. Regression tests:
 reproduced there as 240 replays where 24 were correct). These run in-process in
 seconds rather than requiring a 20-minute demo-integration cycle (#1970).
 
+## Document Boundary: Internal Spec vs. External Companion
+
+This file and `specs/sync-ledger-replication.yaml` are the **internal**
+implementation references for the ledger replication protocol.
+
+A separate **external-facing companion document** (suitable for reviewers
+outside the project alongside the main Vultron protocol RFC) covers the same
+protocol mechanics — see `docs/reference/draft-vultron-replication-spec.md`
+(tracked in issue #2107).
+
+The external companion and the internal SYNC spec cover the same protocol but
+serve different audiences. When the SYNC spec requirements change, the companion
+document MUST be updated to stay consistent. Normative requirements always
+originate in `specs/sync-ledger-replication.yaml`; the companion document is a
+reader-friendly rendering, not an independent source of truth.
+
+The document-boundary decision — why the replication mechanics live in a
+companion document rather than the main RFC — is recorded in
+`docs/adr/0069-ledger-replication-companion-spec.md` (tracked in issue #2107).
+
 ## Related
 
 - `specs/sync-ledger-replication.yaml` — normative requirements

--- a/plan/history/2608/learning/CONCERN-2106.md
+++ b/plan/history/2608/learning/CONCERN-2106.md
@@ -1,0 +1,41 @@
+---
+source: CONCERN-2106
+timestamp: '2026-08-21T20:34:33.273396+00:00'
+title: Ledger replication scope — RFC vs companion spec
+type: learning
+---
+
+## Outcome
+
+Resolved concern #2106: decided that ledger replication mechanics belong in an
+external-facing companion document, not in the main Vultron protocol RFC.
+
+## Decision
+
+- The main RFC (`docs/reference/draft-vultron-spec.md`) will resolve Open
+  Question #2 with a scoping note and a forward reference to the companion doc.
+- A new external-facing companion document
+  (`docs/reference/draft-vultron-replication-spec.md`) will cover replication
+  mechanics in RFC style, suitable for external reviewers.
+- The single-hub / single-writer + fan-out model is **normative** for the
+  Hosting capability set.
+- Distributed consensus (Raft-style multi-node CaseActor cluster) is a future
+  extension, explicitly out of scope for the current spec.
+- ADR-0069 (`docs/adr/0069-ledger-replication-companion-spec.md`) will document
+  the boundary decision and the rationale.
+
+## Notes file updated
+
+`notes/sync-ledger-replication.md` — added "Document Boundary" section
+explaining the split between the internal SYNC spec and the forthcoming
+companion document; notes the companion must stay consistent with
+`specs/sync-ledger-replication.yaml`.
+
+## Docs PR
+
+<https://github.com/CERTCC/Vultron/pull/2493>
+
+## Implementation Issues
+
+- #2494 (size:M) — resolve OQ#2 in RFC, write ADR-0069, confirm single-hub normative
+- #2495 (size:L) — write companion ledger replication spec document


### PR DESCRIPTION
- Closes #2106

## Summary

Plans the resolution of Open Question #2 in `docs/reference/draft-vultron-spec.md`:
ledger replication mechanics belong in an external-facing companion document
(required before RFC circulation), with the main RFC pointing to it. The
single-hub / fan-out model is normative for the Hosting capability set.

## Changes

- **`notes/sync-ledger-replication.md`**: Added "Document Boundary" section
  explaining the split between the internal SYNC spec and the forthcoming
  external companion document; notes the requirement to keep both in sync

## Implementation Issues

- #2494 — resolve OQ#2 in RFC, write ADR-0069, confirm single-hub normative (size:M)
- #2495 — write companion ledger replication spec document (size:L)