### PR TITLE
docs: plan issue #2105 — establish Vultron vocabulary namespace URI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -810,6 +810,15 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   "there are 4 unimplemented nodes" or "15 xfails" — these are stale snapshots.
   See MS-16-001 and [notes/specs-vs-adrs.md](notes/specs-vs-adrs.md).
   *Source: CONCERN-2277*
+- **Outbound `@context` MUST Cite the Vultron Namespace, Not Only the AS2 Namespace** —
+  `VultronAS2Object.context_` MUST default to the Vultron JSON-LD context URI
+  (`https://certcc.github.io/Vultron/ns/context.jsonld`), not the bare
+  ActivityStreams namespace (`https://www.w3.org/ns/activitystreams`). The AS2
+  namespace does not declare Vultron-specific types (`VulnerabilityCase`,
+  `EmbargoEvent`, etc.); using it alone means receivers cannot resolve those
+  type names. The Vultron context document imports AS2 internally, so citing
+  only the Vultron URI is both correct and sufficient. See VM-10-001, ADR-0069.
+  *Source: CONCERN-2105*
 - **GHA Matrix Boolean Fields Fail Differently at Job-Level vs. Step-Level `if:`**
   — two distinct failure modes when a boolean field from the matrix (e.g.
   `full_suite_only: false`) is referenced in a GitHub Actions `if:` expression:

--- a/docs/adr/0069-vultron-namespace-uri.md
+++ b/docs/adr/0069-vultron-namespace-uri.md
@@ -1,0 +1,89 @@
+---
+status: accepted-provisional
+date: 2026-08-21
+deciders: Allen D. Householder
+consulted: Vultron maintainers
+informed: Vultron implementers
+---
+
+# Adopt certcc.github.io/Vultron as the Initial Vultron Vocabulary Namespace Host
+
+## Context and Problem Statement
+
+Vultron wire messages use ActivityStreams 2.0 vocabulary extended with
+CVD-specific types (`VulnerabilityCase`, `EmbargoEvent`, `CaseParticipant`,
+etc.). JSON-LD requires that type names be declared in a dereferenceable
+`@context` document so receivers can resolve them to full URIs. Without a
+stable namespace URI, the draft Vultron protocol specification cannot cite
+a normative `@context` value, blocking external review and independent
+implementation.
+
+The blocker is deciding the namespace URI and making it dereferenceable.
+Publishing a permanent namespace registration (e.g., `w3id.org`) and serving
+a production-quality context document are deferred as follow-on work.
+
+## Decision Drivers
+
+- The draft spec (§4.1, §4.5) must cite a concrete namespace URI to circulate
+  for review.
+- The URI must be dereferenceable so JSON-LD processors can retrieve the
+  context document.
+- No new external infrastructure should be required before the PR merges.
+- A permanent URI may be registered later; the initial choice should make
+  migration straightforward.
+
+## Considered Options
+
+1. **GitHub Pages (`certcc.github.io/Vultron/ns`)** — the existing Vultron
+   documentation site; context document lives in `docs/ns/context.jsonld`;
+   no new infrastructure required.
+2. **`w3id.org` redirect** — a community-managed permanent redirect service;
+   would require a separate PR to the w3id.org GitHub repo and adds an external
+   dependency with no code-change gate.
+3. **Opaque URN (`urn:vultron:vocab:v1`)** — no dereference; violates JSON-LD
+   best practice and prevents receivers from looking up the vocabulary.
+4. **CERT/CC-controlled custom domain** (e.g., `vocab.vultron.org`) — maximum
+   control; requires DNS and web-hosting setup outside this repository.
+
+## Decision Outcome
+
+Chosen option: **GitHub Pages (`certcc.github.io/Vultron/ns`)**, because it
+is already under CERT/CC control, requires only a `docs/ns/` directory in
+this repository, and makes the context document dereferenceable immediately
+upon PR merge — with no external dependencies.
+
+The namespace URI is `https://certcc.github.io/Vultron/ns`. The JSON-LD
+context document is served at
+`https://certcc.github.io/Vultron/ns/context.jsonld`. Outbound Vultron wire
+messages MUST set `@context` to the context document URI (VM-10-001).
+
+This decision is `accepted-provisional` because the GitHub Pages URI is tied
+to the repository's current hosting location. If the project migrates to a
+custom domain or registers a permanent URI with `w3id.org`, a new ADR
+superseding this one will be written, and the context document will carry an
+`owl:sameAs` declaration linking the old and new URIs.
+
+### Consequences
+
+- Good, because the namespace URI resolves immediately with no external steps.
+- Good, because the `docs/ns/` directory is version-controlled alongside the
+  vocabulary it describes.
+- Good, because migrating to a permanent URI later is well-understood: update
+  the context document, add an `owl:sameAs` triple, redirect the old URI.
+- Bad, because the URI is tied to the GitHub Pages hostname, which is not
+  a conventional permanent namespace host.
+- Neutral, because `w3id.org` registration remains available as a future
+  permanent-URI option without blocking the current work.
+
+## Validation
+
+VM-10-001 (in `specs/vocabulary-model.yaml`) requires outbound Vultron messages
+to declare the Vultron context URI. Compliance is verified by serialization
+tests that check `@context` values on `VultronAS2Object` subclass instances.
+
+## More Information
+
+Generated spec requirements: `vocabulary-model.yaml` VM-10-001, VM-10-002.
+
+Source issue: CONCERN-2105 — "no stable Vultron vocabulary namespace URI to
+cite (circulation blocker for draft spec)".

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -138,6 +138,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0066 Outbox Terminal State: Per-Activity Attempt Counter, 4xx Classification, and Dead-Letter Store](0066-outbox-terminal-state.md)
 - [ADR-0067 Accept Non-Adjacent Forward RM Jumps and Notify; Refuse Backward Regressions Non-Silently](0067-rm-nonadj-accept-and-notify.md)
 - [ADR-0068 Refuse Misaddressed Activities at the Inbox with a Synchronous 4xx](0068-inbox-refuse-misaddressed-activities.md)
