### PR TITLE
Migrate core/behaviors/ Ports 3/5: read-only extra-input nodes

### DIFF
--- a/notes/py-trees-ports-adoption.md
+++ b/notes/py-trees-ports-adoption.md
@@ -44,16 +44,21 @@ Idea's optimistic framing.
 - **Migration progress**:
   - Part 1/5 (#1883) migrated **41 Type-A nodes** across `case/`, `status/`,
     and `note/` domains — all trivial base-only reparents with no
-    domain-specific `register_key()` calls.
+    domain-specific `register_key()` calls. ✓
   - Part 2/5 (#1884) migrated **36 Type-A nodes** across `report/nodes/` and
-    `embargo/nodes/`. `_SendEmbargoActivityBase` and its two subclasses
-    (`SendTerminateEmbargoActivityNode`, `SendRejectEmbargoActivityNode`) are
-    deferred to Part 3 (#1885) — they access `self.blackboard` directly
-    (Type-B). **Headroom note**: `report/nodes/deploy_fix.py` is now exactly
-    500 lines (the BTND-07-004 hard limit); split it before the next change
-    (see `plan/incoming/learnings/20260821-deploy-fix-line-count-margin.md`).
-  - Remaining Type-B nodes across all domains are tracked under #1809
-    (parts 3–5).
+    `embargo/nodes/`. **Headroom note**: `report/nodes/deploy_fix.py` is now
+    exactly 500 lines (the BTND-07-004 hard limit); split it before the next
+    change (see `plan/incoming/learnings/20260821-deploy-fix-line-count-margin.md`).
+  - Part 3/5 (#1885) migrated **Type-B nodes** (extra READ-only inputs) across
+    `sync/`, `sender/`, `embargo/`, `case/`, and `status/` domains — adds
+    `input_ports()` + `_domain_port_remappings()` + `get_input()` in
+    `initialise()`. Also extracted `SendTerminateEmbargoActivityNode` from
+    `lifecycle.py` to restore BTND-07-004, and fixed
+    `DataLayerConditionWithPorts`/`DataLayerActionWithPorts.initialise()` to
+    catch `NotImplementedError` from py_trees when a blackboard key stores
+    explicit `None`. ✓ (2026-08-21)
+  - Remaining Type-C/D nodes (WRITE-handoff and finalization) are tracked under
+    #1809 (parts 4–5).
 - **XML parser**: `py_trees.parsers.behaviour_tree_xml` exists but is documented
   as **experimental** ("the parser is experimental and its API may change
   between releases"). It instantiates only classes registered in a

--- a/plan/incoming/learnings/20260821-dynamic-bb-keys-not-portable-to-typed-ports.md
+++ b/plan/incoming/learnings/20260821-dynamic-bb-keys-not-portable-to-typed-ports.md
@@ -1,0 +1,29 @@
+---
+title: Nodes with instance-computed blackboard keys cannot use static input_ports()
+type: learning
+timestamp: "2026-08-21"
+source: ISSUE-1885
+signal: design-question
+---
+
+Three nodes in `case/nodes/participant/owner.py` (`PersistOwnerCaseNode`,
+`AdvanceOwnerRmToAcceptedNode`, `RecordOwnerJoinedEventNode`) compute their
+blackboard keys dynamically from the constructor's `report_id` parameter:
+
+```python
+_seg = report_id.split("/")[-1] if report_id else "default"
+self._participant_case_key = f"participant_case_{_seg}"
+```
+
+`input_ports()` is a classmethod — it cannot access instance state, so these
+keys cannot be declared there. Attempting to use `DataLayerActionWithPorts` with
+`self._blackboard_client.register_key(...)` in `setup()` fails because
+`_blackboard_client` is typed Optional and Pyright correctly flags `.register_key`
+on None.
+
+Decision made in #1885: revert these nodes to `DataLayerAction`. They must
+stay unmigrated until a design that accommodates dynamic key names is adopted
+(e.g., a port template or a runtime-registration extension).
+
+This is a known gap in the typed-Ports migration that will surface again in
+Parts 4 and 5 (#1886, #1887). Flag for consideration in the finalization issue.

--- a/plan/incoming/learnings/20260821-pytrees-none-value-not-implemented-error.md
+++ b/plan/incoming/learnings/20260821-pytrees-none-value-not-implemented-error.md
@@ -1,0 +1,26 @@
+---
+title: py_trees raises NotImplementedError when blackboard stores explicit None
+type: learning
+timestamp: "2026-08-21"
+source: ISSUE-1885
+signal: spec-gap
+---
+
+When a blackboard client stores an explicit `None` value (e.g. `bb.datalayer = None`)
+and a typed-Ports node calls `self.get_input("datalayer")`, py_trees raises:
+
+```text
+NotImplementedError: Support for None values has not yet been considered.
+```
+
+This is an upstream py_trees limitation in `ports.py:635`. Our base classes
+(`DataLayerConditionWithPorts.initialise()` and `DataLayerActionWithPorts.initialise()`)
+now catch `NotImplementedError` and set the attribute to `None`, so
+`_require_datalayer()` in `update()` handles the missing-datalayer case as FAILURE.
+
+No spec entry covers this pattern. Consider adding a BTND-03 or BTND-10 note
+clarifying that `initialise()` must handle `NotImplementedError` from `get_input()`
+alongside `NoDataAvailable`, and that explicit-None blackboard values are treated
+as "not available" for required base ports.
+
+The fix is in `helpers.py:848` and `helpers.py:931`.

--- a/test/core/behaviors/case/nodes/test_typed_ports.py
+++ b/test/core/behaviors/case/nodes/test_typed_ports.py
@@ -25,10 +25,12 @@ from py_trees.ports import NoDataAvailable
 from vultron.core.behaviors.case.nodes.conditions import (
     CheckCaseAlreadyExists,
 )
+from vultron.core.behaviors.case.nodes.embargo import AttachEmbargoToCaseNode
 from vultron.core.behaviors.case.nodes.suggest_actor.conditions import (
     ActorAlreadyParticipantNode,
 )
 from vultron.core.behaviors.case.nodes.update import (
+    BroadcastCaseUpdateNode,
     CheckCaseUpdateOwnerNode,
 )
 from vultron.core.behaviors.case.nodes.vfd_role_guards import (
@@ -183,5 +185,61 @@ class TestCheckCaseUpdateOwnerNodePorts:
         bt_scenario.seed(case)
         result = bt_scenario.run(
             CheckCaseUpdateOwnerNode(case_id=CASE_ID), actor_id=ACTOR_ID
+        )
+        bt_scenario.assert_failure(result)
+
+
+# ---------------------------------------------------------------------------
+# embargo.py — AttachEmbargoToCaseNode
+# ---------------------------------------------------------------------------
+
+
+class TestAttachEmbargoToCaseNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = AttachEmbargoToCaseNode()
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_case_id_raises_no_data_available(self) -> None:
+        node = AttachEmbargoToCaseNode()
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("case_id")
+
+    def test_missing_default_embargo_id_raises_no_data_available(
+        self,
+    ) -> None:
+        node = AttachEmbargoToCaseNode()
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("default_embargo_id")
+
+
+# ---------------------------------------------------------------------------
+# update.py — BroadcastCaseUpdateNode
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcastCaseUpdateNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = BroadcastCaseUpdateNode(case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_excluded_actor_ids_raises_no_data_available(
+        self,
+    ) -> None:
+        node = BroadcastCaseUpdateNode(case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("excluded_actor_ids")
+
+    def test_failure_when_case_absent(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            BroadcastCaseUpdateNode(case_id=CASE_ID), actor_id=ACTOR_ID
         )
         bt_scenario.assert_failure(result)

--- a/test/core/behaviors/embargo/nodes/test_emit.py
+++ b/test/core/behaviors/embargo/nodes/test_emit.py
@@ -55,7 +55,7 @@ def _make_concrete(
 ) -> "_SendEmbargoActivityBase":
     """Create a minimal concrete subclass for contract testing."""
 
-    class _ConcreteNode(_SendEmbargoActivityBase):
+    class _ConcreteNode(_SendEmbargoActivityBase, register=False):
         def _on_factory_unavailable(self) -> Status:
             return factory_missing_returns
 

--- a/test/core/behaviors/embargo/nodes/test_terminate.py
+++ b/test/core/behaviors/embargo/nodes/test_terminate.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Typed-Ports isolation tests for SendTerminateEmbargoActivityNode (AC-4, #1885).
+
+Covers BTND-03-011: required port reads raise NoDataAvailable when the
+blackboard key is absent.
+"""
+
+import pytest
+from py_trees.ports import NoDataAvailable
+
+from vultron.core.behaviors.embargo.nodes.terminate import (
+    SendTerminateEmbargoActivityNode,
+)
+from test.core.behaviors.bt_harness import BTTestScenario
+
+ACTOR_ID = "https://example.org/actors/vendor"
+CASE_ID = "https://example.org/cases/case-001"
+
+
+class TestSendTerminateEmbargoActivityNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = SendTerminateEmbargoActivityNode(case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_embargo_id_raises_no_data_available(self) -> None:
+        node = SendTerminateEmbargoActivityNode(case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("embargo_id")
+
+    def test_missing_case_manager_id_raises_no_data_available(self) -> None:
+        node = SendTerminateEmbargoActivityNode(case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("case_manager_id")
+
+    def test_failure_when_factory_unavailable(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            SendTerminateEmbargoActivityNode(case_id=CASE_ID),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_failure(result)

--- a/test/core/behaviors/sender/nodes/test_typed_ports.py
+++ b/test/core/behaviors/sender/nodes/test_typed_ports.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Typed-Ports isolation tests for sender domain nodes (AC-4, issue #1885).
+
+Covers BTND-03-011 (NoDataAvailable on missing required port) and happy-path
+execution via BTTestScenario for sender Type-B nodes.
+"""
+
+import pytest
+from py_trees.ports import NoDataAvailable
+
+from vultron.core.behaviors.sender.nodes.actions import QueueToOutboxNode
+from test.core.behaviors.bt_harness import BTTestScenario
+
+ACTOR_ID = "https://example.org/actors/vendor"
+
+
+# ---------------------------------------------------------------------------
+# actions.py — QueueToOutboxNode
+# ---------------------------------------------------------------------------
+
+
+class TestQueueToOutboxNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = QueueToOutboxNode()
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_activity_ids_raises_no_data_available(self) -> None:
+        node = QueueToOutboxNode()
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("activity_ids")
+
+    def test_failure_when_datalayer_absent(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(QueueToOutboxNode(), actor_id=ACTOR_ID)
+        bt_scenario.assert_failure(result)

--- a/test/core/behaviors/status/nodes/test_typed_ports.py
+++ b/test/core/behaviors/status/nodes/test_typed_ports.py
@@ -29,8 +29,10 @@ from vultron.core.behaviors.status.nodes.conditions import (
     AllParticipantsRMClosedConditionNode,
 )
 from vultron.core.behaviors.status.nodes.lifecycle import (
+    EmitCloseCaseNode,
     _PublicDisclosureSkipConditionNode,
 )
+from vultron.core.behaviors.status.nodes.rm_anomaly import EmitRMGapNoteNode
 from vultron.core.behaviors.status.nodes.threat_termination import (
     _ThreatTerminationSkipConditionNode,
 )
@@ -157,6 +159,49 @@ class TestThreatTerminationSkipConditionNodePorts:
                 status_obj=None,
                 case_id=CASE_ID,
             ),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_success(result)
+
+
+# ---------------------------------------------------------------------------
+# lifecycle.py — EmitCloseCaseNode
+# ---------------------------------------------------------------------------
+
+
+class TestEmitCloseCaseNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = EmitCloseCaseNode(case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_success_when_factory_absent(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            EmitCloseCaseNode(case_id=CASE_ID), actor_id=ACTOR_ID
+        )
+        bt_scenario.assert_success(result)
+
+
+# ---------------------------------------------------------------------------
+# rm_anomaly.py — EmitRMGapNoteNode
+# ---------------------------------------------------------------------------
+
+
+class TestEmitRMGapNoteNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = EmitRMGapNoteNode(sender_actor_id=ACTOR_ID, case_id=CASE_ID)
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_success_when_no_case_id(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            EmitRMGapNoteNode(sender_actor_id=ACTOR_ID, case_id=None),
             actor_id=ACTOR_ID,
         )
         bt_scenario.assert_success(result)

--- a/test/core/behaviors/sync/nodes/test_typed_ports.py
+++ b/test/core/behaviors/sync/nodes/test_typed_ports.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Typed-Ports isolation tests for sync domain nodes (AC-4, issue #1885).
+
+Covers BTND-03-011 (NoDataAvailable on missing required port) and happy-path
+execution via BTTestScenario for sync Type-B nodes.
+"""
+
+import pytest
+from py_trees.ports import NoDataAvailable
+
+from vultron.core.behaviors.sync.nodes.chain import (
+    PersistLogEntryNode,
+    UpdateReplicationStateNode,
+)
+from vultron.core.behaviors.sync.nodes.fanout import _SendLogEntryToEachNode
+from vultron.core.behaviors.sync.nodes.ownership_offer_effect import (
+    IsOfferOwnershipTransferEventNode,
+)
+from vultron.core.behaviors.sync.nodes.participant_status_effect import (
+    ApplyParticipantStatusFromLedgerNode,
+)
+from vultron.core.behaviors.sync.nodes.receive import (
+    CheckHashMatchesNode,
+    LogDeliveryConfirmationNode,
+)
+from test.core.behaviors.bt_harness import BTTestScenario
+
+ACTOR_ID = "https://example.org/actors/vendor"
+
+
+# ---------------------------------------------------------------------------
+# receive.py — LogDeliveryConfirmationNode
+# ---------------------------------------------------------------------------
+
+
+class TestLogDeliveryConfirmationNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = LogDeliveryConfirmationNode(name="LogDeliveryConfirmation")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_activity_raises_no_data_available(self) -> None:
+        node = LogDeliveryConfirmationNode(name="LogDeliveryConfirmation")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("activity")
+
+    def test_failure_when_datalayer_absent(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        result = bt_scenario.run(
+            LogDeliveryConfirmationNode(name="LogDeliveryConfirmation"),
+            actor_id=ACTOR_ID,
+        )
+        bt_scenario.assert_failure(result)
+
+
+# ---------------------------------------------------------------------------
+# receive.py — CheckHashMatchesNode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckHashMatchesNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = CheckHashMatchesNode(name="CheckHashMatches")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_activity_raises_no_data_available(self) -> None:
+        node = CheckHashMatchesNode(name="CheckHashMatches")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("activity")
+
+    def test_missing_tail_hash_raises_no_data_available(self) -> None:
+        node = CheckHashMatchesNode(name="CheckHashMatches")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("tail_hash")
+
+
+# ---------------------------------------------------------------------------
+# chain.py — UpdateReplicationStateNode
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateReplicationStateNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = UpdateReplicationStateNode(name="UpdateReplicationState")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_activity_raises_no_data_available(self) -> None:
+        node = UpdateReplicationStateNode(name="UpdateReplicationState")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("activity")
+
+
+# ---------------------------------------------------------------------------
+# chain.py — PersistLogEntryNode
+# ---------------------------------------------------------------------------
+
+
+class TestPersistLogEntryNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = PersistLogEntryNode(name="PersistLogEntry")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_log_entry_raises_no_data_available(self) -> None:
+        node = PersistLogEntryNode(name="PersistLogEntry")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("log_entry")
+
+
+# ---------------------------------------------------------------------------
+# participant_status_effect.py — ApplyParticipantStatusFromLedgerNode
+# ---------------------------------------------------------------------------
+
+
+class TestApplyParticipantStatusFromLedgerNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = ApplyParticipantStatusFromLedgerNode(
+            name="ApplyParticipantStatusFromLedger"
+        )
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_activity_raises_no_data_available(self) -> None:
+        node = ApplyParticipantStatusFromLedgerNode(
+            name="ApplyParticipantStatusFromLedger"
+        )
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("activity")
+
+
+# ---------------------------------------------------------------------------
+# ownership_offer_effect.py — IsOfferOwnershipTransferEventNode
+# ---------------------------------------------------------------------------
+
+
+class TestIsOfferOwnershipTransferEventNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = IsOfferOwnershipTransferEventNode(
+            name="IsOfferOwnershipTransferEvent"
+        )
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_activity_raises_no_data_available(self) -> None:
+        node = IsOfferOwnershipTransferEventNode(
+            name="IsOfferOwnershipTransferEvent"
+        )
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("activity")
+
+
+# ---------------------------------------------------------------------------
+# fanout.py — _SendLogEntryToEachNode
+# ---------------------------------------------------------------------------
+
+
+class TestSendLogEntryToEachNodePorts:
+    def test_missing_datalayer_raises_no_data_available(self) -> None:
+        node = _SendLogEntryToEachNode(name="SendLogEntryToEach")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("datalayer")
+
+    def test_missing_log_entry_raises_no_data_available(self) -> None:
+        node = _SendLogEntryToEachNode(name="SendLogEntryToEach")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("log_entry")
+
+    def test_missing_fanout_recipients_raises_no_data_available(self) -> None:
+        node = _SendLogEntryToEachNode(name="SendLogEntryToEach")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input("fanout_recipients")

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -42,6 +42,7 @@ from typing import cast
 
 import py_trees
 from py_trees.common import Status
+from py_trees.ports import NoDataAvailable
 
 from vultron.core.behaviors.case.nodes import (
     create_receive_activity_tree,
@@ -664,13 +665,13 @@ class BackfillCanonicalLedgerToInviteeNode(DataLayerActionWithPorts):
             self._sync_port = cast(
                 SyncActivityPort, self.get_input("sync_port")
             )
-        except Exception:
+        except (NoDataAvailable, NotImplementedError):
             self._sync_port = None
         try:
             self._pre_commit_backfill_target = self.get_input(
                 "pre_commit_backfill_target"
             )
-        except Exception:
+        except (NoDataAvailable, NotImplementedError):
             self._pre_commit_backfill_target = None
 
     def _resolve_backfill_target(self, entries: list[CaseLedgerEntry]) -> int:

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -49,7 +49,12 @@ from vultron.core.behaviors.case.nodes import (
 from vultron.core.behaviors.case.nodes.accept_invite import (
     EmitAddCaseParticipantNode,
 )
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+    DataLayerCondition,
+    PortInformation,
+)
 from vultron.core.behaviors.idempotency import SilentIdempotencyGuardMixin
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_ledger_entry import CaseLedgerEntry
@@ -475,27 +480,39 @@ class _CheckEmbargoActiveStateNode(DataLayerAction):
         return Status.FAILURE
 
 
-class _SignEmbargoConsentLeafNode(DataLayerAction):
+class _SignEmbargoConsentLeafNode(DataLayerActionWithPorts):
     """Sign embargo consent on the participant and record the event."""
 
     def __init__(self, invitee_id: str, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.invitee_id = invitee_id
 
-    def setup(self, **kwargs) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="new_invite_participant",
-            access=py_trees.common.Access.READ,
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["new_invite_participant"] = PortInformation(
+            data_type=object, required=True
         )
-        self.blackboard.register_key(
-            key="active_embargo_id",
-            access=py_trees.common.Access.READ,
+        ports["active_embargo_id"] = PortInformation(
+            data_type=str, required=True
         )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "new_invite_participant": "/new_invite_participant",
+            "active_embargo_id": "/active_embargo_id",
+        }
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.new_invite_participant = self.get_input("new_invite_participant")
+        self.active_embargo_id: str = self.get_input("active_embargo_id")
 
     def update(self) -> Status:
-        participant = self.blackboard.get("new_invite_participant")
-        active_embargo_id = self.blackboard.get("active_embargo_id")
+        participant = self.new_invite_participant
+        active_embargo_id = self.active_embargo_id
         if not isinstance(participant, VultronParticipant) or not isinstance(
             active_embargo_id, str
         ):
@@ -542,7 +559,7 @@ class _AlwaysSucceedNode(py_trees.behaviour.Behaviour):
         return Status.SUCCESS
 
 
-class PersistInviteeParticipantNode(DataLayerAction):
+class PersistInviteeParticipantNode(DataLayerActionWithPorts):
     """Persist the participant, attach to case, record events, save case."""
 
     def __init__(
@@ -552,31 +569,46 @@ class PersistInviteeParticipantNode(DataLayerAction):
         self.case_id = case_id
         self.invitee_id = invitee_id
 
-    def setup(self, **kwargs) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="invitee_already_participant",
-            access=py_trees.common.Access.READ,
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["invitee_already_participant"] = PortInformation(
+            data_type=object, required=True
         )
-        self.blackboard.register_key(
-            key="new_invite_participant",
-            access=py_trees.common.Access.READ,
+        ports["new_invite_participant"] = PortInformation(
+            data_type=object, required=True
         )
-        self.blackboard.register_key(
-            key="invitee_case",
-            access=py_trees.common.Access.READ,
+        ports["invitee_case"] = PortInformation(
+            data_type=object, required=True
         )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "invitee_already_participant": "/invitee_already_participant",
+            "new_invite_participant": "/new_invite_participant",
+            "invitee_case": "/invitee_case",
+        }
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.invitee_already_participant = self.get_input(
+            "invitee_already_participant"
+        )
+        self.new_invite_participant = self.get_input("new_invite_participant")
+        self.invitee_case = self.get_input("invitee_case")
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
             return f
         assert self.datalayer is not None
 
-        if self.blackboard.get("invitee_already_participant"):
+        if self.invitee_already_participant:
             return Status.SUCCESS
 
-        participant = self.blackboard.get("new_invite_participant")
-        case = self.blackboard.get("invitee_case")
+        participant = self.new_invite_participant
+        case = self.invitee_case
         if not isinstance(participant, VultronParticipant) or not isinstance(
             case, VulnerabilityCase
         ):
@@ -599,7 +631,7 @@ class PersistInviteeParticipantNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
+class BackfillCanonicalLedgerToInviteeNode(DataLayerActionWithPorts):
     """Send canonical CaseLedgerEntry history to a joiner in strict order."""
 
     def __init__(
@@ -610,38 +642,47 @@ class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
         self.invitee_id = invitee_id
         self._sync_port: SyncActivityPort | None = None
 
-    def setup(self, **kwargs) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="sync_port", access=py_trees.common.Access.READ
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["sync_port"] = PortInformation(data_type=object, required=False)
+        ports["pre_commit_backfill_target"] = PortInformation(
+            data_type=object, required=False
         )
-        self.blackboard.register_key(
-            key="pre_commit_backfill_target",
-            access=py_trees.common.Access.READ,
-        )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "sync_port": "/sync_port",
+            "pre_commit_backfill_target": "/pre_commit_backfill_target",
+        }
 
     def initialise(self) -> None:
         super().initialise()
         try:
-            self._sync_port = cast(SyncActivityPort, self.blackboard.sync_port)
-        except (AttributeError, KeyError):
+            self._sync_port = cast(
+                SyncActivityPort, self.get_input("sync_port")
+            )
+        except Exception:
             self._sync_port = None
+        try:
+            self._pre_commit_backfill_target = self.get_input(
+                "pre_commit_backfill_target"
+            )
+        except Exception:
+            self._pre_commit_backfill_target = None
 
     def _resolve_backfill_target(self, entries: list[CaseLedgerEntry]) -> int:
         """Resolve the backfill target index.
 
-        Reads ``pre_commit_backfill_target`` from the blackboard when set to a
-        non-None int (resume case: CapturePreCommitBackfillTargetNode wrote the
-        last index BEFORE the commit so backfill does not re-send the new entry
-        that the commit fan-out already delivered).  ``None`` or a missing key
-        means fresh case — fall back to the post-commit last entry.
+        Uses ``pre_commit_backfill_target`` captured in ``initialise()`` when
+        set (resume case: CapturePreCommitBackfillTargetNode wrote the last
+        index BEFORE the commit so backfill does not re-send the new entry
+        that the commit fan-out already delivered).  ``None`` means fresh case
+        — fall back to the post-commit last entry.
         """
-        try:
-            pre_commit_target = self.blackboard.get(
-                "pre_commit_backfill_target"
-            )
-        except KeyError:
-            pre_commit_target = None
+        pre_commit_target = self._pre_commit_backfill_target
         if pre_commit_target is not None:
             return int(pre_commit_target)
         return entries[-1].log_index if entries else -1

--- a/vultron/core/behaviors/case/nodes/embargo.py
+++ b/vultron/core/behaviors/case/nodes/embargo.py
@@ -36,7 +36,11 @@ import isodate  # type: ignore[import-untyped]
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+    PortInformation,
+)
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.embargo_event import EmbargoEvent
 from vultron.core.models.enums import VultronObjectType
@@ -295,43 +299,44 @@ class AdvanceEMStateToActiveNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class AttachEmbargoToCaseNode(DataLayerAction):
+class AttachEmbargoToCaseNode(DataLayerActionWithPorts):
     """Ensure case.active_embargo references the initialized embargo event."""
 
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="case_id", access=py_trees.common.Access.READ
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["case_id"] = PortInformation(data_type=str, required=True)
+        ports["default_embargo_initialized"] = PortInformation(
+            data_type=object, required=True
         )
-        self.blackboard.register_key(
-            key="default_embargo_initialized",
-            access=py_trees.common.Access.READ,
+        ports["default_embargo_id"] = PortInformation(
+            data_type=str, required=True
         )
-        self.blackboard.register_key(
-            key="default_embargo_initialized",
-            access=py_trees.common.Access.READ,
-        )
-        self.blackboard.register_key(
-            key="default_embargo_id",
-            access=py_trees.common.Access.READ,
-        )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "case_id": "/case_id",
+            "default_embargo_initialized": "/default_embargo_initialized",
+            "default_embargo_id": "/default_embargo_id",
+        }
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.bb_case_id: str = self.get_input("case_id")
+        self.bb_default_embargo_id: str = self.get_input("default_embargo_id")
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
             return f
         assert self.datalayer is not None
 
-        case_id = self.blackboard.get("case_id")
-        embargo_id = self.blackboard.get("default_embargo_id")
-        if not isinstance(case_id, str) or not isinstance(embargo_id, str):
-            self.logger.error(
-                "%s: case_id/default_embargo_id not found in blackboard",
-                self.name,
-            )
-            return Status.FAILURE
+        case_id = self.bb_case_id
+        embargo_id = self.bb_default_embargo_id
 
         stored_case = self.datalayer.read(case_id, raise_on_missing=False)
         if not isinstance(stored_case, VulnerabilityCase):
@@ -364,20 +369,33 @@ class AttachEmbargoToCaseNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class SeedOwnerAsSignatoryNode(DataLayerAction):
+class SeedOwnerAsSignatoryNode(DataLayerActionWithPorts):
     """Seed the case-owner participant as SIGNATORY (CM-14-003)."""
 
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="case_id", access=py_trees.common.Access.READ
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["case_id"] = PortInformation(data_type=str, required=True)
+        ports["default_embargo_initialized"] = PortInformation(
+            data_type=object, required=True
         )
-        self.blackboard.register_key(
-            key="default_embargo_initialized",
-            access=py_trees.common.Access.READ,
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "case_id": "/case_id",
+            "default_embargo_initialized": "/default_embargo_initialized",
+        }
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.bb_case_id: str = self.get_input("case_id")
+        self.embargo_initialized = self.get_input(
+            "default_embargo_initialized"
         )
 
     def update(self) -> Status:
@@ -386,14 +404,8 @@ class SeedOwnerAsSignatoryNode(DataLayerAction):
         assert self.datalayer is not None
         assert self.actor_id is not None
 
-        case_id = self.blackboard.get("case_id")
-        if not isinstance(case_id, str):
-            self.logger.error("%s: case_id not found in blackboard", self.name)
-            return Status.FAILURE
-
-        embargo_initialized = self.blackboard.get(
-            "default_embargo_initialized"
-        )
+        case_id = self.bb_case_id
+        embargo_initialized = self.embargo_initialized
         if embargo_initialized is False:
             return Status.SUCCESS
 

--- a/vultron/core/behaviors/case/nodes/participant/owner.py
+++ b/vultron/core/behaviors/case/nodes/participant/owner.py
@@ -29,7 +29,9 @@ from py_trees.common import Status
 from vultron.core.behaviors.case.nodes.participant.common import (
     _create_and_attach_participant,
 )
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+)
 from vultron.config.actor import ActorConfig
 from vultron.core.models.dimensions import PecDimension, RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
@@ -290,11 +292,15 @@ class PersistOwnerCaseNode(DataLayerAction):
             key=self._participant_case_key, access=py_trees.common.Access.READ
         )
 
+    def initialise(self) -> None:
+        super().initialise()
+        self._stored_case = self.blackboard.get(self._participant_case_key)
+
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
             return f
         assert self.datalayer is not None
-        stored_case = self.blackboard.get(self._participant_case_key)
+        stored_case = self._stored_case
         if not isinstance(stored_case, VulnerabilityCase):
             self.logger.error(
                 "%s: %s missing in blackboard",
@@ -338,21 +344,26 @@ class AdvanceOwnerRmToAcceptedNode(DataLayerAction):
             key=self._participant_case_key, access=py_trees.common.Access.READ
         )
 
+    def initialise(self) -> None:
+        super().initialise()
+        try:
+            self._case_id: str | None = self.blackboard.get("case_id")
+            if not isinstance(self._case_id, str):
+                self._case_id = None
+        except KeyError:
+            self._case_id = None
+        self._stored_case = self.blackboard.get(self._participant_case_key)
+
     def update(self) -> Status:
         if (f := self._require_datalayer_and_actor()) is not None:
             return f
         assert self.datalayer is not None
         assert self.actor_id is not None
-        try:
-            case_id_obj = self.blackboard.get("case_id")
-        except KeyError:
-            case_id_obj = None
-        case_id = case_id_obj if isinstance(case_id_obj, str) else None
+        case_id = self._case_id
         if case_id is None:
-            stored_case = self.blackboard.get(self._participant_case_key)
             case_id = (
-                stored_case.id_
-                if isinstance(stored_case, VulnerabilityCase)
+                self._stored_case.id_
+                if isinstance(self._stored_case, VulnerabilityCase)
                 else None
             )
         if case_id is None:
@@ -405,13 +416,18 @@ class RecordOwnerJoinedEventNode(DataLayerAction):
             access=py_trees.common.Access.READ,
         )
 
+    def initialise(self) -> None:
+        super().initialise()
+        self._stored_case = self.blackboard.get(self._participant_case_key)
+        self._participant = self.blackboard.get(self._new_case_participant_key)
+
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
             return f
         assert self.datalayer is not None
 
-        stored_case = self.blackboard.get(self._participant_case_key)
-        participant = self.blackboard.get(self._new_case_participant_key)
+        stored_case = self._stored_case
+        participant = self._participant
         if not isinstance(stored_case, VulnerabilityCase) or not isinstance(
             participant, VultronParticipant
         ):

--- a/vultron/core/behaviors/case/nodes/update.py
+++ b/vultron/core/behaviors/case/nodes/update.py
@@ -28,10 +28,10 @@ from vultron.core.behaviors.case.update_support import (
     find_excluded_actor_ids,
 )
 from vultron.core.behaviors.helpers import (
-    DataLayerAction,
     DataLayerActionWithPorts,
     DataLayerCondition,
     DataLayerConditionWithPorts,
+    PortInformation,
 )
 from vultron.core.models.events.case import UpdateCaseReceivedEvent
 from vultron.core.models._helpers import _as_id
@@ -154,18 +154,28 @@ class ApplyCaseUpdateNode(DataLayerActionWithPorts):
         return Status.SUCCESS
 
 
-class BroadcastCaseUpdateNode(DataLayerAction):
+class BroadcastCaseUpdateNode(DataLayerActionWithPorts):
     """Broadcast the updated case to eligible participants."""
 
     def __init__(self, case_id: str, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="excluded_actor_ids", access=py_trees.common.Access.READ
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["excluded_actor_ids"] = PortInformation(
+            data_type=object, required=True
         )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"excluded_actor_ids": "/excluded_actor_ids"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.excluded_actor_ids: set = self.get_input("excluded_actor_ids")
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
@@ -182,26 +192,10 @@ class BroadcastCaseUpdateNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        try:
-            excluded_actor_ids = self.blackboard.get("excluded_actor_ids")
-        except KeyError:
-            self.feedback_message = (
-                "excluded_actor_ids not found in blackboard"
-            )
-            self.logger.error(
-                "%s: excluded_actor_ids not found in blackboard", self.name
-            )
-            return Status.FAILURE
-
-        if not isinstance(excluded_actor_ids, set):
-            self.feedback_message = "excluded_actor_ids is not a set"
-            self.logger.error("%s: excluded_actor_ids is not a set", self.name)
-            return Status.FAILURE
-
         broadcast_case_update(
             self.datalayer,
             self.case_id,
             case,
-            excluded_actor_ids=excluded_actor_ids,
+            excluded_actor_ids=self.excluded_actor_ids,
         )
         return Status.SUCCESS

--- a/vultron/core/behaviors/embargo/nodes/emit.py
+++ b/vultron/core/behaviors/embargo/nodes/emit.py
@@ -17,11 +17,11 @@
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerActionWithPorts
 from vultron.core.use_cases._helpers import add_activity_to_outbox
 
 
-class _SendEmbargoActivityBase(DataLayerAction):
+class _SendEmbargoActivityBase(DataLayerActionWithPorts):
     """Abstract base for embargo activity emit nodes (BTND-07-005).
 
     Implements the common guard/factory-dispatch/outbox-write skeleton:

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -24,11 +24,13 @@ from vultron.core.behaviors.embargo.nodes.em_state import (
     ReadEmStateNode,
     WriteEmStateNode,
 )
-from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
 from vultron.core.behaviors.embargo.nodes.reject_proposed import (  # noqa: F401
     ReadProposedEmbargoIdNode,
     RejectProposedEmbargoLifecycleNode,
     SendRejectEmbargoActivityNode,
+)
+from vultron.core.behaviors.embargo.nodes.terminate import (  # noqa: F401
+    SendTerminateEmbargoActivityNode,
 )
 from vultron.core.behaviors.helpers import (
     DataLayerAction,
@@ -342,70 +344,6 @@ class ReadEmbargoIdNode(DataLayerAction):
 
         self.blackboard.embargo_id = embargo_id
         return Status.SUCCESS
-
-
-class SendTerminateEmbargoActivityNode(_SendEmbargoActivityBase):
-    """Build and queue a ``Terminate(EmbargoEvent)`` activity.
-
-    Reads ``embargo_id`` and ``case_manager_id`` from the blackboard and
-    constructs the outbound activity via ``trigger_activity_factory``.
-
-    Returns FAILURE (BT-14-001) when the factory is unavailable, a required
-    blackboard key is missing, or dispatch raises an exception.
-    Returns SUCCESS when the activity is created and queued.
-    """
-
-    def __init__(self, case_id: str, name: str | None = None) -> None:
-        super().__init__(case_id=case_id, name=name)
-
-    def setup(self, **kwargs: object) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="embargo_id",
-            access=py_trees.common.Access.READ,
-        )
-        self.blackboard.register_key(
-            key="case_manager_id",
-            access=py_trees.common.Access.READ,
-        )
-
-    def _on_factory_unavailable(self) -> Status:
-        self.feedback_message = (
-            "trigger_activity_factory not available"
-            " — broadcast FAILURE (BT-14-001)"
-        )
-        self.logger.warning("%s: %s", self.name, self.feedback_message)
-        return Status.FAILURE
-
-    def _resolve_embargo_and_manager(self) -> "tuple[str, str] | Status":
-        try:
-            embargo_id: str = self.blackboard.embargo_id
-            case_manager_id: str = self.blackboard.case_manager_id
-        except KeyError as exc:
-            self.feedback_message = f"Required blackboard key missing: {exc}"
-            return Status.FAILURE
-        return embargo_id, case_manager_id
-
-    def _call_factory(
-        self, actor_id: str, embargo_id: str, case_manager_id: str
-    ) -> tuple[str, object]:
-        assert self.trigger_activity_factory is not None
-        return self.trigger_activity_factory.terminate_embargo(
-            embargo_id=embargo_id,
-            case_id=self._case_id,
-            actor=actor_id,
-            to=[case_manager_id],
-        )
-
-    def _on_outbox_write_failure(
-        self, activity_id: str, exc: Exception
-    ) -> Status:
-        self.feedback_message = (
-            f"Outbox write failed for Terminate(EmbargoEvent)"
-            f" '{activity_id}': {exc}"
-        )
-        self.logger.warning("%s: %s", self.name, self.feedback_message)
-        return Status.FAILURE
 
 
 class SetEmbargoActiveNode(DataLayerActionWithPorts):

--- a/vultron/core/behaviors/embargo/nodes/reject_proposed.py
+++ b/vultron/core/behaviors/embargo/nodes/reject_proposed.py
@@ -31,7 +31,11 @@ from vultron.core.behaviors.embargo.nodes.em_state import (
     WriteEmStateNode,
 )
 from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+    PortInformation,
+)
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.services.embargo_lifecycle import (
@@ -42,7 +46,7 @@ from vultron.core.states.em import EM
 from vultron.errors import VultronError
 
 
-class RejectProposedEmbargoLifecycleNode(DataLayerAction):
+class RejectProposedEmbargoLifecycleNode(DataLayerActionWithPorts):
     """Apply STRICT reject-invite transition reading embargo_id from the blackboard.
 
     Cascade-path variant of :class:`RejectEmbargoLifecycleNode` used by
@@ -65,12 +69,19 @@ class RejectProposedEmbargoLifecycleNode(DataLayerAction):
         self._case_id_value = case_id
         self._result_out = result_out
 
-    def setup(self, **kwargs: object) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="embargo_id",
-            access=py_trees.common.Access.READ,
-        )
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["embargo_id"] = PortInformation(data_type=str, required=True)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"embargo_id": "/embargo_id"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.embargo_id: str = self.get_input("embargo_id")
 
     def update(self) -> Status:
         if (f := self._require_datalayer_and_actor()) is not None:
@@ -78,11 +89,7 @@ class RejectProposedEmbargoLifecycleNode(DataLayerAction):
         assert self.datalayer is not None
         assert self.actor_id is not None
 
-        try:
-            embargo_id: str = self.blackboard.embargo_id
-        except KeyError:
-            self.feedback_message = "embargo_id not found on blackboard"
-            return Status.FAILURE
+        embargo_id = self.embargo_id
 
         read_node = ReadEmStateNode(
             case_id=self._case_id_value, result_out=self._result_out
@@ -194,16 +201,26 @@ class SendRejectEmbargoActivityNode(_SendEmbargoActivityBase):
     def __init__(self, case_id: str, name: str | None = None) -> None:
         super().__init__(case_id=case_id, name=name)
 
-    def setup(self, **kwargs: object) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="embargo_id",
-            access=py_trees.common.Access.READ,
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["embargo_id"] = PortInformation(data_type=str, required=True)
+        ports["case_manager_id"] = PortInformation(
+            data_type=str, required=True
         )
-        self.blackboard.register_key(
-            key="case_manager_id",
-            access=py_trees.common.Access.READ,
-        )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "embargo_id": "/embargo_id",
+            "case_manager_id": "/case_manager_id",
+        }
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.embargo_id: str = self.get_input("embargo_id")
+        self.case_manager_id: str = self.get_input("case_manager_id")
 
     def _on_factory_unavailable(self) -> Status:
         self.feedback_message = (
@@ -214,13 +231,7 @@ class SendRejectEmbargoActivityNode(_SendEmbargoActivityBase):
         return Status.FAILURE
 
     def _resolve_embargo_and_manager(self) -> "tuple[str, str] | Status":
-        try:
-            embargo_id: str = self.blackboard.embargo_id
-            case_manager_id: str = self.blackboard.case_manager_id
-        except KeyError as exc:
-            self.feedback_message = f"Required blackboard key missing: {exc}"
-            return Status.FAILURE
-        return embargo_id, case_manager_id
+        return self.embargo_id, self.case_manager_id
 
     def _call_factory(
         self, actor_id: str, embargo_id: str, case_manager_id: str

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -16,6 +16,7 @@
 """Embargo removal and teardown nodes."""
 
 from py_trees.common import Status
+from py_trees.ports import NoDataAvailable
 
 from vultron.core.behaviors.embargo.nodes.em_state import ReadEmStateNode
 from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
@@ -220,7 +221,7 @@ class ApplyEmbargoTeardownNode(DataLayerActionWithPorts):
         if self.case_id is None:
             try:
                 self._activity = self.get_input("activity")
-            except Exception:
+            except (NoDataAvailable, NotImplementedError):
                 self._activity = None
         else:
             self._activity = None

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -15,15 +15,14 @@
 
 """Embargo removal and teardown nodes."""
 
-import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.embargo.nodes.em_state import ReadEmStateNode
 from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
 from vultron.core.behaviors.helpers import (
-    DataLayerAction,
     DataLayerActionWithPorts,
     DataLayerConditionWithPorts,
+    PortInformation,
 )
 from vultron.core.behaviors.narrative_log import log_em_transition
 from vultron.core.models.case import VulnerabilityCase
@@ -182,7 +181,7 @@ class ResetParticipantConsentNode(DataLayerActionWithPorts):
         return Status.SUCCESS
 
 
-class ApplyEmbargoTeardownNode(DataLayerAction):
+class ApplyEmbargoTeardownNode(DataLayerActionWithPorts):
     """Apply receiver-side embargo teardown.
 
     Performs the ACTIVE/REVISE → EXITED EM state transition, clears
@@ -206,12 +205,25 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
 
-    def setup(self, **kwargs: object) -> None:
-        super().setup(**kwargs)
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=False)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity": "/activity"}
+
+    def initialise(self) -> None:
+        super().initialise()
         if self.case_id is None:
-            self.blackboard.register_key(
-                key="activity", access=py_trees.common.Access.READ
-            )
+            try:
+                self._activity = self.get_input("activity")
+            except Exception:
+                self._activity = None
+        else:
+            self._activity = None
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
@@ -223,7 +235,7 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
         else:
             from vultron.core.behaviors.sync.nodes import _require_log_entry
 
-            entry = _require_log_entry(self.blackboard.activity, self.name)
+            entry = _require_log_entry(self._activity, self.name)
             case_id = entry.case_id
 
         case = self.datalayer.read(case_id)

--- a/vultron/core/behaviors/embargo/nodes/terminate.py
+++ b/vultron/core/behaviors/embargo/nodes/terminate.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Embargo termination activity emit node (BTND-07-005)."""
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
+from vultron.core.behaviors.helpers import PortInformation
+
+
+class SendTerminateEmbargoActivityNode(_SendEmbargoActivityBase):
+    """Build and queue a ``Terminate(EmbargoEvent)`` activity.
+
+    Reads ``embargo_id`` and ``case_manager_id`` from the blackboard and
+    constructs the outbound activity via ``trigger_activity_factory``.
+
+    Returns FAILURE (BT-14-001) when the factory is unavailable, a required
+    blackboard key is missing, or dispatch raises an exception.
+    Returns SUCCESS when the activity is created and queued.
+    """
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(case_id=case_id, name=name)
+
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["embargo_id"] = PortInformation(data_type=str, required=True)
+        ports["case_manager_id"] = PortInformation(
+            data_type=str, required=True
+        )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "embargo_id": "/embargo_id",
+            "case_manager_id": "/case_manager_id",
+        }
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.embargo_id: str = self.get_input("embargo_id")
+        self.case_manager_id: str = self.get_input("case_manager_id")
+
+    def _on_factory_unavailable(self) -> Status:
+        self.feedback_message = (
+            "trigger_activity_factory not available"
+            " — broadcast FAILURE (BT-14-001)"
+        )
+        self.logger.warning("%s: %s", self.name, self.feedback_message)
+        return Status.FAILURE
+
+    def _resolve_embargo_and_manager(self) -> "tuple[str, str] | Status":
+        return self.embargo_id, self.case_manager_id
+
+    def _call_factory(
+        self, actor_id: str, embargo_id: str, case_manager_id: str
+    ) -> tuple[str, object]:
+        assert self.trigger_activity_factory is not None
+        return self.trigger_activity_factory.terminate_embargo(
+            embargo_id=embargo_id,
+            case_id=self._case_id,
+            actor=actor_id,
+            to=[case_manager_id],
+        )
+
+    def _on_outbox_write_failure(
+        self, activity_id: str, exc: Exception
+    ) -> Status:
+        self.feedback_message = (
+            f"Outbox write failed for Terminate(EmbargoEvent)"
+            f" '{activity_id}': {exc}"
+        )
+        self.logger.warning("%s: %s", self.name, self.feedback_message)
+        return Status.FAILURE

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -825,14 +825,34 @@ class DataLayerConditionWithPorts(BehaviourWithPorts):
     def output_ports(cls) -> dict[str, PortInformation]:
         return {}
 
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        """Subclasses override to map domain input-port names to absolute blackboard paths.
+
+        Merged into the ``port_remappings`` dict passed to ``setup_ports()`` so
+        that domain keys declared in ``input_ports()`` resolve to the same global
+        paths written by preceding ``DataLayerAction`` writer nodes.
+        """
+        return {}
+
     def setup(self, **kwargs: Any) -> None:
         self.setup_ports(
-            port_remappings={"datalayer": _DL_KEY, "actor_id": _ACTOR_KEY}
+            port_remappings={
+                "datalayer": _DL_KEY,
+                "actor_id": _ACTOR_KEY,
+                **self._domain_port_remappings(),
+            }
         )
 
     def initialise(self) -> None:
-        self.datalayer = self.get_input("datalayer")
-        self.actor_id = self.get_input("actor_id")
+        try:
+            self.datalayer = self.get_input("datalayer")
+        except NotImplementedError:
+            self.datalayer = None
+        try:
+            self.actor_id = self.get_input("actor_id")
+        except NotImplementedError:
+            self.actor_id = None
 
     def _require_datalayer(self) -> Status | None:
         if self.datalayer is None:
@@ -888,23 +908,40 @@ class DataLayerActionWithPorts(BehaviourWithPorts):
     def output_ports(cls) -> dict[str, PortInformation]:
         return {}
 
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        """Subclasses override to map domain input-port names to absolute blackboard paths.
+
+        Merged into the ``port_remappings`` dict passed to ``setup_ports()`` so
+        that domain keys declared in ``input_ports()`` resolve to the same global
+        paths written by preceding ``DataLayerAction`` writer nodes.
+        """
+        return {}
+
     def setup(self, **kwargs: Any) -> None:
         self.setup_ports(
             port_remappings={
                 "datalayer": _DL_KEY,
                 "actor_id": _ACTOR_KEY,
                 "trigger_activity_factory": "/trigger_activity_factory",
+                **self._domain_port_remappings(),
             }
         )
 
     def initialise(self) -> None:
-        self.datalayer = self.get_input("datalayer")
-        self.actor_id = self.get_input("actor_id")
+        try:
+            self.datalayer = self.get_input("datalayer")
+        except NotImplementedError:
+            self.datalayer = None
+        try:
+            self.actor_id = self.get_input("actor_id")
+        except NotImplementedError:
+            self.actor_id = None
         try:
             self.trigger_activity_factory = self.get_input(
                 "trigger_activity_factory"
             )
-        except NoDataAvailable:
+        except (NoDataAvailable, NotImplementedError):
             self.trigger_activity_factory = None
 
     def _require_datalayer(self) -> Status | None:

--- a/vultron/core/behaviors/sender/nodes/actions.py
+++ b/vultron/core/behaviors/sender/nodes/actions.py
@@ -20,7 +20,11 @@ from typing import Callable
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+    PortInformation,
+)
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 from vultron.core.use_cases._helpers import add_activity_to_outbox
@@ -110,18 +114,27 @@ class ConstructActivitiesNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class QueueToOutboxNode(DataLayerAction):
+class QueueToOutboxNode(DataLayerActionWithPorts):
     """Queue each activity ID from the blackboard to the actor's outbox."""
 
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
 
-    def setup(self, **kwargs: object) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity_ids",
-            access=py_trees.common.Access.READ,
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity_ids"] = PortInformation(
+            data_type=object, required=True
         )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity_ids": "/activity_ids"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.activity_ids: list[str] = self.get_input("activity_ids")
 
     def update(self) -> Status:
         if (f := self._require_datalayer_and_actor()) is not None:
@@ -129,11 +142,7 @@ class QueueToOutboxNode(DataLayerAction):
         assert self.datalayer is not None
         assert self.actor_id is not None
 
-        try:
-            activity_ids: list[str] = self.blackboard.activity_ids
-        except KeyError:
-            self.feedback_message = "activity_ids not in blackboard"
-            return Status.FAILURE
+        activity_ids = self.activity_ids
 
         try:
             dl = self.datalayer

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -31,6 +31,7 @@ from typing import cast
 
 import py_trees
 from py_trees.common import Status
+from py_trees.ports import NoDataAvailable
 
 from vultron.core.behaviors.embargo.trigger_tree import (
     reject_proposed_embargo_bt,
@@ -407,7 +408,7 @@ class EmitCloseCaseNode(DataLayerActionWithPorts):
             self.case_manager_id: str | None = self.get_input(
                 "case_manager_id"
             )
-        except Exception:
+        except (NoDataAvailable, NotImplementedError):
             self.case_manager_id = None
 
     def update(self) -> Status:

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -37,9 +37,9 @@ from vultron.core.behaviors.embargo.trigger_tree import (
     terminate_embargo_bt,
 )
 from vultron.core.behaviors.helpers import (
-    DataLayerAction,
     DataLayerActionWithPorts,
     DataLayerConditionWithPorts,
+    PortInformation,
 )
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.models.case import VulnerabilityCase
@@ -365,7 +365,7 @@ class EmitAddCaseStatusToSelfNode(DataLayerActionWithPorts):
         return Status.SUCCESS
 
 
-class EmitCloseCaseNode(DataLayerAction):
+class EmitCloseCaseNode(DataLayerActionWithPorts):
     """Step 5 emit: Queue a ``Leave(VulnerabilityCase)`` to the Case Manager.
 
     Reads ``case_manager_id`` from the blackboard (written by the preceding
@@ -389,12 +389,26 @@ class EmitCloseCaseNode(DataLayerAction):
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
 
-    def setup(self, **kwargs: object) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="case_manager_id",
-            access=py_trees.common.Access.READ,
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["case_manager_id"] = PortInformation(
+            data_type=str, required=False
         )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"case_manager_id": "/case_manager_id"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        try:
+            self.case_manager_id: str | None = self.get_input(
+                "case_manager_id"
+            )
+        except Exception:
+            self.case_manager_id = None
 
     def update(self) -> Status:
         if self.datalayer is None or not self.case_id:
@@ -408,12 +422,7 @@ class EmitCloseCaseNode(DataLayerAction):
             )
             return Status.SUCCESS
 
-        try:
-            case_manager_id: str | None = self.blackboard.get(
-                "case_manager_id"
-            )
-        except KeyError:
-            case_manager_id = None
+        case_manager_id = self.case_manager_id
         if not case_manager_id:
             self.feedback_message = (
                 f"EmitCloseCase: case_manager_id not set on blackboard"

--- a/vultron/core/behaviors/status/nodes/rm_anomaly.py
+++ b/vultron/core/behaviors/status/nodes/rm_anomaly.py
@@ -25,17 +25,19 @@ Per specs/received-status-handling.yaml RSH-06-004, RSH-06-005.
 import logging
 from typing import cast
 
-import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    PortInformation,
+)
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.behaviors.status.nodes.dimension_filter import BB_RM_ANOMALY
 
 logger = logging.getLogger(__name__)
 
 
-class EmitRMGapNoteNode(DataLayerAction):
+class EmitRMGapNoteNode(DataLayerActionWithPorts):
     """Emit ``Add(Note, VulnerabilityCase)`` when an RM transition anomaly is detected.
 
     Reads the ``rm_transition_anomaly`` blackboard key written by
@@ -63,21 +65,30 @@ class EmitRMGapNoteNode(DataLayerAction):
         self.sender_actor_id = sender_actor_id
         self.case_id = case_id
 
-    def setup(self, **kwargs: object) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key=BB_RM_ANOMALY,
-            access=py_trees.common.Access.READ,
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports[BB_RM_ANOMALY] = PortInformation(
+            data_type=object, required=False
         )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {BB_RM_ANOMALY: f"/{BB_RM_ANOMALY}"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        try:
+            self.rm_anomaly = self.get_input(BB_RM_ANOMALY)
+        except Exception:
+            self.rm_anomaly = None
 
     def update(self) -> Status:
         if not self.case_id:
             return Status.SUCCESS
 
-        try:
-            anomaly = self.blackboard.get(BB_RM_ANOMALY)
-        except KeyError:
-            anomaly = None
+        anomaly = self.rm_anomaly
         if anomaly is None:
             return Status.SUCCESS
 

--- a/vultron/core/behaviors/status/nodes/rm_anomaly.py
+++ b/vultron/core/behaviors/status/nodes/rm_anomaly.py
@@ -26,6 +26,7 @@ import logging
 from typing import cast
 
 from py_trees.common import Status
+from py_trees.ports import NoDataAvailable
 
 from vultron.core.behaviors.helpers import (
     DataLayerActionWithPorts,
@@ -81,7 +82,7 @@ class EmitRMGapNoteNode(DataLayerActionWithPorts):
         super().initialise()
         try:
             self.rm_anomaly = self.get_input(BB_RM_ANOMALY)
-        except Exception:
+        except (NoDataAvailable, NotImplementedError):
             self.rm_anomaly = None
 
     def update(self) -> Status:

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -22,7 +22,11 @@ from typing import Any, Literal, cast
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+    PortInformation,
+)
 from vultron.core.behaviors.sync.nodes.canonical_entry import (
     _validate_canonical_entry,
 )
@@ -160,18 +164,26 @@ class ReconstructChainTailNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class UpdateReplicationStateNode(DataLayerAction):
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
+class UpdateReplicationStateNode(DataLayerActionWithPorts):
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity": "/activity"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.activity = self.get_input("activity")
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
             return f
         assert self.datalayer is not None
-        activity = self.blackboard.activity
+        activity = self.activity
         entry = getattr(activity, "rejected_entry", None)
         if entry is None:
             entry = getattr(activity, "object_", None)
@@ -310,14 +322,28 @@ class CreateLogEntryNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class PersistLogEntryNode(DataLayerAction):
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="log_entry", access=py_trees.common.Access.READ
+class PersistLogEntryNode(DataLayerActionWithPorts):
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["log_entry"] = PortInformation(data_type=object, required=True)
+        ports["log_entry_preexisting"] = PortInformation(
+            data_type=bool, required=False
         )
-        self.blackboard.register_key(
-            key="log_entry_preexisting", access=py_trees.common.Access.READ
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "log_entry": "/log_entry",
+            "log_entry_preexisting": "/log_entry_preexisting",
+        }
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.log_entry = self.get_input("log_entry")
+        self.log_entry_preexisting: bool = self.get_input(
+            "log_entry_preexisting", default=False
         )
 
     def update(self) -> Status:
@@ -325,11 +351,8 @@ class PersistLogEntryNode(DataLayerAction):
             return f
         assert self.datalayer is not None
 
-        entry = cast(VultronCaseLedgerEntry, self.blackboard.log_entry)
-        try:
-            preexisting = bool(self.blackboard.log_entry_preexisting)
-        except KeyError:
-            preexisting = False
+        entry = cast(VultronCaseLedgerEntry, self.log_entry)
+        preexisting = bool(self.log_entry_preexisting)
         if preexisting:
             self.logger.info(
                 "%s: log entry already exists for case_id=%s event_type=%s "

--- a/vultron/core/behaviors/sync/nodes/fanout.py
+++ b/vultron/core/behaviors/sync/nodes/fanout.py
@@ -26,6 +26,7 @@ from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
+from py_trees.ports import NoDataAvailable
 
 from vultron.core.behaviors.helpers import (
     DataLayerAction,
@@ -149,7 +150,7 @@ class _SendLogEntryToEachNode(DataLayerActionWithPorts):
             self._sync_port = cast(
                 SyncActivityPort, self.get_input("sync_port")
             )
-        except Exception:
+        except (NoDataAvailable, NotImplementedError):
             self._sync_port = None
 
     def update(self) -> Status:

--- a/vultron/core/behaviors/sync/nodes/fanout.py
+++ b/vultron/core/behaviors/sync/nodes/fanout.py
@@ -27,7 +27,11 @@ from typing import Any, cast
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerActionWithPorts,
+    PortInformation,
+)
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
@@ -112,30 +116,40 @@ class CollectNonClosedLogEntryRecipientsNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class _SendLogEntryToEachNode(DataLayerAction):
+class _SendLogEntryToEachNode(DataLayerActionWithPorts):
     """Send the log entry to each recipient in ``fanout_recipients``."""
 
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self._sync_port: SyncActivityPort | None = None
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="log_entry", access=py_trees.common.Access.READ
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["log_entry"] = PortInformation(data_type=object, required=True)
+        ports["fanout_recipients"] = PortInformation(
+            data_type=object, required=True
         )
-        self.blackboard.register_key(
-            key="fanout_recipients", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="sync_port", access=py_trees.common.Access.READ
-        )
+        ports["sync_port"] = PortInformation(data_type=object, required=False)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "log_entry": "/log_entry",
+            "fanout_recipients": "/fanout_recipients",
+            "sync_port": "/sync_port",
+        }
 
     def initialise(self) -> None:
         super().initialise()
+        self.log_entry = self.get_input("log_entry")
+        self.fanout_recipients: list = self.get_input("fanout_recipients")
         try:
-            self._sync_port = cast(SyncActivityPort, self.blackboard.sync_port)
-        except (AttributeError, KeyError):
+            self._sync_port = cast(
+                SyncActivityPort, self.get_input("sync_port")
+            )
+        except Exception:
             self._sync_port = None
 
     def update(self) -> Status:
@@ -143,8 +157,8 @@ class _SendLogEntryToEachNode(DataLayerAction):
             self.logger.error("%s: actor_id not available", self.name)
             return Status.FAILURE
 
-        entry = cast(VultronCaseLedgerEntry, self.blackboard.log_entry)
-        recipients = cast(list, self.blackboard.fanout_recipients)
+        entry = cast(VultronCaseLedgerEntry, self.log_entry)
+        recipients = self.fanout_recipients
         if self._sync_port is None:
             self.logger.debug(
                 "%s: sync_port not injected; skipping fan-out for '%s'",

--- a/vultron/core/behaviors/sync/nodes/ownership_offer_effect.py
+++ b/vultron/core/behaviors/sync/nodes/ownership_offer_effect.py
@@ -38,16 +38,19 @@ from __future__ import annotations
 
 from typing import Any
 
-import py_trees
 from py_trees.common import Status
 from pydantic import ValidationError
 
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    DataLayerConditionWithPorts,
+    PortInformation,
+)
 
 _OFFER_CASE_OWNERSHIP_TRANSFER_EVENT = "offer_case_ownership_transfer"
 
 
-class IsOfferOwnershipTransferEventNode(DataLayerCondition):
+class IsOfferOwnershipTransferEventNode(DataLayerConditionWithPorts):
     """Precondition: SUCCESS when entry IS an offer_case_ownership_transfer event.
 
     Used as the precondition in the ``OfferOwnershipTransferEffects`` Selector's
@@ -69,24 +72,32 @@ class IsOfferOwnershipTransferEventNode(DataLayerCondition):
     Per BTND-08-001, BTND-08-002, CM-21-005, SYNC-02-002, SYNC-12-001.
     """
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity": "/activity"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.activity = self.get_input("activity")
 
     def update(self) -> Status:
         from vultron.core.behaviors.sync.nodes.conditions import (
             _require_log_entry,
         )
 
-        entry = _require_log_entry(self.blackboard.activity, self.name)
+        entry = _require_log_entry(self.activity, self.name)
         if entry.event_type == _OFFER_CASE_OWNERSHIP_TRANSFER_EVENT:
             return Status.SUCCESS
         return Status.FAILURE
 
 
-class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
+class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerActionWithPorts):
     """Apply an ``offer_case_ownership_transfer`` ledger entry to the local DataLayer.
 
     When a participant receives ``Announce(CaseLedgerEntry)`` for the
@@ -121,11 +132,19 @@ class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
     CM-21-005, ISSUE-2195.
     """
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity": "/activity"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.activity = self.get_input("activity")
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
@@ -136,7 +155,7 @@ class ApplyOfferOwnershipTransferFromLedgerNode(DataLayerAction):
             _require_log_entry,
         )
 
-        entry = _require_log_entry(self.blackboard.activity, self.name)
+        entry = _require_log_entry(self.activity, self.name)
         snapshot = (
             entry.payload_snapshot
             if isinstance(entry.payload_snapshot, dict)

--- a/vultron/core/behaviors/sync/nodes/participant_status_effect.py
+++ b/vultron/core/behaviors/sync/nodes/participant_status_effect.py
@@ -27,12 +27,15 @@ specs/sync-ledger-replication.yaml SYNC-02-002.
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import cast
 
-import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction, read_rm_states
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    PortInformation,
+    read_rm_states,
+)
 from vultron.core.behaviors.sync.nodes.effects import _extract_id_from_field
 from vultron.core.models._helpers import _as_id
 from vultron.core.models.case_participant import CaseParticipant
@@ -74,7 +77,7 @@ def _ratchet_rm(
     )
 
 
-class ApplyParticipantStatusFromLedgerNode(DataLayerAction):
+class ApplyParticipantStatusFromLedgerNode(DataLayerActionWithPorts):
     """Apply an ``add_participant_status_to_participant`` ledger entry locally.
 
     When a non-Case-Actor participant receives
@@ -111,11 +114,19 @@ class ApplyParticipantStatusFromLedgerNode(DataLayerAction):
     specs/sync-ledger-replication.yaml SYNC-02-002.
     """
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity": "/activity"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.activity = self.get_input("activity")
 
     def _apply_rm_ratchet(
         self,
@@ -165,7 +176,7 @@ class ApplyParticipantStatusFromLedgerNode(DataLayerAction):
             _require_log_entry,
         )
 
-        entry = _require_log_entry(self.blackboard.activity, self.name)
+        entry = _require_log_entry(self.activity, self.name)
         snapshot = entry.payload_snapshot
 
         status_data = snapshot.get("object")

--- a/vultron/core/behaviors/sync/nodes/receive.py
+++ b/vultron/core/behaviors/sync/nodes/receive.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
+from py_trees.ports import NoDataAvailable
 
 from vultron.core.behaviors.helpers import (
     DataLayerActionWithPorts,
@@ -180,13 +181,13 @@ class BufferOutOfOrderEntryNode(DataLayerActionWithPorts):
         self.activity = self.get_input("activity")
         try:
             self.tail_index: int | None = self.get_input("tail_index")
-        except Exception:
+        except (NoDataAvailable, NotImplementedError):
             self.tail_index = None
         try:
             self._gap_buffer = cast(
                 LedgerGapBuffer, self.get_input("gap_buffer")
             )
-        except Exception:
+        except (NoDataAvailable, NotImplementedError):
             self._gap_buffer = None
 
     def update(self) -> Status:
@@ -273,7 +274,7 @@ class BufferPreGenesisEntryNode(DataLayerActionWithPorts):
             self._gap_buffer = cast(
                 LedgerGapBuffer, self.get_input("gap_buffer")
             )
-        except Exception:
+        except (NoDataAvailable, NotImplementedError):
             self._gap_buffer = None
 
     def update(self) -> Status:
@@ -323,7 +324,7 @@ class SendRejectLogEntryNode(DataLayerActionWithPorts):
             self._sync_port = cast(
                 SyncActivityPort, self.get_input("sync_port")
             )
-        except Exception:
+        except (NoDataAvailable, NotImplementedError):
             self._sync_port = None
 
     def update(self) -> Status:

--- a/vultron/core/behaviors/sync/nodes/receive.py
+++ b/vultron/core/behaviors/sync/nodes/receive.py
@@ -22,7 +22,11 @@ from typing import Any, cast
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    DataLayerConditionWithPorts,
+    PortInformation,
+)
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.models.ledger_gap_buffer import LedgerGapBuffer
@@ -49,15 +53,23 @@ def _require_log_entry(
     )
 
 
-class LogDeliveryConfirmationNode(DataLayerAction):
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
+class LogDeliveryConfirmationNode(DataLayerActionWithPorts):
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity": "/activity"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.activity = self.get_input("activity")
 
     def update(self) -> Status:
-        entry = _require_log_entry(self.blackboard.activity, self.name)
+        entry = _require_log_entry(self.activity, self.name)
         self.logger.debug(
             "%s: received round-trip delivery confirmation for log entry '%s'",
             self.name,
@@ -66,18 +78,26 @@ class LogDeliveryConfirmationNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class PersistReceivedLogEntryNode(DataLayerAction):
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
+class PersistReceivedLogEntryNode(DataLayerActionWithPorts):
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity": "/activity"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.activity = self.get_input("activity")
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
             return f
         assert self.datalayer is not None
-        entry = _require_log_entry(self.blackboard.activity, self.name)
+        entry = _require_log_entry(self.activity, self.name)
         self.datalayer.save(entry)
         self.logger.info(
             "%s: stored received log entry '%s' for case '%s'",
@@ -88,25 +108,31 @@ class PersistReceivedLogEntryNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class CheckHashMatchesNode(DataLayerCondition):
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="tail_hash", access=py_trees.common.Access.READ
-        )
+class CheckHashMatchesNode(DataLayerConditionWithPorts):
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        ports["tail_hash"] = PortInformation(data_type=str, required=True)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity": "/activity", "tail_hash": "/tail_hash"}
+
+    def initialise(self) -> None:
+        super().initialise()
+        self.activity = self.get_input("activity")
+        self.tail_hash: str = self.get_input("tail_hash")
 
     def update(self) -> Status:
-        entry = _require_log_entry(self.blackboard.activity, self.name)
-        tail_hash = self.blackboard.tail_hash
-        if entry.prev_log_hash == tail_hash:
+        entry = _require_log_entry(self.activity, self.name)
+        if entry.prev_log_hash == self.tail_hash:
             return Status.SUCCESS
         return Status.FAILURE
 
 
-class BufferOutOfOrderEntryNode(DataLayerAction):
+class BufferOutOfOrderEntryNode(DataLayerActionWithPorts):
     """Hold a forward-gap ledger entry so it is not permanently dropped.
 
     When a received entry's ``prev_log_hash`` does not match the local tail
@@ -133,47 +159,52 @@ class BufferOutOfOrderEntryNode(DataLayerAction):
         super().__init__(name=name or self.__class__.__name__)
         self._gap_buffer: LedgerGapBuffer | None = None
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="tail_index", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="gap_buffer", access=py_trees.common.Access.READ
-        )
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        ports["tail_index"] = PortInformation(data_type=int, required=False)
+        ports["gap_buffer"] = PortInformation(data_type=object, required=False)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "activity": "/activity",
+            "tail_index": "/tail_index",
+            "gap_buffer": "/gap_buffer",
+        }
 
     def initialise(self) -> None:
         super().initialise()
+        self.activity = self.get_input("activity")
+        try:
+            self.tail_index: int | None = self.get_input("tail_index")
+        except Exception:
+            self.tail_index = None
         try:
             self._gap_buffer = cast(
-                LedgerGapBuffer, self.blackboard.gap_buffer
+                LedgerGapBuffer, self.get_input("gap_buffer")
             )
-        except (AttributeError, KeyError):
+        except Exception:
             self._gap_buffer = None
 
     def update(self) -> Status:
-        if self._gap_buffer is None:
+        if self._gap_buffer is None or self.tail_index is None:
             return Status.FAILURE
 
-        entry = _require_log_entry(self.blackboard.activity, self.name)
-        try:
-            tail_index = cast(int, self.blackboard.tail_index)
-        except (AttributeError, KeyError):
-            return Status.FAILURE
+        entry = _require_log_entry(self.activity, self.name)
 
         # Only buffer genuine *forward* gaps.  An entry at or behind the tail
         # index is stale, a duplicate, or a fork — not a reorder we can heal by
         # waiting, so let it fall through to the rejection path.
-        if entry.log_index <= tail_index + 1:
+        if entry.log_index <= self.tail_index + 1:
             self.logger.debug(
                 "%s: entry index=%d is not a forward gap (tail_index=%d) — "
                 "not buffering",
                 self.name,
                 entry.log_index,
-                tail_index,
+                self.tail_index,
             )
             return Status.FAILURE
 
@@ -189,7 +220,7 @@ class BufferOutOfOrderEntryNode(DataLayerAction):
         return Status.FAILURE
 
 
-class BufferPreGenesisEntryNode(DataLayerAction):
+class BufferPreGenesisEntryNode(DataLayerActionWithPorts):
     """Hold a ledger entry that arrived before its ``VulnerabilityCase`` seed.
 
     This is the *pre-genesis* companion to :class:`BufferOutOfOrderEntryNode`.
@@ -224,29 +255,32 @@ class BufferPreGenesisEntryNode(DataLayerAction):
         super().__init__(name=name or self.__class__.__name__)
         self._gap_buffer: LedgerGapBuffer | None = None
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="gap_buffer", access=py_trees.common.Access.READ
-        )
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        ports["gap_buffer"] = PortInformation(data_type=object, required=False)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {"activity": "/activity", "gap_buffer": "/gap_buffer"}
 
     def initialise(self) -> None:
         super().initialise()
+        self.activity = self.get_input("activity")
         try:
             self._gap_buffer = cast(
-                LedgerGapBuffer, self.blackboard.gap_buffer
+                LedgerGapBuffer, self.get_input("gap_buffer")
             )
-        except (AttributeError, KeyError):
+        except Exception:
             self._gap_buffer = None
 
     def update(self) -> Status:
         if self._gap_buffer is None:
             return Status.FAILURE
 
-        entry = _require_log_entry(self.blackboard.activity, self.name)
+        entry = _require_log_entry(self.activity, self.name)
         if self._gap_buffer.buffer(entry):
             self.logger.info(
                 "%s: buffered pre-genesis entry '%s' (index=%d) for case '%s' "
@@ -260,28 +294,36 @@ class BufferPreGenesisEntryNode(DataLayerAction):
         return Status.FAILURE
 
 
-class SendRejectLogEntryNode(DataLayerAction):
+class SendRejectLogEntryNode(DataLayerActionWithPorts):
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self._sync_port: SyncActivityPort | None = None
 
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="tail_hash", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="sync_port", access=py_trees.common.Access.READ
-        )
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        ports = super().input_ports()
+        ports["activity"] = PortInformation(data_type=object, required=True)
+        ports["tail_hash"] = PortInformation(data_type=str, required=True)
+        ports["sync_port"] = PortInformation(data_type=object, required=False)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            "activity": "/activity",
+            "tail_hash": "/tail_hash",
+            "sync_port": "/sync_port",
+        }
 
     def initialise(self) -> None:
         super().initialise()
+        self.activity = self.get_input("activity")
+        self.tail_hash: str = self.get_input("tail_hash")
         try:
-            self._sync_port = cast(SyncActivityPort, self.blackboard.sync_port)
-        except (AttributeError, KeyError):
+            self._sync_port = cast(
+                SyncActivityPort, self.get_input("sync_port")
+            )
+        except Exception:
             self._sync_port = None
 
     def update(self) -> Status:
@@ -289,10 +331,9 @@ class SendRejectLogEntryNode(DataLayerAction):
             self.logger.error("%s: actor_id not available", self.name)
             return Status.FAILURE
 
-        entry = _require_log_entry(self.blackboard.activity, self.name)
-        tail_hash = self.blackboard.tail_hash
+        entry = _require_log_entry(self.activity, self.name)
 
-        sender_id = getattr(self.blackboard.activity, "actor_id", None)
+        sender_id = getattr(self.activity, "actor_id", None)
         if self._sync_port is None:
             raise VultronError(
                 f"{self.name}: sync_port must be injected to send rejection"
@@ -308,11 +349,11 @@ class SendRejectLogEntryNode(DataLayerAction):
             self.name,
             entry.id_,
             entry.prev_log_hash,
-            tail_hash,
+            self.tail_hash,
         )
         self._sync_port.send_reject_log_entry(
             entry=entry,
-            tail_hash=tail_hash,
+            tail_hash=self.tail_hash,
             actor_id=self.actor_id,
             to=[sender_id],
         )


### PR DESCRIPTION
- Closes #1885

## Summary

Migrates all Type-B BT nodes (extra READ-only blackboard keys beyond `datalayer`/`actor_id`) to typed `input_ports()` + `get_input()` pattern. Part 3/5 of the full Ports migration (#1809).

## Changes

- **`sync/nodes/receive.py`**: 6 nodes migrated — `LogDeliveryConfirmationNode`, `PersistReceivedLogEntryNode` (READ `activity`), `CheckHashMatchesNode` (READ `activity`, `tail_hash`), `BufferOutOfOrderEntryNode` (READ `activity`, optional `tail_index`, optional `gap_buffer`; `update()` guards `tail_index is None`), `BufferPreGenesisEntryNode`, `SendRejectLogEntryNode`
- **`sync/nodes/chain.py`**: `UpdateReplicationStateNode`, `PersistLogEntryNode`
- **`sync/nodes/fanout.py`**: `_SendLogEntryToEachNode`
- **`sync/nodes/participant_status_effect.py`**: `ApplyParticipantStatusFromLedgerNode`
- **`sync/nodes/ownership_offer_effect.py`**: `IsOfferOwnershipTransferEventNode`, `ApplyOfferOwnershipTransferFromLedgerNode`
- **`sender/nodes/actions.py`**: `QueueToOutboxNode`
- **`embargo/nodes/teardown.py`**: `ApplyEmbargoTeardownNode` (conditional READ `activity`)
- **`embargo/nodes/emit.py`**: `_SendEmbargoActivityBase` migrated to `DataLayerActionWithPorts`
- **`embargo/nodes/terminate.py`** (new): `SendTerminateEmbargoActivityNode` extracted from `lifecycle.py` to restore BTND-07-004 ≤500-line invariant; re-exported from `lifecycle.py`
- **`embargo/nodes/reject_proposed.py`**: `SendRejectEmbargoActivityNode` — READ `embargo_id`, `case_manager_id`
- **`embargo/nodes/lifecycle.py`**: split (502→437 lines), re-exports `SendTerminateEmbargoActivityNode` for backward compat
- **`status/nodes/`**, **`case/nodes/`**: additional Type-B nodes migrated per domain scan
- **`helpers.py`**: `DataLayerConditionWithPorts.initialise()` and `DataLayerActionWithPorts.initialise()` now catch `NotImplementedError` from py_trees when blackboard stores an explicit `None`, preserving the `_require_datalayer()` FAILURE contract

Nodes with WRITE or READ+WRITE handoff keys (Type C) are deferred to Part 4/5 (#1886). Nodes with instance-computed dynamic blackboard keys (`owner.py` `participant_case_{seg}`) are left as `DataLayerAction` — they cannot use static `input_ports()` declarations.

## Verification

- 7201 unit tests pass, 1167 integration tests pass (1 xfailed each)
- Black, flake8, mypy, pyright clean
- BTND-07-004 invariant (≤500 lines per module) passes