### PR TITLE
fix: gate invite-path engage-case and public-disclosure pxa check on causal preconditions

### DIFF
--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -113,7 +113,6 @@ No open entries.
 | `fv Invariant Harness` | #2422 | 2026-08-20 |
 | `fvcv-handoff Demo Integration` | #2257 | 2026-08-18 |
 | `fvcv-handoff Invariant Harness` | #2257 | 2026-08-18 |
-| `fcvcv Demo Integration` | #2376 | 2026-08-21 |
 | `fcv-reject Demo Integration` | #2390 | 2026-08-19 |
 | `fcv-reject Invariant Harness` | #2390 | 2026-08-19 |
 
@@ -124,11 +123,6 @@ No open entries.
 > downstream consequence of incomplete devlogs.  First confirmed 2026-08-20 on
 > PR #2419.
 >
-> `fcvcv Demo Integration` points to #2376 (async race-window class, #2221). Third
-> observed failure mode (2026-08-20, PR #2421): `M7 reporter pxa_state not
-> public-aware` — `fcvcv Invariant Harness` passed confirming orchestration-layer
-> timing. Second mode: coordinator RM.RECEIVED / 422 engage-case (also #2376).
-> First mode (Finder ledger-coverage timeout): closed as #2337 (2026-08-18).
 >
 > `fvcv-handoff Demo Integration` / `fvcv-handoff Invariant Harness` now point to
 > #2257 (`AddCaseParticipantReceivedBT` failure).  Root error:
@@ -149,6 +143,11 @@ No open entries.
 > `fcv-reject Invariant Harness`, `fv Invariant Harness` — these were
 > **deterministic** failures caused by the engage-case 422 (#2233, now fixed).
 > They are gone from this catalog because the fix lands with the PR for #2233.
+>
+> **Removed 2026-08-24:** `fcvcv Demo Integration` — fixed by PR #2508 (`Closes #2376`).
+> Both race windows resolved: invite-path `engage-case` now gated on own RM.VALID
+> (`demo_gate`), and `verify_publicly_disclosed` now polls reporter pxa_state
+> before asserting (ADR-0058).
 >
 > **Re-added 2026-08-13 (`fvcv-handoff` only):** a new intermittent occurrence
 > of `fvcv-handoff Demo Integration` and `fvcv-handoff Invariant Harness` was

--- a/test/demo/test_milestones_replica_polling.py
+++ b/test/demo/test_milestones_replica_polling.py
@@ -11,17 +11,18 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Regression tests for reporter-replica polling in ``verify_case_active``.
+"""Regression tests for reporter-replica polling in milestone helpers.
 
-The reporter's case replica arrives via the receiver's outbox, which runs as a
-background task.  The receiver-side participant count can reach its target tens
-of milliseconds before the reporter has processed
-``Create(VulnerabilityCase)``, so ``verify_case_active`` must poll for the
-replica rather than read once.  Reading once produced an intermittent
-``404 Not Found`` on ``/datalayer/<case_id>`` at the fcv M1 milestone.
+Covers two async race patterns (Bugs #2134-adjacent and #2376):
 
-Scenarios that already call ``wait_for_case_on_container`` themselves are
-unaffected — the extra poll returns on its first attempt.
+1. ``verify_case_active`` — reporter's case replica arrives via an async
+   outbox delivery, so the helper must poll rather than read once.
+2. ``verify_publicly_disclosed`` — after ``actor_notifies_published`` returns
+   HTTP 202, the CaseActor's ``Add(CaseStatus)`` broadcast may not have
+   reached the reporter's DataLayer yet.  ``verify_publicly_disclosed`` must
+   poll for the reporter's pxa_state before asserting it (ADR-0058).
+3. ``wait_for_participant_pxa_state`` — underlying pxa polling helper must
+   retry until pxa_state is public-aware and raise on timeout.
 """
 
 from typing import cast
@@ -29,10 +30,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vultron.demo.helpers.milestones import verify_case_active
+from vultron.core.states.cs import CS_pxa
+from vultron.demo.helpers.milestones import (
+    verify_case_active,
+    verify_publicly_disclosed,
+)
 from vultron.demo.helpers.polling import (
     _is_ownership_transfer_offer_for,
     find_ownership_transfer_offer_for_actor,
+    wait_for_participant_pxa_state,
 )
 from vultron.demo.utils import DataLayerClient
 
@@ -303,3 +309,155 @@ class TestFindOwnershipTransferOfferForActor:
                 timeout_seconds=0.1,
                 poll_interval=0.5,
             )
