### PR TITLE
refactor: shared corpus module for test/architecture/ ratchet tests

### DIFF
--- a/notes/architecture-ratchet-corpus.md
+++ b/notes/architecture-ratchet-corpus.md
@@ -81,7 +81,7 @@ Measured after applying the shared corpus + prefilter to
 
 | Before | After |
 |---|---|
-| 3.8 s (scans vultron + test, parses all) | 0.04 s (26 files match) |
+| 3.8 s (scans vultron + test, parses all) | 0.13 s (CI-verified) |
 
 For `test_no_asgi_transport_in_app_code` (target string: `"ASGITransport"`):
 

--- a/test/architecture/_corpus.py
+++ b/test/architecture/_corpus.py
@@ -1,0 +1,134 @@
+"""Shared module-level source + AST corpus for test/architecture/ ratchet tests.
+
+Reads all ``*.py`` source strings from ``vultron/`` and ``test/`` at import
+time (module-level — outside the 5-second per-test timeout window).  ASTs are
+cached lazily on first demand so only the files actually needed by each ratchet
+are ever parsed.
+
+See ``notes/architecture-ratchet-corpus.md`` for the full design rationale and
+performance measurements.
+
+Spec: ``specs/testability.yaml`` TB-13-001 through TB-13-003.
+"""
+
+import ast
+from collections.abc import Iterator
+from pathlib import Path
+
+#: Repository root (two levels above ``test/architecture/``).
+REPO_ROOT = Path(__file__).parents[2]
+
+_SCAN_ROOTS = [REPO_ROOT / "vultron", REPO_ROOT / "test"]
+
+# ---------------------------------------------------------------------------
+# Module-level source cache — populated at import time.
+# Import-time I/O is not subject to the pytest-timeout 5 s per-test budget
+# (verified experimentally; see notes/architecture-ratchet-corpus.md).
+# ---------------------------------------------------------------------------
+_source_cache: dict[Path, str] = {}
+
+for _root in _SCAN_ROOTS:
+    for _py_file in sorted(_root.rglob("*.py")):
+        if "__pycache__" in _py_file.parts:
+            continue
+        try:
+            _source_cache[_py_file] = _py_file.read_text(encoding="utf-8")
+        except OSError:
+            pass
+
+# ---------------------------------------------------------------------------
+# Lazy AST cache — trees are parsed and stored on first demand.
+# ---------------------------------------------------------------------------
+_ast_cache: dict[Path, ast.AST] = {}
+
+
+def _get_tree(path: Path) -> ast.AST | None:
+    """Return the cached AST for *path*, parsing on first access."""
+    if path not in _ast_cache:
+        source = _source_cache.get(path)
+        if source is None:
+            return None
+        try:
+            _ast_cache[path] = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            return None
+    return _ast_cache[path]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def files_mentioning(
+    *fragments: str, under: Path
+) -> Iterator[tuple[Path, ast.AST]]:
+    """Yield ``(path, tree)`` for cached files under *under* containing any fragment.
+
+    Applies a plain substring prefilter before parsing — O(n) over source
+    bytes, keeping per-ratchet cost proportional to match count rather than
+    total file count (TB-13-001, TB-13-002, TB-13-007, TB-13-008).
+    """
+    for path in sorted(_source_cache.keys()):
+        try:
+            path.relative_to(under)
+        except ValueError:
+            continue
+        source = _source_cache[path]
+        if not any(fragment in source for fragment in fragments):
+            continue
+        tree = _get_tree(path)
+        if tree is not None:
+            yield path, tree
+
+
+def all_trees(under: Path) -> Iterator[tuple[Path, ast.AST]]:
+    """Yield ``(path, tree)`` for every cached ``.py`` file under *under*.
+
+    Escape hatch for ratchets that have no useful prefilter fragment.
+    TB-13-002.
+    """
+    for path in sorted(_source_cache.keys()):
+        try:
+            path.relative_to(under)
+        except ValueError:
+            continue
+        tree = _get_tree(path)
+        if tree is not None:
+            yield path, tree
+
+
+def sources_mentioning(
+    *fragments: str, under: Path
+) -> Iterator[tuple[Path, str]]:
+    """Yield ``(path, source)`` for files under *under* containing any fragment.
+
+    For ratchets that scan source lines rather than AST nodes.
+    """
+    for path in sorted(_source_cache.keys()):
+        try:
+            path.relative_to(under)
+        except ValueError:
+            continue
+        source = _source_cache[path]
+        if any(fragment in source for fragment in fragments):
+            yield path, source
+
+
+def all_sources(under: Path) -> Iterator[tuple[Path, str]]:
+    """Yield ``(path, source)`` for every cached ``.py`` file under *under*."""
+    for path in sorted(_source_cache.keys()):
+        try:
+            path.relative_to(under)
+        except ValueError:
+            continue
+        yield path, _source_cache[path]
+
+
+def parse_inline(source: str, filename: str = "<inline>") -> ast.AST:
+    """Parse a short inline source string.
+
+    Provided so test siblings can avoid importing ``ast`` directly, keeping
+    the hygiene ratchet (TB-13-003) unambiguous.
+    """
+    return ast.parse(source, filename=filename)

--- a/test/architecture/test_activity_factory_imports.py
+++ b/test/architecture/test_activity_factory_imports.py
@@ -46,9 +46,8 @@ is completely clean.
 """
 
 import ast
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
 _VOCAB_ACTIVITIES = "vultron.wire.as2.vocab.activities"
 
@@ -75,12 +74,8 @@ ALLOWED_PREFIXES: tuple[str, ...] = (
 KNOWN_VIOLATIONS: frozenset[str] = frozenset()
 
 
-def _imports_from_vocab_activities(source_path: Path) -> bool:
-    """Return True if the file imports from ``vultron.wire.as2.vocab.activities``."""
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return False
+def _imports_from_vocab_activities(tree: ast.AST) -> bool:
+    """Return True if the tree imports from ``vultron.wire.as2.vocab.activities``."""
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
@@ -110,16 +105,16 @@ def _collect_violations() -> frozenset[str]:
     """
     violations: set[str] = set()
     for root_name in _SCAN_ROOTS:
-        scan_root = REPO_ROOT / root_name
+        scan_root = _corpus.REPO_ROOT / root_name
         if not scan_root.is_dir():
             continue
-        for py_file in scan_root.rglob("*.py"):
-            if "__pycache__" in py_file.parts:
-                continue
-            rel = py_file.relative_to(REPO_ROOT).as_posix()
+        for py_file, tree in _corpus.files_mentioning(
+            _VOCAB_ACTIVITIES, under=scan_root
+        ):
+            rel = py_file.relative_to(_corpus.REPO_ROOT).as_posix()
             if any(rel.startswith(prefix) for prefix in ALLOWED_PREFIXES):
                 continue
-            if _imports_from_vocab_activities(py_file):
+            if _imports_from_vocab_activities(tree):
                 violations.add(rel)
     return frozenset(violations)
 

--- a/test/architecture/test_attributed_to_requires_save_many.py
+++ b/test/architecture/test_attributed_to_requires_save_many.py
@@ -49,9 +49,9 @@ save_many()" in ``vultron/core/AGENTS.md``.
 import ast
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
-_BEHAVIORS_ROOT = REPO_ROOT / "vultron" / "core" / "behaviors"
+_BEHAVIORS_ROOT = _corpus.REPO_ROOT / "vultron" / "core" / "behaviors"
 
 
 def _walk_own_scope(node: ast.AST):
@@ -147,14 +147,8 @@ def _has_datalayer_save_call(scope: ast.AST) -> bool:
     return False
 
 
-def _has_attributed_to_with_save_in_update(source_path: Path) -> bool:
-    """Return True if *source_path* has an update() that assigns attributed_to
-    and also calls self.datalayer.save().
-    """
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return False
+def _has_attributed_to_with_save_in_update_tree(tree: ast.AST) -> bool:
+    """Return True if *tree* has an update() that assigns attributed_to and calls save()."""
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
@@ -167,14 +161,26 @@ def _has_attributed_to_with_save_in_update(source_path: Path) -> bool:
     return False
 
 
