### PR TITLE
feat(skills): add Phase 0 sync to bugfix skill

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -12,6 +12,19 @@ description: >
 No implementation work begins until both the agent and the user agree on what
 bug is being fixed and why.
 
+## Phase 0 — Sync
+
+Move the worktree HEAD to `origin/main` before loading any context. Do **not**
+use `git checkout main` — that branch may be checked out in another worktree.
+
+```bash
+git fetch origin main && git reset --hard origin/main
+```
+
+If this fails, stop and investigate before proceeding. On success, `orient-agent`
+reads fresh specs/ADRs/notes, and the task branch created by `claim-issue.sh` in
+Phase 1 will be rooted at the latest `origin/main` commit.
+
 ## Phase 1 — Identify the Bug
 
 1. Invoke `orient-agent` to load baseline context.

--- a/plan/incoming/learnings/20260821-agents-claude-skills-hardlinks.md
+++ b/plan/incoming/learnings/20260821-agents-claude-skills-hardlinks.md
@@ -1,0 +1,18 @@
+---
+title: .agents/skills/ and .claude/skills/ are hard-linked — edits to either affect both
+type: learning
+timestamp: 2026-08-21
+source: ISSUE-1467
+signal: tooling-issue
+---
+
+`.agents/skills/<name>/SKILL.md` and `.claude/skills/<name>/SKILL.md` share the
+same inode (hard links). Editing one with the Edit tool modifies both on disk.
+
+When both copies need the same change (which is the common case), edit only
+`.agents/skills/<name>/SKILL.md` — the `.claude/skills/` copy updates
+automatically. Editing both in sequence duplicates the change, causing double
+sections.
+
+Confirmed by: `ls -la` showing identical size + timestamp, and `diff` showing
+no differences before and after separate edits.

--- a/plan/incoming/learnings/20260821-issue-1467-plan-issue-already-fixed.md
+++ b/plan/incoming/learnings/20260821-issue-1467-plan-issue-already-fixed.md
@@ -1,0 +1,17 @@
+---
+title: Issue #1467 plan-issue sync was already fixed on origin/main
+type: learning
+timestamp: 2026-08-21
+source: ISSUE-1467
+signal: process-issue
+---
+
+Issue #1467 listed `plan-issue` as missing its sync step (sync-check.sh was
+in Phase 4 instead of Phase 0). When we checked `origin/main` before starting,
+`plan-issue` already had Phase 0b (sync before orient-agent). The only remaining
+fix was `bugfix`, which still had no sync step.
+
+The issue body was partially stale at the time it was worked. The user's
+instruction to "make sure the problem still exists in origin/main" correctly
+identified this risk. Habit: always verify all stated defects against
+`origin/main` HEAD before implementing, not just after a `git fetch`.


### PR DESCRIPTION
- Closes #1467

## Summary

Adds an explicit `git fetch origin main && git reset --hard origin/main` Phase 0
to the `bugfix` skill before `orient-agent`, matching the pattern already in
`build` and `learn`. Ensures the task branch is rooted at the latest
`origin/main` and specs/ADRs/notes are current when the skill runs.

## Changes

- **`.agents/skills/bugfix/SKILL.md`** (hard-linked to `.claude/skills/bugfix/SKILL.md`):
  new Phase 0 — Sync section inserted before Phase 1 — Identify the Bug

## Verification

Audit of all skills named in #1467:

- `build` — already has Phase 0 sync ✅
- `plan-issue` — already has Phase 0b sync (fixed in a prior PR) ✅
- `learn` — already has Phase 0 sync ✅
- `bugfix` — **was missing; added in this PR** ✅
- `create-epic` — creates GitHub issues only, no worktree/branch operations; no sync needed ✅
- `pr-comprehensive-fix` — deprecated; no sync needed ✅
- `update-plan` — read-only gap analysis, no branch creation; no sync needed ✅

markdownlint clean; no Python files changed.