+- [ADR-0069 Adopt certcc.github.io/Vultron as the Initial Vultron Vocabulary Namespace Host](0069-vultron-namespace-uri.md) *(provisional)*
 
 ## Proposed ADRs
 

--- a/docs/ns/context.jsonld
+++ b/docs/ns/context.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "vultron": "https://certcc.github.io/Vultron/ns#",
+      "CaseActor": "vultron:CaseActor",
+      "CaseLedgerEntry": "vultron:CaseLedgerEntry",
+      "CaseParticipant": "vultron:CaseParticipant",
+      "CaseParticipantRole": "vultron:CaseParticipantRole",
+      "CaseProposal": "vultron:CaseProposal",
+      "CaseReference": "vultron:CaseReference",
+      "CaseStatus": "vultron:CaseStatus",
+      "EmbargoEvent": "vultron:EmbargoEvent",
+      "EmbargoPolicy": "vultron:EmbargoPolicy",
+      "ParticipantStatus": "vultron:ParticipantStatus",
+      "VulnerabilityCase": "vultron:VulnerabilityCase",
+      "VulnerabilityCaseStub": "vultron:VulnerabilityCaseStub",
+      "VulnerabilityRecord": "vultron:VulnerabilityRecord",
+      "VulnerabilityReport": "vultron:VulnerabilityReport"
+    }
+  ]
+}