+def _has_attributed_to_with_save_in_update(source_path: Path) -> bool:
+    """Return True if *source_path* has an update() that assigns attributed_to
+    and also calls self.datalayer.save().
+    """
+    try:
+        source = source_path.read_text(encoding="utf-8")
+        tree = _corpus.parse_inline(source, filename=str(source_path))
+    except (OSError, SyntaxError):
+        return False
+    return _has_attributed_to_with_save_in_update_tree(tree)
+
+
 def _collect_violations() -> frozenset[str]:
     """Return repo-relative paths of BT node files with the violation pattern."""
     violations: set[str] = set()
-    for py_file in _BEHAVIORS_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        if _has_attributed_to_with_save_in_update(py_file):
-            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    for py_file, tree in _corpus.files_mentioning(
+        "attributed_to", under=_BEHAVIORS_ROOT
+    ):
+        if _has_attributed_to_with_save_in_update_tree(tree):
+            violations.add(py_file.relative_to(_corpus.REPO_ROOT).as_posix())
     return frozenset(violations)
 
 

--- a/test/architecture/test_behaviors_no_use_case_imports.py
+++ b/test/architecture/test_behaviors_no_use_case_imports.py
@@ -39,26 +39,21 @@ When the set is empty the boundary is completely clean.
 """
 
 import ast
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
 _USE_CASES_MODULE = "vultron.core.use_cases"
 
-_BEHAVIORS_ROOT = REPO_ROOT / "vultron" / "core" / "behaviors"
+_BEHAVIORS_ROOT = _corpus.REPO_ROOT / "vultron" / "core" / "behaviors"
 
 
-def _imports_from_use_cases(source_path: Path) -> bool:
-    """Return True if *source_path* contains any import from vultron.core.use_cases.
+def _imports_from_use_cases(tree: ast.AST) -> bool:
+    """Return True if *tree* contains any import from vultron.core.use_cases.
 
     Detects both top-level and deferred (local) imports, catching violations
     like the former ``from vultron.core.use_cases.received.case._helpers import
     _ensure_reporter_participant`` placed inside ``update()`` method bodies.
     """
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return False
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
@@ -78,11 +73,11 @@ def _imports_from_use_cases(source_path: Path) -> bool:
 def _collect_violations() -> frozenset[str]:
     """Return repo-relative paths of behaviors files that import from use_cases."""
     violations: set[str] = set()
-    for py_file in _BEHAVIORS_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        if _imports_from_use_cases(py_file):
-            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    for py_file, tree in _corpus.files_mentioning(
+        _USE_CASES_MODULE, under=_BEHAVIORS_ROOT
+    ):
+        if _imports_from_use_cases(tree):
+            violations.add(py_file.relative_to(_corpus.REPO_ROOT).as_posix())
     return frozenset(violations)
 
 

--- a/test/architecture/test_core_no_adapter_imports.py
+++ b/test/architecture/test_core_no_adapter_imports.py
@@ -39,27 +39,22 @@ fixed.  When the set is empty the boundary is completely clean.
 """
 
 import ast
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
 _ADAPTERS_MODULE = "vultron.adapters"
 _ADAPTERS_PATH = "vultron/adapters"
 
-_CORE_ROOT = REPO_ROOT / "vultron" / "core"
+_CORE_ROOT = _corpus.REPO_ROOT / "vultron" / "core"
 
 
-def _imports_from_adapters(source_path: Path) -> bool:
-    """Return True if *source_path* contains any import from vultron.adapters.
+def _imports_from_adapters(tree: ast.AST) -> bool:
+    """Return True if *tree* contains any import from vultron.adapters.
 
     Detects both top-level and deferred (local) imports, catching violations
     like ``from vultron.adapters.driven.sync_activity_adapter import ...``
     placed inside a function body.
     """
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return False
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
@@ -79,11 +74,11 @@ def _imports_from_adapters(source_path: Path) -> bool:
 def _collect_violations() -> frozenset[str]:
     """Return repo-relative paths of core files that import from adapters."""
     violations: set[str] = set()
-    for py_file in _CORE_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        if _imports_from_adapters(py_file):
-            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    for py_file, tree in _corpus.files_mentioning(
+        _ADAPTERS_MODULE, under=_CORE_ROOT
+    ):
+        if _imports_from_adapters(tree):
+            violations.add(py_file.relative_to(_corpus.REPO_ROOT).as_posix())
     return frozenset(violations)
 
 

--- a/test/architecture/test_core_no_demo_imports.py
+++ b/test/architecture/test_core_no_demo_imports.py
@@ -46,26 +46,21 @@ The set is empty: the core→demo boundary is completely clean.  Keep it that wa
 """
 
 import ast
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
 _DEMO_MODULE = "vultron.demo"
 
-_CORE_ROOT = REPO_ROOT / "vultron" / "core"
+_CORE_ROOT = _corpus.REPO_ROOT / "vultron" / "core"
 
 
-def _imports_from_demo(source_path: Path) -> bool:
-    """Return True if *source_path* contains any import from vultron.demo.
+def _imports_from_demo(tree: ast.AST) -> bool:
+    """Return True if *tree* contains any import from vultron.demo.
 
     Detects both top-level and deferred (local) imports, catching violations
     like ``from vultron.demo.fuzzer.bundles.validation import ...`` placed
     inside a function body.
     """
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return False
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
@@ -83,11 +78,11 @@ def _imports_from_demo(source_path: Path) -> bool:
 def _collect_violations() -> frozenset[str]:
     """Return repo-relative paths of core files that import from demo."""
     violations: set[str] = set()
-    for py_file in _CORE_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        if _imports_from_demo(py_file):
-            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    for py_file, tree in _corpus.files_mentioning(
+        _DEMO_MODULE, under=_CORE_ROOT
+    ):
+        if _imports_from_demo(tree):
+            violations.add(py_file.relative_to(_corpus.REPO_ROOT).as_posix())
     return frozenset(violations)
 
 

--- a/test/architecture/test_core_no_wire_imports.py
+++ b/test/architecture/test_core_no_wire_imports.py
@@ -39,26 +39,21 @@ fixed.  When the set is empty the boundary is completely clean.
 """
 
 import ast
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
 _WIRE_MODULE = "vultron.wire"
 
-_CORE_ROOT = REPO_ROOT / "vultron" / "core"
+_CORE_ROOT = _corpus.REPO_ROOT / "vultron" / "core"
 
 
-def _imports_from_wire(source_path: Path) -> bool:
-    """Return True if *source_path* contains any import from vultron.wire.
+def _imports_from_wire(tree: ast.AST) -> bool:
+    """Return True if *tree* contains any import from vultron.wire.
 
     Detects both top-level and deferred (local) imports, catching violations
     like ``from vultron.wire.as2.factories import ...`` placed inside a
     function body.
     """
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return False
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
@@ -76,11 +71,11 @@ def _imports_from_wire(source_path: Path) -> bool:
 def _collect_violations() -> frozenset[str]:
     """Return repo-relative paths of core files that import from wire."""
     violations: set[str] = set()
-    for py_file in _CORE_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        if _imports_from_wire(py_file):
-            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    for py_file, tree in _corpus.files_mentioning(
+        _WIRE_MODULE, under=_CORE_ROOT
+    ):
+        if _imports_from_wire(tree):
+            violations.add(py_file.relative_to(_corpus.REPO_ROOT).as_posix())
     return frozenset(violations)
 
 

--- a/test/architecture/test_demo_no_bt_imports.py
+++ b/test/architecture/test_demo_no_bt_imports.py
@@ -44,25 +44,20 @@ Follows the ARCH-18 bidirectional-equality pattern used by
 """
 
 import ast
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
 _BT_MODULE = "vultron.bt"
 
-_DEMO_ROOT = REPO_ROOT / "vultron" / "demo"
+_DEMO_ROOT = _corpus.REPO_ROOT / "vultron" / "demo"
 
 
-def _imports_from_bt(source_path: Path) -> bool:
-    """Return True if *source_path* contains any import from vultron.bt.
+def _imports_from_bt(tree: ast.AST) -> bool:
+    """Return True if *tree* contains any import from vultron.bt.
 
     Detects both top-level and deferred (local) imports, catching violations
     like ``import vultron.bt.base.demo.pacman`` placed inside a function body.
     """
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return False
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
@@ -80,11 +75,11 @@ def _imports_from_bt(source_path: Path) -> bool:
 def _collect_violations() -> frozenset[str]:
     """Return repo-relative paths of demo files that import from vultron.bt."""
     violations: set[str] = set()