+
+
+# ---------------------------------------------------------------------------
+# Bug #2376: pxa_state race in verify_publicly_disclosed
+# ---------------------------------------------------------------------------
+
+_PXA_CASE_ID = "urn:uuid:pxa-case-0001"
+_PXA_RECEIVER_ID = "http://coordinator:7999/api/v2/actors/coordinator"
+
+
+def _pxa_case_payload(em_state: str = "EXITED") -> dict:
+    """Minimal case payload with EM.EXITED and no participants (participants polled separately)."""
+    return {
+        "id": _PXA_CASE_ID,
+        "type": "VulnerabilityCase",
+        "actorParticipantIndex": {},
+        "caseStatuses": [
+            {
+                "id": "urn:uuid:cs-pxa-1",
+                "type": "CaseStatus",
+                "context": _PXA_CASE_ID,
+                "em": {"state": em_state},
+                "pxa": {"state": "PXA"},
+            }
+        ],
+    }
+
+
+def _public_aware_participant(actor_id: str) -> MagicMock:
+    """A participant whose latest status has a public-aware pxa_state."""
+    p = MagicMock()
+    p.id_ = f"urn:uuid:participant-{actor_id.split('/')[-1]}"
+    p.case_roles = []
+    status = MagicMock()
+    cs = MagicMock()
+    cs.pxa_state = CS_pxa.PXA
+    status.case_status = cs
+    p.participant_status = status
+    p.participant_statuses = [status]
+    return p
+
+
+class TestWaitForParticipantPxaState:
+    """wait_for_participant_pxa_state polls until pxa_state is public-aware."""
+
+    def test_returns_immediately_when_already_public_aware(self):
+        participant = _public_aware_participant(_PXA_RECEIVER_ID)
+        with patch(
+            "vultron.demo.helpers.verification._fetch_participant",
+            return_value=participant,
+        ):
+            wait_for_participant_pxa_state(
+                client=cast(DataLayerClient, MagicMock(base_url="http://x")),
+                case_id=_PXA_CASE_ID,
+                actor_id=_PXA_RECEIVER_ID,
+                timeout_seconds=5.0,
+                poll_interval=0.05,
+            )
+
+    def test_polls_until_pxa_becomes_public_aware(self):
+        """pxa_state arrives on the 3rd call; helper must retry."""
+        call_count = 0
+        none_participant = MagicMock()
+        none_participant.case_roles = []
+        none_status = MagicMock()
+        none_cs = MagicMock()
+        none_cs.pxa_state = None
+        none_status.case_status = none_cs
+        none_participant.participant_status = none_status
+        none_participant.participant_statuses = [none_status]
+
+        public_participant = _public_aware_participant(_PXA_RECEIVER_ID)
+
+        def _fetch(client, case_id, actor_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return none_participant
+            return public_participant
+
+        with patch(
+            "vultron.demo.helpers.verification._fetch_participant",
+            side_effect=_fetch,
+        ):
+            wait_for_participant_pxa_state(
+                client=cast(DataLayerClient, MagicMock(base_url="http://x")),
+                case_id=_PXA_CASE_ID,
+                actor_id=_PXA_RECEIVER_ID,
+                timeout_seconds=5.0,
+                poll_interval=0.05,
+            )
+
+        assert call_count >= 3
+
+    def test_raises_assertion_error_on_timeout(self):
+        none_participant = MagicMock()
+        none_status = MagicMock()
+        none_cs = MagicMock()
+        none_cs.pxa_state = None
+        none_status.case_status = none_cs
+        none_participant.participant_status = none_status
+        none_participant.participant_statuses = [none_status]
+
+        with patch(
+            "vultron.demo.helpers.verification._fetch_participant",
+            return_value=none_participant,
+        ):
+            with pytest.raises(AssertionError, match="Timed out"):
+                wait_for_participant_pxa_state(
+                    client=cast(
+                        DataLayerClient, MagicMock(base_url="http://x")
+                    ),
+                    case_id=_PXA_CASE_ID,
+                    actor_id=_PXA_RECEIVER_ID,
+                    timeout_seconds=0.1,
+                    poll_interval=0.5,
+                )
+
+
+class TestVerifyPubliclyDisclosedPollsReporterPxa:
+    """verify_publicly_disclosed must poll reporter's pxa_state before asserting (Bug #2376)."""
+
+    def test_calls_wait_for_participant_pxa_state_on_reporter(self):
+        """The pxa polling gate must be called with the reporter client, not the receiver."""
+        receiver_client = MagicMock(name="receiver_client")
+        reporter_client = MagicMock(name="reporter_client")
+        receiver_client.get.return_value = _pxa_case_payload()
+        reporter_client.get.return_value = _pxa_case_payload()
+
+        participant = _public_aware_participant(_PXA_RECEIVER_ID)
+
+        with (
+            patch(
+                "vultron.demo.helpers.milestones.wait_for_participant_pxa_state"
+            ) as mock_poll,
+            patch(
+                "vultron.demo.helpers.milestones._fetch_participant",
+                return_value=participant,
+            ),
+        ):
+            verify_publicly_disclosed(
+                receiver_client=cast(DataLayerClient, receiver_client),
+                reporter_client=cast(DataLayerClient, reporter_client),
+                case_id=_PXA_CASE_ID,
+                receiver_actor_id=_PXA_RECEIVER_ID,
+            )
+
+        mock_poll.assert_called_once_with(
+            client=cast(DataLayerClient, reporter_client),
+            case_id=_PXA_CASE_ID,
+            actor_id=_PXA_RECEIVER_ID,
+        )

--- a/test/demo/test_workflow_rm_triage.py
+++ b/test/demo/test_workflow_rm_triage.py
@@ -11,14 +11,13 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Regression tests for the direct-path RM triage causal gate (Bug #2134).
+"""Regression tests for the RM triage causal gates (Bugs #2134 and #2376).
 
-``run_direct_path_rm_triage`` must engage the case (RM.VALID → RM.ACCEPTED)
-only *after* the receiver's own participant status has committed RM.VALID.
-``validate-report`` is dispatched asynchronously (HTTP 202), so gating
-``engage-case`` on the mere presence of the case object — which appears
-synchronously during validation — races the async RM.VALID commit and yields
-``TransitionParticipantRMtoAccepted`` (HTTP 422).
+``run_direct_path_rm_triage`` and ``run_invite_path_rm_triage`` must engage
+the case (RM.VALID → RM.ACCEPTED) only *after* the receiver's own participant
+status has committed RM.VALID.  ``validate-report`` is dispatched
+asynchronously (HTTP 202), so engaging without this gate races the async
+commit and yields ``TransitionParticipantRMtoAccepted`` (HTTP 422).
 
 These tests assert causal ordering (x happens THEREFORE y happens), not mere
 sequence, so the fix cannot silently regress to a case-object-presence proxy.
@@ -117,6 +116,142 @@ def test_engage_not_called_when_rm_valid_never_commits(actors):
             receiver_client=receiver_client,
             receiver=receiver,
             offer=offer,
+        )
+
+    engage_called.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Invite-path gate — Bug #2376
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def invite_actors():
+    """Actors, clients, and objects needed by run_invite_path_rm_triage."""
+    invited_client = MagicMock(name="invited_client")
+    invited_actor = MagicMock()
+    invited_actor.id_ = "http://vendor:7999/api/v2/actors/vendor"
+    offer = MagicMock()
+    offer.id_ = "urn:uuid:offer-invite-1"
+    report = MagicMock()
+    report.id_ = "urn:uuid:report-1"
+    finder = MagicMock()
+    auth_client = MagicMock(name="auth_client")
+    case = MagicMock()
+    case.id_ = "urn:uuid:case-invite-1"
+    invited_obj = MagicMock()
+    invited_obj.id_ = "http://vendor:7999/api/v2/actors/vendor"
+    return (
+        invited_client,
+        invited_actor,
+        offer,
+        report,
+        finder,
+        auth_client,
+        case,
+        invited_obj,
+    )
+
+
+def test_invite_path_engage_gated_on_own_rm_valid(invite_actors):
+    """engage-case fires only AFTER the invited actor's own RM.VALID commits."""
+    (
+        invited_client,
+        invited_actor,
+        offer,
+        report,
+        finder,
+        auth_client,
+        case,
+        invited_obj,
+    ) = invite_actors
+    call_order: list[str] = []
+
+    def _wait_rm(*, client, case_id, actor_id, expected_states, **_kwargs):
+        if client is auth_client:
+            call_order.append("wait_caseactor_valid")
+        elif (
+            RM.ACCEPTED in expected_states and RM.VALID not in expected_states
+        ):
+            # own RM.ACCEPTED check
+            call_order.append("wait_own_accepted")
+        else:
+            # own RM.VALID gate
+            call_order.append("wait_own_valid")
+            # Gate must poll the invited actor's OWN container.
+            assert client is invited_client
+            assert actor_id == invited_obj.id_
+
+    def _engage(**_kwargs):
+        call_order.append("engage")
+        return {}
+
+    with (
+        patch.object(workflow, "wait_for_event_type_in_ledger"),
+        patch.object(workflow, "receiver_validates_report"),
+        patch.object(
+            workflow, "wait_for_participant_rm_state", side_effect=_wait_rm
+        ),
+        patch.object(workflow, "receiver_engages_case", side_effect=_engage),
+    ):
+        workflow.run_invite_path_rm_triage(
+            invited_client=invited_client,
+            invited_actor=invited_actor,
+            offer=offer,
+            report=report,
+            finder=finder,
+            auth_client=auth_client,
+            case=case,
+            invited_obj=invited_obj,
+        )
+
+    # Causal invariant: own RM.VALID gate precedes engagement.
+    assert "wait_own_valid" in call_order
+    assert "engage" in call_order
+    assert call_order.index("wait_own_valid") < call_order.index("engage")
+
+
+def test_invite_path_engage_not_called_when_own_rm_valid_never_commits(
+    invite_actors,
+):
+    """If the invited actor's own RM.VALID never commits, engage-case must not fire."""
+    (
+        invited_client,
+        invited_actor,
+        offer,
+        report,
+        finder,
+        auth_client,
+        case,
+        invited_obj,
+    ) = invite_actors
+    engage_called = MagicMock()
+
+    def _wait_rm(*, client, expected_states, **_kwargs):
+        # Simulate own-container RM.VALID never landing on the invited client.
+        if client is invited_client and RM.VALID in expected_states:
+            raise AssertionError("timed out waiting for own RM.VALID")
+
+    with (
+        patch.object(workflow, "wait_for_event_type_in_ledger"),
+        patch.object(workflow, "receiver_validates_report"),
+        patch.object(
+            workflow, "wait_for_participant_rm_state", side_effect=_wait_rm
+        ),
+        patch.object(
+            workflow, "receiver_engages_case", side_effect=engage_called
+        ),
+    ):
+        workflow.run_invite_path_rm_triage(
+            invited_client=invited_client,
+            invited_actor=invited_actor,
+            offer=offer,
+            report=report,
+            finder=finder,
+            auth_client=auth_client,
+            case=case,
+            invited_obj=invited_obj,
         )
 
     engage_called.assert_not_called()

--- a/vultron/demo/helpers/milestones.py
+++ b/vultron/demo/helpers/milestones.py
@@ -26,7 +26,10 @@ import logging
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.em import is_em_embargo_active, is_em_exited
 from vultron.core.states.rm import RM
-from vultron.demo.helpers.polling import wait_for_case_on_container
+from vultron.demo.helpers.polling import (
+    wait_for_case_on_container,
+    wait_for_participant_pxa_state,
+)
 from vultron.demo.helpers.sync import _extract_ref_id
 from vultron.demo.helpers.verification import (
     _assert_participant_pxa_only,
@@ -356,6 +359,16 @@ def verify_publicly_disclosed(
                 f" found {case.current_status.em_state}"
             )
         logger.info("✓ publicly disclosed %s: EM.EXITED", label)
+
+    # Gate: poll reporter replica until receiver_actor_id's pxa_state is
+    # public-aware.  actor_notifies_published returns HTTP 202 before the
+    # CaseActor's Add(CaseStatus) broadcast reaches the reporter's DataLayer,
+    # so an instant assertion races the async commit (ADR-0058).
+    wait_for_participant_pxa_state(
+        client=reporter_client,
+        case_id=case_id,
+        actor_id=receiver_actor_id,
+    )
 
     # Verify receiver participant's pxa state (and VFD only for vendor/deployer)
     # on both the coordinator's and reporter's DataLayer replicas.

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -971,3 +971,80 @@ def wait_for_all_participants_rm_closed(
         "to reach RM.CLOSED",
         swallow_exceptions=True,
     )
+
+
+def wait_for_participant_pxa_state(
+    client: DataLayerClient,
+    case_id: str,
+    actor_id: str,
+    expected_states: "set | None" = None,
+    timeout_seconds: float = 30.0,
+    poll_interval: float = 0.25,
+) -> None:
+    """Poll until *actor_id*'s participant status shows a public-aware pxa_state.
+
+    ``pxa_state`` is nested at ``participant.participant_status.case_status
+    .pxa_state`` and cannot be reached by the generic
+    :func:`_wait_for_participant_status_field` (which handles only top-level
+    fields on ``as_ParticipantStatus``).  This helper handles the two-level
+    attribute access explicitly.
+
+    Args:
+        client: DataLayerClient for the target container.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
+        actor_id: Full URI of the actor to check.
+        expected_states: Set of ``CS_pxa`` values that satisfy the condition.
+            Defaults to all public-aware states: ``{Pxa, PxA, PXa, PXA}``.
+        timeout_seconds: Maximum time to wait (default: 30 s).
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If the expected pxa_state is not reached within
+            *timeout_seconds*.
+
+    Spec: DEMOMA-06-002.
+    """
+    from vultron.core.states.cs import CS_pxa  # noqa: PLC0415
+    from vultron.demo.helpers.verification import (  # noqa: PLC0415
+        _fetch_participant,
+    )
+
+    if expected_states is None:
+        expected_states = {CS_pxa.Pxa, CS_pxa.PxA, CS_pxa.PXa, CS_pxa.PXA}
+
+    deadline = time.monotonic() + timeout_seconds
+    poll_count = 0
+    while time.monotonic() < deadline:
+        poll_count += 1
+        participant = _fetch_participant(client, case_id, actor_id)
+        if participant is not None:
+            latest = participant.participant_status
+            if latest is not None:
+                cs = getattr(latest, "case_status", None)
+                pxa = (
+                    getattr(cs, "pxa_state", None) if cs is not None else None
+                )
+                logger.debug(
+                    "wait_for_participant_pxa_state poll #%d: "
+                    "actor=%r case=%r pxa=%r expected=%r",
+                    poll_count,
+                    actor_id,
+                    case_id,
+                    pxa,
+                    expected_states,
+                )
+                if pxa in expected_states:
+                    return
+        time.sleep(poll_interval)
+
+    participant = _fetch_participant(client, case_id, actor_id)
+    latest = (
+        participant.participant_status if participant is not None else None
+    )
+    cs = getattr(latest, "case_status", None) if latest is not None else None
+    pxa = getattr(cs, "pxa_state", None) if cs is not None else None
+    raise AssertionError(
+        f"Timed out waiting for actor '{actor_id}' pxa_state to be in "
+        f"{expected_states!r}; current={pxa!r}"
+        f" (polled {client.base_url})"
+    )

--- a/vultron/demo/helpers/workflow.py
+++ b/vultron/demo/helpers/workflow.py
@@ -353,7 +353,13 @@ def run_invite_path_rm_triage(
             expected_states={RM.VALID, RM.ACCEPTED},
             timeout_seconds=timeout_seconds,
         )
-    with demo_check(f"{invited_obj.id_} own container at RM.VALID"):
+
+    # Gate engage-case on the invited actor's OWN RM.VALID commit.
+    # validate-report returns HTTP 202 before its ParticipantStatus write
+    # lands, so engaging without the gate races the async commit and yields
+    # TransitionParticipantRMtoAccepted (HTTP 422).  Mirrors the direct-path
+    # causal gate in run_direct_path_rm_triage (ADR-0058).
+    with demo_gate(f"{invited_obj.id_} reached RM.VALID before engage-case"):
         wait_for_participant_rm_state(
             client=invited_client,
             case_id=case.id_,
@@ -361,31 +367,33 @@ def run_invite_path_rm_triage(
             expected_states={RM.VALID, RM.ACCEPTED},
             timeout_seconds=timeout_seconds,
         )
-    logger.info("✓ %s RM state reached VALID", invited_obj.id_)
+        logger.info("✓ %s RM state reached VALID", invited_obj.id_)
 
-    receiver_engages_case(
-        receiver_client=invited_client,
-        receiver=invited_actor,
-        case_id=case.id_,
-    )
+        receiver_engages_case(
+            receiver_client=invited_client,
+            receiver=invited_actor,
+            case_id=case.id_,
+        )
 
-    with demo_check(f"CaseActor reflects {invited_obj.id_} at RM.ACCEPTED"):
-        wait_for_participant_rm_state(
-            client=auth_client,
-            case_id=case.id_,
-            actor_id=invited_obj.id_,
-            expected_states={RM.ACCEPTED},
-            timeout_seconds=timeout_seconds,
-        )
-    with demo_check(f"{invited_obj.id_} own container at RM.ACCEPTED"):
-        wait_for_participant_rm_state(
-            client=invited_client,
-            case_id=case.id_,
-            actor_id=invited_obj.id_,
-            expected_states={RM.ACCEPTED},
-            timeout_seconds=timeout_seconds,
-        )
-    logger.info("✓ %s RM state reached ACCEPTED", invited_obj.id_)
+        with demo_check(
+            f"CaseActor reflects {invited_obj.id_} at RM.ACCEPTED"
+        ):
+            wait_for_participant_rm_state(
+                client=auth_client,
+                case_id=case.id_,
+                actor_id=invited_obj.id_,
+                expected_states={RM.ACCEPTED},
+                timeout_seconds=timeout_seconds,
+            )
+        with demo_check(f"{invited_obj.id_} own container at RM.ACCEPTED"):
+            wait_for_participant_rm_state(
+                client=invited_client,
+                case_id=case.id_,
+                actor_id=invited_obj.id_,
+                expected_states={RM.ACCEPTED},
+                timeout_seconds=timeout_seconds,
+            )
+        logger.info("✓ %s RM state reached ACCEPTED", invited_obj.id_)
 
 
 def run_direct_path_rm_triage(


### PR DESCRIPTION
- Closes #2376
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Fixes two async race windows that caused intermittent RM.RECEIVED/422 and M7 pxa_state=None failures in fcvcv and all other multi-actor demo scenarios.

## Changes

- **`vultron/demo/helpers/workflow.py`**: restructured `run_invite_path_rm_triage` to wrap the own-container RM.VALID wait, `receiver_engages_case`, and post-engage checks in a `demo_gate`, matching the causal-gate pattern from `run_direct_path_rm_triage` (ADR-0058). `demo_check` (non-halting) was previously used, so a slow async RM.VALID commit let engage-case fire at the wrong state → HTTP 422. Affects all 7 invite-path scenarios.
- **`vultron/demo/helpers/polling.py`**: added `wait_for_participant_pxa_state` — a new polling helper for the nested `participant.participant_status.case_status.pxa_state` path (cannot reuse `_wait_for_participant_status_field` which handles only top-level fields on `as_ParticipantStatus`).
- **`vultron/demo/helpers/milestones.py`**: added `wait_for_participant_pxa_state` gate before the instant reporter-replica pxa assertion in `verify_publicly_disclosed`. All 9 scenarios called this immediately after `actor_notifies_published` (HTTP 202), before the CaseActor's `Add(CaseStatus)` broadcast reached the reporter's DataLayer.
- **`test/demo/test_workflow_rm_triage.py`**: 2 new regression tests for the invite-path causal gate (engage gated on own RM.VALID; engage not called when gate times out).
- **`test/demo/test_milestones_replica_polling.py`**: 3 new tests for `wait_for_participant_pxa_state` (immediate success, late pxa, timeout); 1 new test confirming `verify_publicly_disclosed` calls the poll gate with the reporter client.

## Verification

- All 7253 unit tests pass (10 new)
- All 1173 integration tests pass
- Black, flake8, mypy, pyright clean