### PR TITLE
feat(ports-5): migrate non-DataLayer BT nodes to typed Ports, add ratchet test

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -273,16 +273,16 @@ composability, and open architecture questions.
 whether a new use case needs a BT, or implementing a BT-backed use case
 from scratch.
 
-**`py-trees-ports-adoption.md`**
-Planning analysis for adopting py_trees 2.5.0 typed Ports in
-`vultron/core/behaviors/`: the concrete wins (typed data contracts, early
-error detection, isolated node testing), the constructor-parameterization
-(BTND-01) vs. XML port-remapping impedance mismatch, the ADR + BTND spec
-determination, and the staged issue sequence (pilot → full migration → XML
-spike → XML-as-spec Idea) from planning Idea #1558.
-**Load when**: implementing the Ports adoption Tasks, migrating BT nodes to
-typed ports, scoping the XML feasibility spike, or planning the XML-as-spec
-Idea.
+**`py-trees-ports-adoption.md`** *(archived — migration complete)*
+Completed reference for the py_trees 2.5.0 typed-Ports migration
+(`vultron/core/behaviors/`): the eight finalized conventions (Type A–D node
+shapes, execution-scoped keys, read-modify-write dual-alias, `_InboxNodeWithPorts`
+base, `NotImplementedError` on explicit `None`), the composite and
+constructor-parameterized gate exemptions, and the planned XML-as-spec spike.
+**Load when**: writing a new BT node that uses typed Ports and need the
+canonical patterns reference (finalized conventions sections 1–8).
+**Do not load when**: looking for live migration tasks — the migration
+(`#1809` chain, parts 1–5) is complete.
 
 **`bt-canonical-reference.md`**
 Canonical CVD Protocol Behavior Tree structural reference: trunk-removed

--- a/notes/py-trees-ports-adoption.md
+++ b/notes/py-trees-ports-adoption.md
@@ -1,6 +1,6 @@
 ---
 title: py_trees Ports Adoption — Typed Blackboard Contracts and XML Authoring