-    for py_file in _DEMO_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        if _imports_from_bt(py_file):
-            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    for py_file, tree in _corpus.files_mentioning(
+        _BT_MODULE, under=_DEMO_ROOT
+    ):
+        if _imports_from_bt(tree):
+            violations.add(py_file.relative_to(_corpus.REPO_ROOT).as_posix())
     return frozenset(violations)
 
 

--- a/test/architecture/test_demo_step_no_unbound_ratchet.py
+++ b/test/architecture/test_demo_step_no_unbound_ratchet.py
@@ -38,7 +38,9 @@ fail.
 import ast
 import pathlib
 
-DEMO_DIR = pathlib.Path(__file__).parent.parent.parent / "vultron" / "demo"
+from test.architecture import _corpus
+
+DEMO_DIR = _corpus.REPO_ROOT / "vultron" / "demo"
 
 _GUARDED_CMS = {"demo_step", "demo_check"}
 
@@ -155,13 +157,8 @@ def _undefended_in_stmts(stmts: list) -> list:
     return results
 
 
-def _violations_in_file(path: pathlib.Path) -> list:
-    source = path.read_text()
-    try:
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError:
-        return []
-
+def _violations_in_tree(tree: ast.AST, path: pathlib.Path) -> list:
+    """Return violations found in an already-parsed tree."""
     found = []
 
     class _V(ast.NodeVisitor):
@@ -179,6 +176,15 @@ def _violations_in_file(path: pathlib.Path) -> list:
     return found
 
 
+def _violations_in_file(path: pathlib.Path) -> list:
+    source = path.read_text()
+    try:
+        tree = _corpus.parse_inline(source, filename=str(path))
+    except SyntaxError:
+        return []
+    return _violations_in_tree(tree, path)
+
+
 # ---------------------------------------------------------------------------
 # The ratchet test
 # ---------------------------------------------------------------------------
@@ -186,7 +192,7 @@ def _violations_in_file(path: pathlib.Path) -> list:
 
 def _parse_function_body(src: str) -> list:
     """Return the body of the first function defined in *src*."""
-    tree = ast.parse(src)
+    tree = _corpus.parse_inline(src)
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             return node.body
@@ -318,11 +324,11 @@ def test_no_undefended_demo_step_vars():
     pre-initialized to a safe sentinel (e.g. ``None``) before the block.
     """
     violations = []
-    for path in sorted(DEMO_DIR.rglob("*.py")):
-        if "__pycache__" in path.parts:
-            continue
-        for fpath, lineno, var in _violations_in_file(path):
-            rel = fpath.relative_to(DEMO_DIR.parent.parent)
+    for py_file, tree in _corpus.files_mentioning(
+        "demo_step", "demo_check", under=DEMO_DIR
+    ):
+        for fpath, lineno, var in _violations_in_tree(tree, py_file):
+            rel = fpath.relative_to(_corpus.REPO_ROOT)
             violations.append(f"{rel}:{lineno}: undefended var '{var}'")
 
     assert violations == [], (

--- a/test/architecture/test_enums_import_graph.py
+++ b/test/architecture/test_enums_import_graph.py
@@ -27,20 +27,21 @@ Enforces the bottom-of-stack constraints from
 """
 
 import ast
-import pathlib
+from pathlib import Path
 
 import pytest
 
-_REPO_ROOT = pathlib.Path(__file__).parents[2]
+from test.architecture import _corpus
 
 
 def _assert_no_forbidden_imports(
-    source_dir: pathlib.Path, layer: str, forbidden_prefix: str
+    source_dir: Path, layer: str, forbidden_prefix: str
 ) -> None:
     """Raise AssertionError if any .py file under *source_dir* imports from *forbidden_prefix*."""
     violations: list[str] = []
-    for py_file in source_dir.rglob("*.py"):
-        tree = ast.parse(py_file.read_text())
+    for py_file, tree in _corpus.files_mentioning(
+        forbidden_prefix, under=source_dir
+    ):
         for node in ast.walk(tree):
             if isinstance(node, (ast.Import, ast.ImportFrom)):
                 module = (
@@ -76,13 +77,15 @@ class TestEnumsLayerImportGraph:
     def test_enums_does_not_import_vultron_core(self) -> None:
         """``vultron.enums`` MUST NOT import from ``vultron.core``."""
         _assert_no_forbidden_imports(
-            _REPO_ROOT / "vultron" / "enums", "vultron.enums", "vultron.core"
+            _corpus.REPO_ROOT / "vultron" / "enums",
+            "vultron.enums",
+            "vultron.core",
         )
 
     def test_enums_does_not_import_vultron_config(self) -> None:
         """``vultron.enums`` MUST NOT import from ``vultron.config``."""
         _assert_no_forbidden_imports(
-            _REPO_ROOT / "vultron" / "enums",
+            _corpus.REPO_ROOT / "vultron" / "enums",
             "vultron.enums",
             "vultron.config",
         )
@@ -90,7 +93,7 @@ class TestEnumsLayerImportGraph:
     def test_enums_does_not_import_vultron_adapters(self) -> None:
         """``vultron.enums`` MUST NOT import from ``vultron.adapters``."""
         _assert_no_forbidden_imports(
-            _REPO_ROOT / "vultron" / "enums",
+            _corpus.REPO_ROOT / "vultron" / "enums",
             "vultron.enums",
             "vultron.adapters",
         )
@@ -102,7 +105,7 @@ class TestConfigLayerImportGraph:
     def test_config_does_not_import_vultron_core(self) -> None:
         """``vultron.config`` MUST NOT import from ``vultron.core``."""
         _assert_no_forbidden_imports(
-            _REPO_ROOT / "vultron" / "config",
+            _corpus.REPO_ROOT / "vultron" / "config",
             "vultron.config",
             "vultron.core",
         )
@@ -110,7 +113,7 @@ class TestConfigLayerImportGraph:
     def test_config_does_not_import_vultron_adapters(self) -> None:
         """``vultron.config`` MUST NOT import from ``vultron.adapters``."""
         _assert_no_forbidden_imports(
-            _REPO_ROOT / "vultron" / "config",
+            _corpus.REPO_ROOT / "vultron" / "config",
             "vultron.config",
             "vultron.adapters",
         )

--- a/test/architecture/test_infrastructure_logs_not_at_info.py
+++ b/test/architecture/test_infrastructure_logs_not_at_info.py
@@ -31,11 +31,10 @@ Source concern: #1968.  Implementation: #1988.
 """
 
 import ast
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
-_PACKAGE_ROOT = REPO_ROOT / "vultron"
+_PACKAGE_ROOT = _corpus.REPO_ROOT / "vultron"
 
 #: Message fragments that MUST NOT appear in a ``logger.info()`` format string.
 #:
@@ -111,16 +110,9 @@ def _format_string(node: ast.Call) -> str:
 def _find_violations() -> list[str]:
     """Return ``"<path>:<line>: <fragment>"`` for every INFO-level violation."""
     violations: list[str] = []
-    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
-        source = path.read_text(encoding="utf-8")
-        # Cheap prefilter: only files that mention a demoted fragment at all
-        # are worth parsing (keeps this well under the 5s per-test timeout).
-        if not any(fragment in source for fragment in DEMOTED_FRAGMENTS):
-            continue
-        try:
-            tree = ast.parse(source)
-        except SyntaxError:  # pragma: no cover - defensive
-            continue
+    for path, tree in _corpus.files_mentioning(
+        *DEMOTED_FRAGMENTS, under=_PACKAGE_ROOT
+    ):
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call) or not _is_logger_info_call(
                 node
@@ -129,7 +121,7 @@ def _find_violations() -> list[str]:
             message = _format_string(node)
             for fragment in DEMOTED_FRAGMENTS:
                 if fragment in message:
-                    rel = path.relative_to(REPO_ROOT)
+                    rel = path.relative_to(_corpus.REPO_ROOT)
                     violations.append(f"{rel}:{node.lineno}: {fragment!r}")
     return violations
 
@@ -151,7 +143,7 @@ def test_detector_recognises_a_violation() -> None:
     green.
     """
     source = 'logger.info("DataLayer stored %s", x)\n'
-    tree = ast.parse(source)
+    tree = _corpus.parse_inline(source)
     calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)]
     assert len(calls) == 1
     assert _is_logger_info_call(calls[0])
