### PR TITLE
docs: plan concern #2090 — CS ordering constraints normatively specified

### DIFF
--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -180,12 +180,12 @@ Some ECA rules are not just "do A when B" but "do A *before* B." These use
   when the CS PXA state is pXa or pXA (exploit public without public awareness),
   the next CS event MUST be P. This is normatively specified but **not yet
   enforced in BT paths** — `cs_invariants.required_next_cs_events()` is not
-  called from `ValidateCaseStatusTransitionNode`. See CONCERN-2090.
+  called from `ValidateCaseStatusTransitionNode`. See #2524.
 - **CS history validity** (CSB-17-004, CSB-17-005): complete CS histories must
   be one of 70 valid histories; incomplete histories must be valid prefixes.
   Normatively specified but **not yet enforced** — `cs_invariants.is_valid_cs_history()`
   and `is_valid_cs_history_prefix()` are not wired into any receive path. See
-  CONCERN-2090.
+  #2524.
 - **Ledger commit ordering** (from `specs/case-ledger-processing.yaml`
   CLP-10-006): precondition checks → ledger commit → protocol effects.
   Observable from audit replay.

--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -56,9 +56,10 @@ Three levels an independent implementor can achieve:
 
 A fourth level (L4 — Process: correct internal decision structure, e.g.,
 precondition before state write before effect) is enforceable only via a
-reference implementation. Some process ordering leaks into L3 when the sequence
-of outputs is itself observable (e.g., CP must precede ET when public
-disclosure triggers embargo teardown).
+reference implementation. Some process ordering also rises to L3 when the
+sequence of outputs is itself observable. For example, CP-before-ET (when
+public disclosure triggers embargo teardown) is now normatively specified in
+CSB-12-001 as a MUST, not just an implementation convention.
 
 ## Why New Files, Not VP Extensions
 
@@ -170,8 +171,21 @@ fields above) and `relationships:` pointing to VP items via `satisfies`.
 Some ECA rules are not just "do A when B" but "do A *before* B." These use
 `steps:` on `BehavioralSpec` items to encode ordering. Critical ones:
 
-- **CS→P triggers embargo teardown**: record CS state transition *first*, then
-  initiate teardown. Observable: CP must precede ET in the message stream.
+- **CS→P triggers embargo teardown** (CSB-12-001, CSB-04-003): record CS state
+  transition *first*, then initiate teardown. Observable: CP must precede ET in
+  the message stream. This is normatively specified as MUST and is also enforced
+  structurally in `add_case_status_tree` (AppendCaseStatusToCaseNode runs before
+  ThreatTerminationBranchNode).
+- **Ephemeral states: pX→PX invariant** (CSB-13-001, CSB-17-003, CSB-17-012):
+  when the CS PXA state is pXa or pXA (exploit public without public awareness),
+  the next CS event MUST be P. This is normatively specified but **not yet
+  enforced in BT paths** — `cs_invariants.required_next_cs_events()` is not
+  called from `ValidateCaseStatusTransitionNode`. See CONCERN-2090.
+- **CS history validity** (CSB-17-004, CSB-17-005): complete CS histories must
+  be one of 70 valid histories; incomplete histories must be valid prefixes.
+  Normatively specified but **not yet enforced** — `cs_invariants.is_valid_cs_history()`
+  and `is_valid_cs_history_prefix()` are not wired into any receive path. See
+  CONCERN-2090.
 - **Ledger commit ordering** (from `specs/case-ledger-processing.yaml`
   CLP-10-006): precondition checks → ledger commit → protocol effects.
   Observable from audit replay.

--- a/plan/history/2608/learning/CONCERN-2090.md
+++ b/plan/history/2608/learning/CONCERN-2090.md
@@ -1,0 +1,63 @@
+---
+source: CONCERN-2090
+timestamp: '2026-08-24T18:01:52.499286+00:00'
+title: CS ordering constraints (pX→PX, CP-before-ET, possible histories)
+type: learning
+---
+
+# Concern: CS ordering constraints (pX→PX, CP-before-ET, possible histories) are not normatively specified
+
+Filed during critical review of draft protocol spec §6.3.2/§6.3.3.
+Three CS ordering rules existed only as code comments or non-normative references.
+
+## Outcome
+
+All three constraints are now normatively specified in `specs/cs-behavior.yaml` (v0.1.1).
+Two are also implemented; one is structural-only; two have implementation gaps.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2521>
+
+### CP-before-ET ordering
+
+**Spec**: CSB-12-001, CSB-04-003 — MUST record CS→P before emitting ET.
+**Implementation**: Structurally enforced in `add_case_status_tree` —
+`AppendCaseStatusToCaseNode` (step 4) runs before `ThreatTerminationBranchNode`
+(step 6) in the BT sequence. No code change needed.
+
+### pX→PX ephemeral invariant
+
+**Spec**: CSB-13-001, CSB-17-003, CSB-17-012 — pXa and pXA are ephemeral
+states; next CS event MUST be P.
+**Implementation gap**: `ValidateCaseStatusTransitionNode` calls
+`is_valid_pxa_transition` from `cs.py` (structural transitions only), which
+allows A-events from pX states — violating the ephemeral constraint.
+`cs_invariants.required_next_cs_events()` exists but is not called.
+**Task filed**: #2524
+
+### CS history validity
+
+**Spec**: CSB-17-004, CSB-17-005 — complete histories must be one of 70 valid
+histories; incomplete histories must be valid prefixes.
+**Implementation gap**: `cs_invariants.is_valid_cs_history_prefix()` exists
+but is not wired into any receive path.
+**Task filed**: #2524
+
+### ADR-0037 interaction
+
+The interaction between CS ordering constraints and out-of-order ledger delivery
+(ADR-0037 buffer/drain) is unspecified. Does the ephemeral-state guard fire on
+original receipt or on replay? A new Concern is filed: #2527.
+
+## Key discovery
+
+Issue #2090 was filed when `specs/cs-behavior.yaml` was in scaffolding state.
+By the time it was planned, CSB-17 was fully populated (v0.1.1), resolving the
+normative gap. The residual work is implementation enforcement, not spec authorship.
+
+## Root cause
+
+The concern was legitimate at filing: the spec was at v0.0.1 scaffolding when
+the concern was opened. The spec matured independently (via the behavioral
+conformance specs work stream) without the concern being re-evaluated and closed.
+Pattern: spec-filing and concern-triage are decoupled; concerns should be
+re-triaged after major spec group additions in their domain.


### PR DESCRIPTION
- Closes #2090
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Documents the outcome of concern #2090: all three CS ordering constraints
(pX→PX, CP-before-ET, possible histories) are now normatively specified in
`specs/cs-behavior.yaml`. Two invariants are specified but not yet wired into
BT enforcement paths; implementation tasks are filed separately.

## Changes

- **`notes/behavioral-conformance-specs.md`**: Updated L4 framing to note
  CP-before-ET is MUST-level in CSB-12-001; added CSB spec IDs to the Key
  Ordering Constraints section; documented two unimplemented invariants
  (ephemeral state guard, history prefix validation) with links to CONCERN-2090.

## Implementation Issues

- #2524 — Wire cs_invariants ephemeral-state and history guards into CS receive path
- #2527 — Concern: CS ordering constraints under out-of-order ledger delivery (ADR-0037)