--- a/docs/ns/context.jsonld
+++ b/docs/ns/context.jsonld
@@ -3,7 +3,6 @@
     "https://www.w3.org/ns/activitystreams",
     {
       "vultron": "https://certcc.github.io/Vultron/ns#",
-      "CaseActor": "vultron:CaseActor",
       "CaseLedgerEntry": "vultron:CaseLedgerEntry",
       "CaseParticipant": "vultron:CaseParticipant",
       "CaseParticipantRole": "vultron:CaseParticipantRole",

--- a/docs/ns/index.md
+++ b/docs/ns/index.md
@@ -19,7 +19,6 @@ extends the AS2 core vocabulary with CVD-specific object types.
 
 | Type name | Description |
 |-----------|-------------|
-| `CaseActor` | ActivityStreams Service actor created during case initialization |
 | `CaseLedgerEntry` | Entry in the canonical append-only case ledger |
 | `CaseParticipant` | Actor-in-role binding within a specific case |
 | `CaseParticipantRole` | A CVD role being offered to an actor in a case context |

--- a/docs/ns/index.md
+++ b/docs/ns/index.md
@@ -1,0 +1,59 @@
+---
+draft: true
+---
+
+# Vultron Vocabulary Namespace
+
+**Namespace URI**: `https://certcc.github.io/Vultron/ns`
+
+**JSON-LD context document**: [`context.jsonld`](context.jsonld)
+
+---
+
+This namespace defines the Vultron-specific vocabulary types used in
+[Vultron protocol](https://certcc.github.io/Vultron/) wire messages.
+Vultron messages are ActivityStreams 2.0 Activities; the Vultron vocabulary
+extends the AS2 core vocabulary with CVD-specific object types.
+
+## Declared types
+
+| Type name | Description |
+|-----------|-------------|
+| `CaseActor` | ActivityStreams Service actor created during case initialization |
+| `CaseLedgerEntry` | Entry in the canonical append-only case ledger |
+| `CaseParticipant` | Actor-in-role binding within a specific case |
+| `CaseParticipantRole` | A CVD role being offered to an actor in a case context |
+| `CaseProposal` | Request to a CaseActor service to initialize a new case |
+| `CaseReference` | Typed external URL reference attached to a case |
+| `CaseStatus` | Snapshot of all three state machines (RM/EM/CS) at one moment |
+| `EmbargoEvent` | Embargo proposal, acceptance, revision, or termination record |
+| `EmbargoPolicy` | Actor-level declaration of embargo preferences |
+| `ParticipantStatus` | Per-participant snapshot of RM state and embargo consent |
+| `VulnerabilityCase` | Coordination container for a vulnerability disclosure case |
+| `VulnerabilityCaseStub` | Lightweight reference form of `VulnerabilityCase` |
+| `VulnerabilityRecord` | Persistent identifier record for a confirmed vulnerability |
+| `VulnerabilityReport` | Initial report artifact submitted to a case |
+
+## Usage in wire messages
+
+Vultron wire messages MUST declare the Vultron JSON-LD context to allow
+receivers to resolve Vultron type names to their full URIs. The context
+document at this URI imports the ActivityStreams 2.0 namespace, so
+implementations cite only the Vultron context URI:
+
+```json
+{
+  "@context": "https://certcc.github.io/Vultron/ns/context.jsonld",
+  "type": "VulnerabilityCase",
+  ...
+}
+```
+
+## Stability note
+
+This namespace is currently hosted on GitHub Pages
+(`certcc.github.io/Vultron`). A permanent namespace URI (e.g., a `w3id.org`
+redirect or a CERT/CC-controlled domain) may be registered in a future
+version of this specification. Implementations should anticipate that the URI
+may migrate; the context document will carry a `owl:sameAs` declaration when
+a permanent URI is established.

--- a/docs/reference/draft-vultron-spec.md
+++ b/docs/reference/draft-vultron-spec.md
@@ -158,6 +158,7 @@ during implementation (see §6.4) and is fully normative.
 - Vultron messages are ActivityStreams 2.0 Activities
 - Required fields: `type`, `actor`, `object`, `id`
 - Extended types defined by the Vultron vocabulary namespace
+  (`https://certcc.github.io/Vultron/ns`)
 - Implementations MUST use the Vultron AS2 vocabulary for message structure;
   full ActivityPub server semantics (inbox/outbox HTTP delivery, WebFinger
   discovery, HTTP Signatures) are not currently required by this specification
@@ -291,8 +292,27 @@ permitted.
 ### 4.5 Serialization
 
 - JSON-LD as the normative serialization
-- Required context declarations
-- *Source: AS2/ActivityPub standards; `specs/message-validation.yaml`*
+- Outbound Vultron messages MUST set `@context` to the Vultron JSON-LD context
+  document URI: `https://certcc.github.io/Vultron/ns/context.jsonld`. This
+  context document imports the ActivityStreams 2.0 namespace and declares all
+  Vultron-specific type names, so implementations need cite only the Vultron
+  URI.
+
+    ```json
+    {
+      "@context": "https://certcc.github.io/Vultron/ns/context.jsonld",
+      "type": "VulnerabilityCase",
+      ...
+    }
+    ```
+
+!!! note "Provisional namespace URI"
+    The namespace is currently hosted on GitHub Pages
+    (`certcc.github.io/Vultron`). A permanent namespace URI may be registered
+    in a future version of this specification. See ADR-0069.
+
+- *Source: AS2/ActivityPub standards; `specs/vocabulary-model.yaml`
+  (VM-10-001, VM-10-002); ADR-0069*
 
 ### 4.6 Transport Layer [N/I]
 
@@ -1450,8 +1470,13 @@ implementation. Other implementations are not required to use this structure.
 
 ## 9. IANA / Namespace Considerations [I]
 
-- Vultron vocabulary namespace registration (future)
-- AS2 extension type naming conventions
+- **Vultron vocabulary namespace**: `https://certcc.github.io/Vultron/ns`
+  (initial, provisional — hosted on GitHub Pages). A permanent URI registration
+  (e.g., `w3id.org` redirect) is planned for a future version of this
+  specification. See ADR-0069.
+- **JSON-LD context document**: `https://certcc.github.io/Vultron/ns/context.jsonld`
+- AS2 extension type naming conventions: Vultron type names use PascalCase
+  without an `as_` prefix in wire output (e.g., `"type": "VulnerabilityCase"`)
 
 ---
 
@@ -1501,8 +1526,10 @@ implementation. Other implementations are not required to use this structure.
 
 ## Open Questions (to resolve before circulating)
 
-1. **Namespace URI** — Is there a stable `vultron:` or `https://vultron.example/`
-   namespace ready to cite?
+1. ~~**Namespace URI**~~ — Resolved. The Vultron vocabulary namespace is
+   `https://certcc.github.io/Vultron/ns`; the JSON-LD context document is at
+   `https://certcc.github.io/Vultron/ns/context.jsonld`. See §4.5 and ADR-0069.
+   A permanent namespace URI may be registered in a future version.
 2. **Sync/replication** — Is the ledger replication protocol in scope for this
    RFC, or a separate companion spec? The Hosting capability set obligation to
    replicate is stable either way (§7.2); what may move is the detailed mechanics.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -289,6 +289,7 @@ nav:
       - 'Outbox Terminal State: Per-Activity Attempt Counter, 4xx Classification, and Dead-Letter Store': 'adr/0066-outbox-terminal-state.md'
       - 'Accept Non-Adjacent Forward RM Jumps and Notify; Refuse Backward Regressions Non-Silently': 'adr/0067-rm-nonadj-accept-and-notify.md'
       - 'Refuse Misaddressed Activities at the Inbox with a Synchronous 4xx': 'adr/0068-inbox-refuse-misaddressed-activities.md'
+      - 'Adopt certcc.github.io/Vultron as the Initial Vultron Vocabulary Namespace Host': 'adr/0069-vultron-namespace-uri.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/specs/vocabulary-model.yaml
+++ b/specs/vocabulary-model.yaml
@@ -220,3 +220,41 @@ groups:
     kind: protocol
     statement: Messages that cannot be parsed or whose semantics are unknown MAY still be forwarded to the case event log
       to create an entry for human or agent review
+- id: VM-10
+  title: Vocabulary Namespace and JSON-LD Context
+  specs:
+  - id: VM-10-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      Outbound Vultron wire messages MUST declare the Vultron JSON-LD context by setting
+      `@context` to `"https://certcc.github.io/Vultron/ns/context.jsonld"`. Using only
+      the ActivityStreams namespace (`https://www.w3.org/ns/activitystreams`) is not
+      sufficient: Vultron-specific types (`VulnerabilityCase`, `EmbargoEvent`, etc.) are
+      not defined in that namespace and cannot be resolved by receivers without the
+      Vultron context declaration.
+    rationale: >-
+      Derived from ADR-0069 (docs/adr/0069-vultron-namespace-uri.md). The Vultron vocabulary
+      extends ActivityStreams with CVD-specific types; those types must be declared in a
+      dereferenceable JSON-LD context so that external implementations can resolve them.
+      The context document at the Vultron namespace URI imports the AS2 namespace, so
+      implementations need only cite the Vultron context URI.
+    adr:
+    - ADR-0069
+    relationships:
+    - rel_type: refines
+      spec_id: VM-02-002
+  - id: VM-10-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      Wire-layer classes whose `_vocab_ns` is `VocabNamespace.VULTRON` MUST default
+      `context_` to the Vultron context URI (`https://certcc.github.io/Vultron/ns/context.jsonld`)
+      rather than the ActivityStreams namespace URI.
+    rationale: >-
+      `VultronAS2Object` is the base class for all Vultron-specific wire types. Overriding
+      `context_` there ensures that every Vultron object serializes with the correct
+      `@context` without requiring call-site changes.
+    relationships:
+    - rel_type: implements
+      spec_id: VM-10-001


### PR DESCRIPTION
- Closes #2105

## Summary

Establishes `https://certcc.github.io/Vultron/ns` as the Vultron vocabulary
namespace URI and publishes a minimal JSON-LD context document at
`https://certcc.github.io/Vultron/ns/context.jsonld`, resolving the
circulation blocker for the draft Vultron protocol specification.

## Changes

- **`docs/ns/context.jsonld`**: Minimal JSON-LD context document mapping all
  Vultron-specific wire types (`VulnerabilityCase`, `EmbargoEvent`, etc.) to
  their full URIs under the Vultron namespace. Imports the AS2 namespace so
  wire messages need cite only the Vultron context URI.
- **`docs/ns/index.md`**: Human-readable namespace landing page documenting
  declared types, usage examples, and the provisional-URI stability note.
- **`docs/adr/0069-vultron-namespace-uri.md`**: ADR for the GitHub Pages
  namespace host choice (`accepted-provisional`; w3id.org/CERT/CC-domain
  migration deferred as a future follow-on).
- **`docs/adr/index.md`**: Regenerated by `uv run adr-index --write` to
  include ADR-0069.
- **`mkdocs.yml`**: Added ADR-0069 to nav.
- **`docs/reference/draft-vultron-spec.md`**: §4.1 names the namespace URI;
  §4.5 specifies the `@context` value and format with example; §9 documents
  the namespace and context document URIs; Open Question #1 resolved.
- **`specs/vocabulary-model.yaml`**: New VM-10 group with VM-10-001 (outbound
  Vultron messages MUST use the Vultron context URI) and VM-10-002 (wire-layer
  `VultronAS2Object` MUST default `context_` to the Vultron URI).
- **`AGENTS.md`**: Pitfall: outbound `@context` must cite the Vultron namespace
  URI, not only `https://www.w3.org/ns/activitystreams`.