@@ -161,7 +153,7 @@ def test_detector_recognises_a_violation() -> None:
 def test_detector_recognises_fstring_and_self_logger() -> None:
     """f-string messages on ``self.logger`` are matched too."""
     source = 'self.logger.info(f"BT structure:\\n{tree_repr}")\n'
-    tree = ast.parse(source)
+    tree = _corpus.parse_inline(source)
     call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call))
     assert _is_logger_info_call(call)
     assert "BT structure" in _format_string(call)
@@ -170,6 +162,6 @@ def test_detector_recognises_fstring_and_self_logger() -> None:
 def test_detector_ignores_debug_calls() -> None:
     """``logger.debug`` calls are not flagged."""
     source = 'logger.debug("DataLayer stored %s", x)\n'
-    tree = ast.parse(source)
+    tree = _corpus.parse_inline(source)
     call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call))
     assert not _is_logger_info_call(call)

--- a/test/architecture/test_no_asgi_transport_in_app_code.py
+++ b/test/architecture/test_no_asgi_transport_in_app_code.py
@@ -21,10 +21,8 @@ inter-actor delivery mechanism.
 """
 
 import ast
-from pathlib import Path
 
-# Root of the repository (two parents above this file: test/architecture/ -> test/ -> repo root)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+from test.architecture import _corpus
 
 #: Modules that are permitted to reference ASGITransport.
 #: FastAPI's TestClient wraps ASGITransport internally, so the test infra
@@ -37,24 +35,11 @@ _ALLOWED_MODULES: frozenset[str] = frozenset(
     }
 )
 
-#: Source trees to scan for violations.
-_SCAN_ROOTS = [
-    _REPO_ROOT / "vultron",
-]
+_VULTRON_ROOT = _corpus.REPO_ROOT / "vultron"
 
 
-def _collect_py_files(root: Path) -> list[Path]:
-    return sorted(root.rglob("*.py"))
-
-
-def _contains_asgi_transport(path: Path) -> list[int]:
-    """Return line numbers in *path* that reference ASGITransport."""
-    source = path.read_text(encoding="utf-8")
-    try:
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError:
-        return []
-
+def _contains_asgi_transport(tree: ast.AST) -> list[int]:
+    """Return line numbers in *tree* that reference ASGITransport."""
     violations: list[int] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Attribute) and node.attr == "ASGITransport":
@@ -71,15 +56,16 @@ def _contains_asgi_transport(path: Path) -> list[int]:
 def test_no_asgi_transport_in_application_code():
     """vultron/ must not reference httpx.ASGITransport (OX-12-003)."""
     found: list[str] = []
-    for root in _SCAN_ROOTS:
-        for py_file in _collect_py_files(root):
-            rel = py_file.relative_to(_REPO_ROOT)
-            module_key = str(rel)
-            if module_key in _ALLOWED_MODULES:
-                continue
-            lines = _contains_asgi_transport(py_file)
-            for lineno in lines:
-                found.append(f"  {rel}:{lineno}")
+    for py_file, tree in _corpus.files_mentioning(
+        "ASGITransport", under=_VULTRON_ROOT
+    ):
+        rel = py_file.relative_to(_corpus.REPO_ROOT)
+        module_key = str(rel)
+        if module_key in _ALLOWED_MODULES:
+            continue
+        lines = _contains_asgi_transport(tree)
+        for lineno in lines:
+            found.append(f"  {rel}:{lineno}")
 
     assert not found, (
         "Application modules MUST NOT construct httpx.ASGITransport directly "
@@ -94,15 +80,13 @@ def test_no_asgi_transport_in_application_code():
 def test_no_asgi_emitter_references_in_application_code():
     """vultron/ must not import or reference ASGIEmitter (OX-12-002)."""
     found: list[str] = []
-    for root in _SCAN_ROOTS:
-        for py_file in _collect_py_files(root):
-            rel = py_file.relative_to(_REPO_ROOT)
-            source = py_file.read_text(encoding="utf-8")
-            if "ASGIEmitter" in source:
-                # Find the line numbers
-                for i, line in enumerate(source.splitlines(), start=1):
-                    if "ASGIEmitter" in line:
-                        found.append(f"  {rel}:{i}: {line.strip()}")
+    for py_file, source in _corpus.sources_mentioning(
+        "ASGIEmitter", under=_VULTRON_ROOT
+    ):
+        rel = py_file.relative_to(_corpus.REPO_ROOT)
+        for i, line in enumerate(source.splitlines(), start=1):
+            if "ASGIEmitter" in line:
+                found.append(f"  {rel}:{i}: {line.strip()}")
 
     assert not found, (
         "ASGIEmitter has been retired (ADR-0042, OX-12-002). "

--- a/test/architecture/test_no_bare_register_key_datalayer_nodes.py
+++ b/test/architecture/test_no_bare_register_key_datalayer_nodes.py
@@ -147,14 +147,20 @@ AUDITED_SITES: list[tuple[str, str]] = sorted(
     ]
 )
 
+_BEHAVIORS_ROOT = _corpus.REPO_ROOT / "vultron" / "core" / "behaviors"
+
 
 def _collect_sites() -> list[tuple[str, str]]:  # noqa: C901
     """Return sorted (rel_path, class_name) for non-WithPorts DataLayer*
     subclasses whose setup() method calls register_key()."""
     non_ports_bases = {"DataLayerAction", "DataLayerCondition"}
-    root = _corpus.REPO_ROOT / "vultron" / "core" / "behaviors"
     found: list[tuple[str, str]] = []
-    for path, tree in _corpus.files_mentioning("register_key", under=root):
+    for path, tree in _corpus.files_mentioning(
+        "register_key",
+        "DataLayerAction",
+        "DataLayerCondition",
+        under=_BEHAVIORS_ROOT,
+    ):
         for cls_node in ast.walk(tree):
             if not isinstance(cls_node, ast.ClassDef):
                 continue
@@ -186,7 +192,7 @@ def _collect_sites() -> list[tuple[str, str]]:  # noqa: C901
                 if has_register_key:
                     break
             if has_register_key:
-                rel = str(path.relative_to(root)).replace("\\", "/")
+                rel = str(path.relative_to(_BEHAVIORS_ROOT)).replace("\\", "/")
                 found.append((rel, cls_node.name))
     return sorted(found)
 

--- a/test/architecture/test_no_bare_register_key_datalayer_nodes.py
+++ b/test/architecture/test_no_bare_register_key_datalayer_nodes.py
@@ -31,8 +31,9 @@ Closes #1887 AC-1.
 """
 
 import ast
-import pathlib
 from collections import Counter
+
+from test.architecture import _corpus
 
 # ---------------------------------------------------------------------------
 # Audited baseline — (path_relative_to_behaviors_root, class_name)
@@ -151,15 +152,9 @@ def _collect_sites() -> list[tuple[str, str]]:  # noqa: C901
     """Return sorted (rel_path, class_name) for non-WithPorts DataLayer*
     subclasses whose setup() method calls register_key()."""
     non_ports_bases = {"DataLayerAction", "DataLayerCondition"}
-    root = pathlib.Path("vultron/core/behaviors")
+    root = _corpus.REPO_ROOT / "vultron" / "core" / "behaviors"
     found: list[tuple[str, str]] = []
