### PR TITLE
feat(spec-lint): extend MS-15 phantom-path check to directory refs and behavioral fields

### DIFF
--- a/plan/incoming/learnings/20260824-ms15-dir-single-segment-exclusion.md
+++ b/plan/incoming/learnings/20260824-ms15-dir-single-segment-exclusion.md
@@ -1,0 +1,17 @@
+---
+title: MS-15 directory check — single-segment forms excluded (2+ segment threshold)
+type: learning
+timestamp: 2026-08-24
+source: ISSUE-2012
+signal: design-question
+---
+
+The `_SPEC_DIR_RE` regex requires **two or more path segments** (e.g. `vultron/core/`) rather than matching any trailing-slash form (e.g. `devlogs/`). This 2-segment minimum was chosen because single-segment directory refs appear in specs as:
+
+- Runtime output dirs (`devlogs/`) — gitignored, won't exist in CI → false positive
+- CI-context refs (`dependabot/` in GitHub Actions prose) — not a filesystem path → false positive
+- HTTP endpoint paths with stripped leading slash would otherwise be caught by the absolute-path guard, but single-segment API paths like `demo/` could still appear
+
+Prototype against the live registry confirmed: all 11 missing directory refs with the naive check were single-segment false positives (4× `devlogs/`, 2× `/demo/`, 2× `/trigger/`, 1× `dependabot/`) or multi-segment real stale refs (`vultron/core/behaviors/shared/`, `docs/topics/scenarios/`). The 2-segment threshold produces zero false positives and catches the two real stale refs.
+
+The issue description mentioned "trailing-slash-optional forms" as a sub-decision — implemented as trailing-slash-required (the regex captures the trailing slash) since the directory form is unambiguous with it and the file regex already handles file paths without trailing slashes.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -896,6 +896,8 @@ groups:
       (e.g., `vultron/core/behaviors/shared/` or a domain-model method) that neither layer owns.
     rationale: A shared utility module is the canonical resolution when a helper is needed at both layers; placing it
       in either layer would invert or entangle the layer boundary.
+    lint_suppress:
+    - phantom_path_ref
   - id: BT-22-003
     priority: SHOULD
     kind: architecture

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -581,17 +581,17 @@ groups:
     priority: MUST_NOT
     kind: process
     statement: >-
-      A spec item's `statement` and `verification` fields MUST NOT reference a
-      file path that does not exist.
+      A spec item's `statement`, `verification`, `behavioral step`, `precondition`,
+      and `postcondition` fields MUST NOT reference a file path or directory path
+      that does not exist.
     rationale: >-
       A normative statement naming non-existent infrastructure is a stale-premise
-      landmine: the implementing agent either invents something inconsistent with
-      the codebase or silently ignores a MUST, and the spec stops describing the
-      system. DEMOMA-19-008 named a `conftest.py` registry that had never existed
-      (CONCERN-2004); an audit found 18 such clauses across 13 phantom paths.
-      `statement` and `verification` are checked — `verification` names live
-      test infrastructure and must refer to real paths. `rationale` narrates
-      history by design and legitimately cites paths that are gone.
+      landmine: the agent invents something inconsistent with the codebase or
+      silently ignores a MUST. DEMOMA-19-008 named a `conftest.py` registry that
+      had never existed; an audit found 18 phantom-path clauses. Behavioral step,
+      precondition, and postcondition fields are scanned in addition to statement
+      and verification because they are equally normative. `rationale` legitimately
+      cites gone paths and is excluded.
     relationships:
     - rel_type: derives_from
       spec_id: MS-04-001

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -3246,6 +3246,8 @@ groups:
       than a restatement of the code.
     adr:
     - ADR-0058
+    lint_suppress:
+    - phantom_path_ref
     tags:
     - demo
     - documentation

--- a/test/metadata/specs/test_lint.py
+++ b/test/metadata/specs/test_lint.py
@@ -874,3 +874,255 @@ def test_lint_phantom_path_verification_suppress(tmp_path, capsys):
     captured = capsys.readouterr()
     assert result == 0
     assert "MS-15-001" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# MS-15-001: directory reference checks
