### PR TITLE
docs: plan concern #2103 — remove stale Observer provisional note from §7.3.1

### DIFF
--- a/docs/reference/draft-vultron-spec.md
+++ b/docs/reference/draft-vultron-spec.md
@@ -1188,7 +1188,7 @@ transitions it is authorized to drive. An actor may hold multiple process roles.
 | Deployer | Drives its own VFD transition `d→D` (fix deployed, `CD`) |
 | Coordinator | Drives case participant management; coordinates multi-party disclosure |
 | CNA | May directly assign CVE IDs; a non-CNA delegates to an external CNA service. Orthogonal to other roles — typically co-held with Coordinator or Vendor |
-| Observer † | Holds no drive obligations for VFD; may report PXA observations (§7.4.2) |
+| Observer | Holds no drive obligations for VFD; may report PXA observations (§7.4.2) |
 
 **Capability prerequisites.** Every case Participant — whatever its roles — MUST
 implement the Observer capability set (§7.2, §7.3.3). Role extension sets add
@@ -1198,15 +1198,7 @@ completing a role assignment (§6.6.1). The full capability prerequisites per
 role are under active specification; see `docs/reference/vultron-taxonomy.md`
 §"Open Ideas."
 
-!!! note "† Observer: decided (ADR-0057); Finder: still provisional"
-    **Observer** (`CVDRole.OBSERVER`): the rename from `CVDRole.OTHER` is decided
-    (ADR-0057). The implementation task (renaming the enum value and all
-    references) is tracked in a separate issue. Observer semantics are now
-    normative: full participant (CM-25-001), standard Invite/Accept admission
-    (CM-25-002), full case content (CM-25-003), RM triage with engagement
-    semantics (CM-25-004), VFD exclusion for sole-Observer participants (CM-25-005).
-    Role-stacking union principle: CM-26-001.
-
+!!! note "Finder role: still provisional"
     **Finder** still requires an ADR before the removal can be treated as normative.
     The formal protocol definition this document builds on (§3.1, §3.4) defines
     the process count over Finders, Vendors, Coordinators, Deployers, and Others.

--- a/plan/history/2608/learning/CONCERN-2103.md
+++ b/plan/history/2608/learning/CONCERN-2103.md
@@ -1,0 +1,37 @@
+---
+source: CONCERN-2103
+timestamp: '2026-08-24T17:41:23.873720+00:00'
+title: 'ADR + enum change: rename OTHER role to Observer (circulation blocker for
+  draft spec)'
+type: learning
+---
+
+## Concern
+
+`docs/reference/draft-vultron-spec.md` Open Question #6: renaming the `OTHER`
+role to **Observer** needs an ADR, and the enum change needs to be carried into
+the implementation. The PR #2078 body names this as a circulation blocker.
+
+## Relationship to #2093
+
+These are deliberately distinct, and the draft says so: *"renaming without
+settling what an Observer is only relabels the ambiguity."*
+
+- **#2093** — what an Observer *is*: admission path and content scope
+- **this issue** — the `OTHER` → Observer rename decision plus the enum change
+
+## Resolution
+
+**Resolved**: 2026-08-24
+
+At planning time, all three scope items were already complete:
+
+- **ADR recording the rename decision** → ADR-0057 accepted 2026-08-11
+- **Enum change (`OTHER` → `OBSERVER`) and all call sites** → #2192 closed
+- **Open Question #6 struck** → already struck (`~~Observer rename ADR~~`)
+
+Remaining gap: §7.3.1 `†`-footnote still contained stale text ("implementation
+tracked in a separate issue") pointing to the now-closed #2192. Removed in the
+docs PR below.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2519>


### PR DESCRIPTION
- Closes #2103

## Summary

The `†`-footnote and note in §7.3.1 of the draft spec tracked the provisional
status of the Observer rename and pointed to a separate implementation issue.
Both are now stale: ADR-0057 is accepted and implementation issue #2192 is
closed. This PR removes the stale note.

## Changes

- **`docs/reference/draft-vultron-spec.md`**: Remove `†` marker from Observer
  row in §7.3.1 role table; remove Observer block from the provisional note;
  retitle the note to "Finder role: still provisional" (Finder block unchanged).