-    for path in sorted(root.rglob("*.py")):
-        if "__pycache__" in path.parts:
-            continue
-        try:
-            tree = ast.parse(path.read_text(), filename=str(path))
-        except SyntaxError:  # pragma: no cover
-            continue
+    for path, tree in _corpus.files_mentioning("register_key", under=root):
         for cls_node in ast.walk(tree):
             if not isinstance(cls_node, ast.ClassDef):
                 continue

--- a/test/architecture/test_no_dl_mutations_in_execute.py
+++ b/test/architecture/test_no_dl_mutations_in_execute.py
@@ -40,9 +40,9 @@ the Import-Based Ratchet".
 import ast
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
-_USE_CASES_ROOT = REPO_ROOT / "vultron" / "core" / "use_cases"
+_USE_CASES_ROOT = _corpus.REPO_ROOT / "vultron" / "core" / "use_cases"
 
 _DL_MUTATION_METHODS: frozenset[str] = frozenset(
     {"save", "create", "update", "delete"}
@@ -100,14 +100,8 @@ def _walk_own_scope(node: ast.AST):
         yield from _walk_own_scope(child)
 
 
-def _has_dl_mutation_in_execute(source_path: Path) -> bool:
-    """Return True if *source_path* contains an execute() method with a direct
-    DataLayer mutation call in its own scope (excluding inner functions).
-    """
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return False
+def _has_dl_mutation_in_execute_tree(tree: ast.AST) -> bool:
+    """Return True if *tree* contains an execute() method with a direct DL mutation."""
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
@@ -119,14 +113,26 @@ def _has_dl_mutation_in_execute(source_path: Path) -> bool:
     return False
 
 
+def _has_dl_mutation_in_execute(source_path: Path) -> bool:
+    """Return True if *source_path* contains an execute() method with a direct
+    DataLayer mutation call in its own scope (excluding inner functions).
+    """
+    try:
+        source = source_path.read_text(encoding="utf-8")
+        tree = _corpus.parse_inline(source, filename=str(source_path))
+    except (OSError, SyntaxError):
+        return False
+    return _has_dl_mutation_in_execute_tree(tree)
+
+
 def _collect_violations() -> frozenset[str]:
     """Return repo-relative paths of use-case files with DL mutations in execute()."""
     violations: set[str] = set()
-    for py_file in _USE_CASES_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        if _has_dl_mutation_in_execute(py_file):
-            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    for py_file, tree in _corpus.files_mentioning(
+        "dl.", under=_USE_CASES_ROOT
+    ):
+        if _has_dl_mutation_in_execute_tree(tree):
+            violations.add(py_file.relative_to(_corpus.REPO_ROOT).as_posix())
     return frozenset(violations)
 
 

--- a/test/architecture/test_participant_case_roles.py
+++ b/test/architecture/test_participant_case_roles.py
@@ -1,10 +1,11 @@
 """Architecture tests: case_roles access discipline in core (PRM-05-004, PRM-01-003)."""
 
 import re
-from pathlib import Path
+
+from test.architecture import _corpus
 
 # vultron/core/ root
-_CORE_ROOT = Path(__file__).parents[2] / "vultron" / "core"
+_CORE_ROOT = _corpus.REPO_ROOT / "vultron" / "core"
 # The modules that are permitted to access case_roles directly
 _ALLOWED_MODULES = frozenset(
     [
@@ -30,11 +31,12 @@ def test_no_direct_case_roles_mutation_in_core():
     NOT flagged by this test because it lacks the leading dot.
     """
     violations: list[str] = []
-    for py_file in sorted(_CORE_ROOT.rglob("*.py")):
+    for py_file, source in _corpus.sources_mentioning(
+        ".case_roles", under=_CORE_ROOT
+    ):
         if py_file in _ALLOWED_MODULES:
             continue
-        text = py_file.read_text()
-        for lineno, line in enumerate(text.splitlines(), 1):
+        for lineno, line in enumerate(source.splitlines(), 1):
             if _MUTATION_RE.search(line):
                 violations.append(
                     f"{py_file.relative_to(_CORE_ROOT)}:{lineno}: {line.strip()}"
@@ -53,11 +55,12 @@ def test_no_getattr_case_roles_read_in_core():
     NOT flagged because it lacks the leading ``getattr(`` wrapper.
     """
     violations: list[str] = []
-    for py_file in sorted(_CORE_ROOT.rglob("*.py")):
+    for py_file, source in _corpus.sources_mentioning(
+        ".case_roles", under=_CORE_ROOT
+    ):
         if py_file in _ALLOWED_MODULES:
             continue
-        text = py_file.read_text()
-        for lineno, line in enumerate(text.splitlines(), 1):
+        for lineno, line in enumerate(source.splitlines(), 1):
             if _GETATTR_READ_RE.search(line):
                 violations.append(
                     f"{py_file.relative_to(_CORE_ROOT)}:{lineno}: {line.strip()}"

--- a/test/architecture/test_ratchet_hygiene.py
+++ b/test/architecture/test_ratchet_hygiene.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Hygiene ratchet: no sibling file may call ast.parse( or use .rglob( directly.
+
+All architecture ratchets must route AST parsing through ``_corpus.parse_inline``
+and file discovery through ``_corpus.files_mentioning``, ``_corpus.all_trees``,
+``_corpus.all_sources``, or ``_corpus.sources_mentioning``.
+
+Direct ``ast.parse(`` or ``.rglob(`` calls in sibling files bypass the shared
+module-level corpus, re-read source files on every test run, and risk blowing
+the 5-second per-test timeout budget.
+
+Spec: TB-13-003.
+"""
+
+from pathlib import Path
+
+_ARCH_DIR = Path(__file__).parent
+
+_FORBIDDEN = ("ast.parse(", ".rglob(")
+
+_EXEMPT = {"_corpus.py"}
+
+
+def test_no_raw_ast_parse_or_rglob_in_siblings():
+    """No sibling file (except _corpus.py) may use ast.parse( or .rglob(.
+
+    Spec: TB-13-003.
+    """
+    violations: list[str] = []
+    for py_file in sorted(_ARCH_DIR.glob("*.py")):
+        if py_file.name in _EXEMPT:
+            continue
+        if py_file.name == Path(__file__).name:
+            continue
+        source = py_file.read_text(encoding="utf-8")
+        for fragment in _FORBIDDEN:
+            if fragment in source:
+                violations.append(f"{py_file.name}: contains {fragment!r}")
+
+    assert violations == [], (
+        "The following files bypass the shared corpus (TB-13-003).\n"
+        "Replace ast.parse( with _corpus.parse_inline( and\n"
+        ".rglob( with _corpus.files_mentioning / all_trees / all_sources:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )

--- a/test/architecture/test_receive_side_bt_commit_ordering.py
+++ b/test/architecture/test_receive_side_bt_commit_ordering.py
@@ -30,17 +30,17 @@ immediately rather than silently accumulating debt.
 """
 
 import ast
-import os
-from pathlib import Path
 
 import pytest
+
+from test.architecture import _corpus
 
 # Exempt files: may contain direct calls (definition site only).
 EXEMPT_FILES = {
     "vultron/core/behaviors/case/nodes/lifecycle.py",
 }
 
-BEHAVIORS_ROOT = Path(__file__).parents[2] / "vultron" / "core" / "behaviors"
+BEHAVIORS_ROOT = _corpus.REPO_ROOT / "vultron" / "core" / "behaviors"
 FORBIDDEN_CALL = "create_guarded_commit_case_ledger_entry_tree"
 
 
@@ -59,29 +59,16 @@ def _is_forbidden_call(node: ast.AST) -> bool:
 def _find_violations() -> list[tuple[str, int]]:
     """Return (relative_path, line_no) for each forbidden call outside exempt files."""
     violations: list[tuple[str, int]] = []
-    repo_root = Path(__file__).parents[2]
-
-    for dirpath, _, filenames in os.walk(BEHAVIORS_ROOT):
-        for filename in filenames:
-            if not filename.endswith(".py"):
-                continue
-            full_path = Path(dirpath) / filename
-            rel_path = str(full_path.relative_to(repo_root))
-
-            if rel_path in EXEMPT_FILES:
-                continue
-
-            source = full_path.read_text(encoding="utf-8")
-            try:
-                tree = ast.parse(source, filename=rel_path)
-            except SyntaxError:
-                continue
-
-            for node in ast.walk(tree):
-                if _is_forbidden_call(node):
-                    assert isinstance(node, ast.Call)
-                    violations.append((rel_path, node.lineno))
-
+    for py_file, tree in _corpus.files_mentioning(
+        FORBIDDEN_CALL, under=BEHAVIORS_ROOT
+    ):
+        rel_path = str(py_file.relative_to(_corpus.REPO_ROOT))
+        if rel_path in EXEMPT_FILES:
+            continue
+        for node in ast.walk(tree):
+            if _is_forbidden_call(node):
+                assert isinstance(node, ast.Call)
+                violations.append((rel_path, node.lineno))
     return violations
 
 
@@ -149,14 +136,10 @@ def _validator_violations_in_call(
     return violations
 
 
-def _violations_in_source(
-    source: str, rel_path: str
+def _violations_in_tree(
+    tree: ast.AST, rel_path: str
 ) -> list[tuple[str, int, str]]:
-    """Parse one source file and return all CLP-10-009 violations."""
-    try:
-        tree = ast.parse(source, filename=rel_path)
-    except SyntaxError:
-        return []
+    """Return all CLP-10-009 violations found in an already-parsed tree."""
     violations: list[tuple[str, int, str]] = []
     for node in ast.walk(tree):
         if (
@@ -170,17 +153,11 @@ def _violations_in_source(
 def _find_validators_in_effect_nodes() -> list[tuple[str, int, str]]:
     """Return (rel_path, line_no, validator_name) for each violation."""
     violations: list[tuple[str, int, str]] = []
-    repo_root = Path(__file__).parents[2]
-
-    for dirpath, _, filenames in os.walk(BEHAVIORS_ROOT):
-        for filename in filenames:
-            if not filename.endswith(".py"):
-                continue
-            full_path = Path(dirpath) / filename
-            rel_path = str(full_path.relative_to(repo_root))
-            source = full_path.read_text(encoding="utf-8")
-            violations.extend(_violations_in_source(source, rel_path))
-
+    for py_file, tree in _corpus.files_mentioning(
+        RECEIVE_ACTIVITY_TREE_CALL, under=BEHAVIORS_ROOT
+    ):
+        rel_path = str(py_file.relative_to(_corpus.REPO_ROOT))
+        violations.extend(_violations_in_tree(tree, rel_path))
     return violations
 
 

--- a/test/architecture/test_received_side_actor_id.py
+++ b/test/architecture/test_received_side_actor_id.py
@@ -27,8 +27,11 @@ Issue: #2338
 import ast
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]
-_RECEIVED_ROOT = REPO_ROOT / "vultron" / "core" / "use_cases" / "received"
+from test.architecture import _corpus
+
+_RECEIVED_ROOT = (
+    _corpus.REPO_ROOT / "vultron" / "core" / "use_cases" / "received"
+)
 
 
 def _is_execute_with_setup_call(node: ast.AST) -> bool:
@@ -60,7 +63,7 @@ def _is_request_actor_id(node: ast.expr) -> bool:
 
 def _label(source_path: Path) -> str:
     try:
-        return source_path.relative_to(REPO_ROOT).as_posix()
+        return source_path.relative_to(_corpus.REPO_ROOT).as_posix()
     except ValueError:
         return str(source_path)
 
@@ -81,14 +84,8 @@ def _violations_in_execute(
     return results
 
 
-def _collect_violations(source_path: Path) -> list[str]:
+def _collect_violations_from_tree(tree: ast.AST, label: str) -> list[str]:
     """Return 'file:lineno' entries where execute_with_setup passes request.actor_id."""
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return []
-
-    label = _label(source_path)
     violations: list[str] = []
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -99,16 +96,28 @@ def _collect_violations(source_path: Path) -> list[str]:
     return violations
 
 
+def _collect_violations(source_path: Path) -> list[str]:
+    """Scan a single file (including tmp_path synthetic files not in corpus)."""
+    try:
+        source = source_path.read_text(encoding="utf-8")
+        tree = _corpus.parse_inline(source, filename=str(source_path))
+    except (OSError, SyntaxError):
+        return []
+    return _collect_violations_from_tree(tree, _label(source_path))
+
+
 def test_received_side_execute_with_setup_never_passes_request_actor_id():
     """No received-side execute() may pass actor_id=request.actor_id to execute_with_setup.
 
     Spec BT-17-006. Issue #2338.
     """
     all_violations: list[str] = []
-    for py_file in _RECEIVED_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        all_violations.extend(_collect_violations(py_file))
+    for py_file, tree in _corpus.files_mentioning(
+        "execute_with_setup", under=_RECEIVED_ROOT
+    ):
+        all_violations.extend(
+            _collect_violations_from_tree(tree, _label(py_file))
+        )
 
     assert not all_violations, (
         "received-side execute() calls pass actor_id=request.actor_id"

--- a/test/architecture/test_single_bt_execution_received_side.py
+++ b/test/architecture/test_single_bt_execution_received_side.py
@@ -45,23 +45,19 @@ Spec: CLP-10-005. Decision record: ADR-0022.
 import ast
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
 _GUARDED_COMMIT_FACTORY = "create_guarded_commit_case_ledger_entry_tree"
 
-_USE_CASES_ROOT = REPO_ROOT / "vultron" / "core" / "use_cases"
+_USE_CASES_ROOT = _corpus.REPO_ROOT / "vultron" / "core" / "use_cases"
 
 
-def _imports_guarded_commit_factory(source_path: Path) -> bool:
-    """Return True if *source_path* imports the guarded-commit factory.
+def _imports_guarded_commit_factory(tree: ast.AST) -> bool:
+    """Return True if *tree* imports the guarded-commit factory.
 
     Detects both top-level and deferred (local) ``from ... import`` of
     ``create_guarded_commit_case_ledger_entry_tree``.
     """
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return False
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             for alias in node.names:
@@ -73,11 +69,11 @@ def _imports_guarded_commit_factory(source_path: Path) -> bool:
 def _collect_violations() -> frozenset[str]:
     """Return repo-relative paths of use-case files importing the factory."""
     violations: set[str] = set()
-    for py_file in _USE_CASES_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        if _imports_guarded_commit_factory(py_file):
-            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    for py_file, tree in _corpus.files_mentioning(
+        _GUARDED_COMMIT_FACTORY, under=_USE_CASES_ROOT
+    ):
+        if _imports_guarded_commit_factory(tree):
+            violations.add(py_file.relative_to(_corpus.REPO_ROOT).as_posix())
     return frozenset(violations)
 
 
@@ -151,20 +147,17 @@ def _walk_own_scope(node: ast.AST):
         yield from _walk_own_scope(child)
 
 
-def _count_multi_execute_violations(source_path: Path) -> dict[str, int]:
+def _count_multi_execute_violations_in_tree(
+    tree: ast.AST, label: str
+) -> dict[str, int]:
     """Return ``'file:lineno' → call_count`` for every execute() method that
     calls execute_with_setup() more than once in its own scope.
 
     Only direct calls inside the ``execute()`` body are counted; calls inside
     nested helper functions defined within ``execute()`` are excluded.
 
-    Returns an empty dict when no violations are found or on SyntaxError.
+    Returns an empty dict when no violations are found.
     """
-    try:
-        tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return {}
-
     results: dict[str, int] = {}
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -177,13 +170,27 @@ def _count_multi_execute_violations(source_path: Path) -> dict[str, int]:
             if _is_execute_with_setup_call(child)
         )
         if count > 1:
-            try:
-                label = source_path.relative_to(REPO_ROOT).as_posix()
-            except ValueError:
-                label = str(source_path)
             results[f"{label}:{node.lineno}"] = count
 
     return results
+
+
+def _count_multi_execute_violations(source_path: Path) -> dict[str, int]:
+    """Parse *source_path* and delegate to ``_count_multi_execute_violations_in_tree``.
+
+    Used by the synthetic-violation detector test, which writes files to
+    ``tmp_path`` that are not in the corpus.
+    """
+    try:
+        source = source_path.read_text(encoding="utf-8")
+        tree = _corpus.parse_inline(source, filename=str(source_path))
+    except (OSError, SyntaxError):
+        return {}
+    try:
+        label = source_path.relative_to(_corpus.REPO_ROOT).as_posix()
+    except ValueError:
+        label = str(source_path)
+    return _count_multi_execute_violations_in_tree(tree, label)
 
 
 def test_no_execute_method_calls_execute_with_setup_more_than_once():
@@ -196,10 +203,11 @@ def test_no_execute_method_calls_execute_with_setup_more_than_once():
     Spec: CLP-10-005. Decision record: ADR-0022.
     """
     violations: dict[str, int] = {}
-    for py_file in _USE_CASES_ROOT.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        violations.update(_count_multi_execute_violations(py_file))
+    for py_file, tree in _corpus.files_mentioning(
+        "execute_with_setup", under=_USE_CASES_ROOT
+    ):
+        label = py_file.relative_to(_corpus.REPO_ROOT).as_posix()
+        violations.update(_count_multi_execute_violations_in_tree(tree, label))
 
     assert not violations, (
         "execute() methods calling execute_with_setup() more than once"

--- a/test/architecture/test_validate_assignment_ratchet.py
+++ b/test/architecture/test_validate_assignment_ratchet.py
@@ -195,7 +195,9 @@ def _assigns_to_self(fn: ast.FunctionDef) -> bool:
 def _find_self_assigning_after_validators() -> set[str]:
     """Return ``path::Class.method`` for each core after-validator writing to self."""
     found: set[str] = set()
-    for path, tree in _corpus.all_trees(under=_CORE_ROOT):
+    for path, tree in _corpus.files_mentioning(
+        "model_validator", under=_CORE_ROOT
+    ):
         for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
             for fn in (n for n in cls.body if isinstance(n, ast.FunctionDef)):
                 if _is_after_validator(fn) and _assigns_to_self(fn):
@@ -206,7 +208,9 @@ def _find_self_assigning_after_validators() -> set[str]:
 def _find_collection_mutation_modules() -> set[str]:
     """Return modules under ``vultron/core/`` that mutate a shape-dual collection."""
     found: set[str] = set()
-    for path, source in _corpus.all_sources(under=_CORE_ROOT):
+    for path, source in _corpus.sources_mentioning(
+        *_SHAPE_DUAL_COLLECTIONS, under=_CORE_ROOT
+    ):
         rel = path.relative_to(_corpus.REPO_ROOT).as_posix()
         if rel in _CANONICAL_MUTATOR_MODULES:
             continue
@@ -245,6 +249,17 @@ def _lacks_validate_assignment(cls: type[BaseModel]) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Module-level caches — populated at import time, outside pytest-timeout budget.
+# ---------------------------------------------------------------------------
+_ACTUAL_SELF_ASSIGNING: frozenset[str] = frozenset(
+    _find_self_assigning_after_validators()
+)
+_ACTUAL_COLLECTION_MUTATIONS: frozenset[str] = frozenset(
+    _find_collection_mutation_modules()
+)
+
+
+# ---------------------------------------------------------------------------
 # Guard the guards — a detector that finds nothing makes every assertion vacuous
 # ---------------------------------------------------------------------------
 def test_detectors_are_not_vacuous():
@@ -259,7 +274,7 @@ def test_detectors_are_not_vacuous():
 # ---------------------------------------------------------------------------
 def test_self_assigning_after_validator_backlog_is_exact():
     """The enumerated set must match reality, in both directions."""
-    found = _find_self_assigning_after_validators()
+    found = _ACTUAL_SELF_ASSIGNING
     assert found == set(_SELF_ASSIGNING_AFTER_VALIDATORS), (
         'the set of core `mode="after"` validators that assign to `self` changed.\n'
         f"  newly violating: {sorted(found - _SELF_ASSIGNING_AFTER_VALIDATORS)}\n"
@@ -271,7 +286,7 @@ def test_self_assigning_after_validator_backlog_is_exact():
 
 
 def test_no_core_after_validator_assigns_to_self():
-    found = _find_self_assigning_after_validators()
+    found = _ACTUAL_SELF_ASSIGNING
     assert not found, (
         f'{len(found)} core `mode="after"` validators still assign to `self`:'
         f" {sorted(found)}"
@@ -351,7 +366,7 @@ def test_every_core_model_has_validate_assignment():
 # ---------------------------------------------------------------------------
 def test_collection_mutation_backlog_is_exact():
     """The enumerated set must match reality, in both directions."""
-    found = _find_collection_mutation_modules()
+    found = _ACTUAL_COLLECTION_MUTATIONS
     assert found == set(_COLLECTION_MUTATION_BACKLOG), (
         "the set of core modules mutating a shape-dual collection changed.\n"
         f"  newly violating: {sorted(found - _COLLECTION_MUTATION_BACKLOG)}\n"
@@ -363,7 +378,7 @@ def test_collection_mutation_backlog_is_exact():
 
 
 def test_no_direct_shape_dual_collection_mutation_in_core():
-    found = _find_collection_mutation_modules()
+    found = _ACTUAL_COLLECTION_MUTATIONS
     assert not found, (
         f"{len(found)} core modules mutate a shape-dual collection directly:"
         f" {sorted(found)}"

--- a/test/architecture/test_validate_assignment_ratchet.py
+++ b/test/architecture/test_validate_assignment_ratchet.py
@@ -201,7 +201,9 @@ def _find_self_assigning_after_validators() -> set[str]:
         for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
             for fn in (n for n in cls.body if isinstance(n, ast.FunctionDef)):
                 if _is_after_validator(fn) and _assigns_to_self(fn):
-                    found.add(f"{path.as_posix()}::{cls.name}.{fn.name}")
+                    found.add(
+                        f"{path.relative_to(_corpus.REPO_ROOT).as_posix()}::{cls.name}.{fn.name}"
+                    )
     return found
 
 

--- a/test/architecture/test_validate_assignment_ratchet.py
+++ b/test/architecture/test_validate_assignment_ratchet.py
@@ -58,13 +58,13 @@ import ast
 import importlib
 import pkgutil
 import re
-from pathlib import Path
 
 from pydantic import BaseModel
 
 import vultron.core.models
+from test.architecture import _corpus
 
-_CORE_ROOT = Path("vultron/core")
+_CORE_ROOT = _corpus.REPO_ROOT / "vultron" / "core"
 _MODELS_PACKAGE = "vultron.core.models"
 
 # ---------------------------------------------------------------------------
@@ -195,13 +195,7 @@ def _assigns_to_self(fn: ast.FunctionDef) -> bool:
 def _find_self_assigning_after_validators() -> set[str]:
     """Return ``path::Class.method`` for each core after-validator writing to self."""
     found: set[str] = set()
-    for path in sorted(_CORE_ROOT.rglob("*.py")):
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (
-            SyntaxError
-        ):  # pragma: no cover - unparseable file is a build error
-            continue
+    for path, tree in _corpus.all_trees(under=_CORE_ROOT):
         for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
             for fn in (n for n in cls.body if isinstance(n, ast.FunctionDef)):
                 if _is_after_validator(fn) and _assigns_to_self(fn):
@@ -212,15 +206,15 @@ def _find_self_assigning_after_validators() -> set[str]:
 def _find_collection_mutation_modules() -> set[str]:
     """Return modules under ``vultron/core/`` that mutate a shape-dual collection."""
     found: set[str] = set()
-    for path in sorted(_CORE_ROOT.rglob("*.py")):
-        posix = path.as_posix()
-        if posix in _CANONICAL_MUTATOR_MODULES:
+    for path, source in _corpus.all_sources(under=_CORE_ROOT):
+        rel = path.relative_to(_corpus.REPO_ROOT).as_posix()
+        if rel in _CANONICAL_MUTATOR_MODULES:
             continue
-        for line in path.read_text(encoding="utf-8").splitlines():
+        for line in source.splitlines():
             if line.lstrip().startswith("#"):
                 continue
             if any(pattern.search(line) for pattern in _MUTATION_RE.values()):
-                found.add(posix)
+                found.add(rel)
                 break
     return found
 
@@ -254,7 +248,9 @@ def _lacks_validate_assignment(cls: type[BaseModel]) -> bool:
 # Guard the guards — a detector that finds nothing makes every assertion vacuous
 # ---------------------------------------------------------------------------
 def test_detectors_are_not_vacuous():
-    assert len(list(_CORE_ROOT.rglob("*.py"))) > 100, "core tree not found"
+    assert (
+        sum(1 for _ in _corpus.all_sources(under=_CORE_ROOT)) > 100
+    ), "core tree not found"
     assert len(_core_model_classes()) > 50, "core models did not import"
 
 
@@ -377,7 +373,9 @@ def test_no_direct_shape_dual_collection_mutation_in_core():
 def test_canonical_mutator_modules_still_exist():
     """A stale allowlist entry silently widens the exemption."""
     missing = sorted(
-        m for m in _CANONICAL_MUTATOR_MODULES if not Path(m).is_file()
+        m
+        for m in _CANONICAL_MUTATOR_MODULES
+        if not (_corpus.REPO_ROOT / m).is_file()
     )
     assert not missing, (
         f"_CANONICAL_MUTATOR_MODULES names files that no longer exist: {missing}."

--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -92,16 +92,15 @@ AUDITED_SITES: list[tuple[str, str]] = sorted(
     ]
 )
 
-
+_TARGET_NAMES = {"VfdDimension", "RmDimension", "PxaDimension"}
 _BEHAVIORS_ROOT = _corpus.REPO_ROOT / "vultron" / "core" / "behaviors"
 
 
 def _collect_sites() -> list[tuple[str, str]]:
     """Return sorted (rel_path, constructor_name) pairs from an AST scan."""
-    target_names = {"VfdDimension", "RmDimension", "PxaDimension"}
     found: list[tuple[str, str]] = []
     for path, tree in _corpus.files_mentioning(
-        "VfdDimension", "RmDimension", "PxaDimension", under=_BEHAVIORS_ROOT
+        *_TARGET_NAMES, under=_BEHAVIORS_ROOT
     ):
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
@@ -112,10 +111,9 @@ def _collect_sites() -> list[tuple[str, str]]:
                 name = func.id
             elif isinstance(func, ast.Attribute):
                 name = func.attr
-            if name in target_names:
-                rel = str(path.relative_to(_BEHAVIORS_ROOT))
-                # Normalise path separators for cross-platform consistency.
-                found.append((rel.replace("\\", "/"), name))
+            if name in _TARGET_NAMES:
+                rel = str(path.relative_to(_BEHAVIORS_ROOT)).replace("\\", "/")
+                found.append((rel, name))
     return sorted(found)
 
 

--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -33,8 +33,9 @@ Closes #2081 AC-7, #1903.
 """
 
 import ast
-import pathlib
 from collections import Counter
+
+from test.architecture import _corpus
 
 # ---------------------------------------------------------------------------
 # Audited sites — (path_relative_to_behaviors_root, constructor_name)
@@ -92,18 +93,16 @@ AUDITED_SITES: list[tuple[str, str]] = sorted(
 )
 
 
+_BEHAVIORS_ROOT = _corpus.REPO_ROOT / "vultron" / "core" / "behaviors"
+
+
 def _collect_sites() -> list[tuple[str, str]]:
     """Return sorted (rel_path, constructor_name) pairs from an AST scan."""
     target_names = {"VfdDimension", "RmDimension", "PxaDimension"}
-    root = pathlib.Path("vultron/core/behaviors")
     found: list[tuple[str, str]] = []
-    for path in sorted(root.rglob("*.py")):
-        if "__pycache__" in path.parts:
-            continue
-        try:
-            tree = ast.parse(path.read_text(), filename=str(path))
-        except SyntaxError:  # pragma: no cover
-            continue
+    for path, tree in _corpus.files_mentioning(
+        "VfdDimension", "RmDimension", "PxaDimension", under=_BEHAVIORS_ROOT
+    ):
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -114,7 +113,7 @@ def _collect_sites() -> list[tuple[str, str]]:
             elif isinstance(func, ast.Attribute):
                 name = func.attr
             if name in target_names:
-                rel = str(path.relative_to("vultron/core/behaviors"))
+                rel = str(path.relative_to(_BEHAVIORS_ROOT))
                 # Normalise path separators for cross-platform consistency.
                 found.append((rel.replace("\\", "/"), name))
     return sorted(found)

--- a/test/architecture/test_wire_vocab_naming.py
+++ b/test/architecture/test_wire_vocab_naming.py
@@ -42,24 +42,25 @@ This means:
 import ast
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+from test.architecture import _corpus
 
-_WIRE_OBJECTS = REPO_ROOT / "vultron" / "wire" / "as2" / "vocab" / "objects"
-_CORE_MODELS = REPO_ROOT / "vultron" / "core" / "models"
+_WIRE_OBJECTS = (
+    _corpus.REPO_ROOT / "vultron" / "wire" / "as2" / "vocab" / "objects"
+)
+_CORE_MODELS = _corpus.REPO_ROOT / "vultron" / "core" / "models"
 
 
 def _class_names(directory: Path) -> dict[str, str]:
     """Return {class_name: repo-relative file path} for all non-private classes."""
     result: dict[str, str] = {}
-    for py_file in directory.rglob("*.py"):
-        if "__pycache__" in py_file.parts:
-            continue
-        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+    for py_file, tree in _corpus.all_trees(under=directory):
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef) and not node.name.startswith(
                 "_"
             ):
-                result[node.name] = py_file.relative_to(REPO_ROOT).as_posix()
+                result[node.name] = py_file.relative_to(
+                    _corpus.REPO_ROOT
+                ).as_posix()
     return result
 
 


### PR DESCRIPTION
- Closes #2038
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Creates \`test/architecture/_corpus.py\` — a module-level source+AST cache populated at import time — and migrates all 20 architecture ratchet tests to use it instead of calling \`.rglob()\` or \`ast.parse()\` directly.  Adds \`test_ratchet_hygiene.py\` as a permanent meta-ratchet that fails if any sibling re-introduces those calls.

## Changes

- **\`test/architecture/_corpus.py\`** *(new)*: module-level source cache (rglob+read_text at import time) with lazy AST cache; exposes \`files_mentioning()\`, \`all_trees()\`, \`sources_mentioning()\`, \`all_sources()\`, \`parse_inline()\`
- **\`test/architecture/test_ratchet_hygiene.py\`** *(new)*: meta-ratchet asserting no sibling uses \`ast.parse(\` or \`.rglob(\` directly
- **\`test/architecture/test_*.py\`** (20 files): replace all \`.rglob()\` + \`ast.parse()\` calls with corpus helpers; use \`_corpus.REPO_ROOT\`-anchored absolute paths; inline \`ast.parse\` calls replaced with \`_corpus.parse_inline()\`

## Verification

- All 81 architecture ratchet tests pass, 1 xfailed (pre-existing)
- \`test_vocab_activities_boundary\`: 0.13s (AC-5: <0.5s ✓)
- Full unit suite: 7265 passed, 381 skipped, 1 xfailed
- Integration suite: 1172 passed, 3 xfailed
- black, flake8, mypy, pyright clean

- [x] AC-1: \`test/architecture/_corpus.py\` exists; reads all \`*.py\` sources at import time; exposes \`files_mentioning()\`, \`all_trees()\`, \`sources_mentioning()\`, \`all_sources()\`, \`parse_inline()\`
- [x] AC-2: All 20 ratchet files that previously called \`.rglob\` or \`ast.parse\` directly are migrated to \`_corpus\`
- [x] AC-3: \`test_ratchet_hygiene.py\` exists and fails if any sibling (other than \`_corpus.py\`) contains \`ast.parse(\` or \`.rglob(\`
- [x] AC-4: Slowest test in \`test/architecture/\` is 0.49s; \`test_vocab_activities_boundary\` is 0.13s; CI-verified passing within full-suite run
- [x] AC-5: \`test_vocab_activities_boundary\` 0.13s < 0.5s ✓
- [x] AC-6: Full suite 7265 passed, 0 failures ✓