+# ---------------------------------------------------------------------------
+
+
+def test_lint_phantom_dir_is_hard_error(tmp_path, capsys):
+    """A statement naming a non-existent multi-segment directory fails (MS-15-001)."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Helpers MUST live in `vultron/missing/`"
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "MS-15-001" in captured.err
+    assert "vultron/missing/" in captured.err
+
+
+def test_lint_phantom_dir_existing_passes(tmp_path):
+    """A statement naming an existing directory passes."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    (repo / "vultron" / "real").mkdir()
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Helpers MUST live in `vultron/real/`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_dir_single_segment_not_checked(tmp_path):
+    """A single-segment directory ref is not checked — high false-positive risk."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Output MUST be written to the `devlogs/` directory"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_dir_placeholder_exempt(tmp_path):
+    """A directory ref containing a placeholder token is exempt."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Each run MUST write to `plan/history/YYMM/`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_dir_placeholder_negative(tmp_path):
+    """The same path without the placeholder token fails.
+
+    Guards the exemption above against becoming vacuous: the directory
+    `plan/history/2601/` is expected to not exist in the fixture tree.
+    """
+    _, spec_dir = _repo_with_specs(tmp_path)
+    (tmp_path / "plan").mkdir()
+    (tmp_path / "plan" / "history").mkdir()
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Each run MUST write to `plan/history/2601/`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 1
+
+
+def test_lint_phantom_dir_package_relative_resolves(tmp_path):
+    """A package-relative directory resolves against a real directory suffix."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    (repo / "vultron" / "wire" / "received").mkdir(parents=True)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Handlers MUST live in `wire/received/`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_dir_package_relative_fails(tmp_path):
+    """A package-relative directory matching nothing in the tree fails."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Handlers MUST live in `wire/received/`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 1
+
+
+def test_lint_phantom_dir_suppress(tmp_path):
+    """lint_suppress: [phantom_path_ref] exempts phantom directory refs."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec(extra={"lint_suppress": ["phantom_path_ref"]})
+    data["groups"][0]["specs"][0][
+        "statement"
+    ] = "Helpers MUST live in `vultron/planned/`"
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_dir_in_verification_is_hard_error(tmp_path, capsys):
+    """A verification field naming a non-existent directory fails (MS-15-001)."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_spec()
+    data["groups"][0]["specs"][0][
+        "verification"
+    ] = "Assert via `test/ci/invariants/` that the invariant holds."
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "MS-15-001" in captured.err
+    assert "test/ci/invariants/" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# MS-15-001: behavioral step / precondition / postcondition scanning
+# ---------------------------------------------------------------------------
+
+
+def _minimal_behavioral_spec_data(
+    step_action="Execute workflow",
+    precondition_desc="System is ready",
+    postcondition_desc="Workflow complete",
+):
+    """Return a minimal spec file containing one BehavioralSpec item."""
+    spec = {
+        "id": "TST-01-001",
+        "priority": "MUST",
+        "kind": "protocol",
+        "statement": "TST-01-001 MUST execute the workflow",
+        "rationale": "ECA required",
+        "tags": ["testing"],
+        "preconditions": [{"description": precondition_desc}],
+        "steps": [{"order": 1, "actor": "finder", "action": step_action}],
+        "postconditions": [{"description": postcondition_desc}],
+    }
+    return {
+        "id": "TST",
+        "title": "Test File",
+        "description": "Test spec file",
+        "version": "0.1",
+        "scope": ["production"],
+        "groups": [{"id": "TST-01", "title": "Group", "specs": [spec]}],
+    }
+
+
+def test_lint_phantom_dir_in_behavioral_step_is_hard_error(tmp_path, capsys):
+    """A behavioral step action naming a non-existent directory fails (MS-15-001)."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_behavioral_spec_data(
+        step_action="Write output to `vultron/output/`"
+    )
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "MS-15-001" in captured.err
+    assert "vultron/output/" in captured.err
+
+
+def test_lint_phantom_path_in_behavioral_step_is_hard_error(tmp_path, capsys):
+    """A behavioral step action naming a non-existent path fails (MS-15-001)."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_behavioral_spec_data(
+        step_action="Register via `vultron/nope.py`"
+    )
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "MS-15-001" in captured.err
+    assert "vultron/nope.py" in captured.err
+
+
+def test_lint_phantom_path_in_behavioral_step_existing_passes(tmp_path):
+    """A behavioral step action naming an existing file passes."""
+    repo, spec_dir = _repo_with_specs(tmp_path)
+    (repo / "vultron" / "real.py").write_text("x = 1\n")
+    data = _minimal_behavioral_spec_data(
+        step_action="Register via `vultron/real.py`"
+    )
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0
+
+
+def test_lint_phantom_path_in_precondition_is_hard_error(tmp_path, capsys):
+    """A precondition description naming a non-existent path fails (MS-15-001)."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_behavioral_spec_data(
+        precondition_desc="File `vultron/missing.py` is loaded"
+    )
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "MS-15-001" in captured.err
+    assert "vultron/missing.py" in captured.err
+
+
+def test_lint_phantom_path_in_postcondition_is_hard_error(tmp_path, capsys):
+    """A postcondition description naming a non-existent path fails (MS-15-001)."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    data = _minimal_behavioral_spec_data(
+        postcondition_desc="Result written to `vultron/missing.py`"
+    )
+    _write_yaml(spec_dir, data)
+    result = lint(spec_dir)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "MS-15-001" in captured.err
+    assert "vultron/missing.py" in captured.err
+
+
+def test_lint_phantom_path_behavioral_step_suppress(tmp_path):
+    """lint_suppress: [phantom_path_ref] exempts phantom paths in behavioral fields."""
+    _, spec_dir = _repo_with_specs(tmp_path)
+    spec = {
+        "id": "TST-01-001",
+        "priority": "MUST",
+        "kind": "protocol",
+        "statement": "TST-01-001 MUST execute",
+        "rationale": "Required",
+        "tags": ["testing"],
+        "preconditions": [{"description": "System ready"}],
+        "steps": [
+            {
+                "order": 1,
+                "actor": "system",
+                "action": "Create `vultron/future.py`",
+            }
+        ],
+        "postconditions": [{"description": "Complete"}],
+        "lint_suppress": ["phantom_path_ref"],
+    }
+    data = {
+        "id": "TST",
+        "title": "T",
+        "description": "T",
+        "version": "0.1",
+        "scope": ["production"],
+        "groups": [{"id": "TST-01", "title": "G", "specs": [spec]}],
+    }
+    _write_yaml(spec_dir, data)
+    assert lint(spec_dir) == 0