-status: active
+status: archived
 description: >
   Planning analysis for adopting py_trees 2.5.0 typed Ports in vultron/core/behaviors/:
   the concrete wins (typed data contracts, early error detection, isolated node
@@ -29,7 +29,7 @@ adopting, what is deferred, the known technical mismatch, and the issue
 sequence — so each implementing agent starts from evidence rather than the
 Idea's optimistic framing.
 
-## Current state (migration in progress — verified 2026-08-21)
+## Current state (migration complete — verified 2026-08-24)
 
 - **Dependency**: `pyproject.toml` already pins `py-trees>=2.5.0`. The Idea's
   "evaluate the upgrade path from the current pin" step is already satisfied —
@@ -62,8 +62,21 @@ Idea's optimistic framing.
     (BTND-03-012, BTND-03-013) and migrates **Type-C WRITE-handoff nodes** across
     `sync/`, `case/`, `embargo/`, `report/`, `sender/`, and `status/` domains.
     Nodes with instance-computed (execution-scoped) physical keys are deferred to #1887.
-  - Remaining finalization (#1887) covers non-DataLayer nodes, composite exemptions,
-    and deferred dynamic-key nodes.
+  - Part 5/5 (#1887) migrated **non-DataLayer bare `Behaviour` nodes** that touch
+    the blackboard across `inbox/nodes/pipeline.py`, `report/`,
+    `status/nodes/append/conditions.py`, and `case/nodes/actor.py`.
+    Created `_InboxNodeWithPorts` (parallel to `DataLayerActionWithPorts`) as
+    the base for inbox pipeline nodes (IO-02-002).  Execution-scoped output
+    ports (BTND-03-013) applied to `EvaluateDefaultRolesNode` and
+    `_WriteRolesNode`.  Added architecture ratchet test
+    (`test/architecture/test_no_bare_register_key_datalayer_nodes.py`) with a
+    51-node audited baseline to prevent new `register_key`-only `DataLayer*`
+    leaf nodes.  Composite `Sequence`/`Selector` subclasses are explicitly
+    exempt: they are structural orchestrators with no leaf data-flow contract.
+    Nodes with no blackboard access (`CheckAutoCaseCreationEnabledNode`,
+    `ShouldAdvanceOwnerToAcceptedNode`, `AlwaysSucceed`, `AlwaysFail`,
+    `_AlwaysSucceedNode`) are exempt as constructor-parameterized gates.
+    ✓ (2026-08-24)
 - **XML parser**: `py_trees.parsers.behaviour_tree_xml` exists but is documented
   as **experimental** ("the parser is experimental and its API may change
   between releases"). It instantiates only classes registered in a
@@ -304,6 +317,74 @@ def test_missing_required_port():
     with pytest.raises(NoDataAvailable):
         node.get_input("datalayer")
 ```
+
+## Exemptions (nodes NOT migrated, with justification)
+
+### Composite nodes (Sequence/Selector subclasses)
+
+`py_trees.composites.Sequence` and `py_trees.composites.Selector` subclasses
+throughout `vultron/core/behaviors/` are **structurally exempt**.  Composites
+are orchestrators — they have no leaf data-flow contract and own no blackboard
+keys.  The typed-Ports contract (BTND-03-009) applies to *leaf* nodes that
+read or write data; composites pass control to their children and never touch
+the blackboard directly.
+
+### Constructor-parameterized policy gates (no blackboard access)
+
+The following bare `py_trees.behaviour.Behaviour` subclasses have **no
+blackboard access** — they make decisions based solely on constructor-injected
+values:
+
+- `CheckAutoCaseCreationEnabledNode` (`case/nodes/conditions.py`): reads
+  `ActorConfig.auto_create_case` from a constructor-injected object.
+- `ShouldAdvanceOwnerToAcceptedNode` (`case/nodes/participant/owner.py`):
+  reads a constructor-injected boolean.
+- `AlwaysSucceed` / `AlwaysFail` (`call_out/nodes.py`): stateless; always
+  return a fixed Status.
+- `_AlwaysSucceedNode` (`case/accept_invite_tree.py`): same.
+
+Migrating these to `BehaviourWithPorts` would add no contract value — there
+are no ports to declare.
+
+## Finalized conventions (established across parts 1–5)
+
+1. **Type-A nodes** (no domain blackboard keys beyond DataLayer standard):
+   pure base-class reparent, no override needed (established by #1883–#1884).
+
+2. **Type-B nodes** (extra READ-only inputs):
+   override `input_ports()` + `_domain_port_remappings()` + `get_input()`
+   in `initialise()` (established by #1885).
+
+3. **Type-C WRITE-handoff nodes** (static physical key):
+   override `output_ports()` + `_domain_port_remappings()` + `_set_output()`
+   in `update()` (established by #1886, BTND-03-012).
+
+4. **Type-C execution-scoped physical key** (BTND-03-013):
+   declare stable logical port in `output_ports()`, compute physical key in
+   `__init__`, wire via instance `setup_ports()` override (not classmethod
+   `_domain_port_remappings()`).
+
+5. **Non-DataLayer nodes with blackboard access** (established by #1887):
+   extend `BehaviourWithPorts` directly; declare `input_ports()` and/or
+   `output_ports()`; call `setup_ports()` in `setup()` with explicit
+   `port_remappings` wired to the flat absolute keys.
+
+6. **Inbox pipeline nodes** (`_InboxNodeWithPorts`, #1887):
+   parallel to `DataLayerActionWithPorts` for the `inbox_*` key namespace;
+   shared output ports for `inbox_outcome_status` and `inbox_failure_reason`;
+   `_reject()` uses `_set_output()`; `_domain_port_remappings()` classmethod
+   extended by subclasses (IO-02-002).
+
+7. **Read-modify-write same key** (`RehydrateActivityNode`, #1887):
+   declare a separate input port alias (e.g. `inbox_activity_in`) for the
+   READ path and the normal output port for the WRITE path; both remapped to
+   the same absolute key.  Two different client-local names → two access
+   levels → same storage slot.
+
+8. **`NotImplementedError` on explicit `None`** (fixed in #1885 and #1887):
+   `get_input()` raises `NotImplementedError` when the blackboard key holds
+   an explicit `None` value (py_trees quirk).  Optional-or-nullable inputs
+   must catch `(NotImplementedError, NoDataAvailable)`.
 
 ## Issue sequence
 

--- a/test/architecture/test_no_bare_register_key_datalayer_nodes.py
+++ b/test/architecture/test_no_bare_register_key_datalayer_nodes.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""AC-1 architecture ratchet: no new bare register_key DataLayer* leaf nodes.
+
+AST-scans ``vultron/core/behaviors/`` for classes that:
+  - directly inherit from ``DataLayerAction`` or ``DataLayerCondition``
+    (the non-WithPorts variants), AND
+  - contain a ``register_key()`` call in their ``setup()`` method.
+
+Asserts the result matches the audited baseline below.  A new entry
+means a new DataLayer node was added using the legacy ``register_key``
+pattern instead of typed Ports — the test fails immediately, forcing an
+explicit migration decision.  A removed entry means an audited node was
+migrated to typed Ports — update the baseline to keep the ratchet tight.
+
+Per specs/behavior-tree-node-design.yaml BTND-03-009.
+Closes #1887 AC-1.
+"""
+
+import ast
+import pathlib
+from collections import Counter
+
+# ---------------------------------------------------------------------------
+# Audited baseline — (path_relative_to_behaviors_root, class_name)
+#
+# Each entry is a DataLayerAction or DataLayerCondition (non-WithPorts)
+# subclass that still calls register_key() in setup().  These represent
+# the migration backlog.  Do NOT add new entries; migrate instead.
+# To retire an entry, replace register_key() with typed Ports and remove it.
+# ---------------------------------------------------------------------------
+AUDITED_SITES: list[tuple[str, str]] = sorted(
+    [
+        (
+            "case/case_proposal_received_tree.py",
+            "_AddCaseActorParticipantNode",
+        ),
+        ("case/case_proposal_received_tree.py", "_AddReporterParticipantNode"),
+        (
+            "case/case_proposal_received_tree.py",
+            "_AddVendorOwnerParticipantNode",
+        ),
+        (
+            "case/case_proposal_received_tree.py",
+            "_CommitNativeLedgerEntriesNode",
+        ),
+        ("case/case_proposal_received_tree.py", "_SeedReporterSignatoryNode"),
+        (
+            "case/case_proposal_received_tree.py",
+            "_SeedVendorOwnerSignatoryNode",
+        ),
+        ("case/case_proposal_received_tree.py", "_WriteCreateCaseMarkerNode"),
+        ("case/nodes/accept_invite.py", "EmitAddCaseParticipantNode"),
+        ("case/nodes/actor.py", "EmitInviteActorToCaseNode"),
+        ("case/nodes/actor.py", "ProposeCaseToActorNode"),
+        ("case/nodes/conditions.py", "CheckIsCaseManagerNode"),
+        ("case/nodes/lifecycle.py", "CommitCaseLedgerEntryNode"),
+        ("case/nodes/participant/owner.py", "AdvanceOwnerRmToAcceptedNode"),
+        (
+            "case/nodes/participant/owner.py",
+            "AttachOwnerParticipantToCaseNode",
+        ),
+        ("case/nodes/participant/owner.py", "CreateOwnerParticipantNode"),
+        ("case/nodes/participant/owner.py", "PersistOwnerCaseNode"),
+        ("case/nodes/participant/owner.py", "RecordOwnerJoinedEventNode"),
+        ("case/nodes/participant/owner.py", "ResolveOwnerInitialStatusNode"),
+        (
+            "case/nodes/participant/participant_add.py",
+            "AttachParticipantToCaseNode",
+        ),
+        (
+            "case/nodes/participant/participant_add.py",
+            "CaseHasActiveEmbargoNode",
+        ),
+        (
+            "case/nodes/participant/participant_add.py",
+            "CaseHasNoActiveEmbargoNode",
+        ),
+        ("case/nodes/participant/participant_add.py", "CreateParticipantNode"),
+        (
+            "case/nodes/participant/participant_add.py",
+            "QueueAddParticipantNotificationNode",
+        ),
+        (
+            "case/nodes/participant/participant_add.py",
+            "RecordParticipantAddedEventNode",
+        ),
+        (
+            "case/nodes/participant/participant_add.py",
+            "ResolveParticipantAcceptedStatusNode",
+        ),
+        (
+            "case/nodes/participant/participant_add.py",
+            "SeedParticipantAsSignatoryNode",
+        ),
+        (
+            "case/nodes/suggest_actor/emit.py",
+            "EmitOfferCaseParticipantToOwnerNode",
+        ),
+        ("case/nodes/vfd_role_guards.py", "CheckIsCaseOwnerNode"),
+        ("embargo/nodes/proposal.py", "CreateAndStoreInviteNode"),
+        ("embargo/nodes/proposal.py", "RemoveStaleAcceptanceNode"),
+        ("embargo/nodes/proposal.py", "UpdateParticipantEmbargoPecNode"),
+        ("helpers.py", "FindParticipantByActorIdNode"),
+        ("helpers.py", "ReadObject"),
+        ("helpers.py", "UpdateActorOutbox"),
+        ("helpers.py", "UpdateObject"),
+        ("report/nodes/deploy_fix.py", "CheckNoNewDeploymentInfoNode"),
+        (
+            "status/nodes/append/conditions.py",
+            "CheckStatusNotAlreadyAppendedNode",
+        ),
+        ("sync/nodes/_helpers.py", "_LedgerEffectNode"),
+        ("sync/nodes/conditions.py", "CheckIsNotOwnCaseActorNode"),
+        ("sync/nodes/conditions.py", "CheckLedgerEntryAlreadyStoredNode"),
+        ("sync/nodes/conditions.py", "CheckLedgerFreshnessNode"),
+        ("sync/nodes/conditions.py", "VerifySenderIsOwnIdNode"),
+        ("sync/nodes/event_conditions.py", "IsAddNoteEventNode"),
+        ("sync/nodes/event_conditions.py", "IsCloseCaseEventNode"),
+        ("sync/nodes/event_conditions.py", "IsInviteAcceptEventNode"),
+        ("sync/nodes/event_conditions.py", "IsOwnershipTransferEventNode"),
+        ("sync/nodes/event_conditions.py", "IsParticipantStatusEventNode"),
+        ("sync/nodes/event_conditions.py", "IsRemoveEmbargoEventNode"),
+        ("sync/nodes/event_conditions.py", "IsSubmitReportEventNode"),
+        (
+            "sync/nodes/offer_report_effect.py",
+            "ApplyOfferReportFromLedgerNode",
+        ),
+        (
+            "sync/nodes/ownership_effects.py",
+            "ApplyOwnershipTransferFromLedgerNode",
+        ),
+    ]
+)
+
+
+def _collect_sites() -> list[tuple[str, str]]:  # noqa: C901
+    """Return sorted (rel_path, class_name) for non-WithPorts DataLayer*
+    subclasses whose setup() method calls register_key()."""
+    non_ports_bases = {"DataLayerAction", "DataLayerCondition"}
+    root = pathlib.Path("vultron/core/behaviors")
+    found: list[tuple[str, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:  # pragma: no cover
+            continue
+        for cls_node in ast.walk(tree):
+            if not isinstance(cls_node, ast.ClassDef):
+                continue
+            base_names: set[str] = set()
+            for base in cls_node.bases:
+                if isinstance(base, ast.Name):
+                    base_names.add(base.id)
+                elif isinstance(base, ast.Attribute):
+                    base_names.add(base.attr)
+            if not (base_names & non_ports_bases):
+                continue
+            # Scan the setup() method for register_key calls.
+            has_register_key = False
+            for item in cls_node.body:
+                if not (
+                    isinstance(item, ast.FunctionDef) and item.name == "setup"
+                ):
+                    continue
+                for stmt in ast.walk(item):
+                    if not isinstance(stmt, ast.Call):
+                        continue
+                    func = stmt.func
+                    if (
+                        isinstance(func, ast.Attribute)
+                        and func.attr == "register_key"
+                    ):
+                        has_register_key = True
+                        break
+                if has_register_key:
+                    break
+            if has_register_key:
+                rel = str(path.relative_to(root)).replace("\\", "/")
+                found.append((rel, cls_node.name))
+    return sorted(found)
+
+
+def test_no_new_bare_register_key_datalayer_nodes() -> None:
+    """No new non-WithPorts DataLayer* nodes with register_key() in setup().
+
+    A NEW entry (a class added with the legacy pattern) fails this test
+    immediately — migrate to typed Ports instead.  A REMOVED entry means a
+    node was successfully migrated — remove it from AUDITED_SITES to keep the
+    ratchet tight.
+    """
+    actual = _collect_sites()
+    actual_counts = Counter(actual)
+    expected_counts = Counter(AUDITED_SITES)
+
+    new_sites = actual_counts - expected_counts
+    removed_sites = expected_counts - actual_counts
+
+    messages: list[str] = []
+    if new_sites:
+        messages.append(
+            "NEW non-WithPorts DataLayer* nodes with register_key() found —"
+            " migrate to typed Ports (BehaviourWithPorts / DataLayerConditionWithPorts /"
+            " DataLayerActionWithPorts) or add a justified exemption:\n"
+            + "\n".join(
+                f"  + {path!r}  {cls}" for path, cls in sorted(new_sites)
+            )
+        )
+    if removed_sites:
+        messages.append(
+            "Nodes in AUDITED_SITES were migrated away from register_key()"
+            " — remove them from the baseline to keep the ratchet tight:\n"
+            + "\n".join(
+                f"  - {path!r}  {cls}" for path, cls in sorted(removed_sites)
+            )
+        )
+    assert not messages, "\n\n".join(messages)

--- a/test/core/behaviors/inbox/nodes/test_typed_ports.py
+++ b/test/core/behaviors/inbox/nodes/test_typed_ports.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Typed-Ports isolation tests for inbox pipeline nodes (AC-2, issue #1887).
+
+Covers BTND-03-011 (NoDataAvailable on missing required port) for each
+migrated inbox node, plus a happy-path write test for BuildOutcomeNode.
+"""
+
+import py_trees
+import pytest
+from py_trees.common import Status
+from py_trees.ports import NoDataAvailable
+
+from vultron.core.behaviors.inbox.nodes.pipeline import (
+    BuildOutcomeNode,
+    DeferCheckNode,
+    DispatchNode,
+    ExtractSemanticsNode,
+    KEY_ACTIVITY,
+    KEY_DISPATCH,
+    KEY_EVENT,
+    KEY_INGRESS,
+    KEY_OUTCOME_STATUS,
+    KEY_PAYLOAD,
+    ParsePayloadNode,
+    RehydrateActivityNode,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_blackboard():
+    yield
+    py_trees.blackboard.Blackboard.enable_activity_stream()
+    py_trees.blackboard.Blackboard.storage.clear()
+    py_trees.blackboard.Blackboard.clients.clear()
+
+
+# ---------------------------------------------------------------------------
+# ParsePayloadNode
+# ---------------------------------------------------------------------------
+
+
+class TestParsePayloadNodePorts:
+    def test_missing_inbox_payload_raises_no_data_available(self) -> None:
+        node = ParsePayloadNode(name="ParsePayloadNode")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input(KEY_PAYLOAD)
+
+    def test_missing_inbox_ingress_raises_no_data_available(self) -> None:
+        node = ParsePayloadNode(name="ParsePayloadNode")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input(KEY_INGRESS)
+
+
+# ---------------------------------------------------------------------------
+# RehydrateActivityNode
+# ---------------------------------------------------------------------------
+
+
+class TestRehydrateActivityNodePorts:
+    def test_missing_inbox_activity_in_raises_no_data_available(self) -> None:
+        node = RehydrateActivityNode(name="RehydrateActivityNode")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input(RehydrateActivityNode._PORT_ACTIVITY_IN)
+
+    def test_missing_inbox_ingress_raises_no_data_available(self) -> None:
+        node = RehydrateActivityNode(name="RehydrateActivityNode")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input(KEY_INGRESS)
+
+
+# ---------------------------------------------------------------------------
+# ExtractSemanticsNode
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSemanticsNodePorts:
+    def test_missing_inbox_activity_raises_no_data_available(self) -> None:
+        node = ExtractSemanticsNode(name="ExtractSemanticsNode")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input(KEY_ACTIVITY)
+
+
+# ---------------------------------------------------------------------------
+# DeferCheckNode
+# ---------------------------------------------------------------------------
+
+
+class TestDeferCheckNodePorts:
+    def test_missing_inbox_event_raises_no_data_available(self) -> None:
+        node = DeferCheckNode(name="DeferCheckNode")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input(KEY_EVENT)
+
+
+# ---------------------------------------------------------------------------
+# DispatchNode
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchNodePorts:
+    def test_missing_inbox_event_raises_no_data_available(self) -> None:
+        node = DispatchNode(name="DispatchNode")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input(KEY_EVENT)
+
+    def test_missing_inbox_dispatch_raises_no_data_available(self) -> None:
+        node = DispatchNode(name="DispatchNode")
+        node.setup_ports()
+        with pytest.raises(NoDataAvailable):
+            node.get_input(KEY_DISPATCH)
+
+
+# ---------------------------------------------------------------------------
+# BuildOutcomeNode — writes inbox_outcome_status = "processed"
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOutcomeNodePorts:
+    def test_writes_processed_outcome(self) -> None:
+        """BuildOutcomeNode writes 'processed' to /inbox_outcome_status."""
+        node = BuildOutcomeNode(name="BuildOutcomeNode")
+        tree = py_trees.trees.BehaviourTree(root=node)
+        tree.setup()
+        tree.tick()
+        assert node.status == Status.SUCCESS
+        stored = py_trees.blackboard.Blackboard.storage.get(
+            f"/{KEY_OUTCOME_STATUS}"
+        )
+        assert stored == "processed"

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -41,6 +41,7 @@ from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
+from py_trees.ports import BehaviourWithPorts, PortInformation
 
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.helpers import DataLayerAction
@@ -345,7 +346,7 @@ class ProposeCaseToActorNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
+class EvaluateDefaultRolesNode(BehaviourWithPorts):
     """Assign default CVD roles for a suggested actor (CM-16-003).
 
     ADR-0024 Evaluator shape.  Writes ``suggested_roles_{id_segment}``
@@ -354,6 +355,11 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
     otherwise falls back to ``_compute_roles()`` (default: ``[CVDRole.VENDOR]``).
     Subclasses may override ``_compute_roles()``; an empty return produces
     ``FAILURE`` (AC-1).
+
+    The physical blackboard key is execution-scoped (BTND-03-013): the stable
+    logical port name ``suggested_roles`` is declared in ``output_ports()`` and
+    wired to the physical key ``suggested_roles_{id_segment}`` in ``setup()``
+    using an instance-computed remapping.
     """
 
     logger: logging.Logger  # type: ignore[assignment]
@@ -374,6 +380,8 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
         self._injected_roles = self._coerce_injected_roles(injected_roles)
+        _seg = recommendation_id.split("/")[-1]
+        self._roles_key = f"suggested_roles_{_seg}"
 
     def _coerce_injected_roles(
         self, injected_roles: list[str] | None
@@ -412,13 +420,19 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
             return None
         return coerced
 
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {}
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        return {
+            "suggested_roles": PortInformation(data_type=list, required=True),
+        }
+
     def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        id_segment = self.recommendation_id.split("/")[-1]
-        self.blackboard_key = f"suggested_roles_{id_segment}"
-        self.blackboard.register_key(
-            key=self.blackboard_key, access=py_trees.common.Access.WRITE
+        self.setup_ports(
+            port_remappings={"suggested_roles": f"/{self._roles_key}"}
         )
 
     def _compute_roles(self) -> list[CVDRole]:
@@ -438,7 +452,7 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
             )
             self.logger.error(self.feedback_message)
             return Status.FAILURE
-        setattr(self.blackboard, self.blackboard_key, roles)
+        self._set_output("suggested_roles", roles)
         self.logger.debug(
             "%s: assigned roles %s for actor '%s' in case '%s'",
             self.name,

--- a/vultron/core/behaviors/inbox/nodes/pipeline.py
+++ b/vultron/core/behaviors/inbox/nodes/pipeline.py
@@ -486,9 +486,3 @@ class BuildOutcomeNode(_InboxNodeWithPorts):
         self._set_output(KEY_OUTCOME_STATUS, "processed")
         self.logger.debug("%s: outcome = processed", self.name)
         return Status.SUCCESS
-
-
-# Backward-compatibility alias: _InboxNode was the pre-migration base class
-# for the six pipeline nodes.  It is not exported and should not be
-# subclassed by new code — use _InboxNodeWithPorts instead.
-_InboxNode = _InboxNodeWithPorts

--- a/vultron/core/behaviors/inbox/nodes/pipeline.py
+++ b/vultron/core/behaviors/inbox/nodes/pipeline.py
@@ -43,8 +43,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import py_trees
-from py_trees.common import Access, Status
+from py_trees.common import Status
+from py_trees.ports import BehaviourWithPorts, NoDataAvailable, PortInformation
 
 from vultron.core.models.events import (
     is_case_bootstrap,
@@ -78,36 +78,68 @@ ALL_INBOX_KEYS = (
 )
 
 
-class _InboxNode(py_trees.behaviour.Behaviour):
-    """Base class for inbox pipeline nodes.
+class _InboxNodeWithPorts(BehaviourWithPorts):
+    """Base class for typed-Ports inbox pipeline nodes.
 
-    Provides a properly-wired logger and helper methods for writing
-    failure outcomes to the blackboard.
+    Declares the shared outcome output ports (inbox_outcome_status,
+    inbox_failure_reason) and wires them to the flat blackboard keys
+    used by process_payload for cleanup.  Subclasses override
+    _domain_port_remappings() to add their domain-specific port-to-key
+    mappings, and declare their own input_ports()/output_ports().
+
+    Per specs/inbox-orchestration.yaml IO-02-002.
+    Per specs/behavior-tree-node-design.yaml BTND-03-012.
     """
 
     logger: logging.Logger  # type: ignore[assignment]
-    blackboard: py_trees.blackboard.Client
 
     def __init__(self, name: str) -> None:
         super().__init__(name=name)
-        # Replace py_trees' parentless logger with a hierarchy-wired one.
         self.logger = logging.getLogger(  # type: ignore[assignment]
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
 
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        """Domain-specific port-to-absolute-key remappings for this subclass."""
+        return {}
+
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {}
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        return {
+            KEY_OUTCOME_STATUS: PortInformation(data_type=str, required=False),
+            KEY_FAILURE_REASON: PortInformation(data_type=str, required=False),
+        }
+
+    def setup(self, **kwargs: Any) -> None:
+        self.setup_ports(
+            port_remappings={
+                KEY_OUTCOME_STATUS: f"/{KEY_OUTCOME_STATUS}",
+                KEY_FAILURE_REASON: f"/{KEY_FAILURE_REASON}",
+                **self._domain_port_remappings(),
+            }
+        )
+
     def _reject(self, reason: str) -> Status:
-        """Write rejected outcome to blackboard and return FAILURE."""
+        """Write rejected outcome via typed output ports and return FAILURE."""
         self.feedback_message = reason
         try:
-            self.blackboard.inbox_outcome_status = "rejected"
-            self.blackboard.inbox_failure_reason = reason
+            self._set_output(KEY_OUTCOME_STATUS, "rejected")
+            self._set_output(KEY_FAILURE_REASON, reason)
         except Exception:
             pass
         self.logger.warning("%s: rejected — %s", self.name, reason)
         return Status.FAILURE
 
+    def update(self) -> Status:
+        raise NotImplementedError
 
-class ParsePayloadNode(_InboxNode):
+
+class ParsePayloadNode(_InboxNodeWithPorts):
     """Step 1: parse raw payload into a typed Activity.
 
     Reads ``inbox_payload`` and ``inbox_ingress``; writes
@@ -115,19 +147,32 @@ class ParsePayloadNode(_InboxNode):
     parsing fails.
     """
 
-    def setup(self, **kwargs: Any) -> None:
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(KEY_PAYLOAD, access=Access.READ)
-        self.blackboard.register_key(KEY_INGRESS, access=Access.READ)
-        self.blackboard.register_key(KEY_ACTIVITY, access=Access.WRITE)
-        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
-        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            KEY_PAYLOAD: PortInformation(data_type=object, required=True),
+            KEY_INGRESS: PortInformation(data_type=object, required=True),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        ports = super().output_ports()
+        ports[KEY_ACTIVITY] = PortInformation(data_type=object, required=False)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            KEY_PAYLOAD: f"/{KEY_PAYLOAD}",
+            KEY_INGRESS: f"/{KEY_INGRESS}",
+            KEY_ACTIVITY: f"/{KEY_ACTIVITY}",
+        }
 
     def update(self) -> Status:
         try:
-            payload = self.blackboard.inbox_payload
-            ingress = self.blackboard.inbox_ingress
-        except KeyError as exc:
+            payload = self.get_input(KEY_PAYLOAD)
+            ingress = self.get_input(KEY_INGRESS)
+        except (KeyError, NoDataAvailable) as exc:
             return self._reject(f"Missing blackboard key: {exc}")
 
         try:
@@ -138,7 +183,7 @@ class ParsePayloadNode(_InboxNode):
         if activity is None:
             return self._reject("Ingress adapter returned None from parse()")
 
-        self.blackboard.inbox_activity = activity
+        self._set_output(KEY_ACTIVITY, activity)
         self.logger.debug(
             "%s: parsed activity type=%s id=%s",
             self.name,
@@ -148,25 +193,51 @@ class ParsePayloadNode(_InboxNode):
         return Status.SUCCESS
 
 
-class RehydrateActivityNode(_InboxNode):
+class RehydrateActivityNode(_InboxNodeWithPorts):
     """Step 2: resolve nested object references in the parsed Activity.
 
     Reads ``inbox_activity`` and ``inbox_ingress``; overwrites
     ``inbox_activity`` with the rehydrated result.
+
+    The read and write of ``inbox_activity`` use separate port names:
+    ``inbox_activity_in`` (READ) and ``inbox_activity`` (WRITE), both
+    remapped to ``/inbox_activity`` so the same blackboard slot is
+    used — this makes the read-modify-write data flow explicit in the
+    typed-Ports contract.
     """
 
-    def setup(self, **kwargs: Any) -> None:
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(KEY_ACTIVITY, access=Access.WRITE)
-        self.blackboard.register_key(KEY_INGRESS, access=Access.READ)
-        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
-        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+    # Port alias for reading the pre-rehydration activity value.
+    _PORT_ACTIVITY_IN = "inbox_activity_in"
+
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            cls._PORT_ACTIVITY_IN: PortInformation(
+                data_type=object, required=True
+            ),
+            KEY_INGRESS: PortInformation(data_type=object, required=True),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        ports = super().output_ports()
+        ports[KEY_ACTIVITY] = PortInformation(data_type=object, required=False)
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            # Both read alias and write port remap to the same physical key.
+            cls._PORT_ACTIVITY_IN: f"/{KEY_ACTIVITY}",
+            KEY_INGRESS: f"/{KEY_INGRESS}",
+            KEY_ACTIVITY: f"/{KEY_ACTIVITY}",
+        }
 
     def update(self) -> Status:
         try:
-            activity = self.blackboard.inbox_activity
-            ingress = self.blackboard.inbox_ingress
-        except KeyError as exc:
+            activity = self.get_input(self._PORT_ACTIVITY_IN)
+            ingress = self.get_input(KEY_INGRESS)
+        except (KeyError, NoDataAvailable) as exc:
             return self._reject(f"Missing blackboard key: {exc}")
 
         try:
@@ -174,7 +245,7 @@ class RehydrateActivityNode(_InboxNode):
         except Exception as exc:
             return self._reject(f"Rehydrate raised exception: {exc}")
 
-        self.blackboard.inbox_activity = rehydrated
+        self._set_output(KEY_ACTIVITY, rehydrated)
         self.logger.debug(
             "%s: rehydrated activity id=%s",
             self.name,
@@ -183,25 +254,40 @@ class RehydrateActivityNode(_InboxNode):
         return Status.SUCCESS
 
 
-class ExtractSemanticsNode(_InboxNode):
+class ExtractSemanticsNode(_InboxNodeWithPorts):
     """Step 3: extract MessageSemantics from the rehydrated Activity.
 
     Reads ``inbox_activity``; writes ``inbox_event`` and
     ``inbox_context_id``.
     """
 
-    def setup(self, **kwargs: Any) -> None:
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(KEY_ACTIVITY, access=Access.READ)
-        self.blackboard.register_key(KEY_EVENT, access=Access.WRITE)
-        self.blackboard.register_key(KEY_CONTEXT_ID, access=Access.WRITE)
-        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
-        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            KEY_ACTIVITY: PortInformation(data_type=object, required=True),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        ports = super().output_ports()
+        ports[KEY_EVENT] = PortInformation(data_type=object, required=False)
+        ports[KEY_CONTEXT_ID] = PortInformation(
+            data_type=object, required=False
+        )
+        return ports
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            KEY_ACTIVITY: f"/{KEY_ACTIVITY}",
+            KEY_EVENT: f"/{KEY_EVENT}",
+            KEY_CONTEXT_ID: f"/{KEY_CONTEXT_ID}",
+        }
 
     def update(self) -> Status:
         try:
-            activity: Any = self.blackboard.inbox_activity
-        except KeyError as exc:
+            activity: Any = self.get_input(KEY_ACTIVITY)
+        except (KeyError, NoDataAvailable) as exc:
             return self._reject(f"Missing blackboard key: {exc}")
 
         try:
@@ -209,7 +295,7 @@ class ExtractSemanticsNode(_InboxNode):
         except Exception as exc:
             return self._reject(f"extract_event raised exception: {exc}")
 
-        self.blackboard.inbox_event = event
+        self._set_output(KEY_EVENT, event)
 
         # Resolve the case this activity is scoped to.  See
         # ``vultron.core.models.events.case_context`` for the precedence rules
@@ -221,7 +307,7 @@ class ExtractSemanticsNode(_InboxNode):
         context_id = resolve_case_context_id(
             event, wire_context=getattr(activity, "context", None)
         )
-        self.blackboard.inbox_context_id = context_id
+        self._set_output(KEY_CONTEXT_ID, context_id)
 
         self.logger.debug(
             "%s: extracted semantics=%s context_id=%s",
@@ -232,7 +318,7 @@ class ExtractSemanticsNode(_InboxNode):
         return Status.SUCCESS
 
 
-class DeferCheckNode(_InboxNode):
+class DeferCheckNode(_InboxNodeWithPorts):
     """Step 4: defer activity when its case context is not yet known.
 
     If a case context ID is present, the activity semantic is not one of
@@ -245,24 +331,37 @@ class DeferCheckNode(_InboxNode):
     Passes through to SUCCESS when no deferral is needed.
     """
 
-    def setup(self, **kwargs: Any) -> None:
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(KEY_EVENT, access=Access.READ)
-        self.blackboard.register_key(KEY_CONTEXT_ID, access=Access.READ)
-        self.blackboard.register_key(KEY_QUEUE, access=Access.READ)
-        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
-        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            KEY_EVENT: PortInformation(data_type=object, required=True),
+            KEY_CONTEXT_ID: PortInformation(data_type=object, required=False),
+            KEY_QUEUE: PortInformation(data_type=object, required=False),
+        }
 
-    def update(self) -> Status:
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            KEY_EVENT: f"/{KEY_EVENT}",
+            KEY_CONTEXT_ID: f"/{KEY_CONTEXT_ID}",
+            KEY_QUEUE: f"/{KEY_QUEUE}",
+        }
+
+    def update(self) -> Status:  # noqa: C901
         try:
-            event = self.blackboard.inbox_event
-            context_id: str | None = self.blackboard.inbox_context_id
-        except KeyError as exc:
+            event = self.get_input(KEY_EVENT)
+        except (KeyError, NoDataAvailable) as exc:
             return self._reject(f"Missing blackboard key: {exc}")
 
+        # context_id can legitimately be None (no case scope on the activity).
         try:
-            queue = self.blackboard.inbox_queue
-        except KeyError:
+            context_id: str | None = self.get_input(KEY_CONTEXT_ID)
+        except (NotImplementedError, NoDataAvailable):
+            context_id = None
+
+        try:
+            queue = self.get_input(KEY_QUEUE)
+        except (NotImplementedError, NoDataAvailable, KeyError):
             queue = None
 
         # No deferral needed when there is no case context, when
@@ -287,8 +386,8 @@ class DeferCheckNode(_InboxNode):
                 "resend required after new bootstrap"
             )
             self.feedback_message = reason
-            self.blackboard.inbox_outcome_status = "rejected"
-            self.blackboard.inbox_failure_reason = reason
+            self._set_output(KEY_OUTCOME_STATUS, "rejected")
+            self._set_output(KEY_FAILURE_REASON, reason)
             self.logger.warning("%s: %s", self.name, reason)
             return Status.FAILURE
 
@@ -300,33 +399,42 @@ class DeferCheckNode(_InboxNode):
         )
         reason = f"Deferred: case '{context_id}' not yet known locally"
         self.feedback_message = reason
-        self.blackboard.inbox_outcome_status = "deferred"
-        self.blackboard.inbox_failure_reason = reason
+        self._set_output(KEY_OUTCOME_STATUS, "deferred")
+        self._set_output(KEY_FAILURE_REASON, reason)
         self.logger.info("%s: %s", self.name, reason)
         return Status.FAILURE
 
 
-class DispatchNode(_InboxNode):
+class DispatchNode(_InboxNodeWithPorts):
     """Step 5: dispatch the domain event to the appropriate use case.
 
     After a successful bootstrap dispatch, triggers replay of any
     activities that were deferred pending this case's local replica.
     """
 
-    def setup(self, **kwargs: Any) -> None:
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(KEY_EVENT, access=Access.READ)
-        self.blackboard.register_key(KEY_DISPATCH, access=Access.READ)
-        self.blackboard.register_key(KEY_CONTEXT_ID, access=Access.READ)
-        self.blackboard.register_key(KEY_QUEUE, access=Access.READ)
-        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
-        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            KEY_EVENT: PortInformation(data_type=object, required=True),
+            KEY_DISPATCH: PortInformation(data_type=object, required=True),
+            KEY_CONTEXT_ID: PortInformation(data_type=object, required=False),
+            KEY_QUEUE: PortInformation(data_type=object, required=False),
+        }
+
+    @classmethod
+    def _domain_port_remappings(cls) -> dict[str, str]:
+        return {
+            KEY_EVENT: f"/{KEY_EVENT}",
+            KEY_DISPATCH: f"/{KEY_DISPATCH}",
+            KEY_CONTEXT_ID: f"/{KEY_CONTEXT_ID}",
+            KEY_QUEUE: f"/{KEY_QUEUE}",
+        }
 
     def update(self) -> Status:
         try:
-            event = self.blackboard.inbox_event
-            dispatch = self.blackboard.inbox_dispatch
-        except KeyError as exc:
+            event = self.get_input(KEY_EVENT)
+            dispatch = self.get_input(KEY_DISPATCH)
+        except (KeyError, NoDataAvailable) as exc:
             return self._reject(f"Missing blackboard key: {exc}")
 
         try:
@@ -344,10 +452,13 @@ class DispatchNode(_InboxNode):
         # After bootstrap, replay any activities that were held pending
         # this case's local replica becoming available.
         try:
-            context_id: str | None = self.blackboard.inbox_context_id
-            queue = self.blackboard.inbox_queue
-        except KeyError:
+            context_id: str | None = self.get_input(KEY_CONTEXT_ID)
+        except (NotImplementedError, NoDataAvailable):
             context_id = None
+
+        try:
+            queue = self.get_input(KEY_QUEUE)
+        except (NotImplementedError, NoDataAvailable, KeyError):
             queue = None
 
         if (
@@ -363,7 +474,7 @@ class DispatchNode(_InboxNode):
         return Status.SUCCESS
 
 
-class BuildOutcomeNode(_InboxNode):
+class BuildOutcomeNode(_InboxNodeWithPorts):
     """Step 6: record the processed outcome on the blackboard.
 
     Runs only when all preceding Sequence nodes succeeded.  Writes
@@ -371,11 +482,13 @@ class BuildOutcomeNode(_InboxNode):
     can assemble the final :class:`InboxOutcome`.
     """
 
-    def setup(self, **kwargs: Any) -> None:
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
-
     def update(self) -> Status:
-        self.blackboard.inbox_outcome_status = "processed"
+        self._set_output(KEY_OUTCOME_STATUS, "processed")
         self.logger.debug("%s: outcome = processed", self.name)
         return Status.SUCCESS
+
+
+# Backward-compatibility alias: _InboxNode was the pre-migration base class
+# for the six pipeline nodes.  It is not exported and should not be
+# subclassed by new code — use _InboxNodeWithPorts instead.
+_InboxNode = _InboxNodeWithPorts

--- a/vultron/core/behaviors/report/assign_cve_id_tree.py
+++ b/vultron/core/behaviors/report/assign_cve_id_tree.py
@@ -61,7 +61,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import py_trees
-from py_trees.common import Access, Status
+from py_trees.common import Status
+from py_trees.ports import BehaviourWithPorts, NoDataAvailable, PortInformation
 
 from vultron.enums.roles import CVDRole
 
@@ -81,7 +82,7 @@ _ACTOR_ROLES_KEY = "actor_roles"
 _PUBLICATION_INTENT_SET_KEY = "publication_intent_set"
 
 
-class _IsIDAssignmentAuthorityNode(py_trees.behaviour.Behaviour):
+class _IsIDAssignmentAuthorityNode(BehaviourWithPorts):
     """ProtocolInternal: check whether this actor holds CNA role.
 
     Reads ``actor_roles`` from the blackboard (written by the BT setup phase)
@@ -90,25 +91,39 @@ class _IsIDAssignmentAuthorityNode(py_trees.behaviour.Behaviour):
     ``notes/bt-fuzzer-rm-id-assignment.md``).
     """
 
+    logger: logging.Logger  # type: ignore[assignment]
+
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.logger = logging.getLogger(  # type: ignore[assignment]
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
 
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            _ACTOR_ROLES_KEY: PortInformation(data_type=list, required=False),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        return {}
+
     def setup(self, **kwargs: Any) -> None:
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(key=_ACTOR_ROLES_KEY, access=Access.READ)
+        self.setup_ports(
+            port_remappings={_ACTOR_ROLES_KEY: f"/{_ACTOR_ROLES_KEY}"}
+        )
 
     def update(self) -> Status:
-        if not self.blackboard.exists(_ACTOR_ROLES_KEY):
+        try:
+            roles = self.get_input(_ACTOR_ROLES_KEY)
+        except (KeyError, NoDataAvailable, NotImplementedError):
             self.logger.debug(
                 f"{self.name}: {_ACTOR_ROLES_KEY} not on blackboard"
                 " — treating as non-CNA"
             )
             return Status.FAILURE
 
-        roles = self.blackboard.get(_ACTOR_ROLES_KEY)
         if not isinstance(roles, list):
             self.logger.warning(
                 f"{self.name}: {_ACTOR_ROLES_KEY} is"
@@ -130,7 +145,7 @@ class _IsIDAssignmentAuthorityNode(py_trees.behaviour.Behaviour):
         return Status.FAILURE
 
 
-class _IsOrWillBePubliclyDisclosedNode(py_trees.behaviour.Behaviour):
+class _IsOrWillBePubliclyDisclosedNode(BehaviourWithPorts):
     """ProtocolInternal: OR-gate for public disclosure status.
 
     Returns SUCCESS when ``publication_intent_set`` is truthy on the
@@ -142,26 +157,42 @@ class _IsOrWillBePubliclyDisclosedNode(py_trees.behaviour.Behaviour):
     CVE ID assignment step runs in the same tick sequence.
     """
 
+    logger: logging.Logger  # type: ignore[assignment]
+
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.logger = logging.getLogger(  # type: ignore[assignment]
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
 
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            _PUBLICATION_INTENT_SET_KEY: PortInformation(
+                data_type=object, required=False
+            ),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        return {}
+
     def setup(self, **kwargs: Any) -> None:
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(
-            key=_PUBLICATION_INTENT_SET_KEY, access=Access.READ
+        self.setup_ports(
+            port_remappings={
+                _PUBLICATION_INTENT_SET_KEY: f"/{_PUBLICATION_INTENT_SET_KEY}"
+            }
         )
 
     def update(self) -> Status:
-        if not self.blackboard.exists(_PUBLICATION_INTENT_SET_KEY):
+        try:
+            intent_set = self.get_input(_PUBLICATION_INTENT_SET_KEY)
+        except (KeyError, NoDataAvailable, NotImplementedError):
             self.logger.debug(
                 f"{self.name}: no publication intent on blackboard — FAILURE"
             )
             return Status.FAILURE
 
-        intent_set = self.blackboard.get(_PUBLICATION_INTENT_SET_KEY)
         if intent_set:
             self.logger.debug(
                 f"{self.name}: publication intent is set — SUCCESS"

--- a/vultron/core/behaviors/report/publication_tree.py
+++ b/vultron/core/behaviors/report/publication_tree.py
@@ -65,7 +65,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import py_trees
-from py_trees.common import Access, Status
+from py_trees.common import Status
+from py_trees.ports import BehaviourWithPorts, NoDataAvailable, PortInformation
 from pydantic import BaseModel
 
 from vultron.core.behaviors.call_out_point import CallOutBackendFactory
@@ -116,7 +117,7 @@ class PublicationIntentDecision(BaseModel):
     rationale: str = ""
 
 
-class _ShouldPublishArtifactGate(py_trees.behaviour.Behaviour):
+class _ShouldPublishArtifactGate(BehaviourWithPorts):
     """ProtocolInternal gate: read the intent record and check one artifact flag.
 
     Reads the :class:`PublicationIntentDecision` written to
@@ -142,11 +143,24 @@ class _ShouldPublishArtifactGate(py_trees.behaviour.Behaviour):
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
 
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            # data_type=object: accept any value; isinstance check in update()
+            # handles the type contract (avoid TypeError from get_input).
+            INTENT_DECISION_KEY: PortInformation(
+                data_type=object, required=False
+            ),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        return {}
+
     def setup(self, **kwargs: Any) -> None:
-        """Register READ access to the shared intent-decision blackboard key."""
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(
-            key=INTENT_DECISION_KEY, access=Access.READ
+        """Wire input port to the shared intent-decision blackboard key."""
+        self.setup_ports(
+            port_remappings={INTENT_DECISION_KEY: f"/{INTENT_DECISION_KEY}"}
         )
 
     def update(self) -> Status:
@@ -156,7 +170,9 @@ class _ShouldPublishArtifactGate(py_trees.behaviour.Behaviour):
             SUCCESS when the intent record's :attr:`_intent_field` is truthy;
             FAILURE when it is falsy or when no intent record has been written.
         """
-        if not self.blackboard.exists(INTENT_DECISION_KEY):
+        try:
+            decision = self.get_input(INTENT_DECISION_KEY)
+        except (KeyError, NoDataAvailable, NotImplementedError):
             self.logger.debug(
                 "%s: no %s on blackboard — treating as 'do not publish'",
                 self.name,
@@ -164,7 +180,6 @@ class _ShouldPublishArtifactGate(py_trees.behaviour.Behaviour):
             )
             return Status.FAILURE
 
-        decision = self.blackboard.get(INTENT_DECISION_KEY)
         if not isinstance(decision, PublicationIntentDecision):
             # A present-but-wrong-type value is a call-out-point contract
             # violation (the Evaluator must write a PublicationIntentDecision on

--- a/vultron/core/behaviors/report/publish_artifact_tree.py
+++ b/vultron/core/behaviors/report/publish_artifact_tree.py
@@ -66,7 +66,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import py_trees
-from py_trees.common import Access, Status
+from py_trees.common import Status
+from py_trees.ports import BehaviourWithPorts, NoDataAvailable, PortInformation
 from pydantic import BaseModel
 
 from vultron.core.behaviors.call_out_point import CallOutBackendFactory
@@ -120,7 +121,7 @@ class AdvisoryReviewDecision(BaseModel):
     feedback: str = ""
 
 
-class _NeedsRevisionGate(py_trees.behaviour.Behaviour):
+class _NeedsRevisionGate(BehaviourWithPorts):
     """ProtocolInternal gate: read the review decision and check needs_revision.
 
     Reads the :class:`AdvisoryReviewDecision` written to :data:`REVIEW_DECISION_KEY`
@@ -139,11 +140,24 @@ class _NeedsRevisionGate(py_trees.behaviour.Behaviour):
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
 
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            # data_type=object: accept any value; isinstance check in update()
+            # handles the type contract (avoid TypeError from get_input).
+            REVIEW_DECISION_KEY: PortInformation(
+                data_type=object, required=False
+            ),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        return {}
+
     def setup(self, **kwargs: Any) -> None:
-        """Register READ access to the shared review-decision blackboard key."""
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        self.blackboard.register_key(
-            key=REVIEW_DECISION_KEY, access=Access.READ
+        """Wire input port to the shared review-decision blackboard key."""
+        self.setup_ports(
+            port_remappings={REVIEW_DECISION_KEY: f"/{REVIEW_DECISION_KEY}"}
         )
 
     def update(self) -> Status:
@@ -154,7 +168,9 @@ class _NeedsRevisionGate(py_trees.behaviour.Behaviour):
             truthy; FAILURE when it is falsy or when no decision has been
             written (i.e., the auto-approve path, which skips revision).
         """
-        if not self.blackboard.exists(REVIEW_DECISION_KEY):
+        try:
+            decision = self.get_input(REVIEW_DECISION_KEY)
+        except (KeyError, NoDataAvailable, NotImplementedError):
             self.logger.debug(
                 "%s: no %s on blackboard — skipping revision",
                 self.name,
@@ -162,7 +178,6 @@ class _NeedsRevisionGate(py_trees.behaviour.Behaviour):
             )
             return Status.FAILURE
 
-        decision = self.blackboard.get(REVIEW_DECISION_KEY)
         if not isinstance(decision, AdvisoryReviewDecision):
             self.logger.warning(
                 "%s: %s holds %s, not an AdvisoryReviewDecision — "

--- a/vultron/core/behaviors/report/report_to_others_tree.py
+++ b/vultron/core/behaviors/report/report_to_others_tree.py
@@ -66,7 +66,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import py_trees
-from py_trees.common import Access, Status
+from py_trees.common import Status
+from py_trees.ports import BehaviourWithPorts, PortInformation
 
 from vultron.core.behaviors.call_out_point import CallOutBackendFactory
 from vultron.enums.roles import CVDRole
@@ -79,7 +80,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class _WriteRolesNode(py_trees.behaviour.Behaviour):
+class _WriteRolesNode(BehaviourWithPorts):
     """ProtocolInternal: write ``suggested_roles_{case_id_segment}`` to the blackboard.
 
     Written before each sub-loop's ``suggest-actor-to-case`` trigger so the
@@ -89,6 +90,11 @@ class _WriteRolesNode(py_trees.behaviour.Behaviour):
     This node is constructed directly by the tree builder (not via a factory)
     because it is a ProtocolInternal handoff write — not a call-out point to
     an external system (ADR-0025).
+
+    The physical blackboard key is execution-scoped (BTND-03-013): the stable
+    logical port name ``suggested_roles`` is declared in ``output_ports()`` and
+    wired to the physical key ``suggested_roles_{case_id_segment}`` in
+    ``setup()`` using ``setup_ports()`` with an instance-computed remapping.
     """
 
     logger: logging.Logger  # type: ignore[assignment]
@@ -105,18 +111,26 @@ class _WriteRolesNode(py_trees.behaviour.Behaviour):
         self.logger = logging.getLogger(  # type: ignore[assignment]
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
+        _seg = case_id.split("/")[-1]
+        self._roles_key = f"suggested_roles_{_seg}"
+
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {}
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        return {
+            "suggested_roles": PortInformation(data_type=list, required=True),
+        }
 
     def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard = self.attach_blackboard_client(name=self.name)
-        id_segment = self.case_id.split("/")[-1]
-        self.blackboard_key = f"suggested_roles_{id_segment}"
-        self.blackboard.register_key(
-            key=self.blackboard_key, access=Access.WRITE
+        self.setup_ports(
+            port_remappings={"suggested_roles": f"/{self._roles_key}"}
         )
 
     def update(self) -> Status:
-        setattr(self.blackboard, self.blackboard_key, list(self.roles))
+        self._set_output("suggested_roles", list(self.roles))
         self.logger.debug(
             "%s: wrote suggested_roles %s for case '%s'",
             self.name,

--- a/vultron/core/behaviors/status/nodes/append/conditions.py
+++ b/vultron/core/behaviors/status/nodes/append/conditions.py
@@ -32,6 +32,7 @@ from typing import Any
 
 import py_trees
 from py_trees.common import Status
+from py_trees.ports import BehaviourWithPorts, NoDataAvailable, PortInformation
 
 from vultron.core.behaviors.helpers import DataLayerCondition
 from vultron.core.models._helpers import _as_id
@@ -56,7 +57,7 @@ def _has_status_in_participant(participant: Any, status_id: str) -> bool:
     return status_id in existing_ids
 
 
-class SkipIfIdempotentNode(py_trees.behaviour.Behaviour):
+class SkipIfIdempotentNode(BehaviourWithPorts):
     """Idempotency guard for the append-participant-status Selector.
 
     Returns SUCCESS when *status_id* is already present in the participant's
@@ -81,16 +82,31 @@ class SkipIfIdempotentNode(py_trees.behaviour.Behaviour):
         self.status_id = status_id
         self.participant_id = participant_id
 
+    @classmethod
+    def input_ports(cls) -> dict[str, PortInformation]:
+        return {
+            "append_status_participant": PortInformation(
+                data_type=object, required=False
+            ),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict[str, PortInformation]:
+        return {}
+
     def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard = py_trees.blackboard.Client(name=self.name)
-        self.blackboard.register_key(
-            key="append_status_participant",
-            access=py_trees.common.Access.READ,
+        self.setup_ports(
+            port_remappings={
+                "append_status_participant": "/append_status_participant"
+            }
         )
 
     def update(self) -> Status:
-        participant = self.blackboard.get("append_status_participant")
+        try:
+            participant = self.get_input("append_status_participant")
+        except (KeyError, NoDataAvailable, NotImplementedError):
+            return Status.FAILURE
+
         if participant is None:
             return Status.FAILURE
 


### PR DESCRIPTION
- Closes #1887

## Summary

Final part (5/5) of the #1809 py_trees typed-Ports migration chain. Migrates all remaining bare `py_trees.behaviour.Behaviour` and `_InboxNode` subclasses to `BehaviourWithPorts`, adds an AST ratchet test to prevent regression, and marks the migration complete in the design notes.

## Changes

- **`vultron/core/behaviors/inbox/nodes/pipeline.py`**: `_InboxNode` → `_InboxNodeWithPorts(BehaviourWithPorts)` with shared outcome output ports and `_domain_port_remappings()` hook; all six pipeline nodes migrated (`ParsePayloadNode`, `RehydrateActivityNode` with read-modify-write dual-alias pattern, `ExtractSemanticsNode`, `DeferCheckNode`, `DispatchNode`, `BuildOutcomeNode`)
- **`vultron/core/behaviors/report/assign_cve_id_tree.py`**: `_IsIDAssignmentAuthorityNode`, `_IsOrWillBePubliclyDisclosedNode` → `BehaviourWithPorts`
- **`vultron/core/behaviors/report/publication_tree.py`**: `_ShouldPublishArtifactGate` → `BehaviourWithPorts`
- **`vultron/core/behaviors/report/publish_artifact_tree.py`**: `_NeedsRevisionGate` → `BehaviourWithPorts`
- **`vultron/core/behaviors/report/report_to_others_tree.py`**: `_WriteRolesNode` → `BehaviourWithPorts`, execution-scoped output key (BTND-03-013)
- **`vultron/core/behaviors/status/nodes/append/conditions.py`**: `SkipIfIdempotentNode` → `BehaviourWithPorts`
- **`vultron/core/behaviors/case/nodes/actor.py`**: `EvaluateDefaultRolesNode` → `BehaviourWithPorts`, execution-scoped output key
- **`test/architecture/test_no_bare_register_key_datalayer_nodes.py`** (new, AC-1): AST ratchet with 51-entry baseline; new `register_key` DataLayer nodes fail the test
- **`test/core/behaviors/inbox/nodes/test_typed_ports.py`** (new, AC-2): `NoDataAvailable` isolation tests for all six pipeline nodes; `BuildOutcomeNode` write-path test
- **`notes/py-trees-ports-adoption.md`** (AC-3, AC-4): status → `archived`, Exemptions section (composites, constructor-parameterized gates), Finalized Conventions section (8 patterns from Parts 1–5)

## Key patterns finalized

- Read-modify-write via dual-alias ports (`inbox_activity_in` READ + `inbox_activity` WRITE → same `/inbox_activity` key)
- `data_type=object` for nullable/any ports; `isinstance()` in `update()` handles type contract
- `except (NotImplementedError, NoDataAvailable)` for explicitly-`None` optional blackboard keys
- Execution-scoped physical keys: computed in `__init__`, wired in instance `setup()` (not classmethod)

## Verification

- 7264 unit tests pass (10 new), 1166 integration tests pass
- Black, flake8, mypy, pyright all clean