### PR TITLE
impl(csb-16-001): VFD transition validation at CreateParticipantStatusNode write boundary

### DIFF
--- a/notes/bt-pitfalls.md
+++ b/notes/bt-pitfalls.md
@@ -1172,44 +1172,47 @@ governing spec.
 
 ---
 
-## State-Validation Bypass: `CreateParticipantStatusNode` Does Not Validate Transitions
+## VFD/PXA Write-Boundary Validation in `CreateParticipantStatusNode`
 
-(ISSUE-1825, 2026-07-30; see also `notes/case-state-model.md`)
+(ISSUE-1825, 2026-07-30; ISSUE-2478, 2026-08-22; see also `notes/case-state-model.md`)
 
-`CreateParticipantStatusNode.update()` constructs `VfdDimension(state=<target>)`
-and persists it directly without calling `VfdDimension.transition()` or
-`is_valid_vfd_transition`. **State validity is enforced entirely by upstream BT
-guard nodes** — nothing at the persistence boundary rejects an invalid jump
-(e.g., `vfd → VFD`).
+**Current state (PR #2503 / ISSUE-2478, 2026-08-22)**: `CreateParticipantStatusNode`
+now validates VFD and PXA transitions inline at the write boundary before any
+`dl.create()` / `dl.save()` call:
 
-This is a known fragility (GitHub concern #1896): if a guard node is too weak
-(see "Guard Name Must Match the State-Machine Transition Precondition" above),
-an invalid status snapshot can be persisted silently. The same issue applies
-to RM and PXA dimension writes through this node.
+- `_check_vfd_preconditions()` calls `is_valid_vfd_transition(current, target)` and
+  enforces role preconditions (CVDRole.VENDOR for `VFd`, CVDRole.DEPLOYER for `VFD`).
+  Same-state writes pass through. Invalid jumps return `Status.FAILURE` (CSB-16-001,
+  CSB-15-001/002).
+- `_check_pxa_precondition()` calls `is_valid_pxa_transition(current, target)`.
+  Invalid backward moves return `Status.FAILURE` (CSB-16-002).
 
-**Status (PR #2307, 2026-08-14)**: the fragility is now mitigated for all
-known write paths:
+This closes the fragility identified in concern #1896: guard bypass or a missing
+upstream guard can no longer silently persist an illegal VFD/PXA snapshot.
 
-- **Trigger path** (`add_participant_status_trigger_bt`): guarded by
-  `ValidateTriggerTransitionsNode` (new in PR #2307, issues #2081 / #1903).
-  Fail-closed: an invalid RM/VFD/PXA jump raises `VultronValidationError` and
-  no snapshot is written.
-- **Received wire path** (`add_participant_status_tree`): guarded by
-  `FilterParticipantStatusDimensionsNode` + `ValidateRMTransitionNode`
-  (in place since `a17d7649`). Partial-accept: refused dimensions carry forward
-  the current value so other dimensions still land.
+**Defence layers as of PR #2503:**
 
-`CreateParticipantStatusNode` itself still does not validate inline.
-`test/architecture/test_vfd_rm_pxa_write_sites.py` (the AC-7 ratchet, also
-added in PR #2307) AST-audits every `VfdDimension`/`RmDimension`/`PxaDimension`
-constructor call in `vultron/core/behaviors/` and fails immediately on any new
-unclassified site, forcing an explicit audit before merge.
+- **Write node** (`CreateParticipantStatusNode`): fail-closed inline validation for
+  VFD adjacency, VFD role preconditions, and PXA monotonicity (primary boundary).
+- **Trigger path** (`add_participant_status_trigger_bt`): upstream
+  `ValidateTriggerTransitionsNode` raises `VultronValidationError` before the BT
+  write node is reached (added in PR #2307 / issues #2081, #1903).
+- **Received wire path** (`add_participant_status_tree`): `FilterParticipantStatusDimensionsNode`
+  - `ValidateRMTransitionNode` guard upstream (in place since `a17d7649`). Uses the weaker
+  `is_monotonic_vfd_forward` check intentionally — remote peers may advance through
+  multiple VFD steps between status messages; strict adjacency applies only to local
+  write nodes (CSB-16-001, AC-3).
+- **Architecture ratchet** (`test/architecture/test_vfd_rm_pxa_write_sites.py`): AST-audits
+  every `VfdDimension`/`RmDimension`/`PxaDimension` constructor call in `vultron/core/behaviors/`
+  and fails on any new unclassified site (added in PR #2307).
 
 **When writing or reviewing guard nodes that precede `CreateParticipantStatusNode`**:
-treat the guard as the *only* line of defence for transition validity and verify
-it against the state-machine transitions defined in `vultron/core/states/`.
+the write node is now a second line of defence, but upstream guards still matter —
+they surface invalid requests with richer error context (`VultronValidationError`) before
+the BT write node is reached, and they protect RM dimension writes (not validated by
+`CreateParticipantStatusNode` inline).
 
-<!-- Source: ISSUE-1825; GitHub concern #1896; PR #2307 -->
+<!-- Source: ISSUE-1825; GitHub concern #1896; PR #2307; ISSUE-2478; PR #2503 -->
 
 ---
 

--- a/plan/incoming/learnings/20260822-csb-16-001-received-wire-scope-ambiguity.md
+++ b/plan/incoming/learnings/20260822-csb-16-001-received-wire-scope-ambiguity.md
@@ -1,0 +1,15 @@
+---
+title: "CSB-16-001 scope: received-wire adjudication is exempt from strict VFD adjacency"
+type: learning
+timestamp: "2026-08-22T00:00:00Z"
+source: ISSUE-2478
+signal: spec-ambiguity
+---
+
+During implementation of CSB-16-001 (VFD transition validation at write boundary), it was unclear whether the spec also required the received-wire adjudication path (`_adjudicate_dimensions` in `_adjudication.py`) to use `is_valid_vfd_transition` (strict adjacency) or whether the weaker `is_monotonic_vfd_forward` check already in use was acceptable.
+
+**Interpretation made**: The received-wire path is explicitly exempt from strict adjacency. A remote peer may legitimately advance through multiple VFD states between status messages (e.g. the vendor becomes aware and develops a fix offline, then sends a single `VFD=VFd` status). The strict adjacency rule of CSB-16-001 applies only to *local* write nodes that advance an actor's own state.
+
+**Evidence**: `_adjudication.py` uses `is_monotonic_vfd_forward` intentionally. A comment was added to document this rationale. CSB-16-001 refers to "a BT node or helper that writes a VFD state" — the adjudication path filters inbound state assertions rather than writing them unconditionally, so the spec's intent appears to be local writes only.
+
+**Recommended follow-up**: CSB-16-001 should be amended to explicitly scope it to local-write paths and carve out the received-wire adjudication exemption. A `spec-gap` or `spec-ambiguity` Concern issue may be appropriate.

--- a/plan/incoming/learnings/20260822-develop-fix-implicit-vfd-advance.md
+++ b/plan/incoming/learnings/20260822-develop-fix-implicit-vfd-advance.md
@@ -1,0 +1,17 @@
+---
+title: "TransitionCStoFixReady now advances through Vfd if actor is at vfd"
+type: learning
+timestamp: "2026-08-22T00:00:00Z"
+source: ISSUE-2478
+signal: design-question
+---
+
+Enforcing CSB-16-001 strict adjacency in `CreateParticipantStatusNode` caused three regressions in `test_develop_fix_tree.py`: `TransitionCStoFixReady` was calling `CreateParticipantStatusNode(vfd_state=CS_vfd.VFd)` from an actor at `vfd` (the default starting state), which jumps two steps and violates strict adjacency.
+
+**Decision made**: `TransitionCStoFixReady.update()` now checks whether the actor is still at `vfd` and, if so, calls `CreateParticipantStatusNode(vfd_state=CS_vfd.Vfd)` first (implicit V event), then the `VFd` write. This advances through the required intermediate state automatically.
+
+**Rationale**: A vendor who reports a fix ready for a new case has implicitly been vendor-aware since they engaged. Requiring callers of `TransitionCStoFixReady` to pre-advance to `Vfd` would be a leaky abstraction. The node handles the protocol detail internally.
+
+**Side effect**: When a vendor processes a new case through `DevelopFixBT`, two `ParticipantStatus` records are now written (one for `Vfd`, one for `VFd`) instead of one. The narrative log emits two CS INFO lines. The `test_fix_ready_logged_in_narrative_form` test was updated accordingly.
+
+**Spec note**: The DevelopFix BT spec (`specs/behavior-tree-integration.yaml`) does not document this intermediate-state advancement. A spec update may be warranted.

--- a/test/core/behaviors/report/test_develop_fix_tree.py
+++ b/test/core/behaviors/report/test_develop_fix_tree.py
@@ -523,11 +523,18 @@ class TestTransitionCStoFixReady:
             if " CS: " in r.getMessage() and r.levelno == logging.INFO
         ]
         assert narrative, "Expected a CS narrative line at INFO"
-        message = narrative[0].getMessage()
-        # The fixture participant starts at `vfd`, so this single write
-        # advances two sub-dimensions and the label names both.
-        assert f"Actor '{VENDOR_ACTOR_ID}' CS: vfd → VFd" in message
-        assert "fix ready" in message
+        messages = [r.getMessage() for r in narrative]
+        # The fixture participant starts at `vfd`.  TransitionCStoFixReady
+        # now advances through Vfd (vendor-aware) first, then VFd (fix-ready),
+        # so two narrative lines are emitted.
+        assert any(
+            "vfd → Vfd" in m for m in messages
+        ), "Expected vendor-aware milestone line"
+        fix_ready = [m for m in messages if "fix ready" in m]
+        assert fix_ready, "Expected a 'fix ready' CS narrative line at INFO"
+        assert any(
+            f"Actor '{VENDOR_ACTOR_ID}' CS: Vfd → VFd" in m for m in fix_ready
+        )
 
         detail = [
             r

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -766,6 +766,93 @@ class TestCreateParticipantStatusNode:
 
         assert not self._rm_narrative_records(caplog)
 
+    # ------------------------------------------------------------------
+    # AC-4: write-boundary validation (CSB-16-001, CSB-15-001/002) — these
+    # tests call _run_node() directly, bypassing ValidateTriggerTransitionsNode
+    # ------------------------------------------------------------------
+
+    def _seed_participant_vfd_state(self, vfd_target: CS_vfd) -> None:
+        """Directly persist a ParticipantStatus to advance the actor to vfd_target."""
+        from vultron.core.models.case_participant import CaseParticipant
+        from vultron.core.models.participant_status import ParticipantStatus
+        from vultron.core.models.dimensions import RmDimension, VfdDimension
+
+        seed = ParticipantStatus(
+            context=self.case.id_,
+            attributed_to=self.actor.id_,
+            rm=RmDimension(state=RM.START),
+            vfd=VfdDimension(state=vfd_target),
+        )
+        self.dl.create(seed)
+        participant = self.dl.read(self.actor_participant.id_)
+        if isinstance(participant, CaseParticipant):
+            participant.add_participant_status(seed)
+            self.dl.save(participant)
+
+    def test_invalid_vfd_jump_blocked_at_write_node(self):
+        """CSB-16-001: illegal multi-step VFD jump is rejected at the write boundary.
+
+        vfd → VFD skips two intermediate states; CreateParticipantStatusNode must
+        return FAILURE without writing, independent of upstream guard coverage (AC-4).
+        """
+        from py_trees.common import Status
+
+        bt_result, result_out = self._run_node(
+            rm_state=None, vfd_state=CS_vfd.VFD, pxa_state=None
+        )
+
+        assert bt_result.status == Status.FAILURE
+        assert "status_id" not in result_out
+
+    def test_same_state_vfd_write_allowed_at_write_node(self):
+        """CSB-16-001: same-state VFD write (no actual transition) is allowed."""
+        from py_trees.common import Status
+
+        bt_result, result_out = self._run_node(
+            rm_state=None, vfd_state=CS_vfd.vfd, pxa_state=None
+        )
+
+        assert bt_result.status == Status.SUCCESS
+        assert "status_id" in result_out
+
+    def test_fix_ready_requires_vendor_role_at_write_node(self):
+        """CSB-15-001: VFd target is blocked when the actor has no VENDOR role.
+
+        The adjacent transition Vfd → VFd is structurally valid; the node must
+        still refuse it because the FINDER actor lacks the required VENDOR role.
+        """
+        from py_trees.common import Status
+
+        # Seed actor to Vfd so the transition check passes; role check fires next.
+        self._seed_participant_vfd_state(CS_vfd.Vfd)
+
+        bt_result, result_out = self._run_node(
+            rm_state=None, vfd_state=CS_vfd.VFd, pxa_state=None
+        )
+
+        assert bt_result.status == Status.FAILURE
+        assert "status_id" not in result_out
+        assert "CSB-15-001" in bt_result.feedback_message
+
+    def test_fix_deployed_requires_deployer_role_at_write_node(self):
+        """CSB-15-002: VFD target is blocked when the actor has no DEPLOYER role.
+
+        The adjacent transition VFd → VFD is structurally valid; the node must
+        still refuse it because the FINDER actor lacks the required DEPLOYER role.
+        """
+        from py_trees.common import Status
+
+        # Seed actor to VFd so the transition check passes; role check fires next.
+        self._seed_participant_vfd_state(CS_vfd.VFd)
+
+        bt_result, result_out = self._run_node(
+            rm_state=None, vfd_state=CS_vfd.VFD, pxa_state=None
+        )
+
+        assert bt_result.status == Status.FAILURE
+        assert "status_id" not in result_out
+        assert "CSB-15-002" in bt_result.feedback_message
+
 
 # ---------------------------------------------------------------------------
 # ValidateTriggerTransitionsNode — AC-1 through AC-6 (issues #2081, #1903)

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -40,9 +40,15 @@ from vultron.core.models.dimensions import (
     RmDimension,
     VfdDimension,
 )
-from vultron.core.states.cs import CS_pxa, CS_vfd
+from vultron.core.states.cs import (
+    CS_pxa,
+    CS_vfd,
+    is_valid_pxa_transition,
+    is_valid_vfd_transition,
+)
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
+from vultron.enums.roles import CVDRole
 
 
 def _resolve_em_state(case: object) -> EM:
@@ -112,6 +118,71 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
         self._pxa_state = pxa_state
         self._result_out = result_out
 
+    def _check_vfd_preconditions(
+        self, current_vfd: CS_vfd, participant_obj: object
+    ) -> "Status | None":
+        """CSB-16-001 / CSB-15-001/002: validate VFD transition and role before writing."""
+        if self._vfd_state is not None and self._vfd_state != current_vfd:
+            if not is_valid_vfd_transition(current_vfd, self._vfd_state):
+                self.logger.warning(
+                    "%s: invalid VFD transition %s → %s for actor '%s'",
+                    self.name,
+                    current_vfd,
+                    self._vfd_state,
+                    self._actor_id,
+                )
+                self.feedback_message = f"Invalid VFD transition {current_vfd!r} → {self._vfd_state!r}"
+                return Status.FAILURE
+        actor_roles = (
+            participant_obj.roles  # type: ignore[attr-defined]
+            if isinstance(participant_obj, CaseParticipant)
+            else []
+        )
+        if self._vfd_state == CS_vfd.VFd and CVDRole.VENDOR not in actor_roles:
+            self.logger.warning(
+                "%s: actor '%s' lacks VENDOR role required for VFd (CSB-15-001)",
+                self.name,
+                self._actor_id,
+            )
+            self.feedback_message = (
+                "VENDOR role required for VFd target (CSB-15-001)"
+            )
+            return Status.FAILURE
+        if (
+            self._vfd_state == CS_vfd.VFD
+            and CVDRole.DEPLOYER not in actor_roles
+        ):
+            self.logger.warning(
+                "%s: actor '%s' lacks DEPLOYER role required for VFD (CSB-15-002)",
+                self.name,
+                self._actor_id,
+            )
+            self.feedback_message = (
+                "DEPLOYER role required for VFD target (CSB-15-002)"
+            )
+            return Status.FAILURE
+        return None
+
+    def _check_pxa_precondition(self, pxa_before: CS_pxa) -> "Status | None":
+        """CSB-16-002: validate PXA transition before writing."""
+        if self._pxa_state is None:
+            return None
+        if self._pxa_state != pxa_before and not is_valid_pxa_transition(
+            pxa_before, self._pxa_state
+        ):
+            self.logger.warning(
+                "%s: invalid PXA transition %s → %s for actor '%s'",
+                self.name,
+                pxa_before,
+                self._pxa_state,
+                self._actor_id,
+            )
+            self.feedback_message = (
+                f"Invalid PXA transition {pxa_before!r} → {self._pxa_state!r}"
+            )
+            return Status.FAILURE
+        return None
+
     def update(self) -> Status:
         dl = self.datalayer
         if dl is None:
@@ -148,10 +219,17 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
         )
         participant_obj = dl.read(participant_id)
 
+        guard = self._check_vfd_preconditions(current_vfd, participant_obj)
+        if guard is not None:
+            return guard
+
         case_status: CaseStatus | None = None
         pxa_before: CS_pxa | None = None
         if self._pxa_state is not None:
             pxa_before = _resolve_pxa_state(case, participant_obj)
+            guard = self._check_pxa_precondition(pxa_before)
+            if guard is not None:
+                return guard
             case_status = CaseStatus(
                 context=self._case_id,
                 attributed_to=self._actor_id,

--- a/vultron/core/behaviors/report/nodes/develop_fix.py
+++ b/vultron/core/behaviors/report/nodes/develop_fix.py
@@ -29,7 +29,12 @@ References
 """
 
 import logging
-from typing import cast
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from vultron.core.behaviors.case.nodes.participant.status import (
+        CreateParticipantStatusNode,
+    )
 
 from py_trees.common import Status
 
@@ -293,26 +298,55 @@ class TransitionCStoFixReady(DataLayerActionWithPorts):
         self._actor_id = actor_id
         self._result_out = result_out if result_out is not None else {}
 
+    def _make_status_node(
+        self, vfd_state: CS_vfd, label: str
+    ) -> "CreateParticipantStatusNode":
+        from vultron.core.behaviors.case.nodes.participant.status import (
+            CreateParticipantStatusNode,
+        )
+
+        assert self.datalayer is not None
+        node = CreateParticipantStatusNode(
+            case_id=self._case_id,
+            actor_id=self._actor_id,
+            rm_state=None,
+            vfd_state=vfd_state,
+            pxa_state=None,
+            result_out=self._result_out,
+            name=f"{self.name}.{label}",
+        )
+        node.datalayer = self.datalayer
+        return node
+
+    def _ensure_vendor_aware(self) -> Status:
+        """Advance actor to Vfd if still at vfd (CSB-16-001 strict adjacency)."""
+        assert self.datalayer is not None
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            return Status.SUCCESS
+        participant_id = case.actor_participant_index.get(self._actor_id)
+        if participant_id is None:
+            return Status.SUCCESS
+        _, current_vfd = resolve_participant_state_from_dl(
+            self.datalayer, participant_id
+        )
+        if current_vfd != CS_vfd.vfd:
+            return Status.SUCCESS
+        try:
+            return self._make_status_node(CS_vfd.Vfd, "_VendorAware").update()
+        except Exception as e:
+            self.logger.error("%s: Error advancing to Vfd: %s", self.name, e)
+            return Status.FAILURE
+
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
             return f
         assert self.datalayer is not None
 
-        from vultron.core.behaviors.case.nodes.participant.status import (
-            CreateParticipantStatusNode,
-        )
+        if self._ensure_vendor_aware() != Status.SUCCESS:
+            return Status.FAILURE
 
-        node = CreateParticipantStatusNode(
-            case_id=self._case_id,
-            actor_id=self._actor_id,
-            rm_state=None,
-            vfd_state=CS_vfd.VFd,
-            pxa_state=None,
-            result_out=self._result_out,
-            name=f"{self.name}._Create",
-        )
-        node.datalayer = self.datalayer
-
+        node = self._make_status_node(CS_vfd.VFd, "_Create")
         try:
             status = node.update()
             if status == Status.SUCCESS:

--- a/vultron/core/behaviors/status/nodes/_adjudication.py
+++ b/vultron/core/behaviors/status/nodes/_adjudication.py
@@ -85,6 +85,11 @@ def _adjudicate_dimensions(
 
     current_vfd = current.vfd.state
     asserted_vfd = asserted.vfd.state
+    # Intentionally uses the weaker monotone check rather than strict adjacency
+    # (is_valid_vfd_transition): a remote peer may have advanced through multiple
+    # VFD steps between status messages (e.g. vfd→VFD in one update), which is
+    # legitimate on the received-wire path.  The strict adjacency guard belongs
+    # only at local write nodes (CSB-16-001, enforced by CreateParticipantStatusNode).
     if asserted_vfd != current_vfd and not is_monotonic_vfd_forward(
         current_vfd, asserted_vfd
     ):


### PR DESCRIPTION
- Closes #2478

## Summary

Enforces CSB-16-001 (and CSB-15-001/002) as a redundant write-boundary check inside `CreateParticipantStatusNode.update()`, independent of upstream BT guard coverage. Also fixes `TransitionCStoFixReady` to advance through `Vfd` before `VFd` per strict adjacency.

## Changes

- **`vultron/core/behaviors/case/nodes/participant/status.py`**: Added `_check_vfd_preconditions()` — rejects illegal VFD transitions via `is_valid_vfd_transition()` (CSB-16-001) and enforces role preconditions (`CVDRole.VENDOR` for `VFd`, `CVDRole.DEPLOYER` for `VFD`). Added `_check_pxa_precondition()` — rejects illegal PXA transitions via `is_valid_pxa_transition()` (CSB-16-002). Both called from `update()` before any write; same-state writes pass through.
- **`vultron/core/behaviors/report/nodes/develop_fix.py`**: `TransitionCStoFixReady` now advances through `Vfd` implicitly when the actor is still at `vfd` (satisfies CSB-16-001 strict adjacency `vfd → Vfd → VFd`). Extracted `_ensure_vendor_aware()` and `_make_status_node()` helpers to stay within McCabe limits.
- **`vultron/core/behaviors/status/nodes/_adjudication.py`**: Added comment explaining `is_monotonic_vfd_forward` is intentionally weaker — remote peers may advance multiple VFD steps between messages; strict adjacency applies only at local write nodes (AC-3).
- **`test/core/use_cases/triggers/case/test_add_participant_status.py`**: 4 new write-boundary tests in `TestCreateParticipantStatusNode` calling `_run_node()` directly (bypassing `ValidateTriggerTransitionsNode`): illegal jump blocked, same-state allowed, VENDOR required for VFd, DEPLOYER required for VFD (AC-4).
- **`test/core/behaviors/report/test_develop_fix_tree.py`**: Updated narrative-log test to expect two lines (`vfd → Vfd`, `Vfd → VFd`) instead of old direct-jump line.

## Verification

- 7239 unit tests pass (4 new)
- 1167 integration tests pass
- black, flake8, mypy, pyright clean