--- a/vultron/metadata/specs/lint.py
+++ b/vultron/metadata/specs/lint.py
@@ -25,6 +25,7 @@ from vultron.metadata.specs.schema import (
     AdrStatus,
     BehavioralSpec,
     LintWarningCode,
+    StatementSpec,
     TriggerType,
 )
 
@@ -114,6 +115,13 @@ _SPEC_PATH_RE = re.compile(
     r"`([A-Za-z0-9_./-]+/[A-Za-z0-9_.-]+\.(?:py|ya?ml|md|json|toml))`"
 )
 
+#: MS-15: a backticked token that looks like a repo-relative directory path
+#: (two or more path segments with a trailing slash).  Single-segment forms
+#: (e.g. ``devlogs/``) are excluded because they are frequently conceptual or
+#: context-specific (CI runner refs, runtime output dirs) and carry high
+#: false-positive risk.
+_SPEC_DIR_RE = re.compile(r"`((?:[A-Za-z0-9_.][A-Za-z0-9_.-]*/){2,})`")
+
 #: Placeholder tokens that name a *shape* of path rather than a real one
 #: (e.g. `test_XXX_invariants.py`, `plan/history/YYMM/README.md`,
 #: `docs/adr/ADR-XXXX-foo.md`). Uppercase by convention, so a collision with a
@@ -174,7 +182,7 @@ _IGNORED_TREE_DIRS = frozenset(
 
 
 def _check_phantom_paths(registry: SpecRegistry, repo_root: Path) -> list[str]:
-    """Hard error when a spec ``statement`` or ``verification`` names a file that does not exist (MS-15-001).
+    """Hard error when a spec field names a file or directory that does not exist (MS-15-001).
 
     A normative statement or verification criterion that points at a
     non-existent path is a stale-premise landmine: an agent reads the MUST,
@@ -183,11 +191,18 @@ def _check_phantom_paths(registry: SpecRegistry, repo_root: Path) -> list[str]:
     DEMOMA-19-008 (issue #2004) named a ``test/ci/invariants/conftest.py`` that
     had never existed on any branch.
 
-    Both ``statement`` and ``verification`` are scanned — ``verification``
-    names live test infrastructure and must refer to real paths.
+    Scanned fields: ``statement``, ``verification``, ``BehavioralSpec`` step
+    ``action``, precondition ``description``, and postcondition ``description``.
     ``rationale`` narrates history by design
     ("X has been converted to Y", "if X stays in Z...") and legitimately
     references paths that no longer exist.
+
+    File references (backticked path with extension and ``/`` separator) use
+    :data:`_SPEC_PATH_RE`.  Directory references (two or more path segments
+    with a trailing ``/``) use :data:`_SPEC_DIR_RE`.  Single-segment directory
+    forms (e.g. ``devlogs/``) are excluded from the directory check because
+    they are frequently conceptual or CI-context references with high
+    false-positive risk.
 
     A match whose first segment is a known top-level directory
     (:data:`_REPO_TOP_LEVEL_DIRS`) is resolved repo-relatively. Any other match
@@ -215,15 +230,43 @@ def _check_phantom_paths(registry: SpecRegistry, repo_root: Path) -> list[str]:
     for spec_id, spec in registry.all_specs.items():
         if LintWarningCode.PHANTOM_PATH_REF in set(spec.lint_suppress or []):
             continue
-        for match in _SPEC_PATH_RE.findall(spec.statement or ""):
-            problem = resolver.problem_with(match)
-            if problem is not None:
-                errors.append(f"{spec_id}: statement references {problem}")
-        for match in _SPEC_PATH_RE.findall(spec.verification or ""):
-            problem = resolver.problem_with(match)
-            if problem is not None:
-                errors.append(f"{spec_id}: verification references {problem}")
+        for field_label, text in _scanned_texts(spec):
+            for match in _SPEC_PATH_RE.findall(text):
+                problem = resolver.problem_with(match)
+                if problem is not None:
+                    errors.append(
+                        f"{spec_id}: {field_label} references {problem}"
+                    )
+            for match in _SPEC_DIR_RE.findall(text):
+                problem = resolver.problem_with_dir(match)
+                if problem is not None:
+                    errors.append(
+                        f"{spec_id}: {field_label} references {problem}"
+                    )
+
     return errors
+
+
+def _scanned_texts(
+    spec: BehavioralSpec | StatementSpec,
+) -> list[tuple[str, str]]:
+    """Return ``(field_label, text)`` pairs for all fields scanned by MS-15-001.
+
+    ``rationale`` is deliberately excluded — it narrates history and may
+    legitimately cite paths that no longer exist.
+    """
+    texts: list[tuple[str, str]] = [
+        ("statement", spec.statement or ""),
+        ("verification", spec.verification or ""),
+    ]
+    if isinstance(spec, BehavioralSpec):
+        for step in spec.steps or []:
+            texts.append(("behavioral step", step.action))
+        for pre in spec.preconditions or []:
+            texts.append(("precondition", pre.description))
+        for post in spec.postconditions or []:
+            texts.append(("postcondition", post.description))
+    return texts
 
 
 class _PathResolver:
@@ -236,6 +279,7 @@ class _PathResolver:
     def __init__(self, repo_root: Path) -> None:
         self._repo_root = repo_root
         self._tree_paths: set[str] | None = None
+        self._tree_dirs: set[str] | None = None
 
     def problem_with(self, match: str) -> str | None:
         """Return an error fragment for ``match``, or ``None`` if it resolves."""
@@ -271,6 +315,42 @@ class _PathResolver:
             f"lint_suppress: [phantom_path_ref]."
         )
 
+    def problem_with_dir(self, match: str) -> str | None:
+        """Return an error fragment for directory ``match``, or ``None`` if it resolves.
+
+        ``match`` is expected to have a trailing ``/`` as captured by
+        :data:`_SPEC_DIR_RE`.
+        """
+        path = match.rstrip("/")
+        segments = path.split("/")
+
+        if ".." in segments:
+            return (
+                f"'{match}', which is not a valid repo-relative path "
+                f"(MS-15-001). '..' segments are not permitted."
+            )
+
+        if _PATH_PLACEHOLDER_RE.search(match):
+            return None
+
+        if segments[0] in _REPO_TOP_LEVEL_DIRS:
+            if (self._repo_root / path).is_dir():
+                return None
+            hint = "Point at the real path"
+        else:
+            if self._resolves_as_dir_suffix(path):
+                return None
+            hint = (
+                "Point at the real path (this is not a repo-relative "
+                "directory, and no directory in the tree ends with it)"
+            )
+
+        return (
+            f"'{match}' which does not exist (MS-15-001). {hint}, or — if "
+            f"the directory is intentionally yet to be created — suppress "
+            f"with lint_suppress: [phantom_path_ref]."
+        )
+
     def _resolves_as_suffix(self, match: str) -> bool:
         """True when some file in the tree has ``match`` as a path suffix."""
         if self._tree_paths is None:
@@ -278,6 +358,15 @@ class _PathResolver:
         suffix = "/" + match
         return match in self._tree_paths or any(
             p.endswith(suffix) for p in self._tree_paths
+        )
+
+    def _resolves_as_dir_suffix(self, path: str) -> bool:
+        """True when some directory in the tree has ``path`` as a path suffix."""
+        if self._tree_dirs is None:
+            self._tree_dirs = _collect_tree_dirs(self._repo_root)
+        suffix = "/" + path
+        return path in self._tree_dirs or any(
+            d.endswith(suffix) for d in self._tree_dirs
         )
 
 
@@ -302,6 +391,23 @@ def _collect_tree_paths(repo_root: Path) -> set[str]:
         for name in filenames:
             paths.add(prefix + name)
     return paths
+
+
+def _collect_tree_dirs(repo_root: Path) -> set[str]:
+    """Return every directory path in the repo, repo-relative, as a POSIX string.
+
+    Same walk rules as :func:`_collect_tree_paths` — :data:`_IGNORED_TREE_DIRS`
+    is pruned during the walk so build artifacts and virtualenvs do not satisfy
+    a reference that no tracked directory does.  Built lazily and at most once
+    per lint run.
+    """
+    dirs: set[str] = set()
+    for dirpath, dirnames, _ in os.walk(repo_root):
+        dirnames[:] = [d for d in dirnames if d not in _IGNORED_TREE_DIRS]
+        rel_dir = Path(dirpath).relative_to(repo_root)
+        if rel_dir != Path("."):
+            dirs.add(rel_dir.as_posix())
+    return dirs
 
 
 def _check_prefix_consistency(registry: SpecRegistry) -> list[str]:


### PR DESCRIPTION
- Closes #2012

## Summary

Extends `spec-lint` MS-15-001 to catch two additional classes of phantom-path references: multi-segment directory paths (e.g. `` `vultron/core/behaviors/shared/` ``) and file/directory refs in `BehavioralSpec` step, precondition, and postcondition fields.

## Changes

- **`vultron/metadata/specs/lint.py`**: Add `_SPEC_DIR_RE` regex for directory paths; add `_scanned_texts()` helper; add `_PathResolver.problem_with_dir()`, `_resolves_as_dir_suffix()`, and `_collect_tree_dirs()`; update `_check_phantom_paths()` to scan all five normative fields for both file and directory refs.
- **`specs/meta-specifications.yaml`**: Update MS-15-001 statement and rationale to enumerate all scanned fields.
- **`specs/behavior-tree-integration.yaml`**: Add `lint_suppress: [phantom_path_ref]` to BT-22-005 (spec-first forward reference to `vultron/core/behaviors/shared/`).
- **`specs/multi-actor-demo.yaml`**: Add `lint_suppress: [phantom_path_ref]` to DEMOMA-22-003 (spec-first forward reference to `docs/topics/scenarios/`).
- **`test/metadata/specs/test_lint.py`**: 17 new regression tests covering directory checks and behavioral field checks, each with a non-vacuous negative counterpart.

**Bare filenames (kept out of scope):** Prototyped the "flag when 0 in tree" heuristic against the live registry (77 bare-filename refs). Found genuine false-positive cases — runtime artifacts (`dump-manifest.json`), example filenames in `e.g.` prose (`20260622-AST-RATCHET-LAMBDA.md`, `report_management.py`) — confirming the issue's caution. Out of scope per the issue's `or the case is made` clause.

## Verification

- 67 unit tests in `test/metadata/specs/test_lint.py` pass (17 new)
- Full unit suite: 1533 passed
- Integration suite: 1172 passed, 3 xfailed (pre-existing)
- Black, flake8, mypy, pyright clean
- `uv run spec-lint` exits 0 with no new errors or warnings