### PR TITLE
docs: plan issue #2219 — inline Activity sub-field snapshot semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -835,6 +835,20 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   type names. The Vultron context document imports AS2 internally, so citing
   only the Vultron URI is both correct and sufficient. See VM-10-001, ADR-0069.
   *Source: CONCERN-2105*
+- **Do Not Add Recursive Dehydration to Inline Activity Sub-Fields in
+  `_dehydrate_data`** — `_dehydrate_data`
+  (`vultron/adapters/driven/db_record.py`) intentionally does NOT recurse into
+  inline Activity objects' sub-fields. A received Activity is an artifact; its
+  sub-field values are a snapshot of state at receipt time (e.g., the
+  `VulnerabilityCase` inside a stored `Offer` captures what the case looked
+  like when the offer was made). Even if Activities gain independent DataLayer
+  records and the technical reason in `_KEEP_INLINE_NESTED_TYPES` is resolved,
+  the snapshot semantic must be preserved. If you extract an object from a
+  received Activity and maintain it as a live record, the two copies diverge by
+  design — never write the snapshot back over the live record. See
+  `notes/datalayer-design.md`
+  § "Received Activity Artifacts: Inline Sub-Field Snapshots Are Intentional".
+  *Source: CONCERN-2219*
 - **GHA Matrix Boolean Fields Fail Differently at Job-Level vs. Step-Level `if:`**
   — two distinct failure modes when a boolean field from the matrix (e.g.
   `full_suite_only: false`) is referenced in a GitHub Actions `if:` expression:

--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -382,6 +382,53 @@ that concern, children of Epic #1394). As each B site migrates, remove its
 Activity type from the DL-05-004 exemption set (DL-06-005) until the set reaches
 zero.
 
+## Received Activity Artifacts: Inline Sub-Field Snapshots Are Intentional
+
+**Principle.** A received Activity is an **artifact** — the exact wire object
+received is worth storing as-is. `_dehydrate_data` in
+`vultron/adapters/driven/db_record.py` deliberately does NOT recursively
+dehydrate the sub-fields of an inline Activity object. When `Accept` stores an
+inline `Offer`, the `Offer`'s own `object_`, `target`, etc. are preserved as a
+snapshot of what they contained at receipt time — not collapsed to ID strings.
+
+This is correct behaviour and must not be changed. The rationale has two parts:
+
+1. **Technical**: inline Activities may not have independent DataLayer records
+   (e.g., a reconstituted `Offer` in the validate-report path, a
+   `CaseLedgerEntry` inside an `Announce` envelope). Collapsing them to a bare
+   ID would make rehydration impossible on read-back.
+
+2. **Semantic (more important)**: even where independent records exist, the
+   snapshot captures state at receipt time — "when you offered me this case, it
+   looked like this." An `Accept(Offer(VulnerabilityCase))` is a contract: it
+   records what was offered at the moment of acceptance, not the current state
+   of the case. The case will evolve; the contract must not.
+
+**Two copies, not one.** If an actor receives `Offer(Case)` and then extracts
+the case to seed a live record in its DataLayer, two distinct things now exist:
+
+- The **artifact** — the stored `Offer` with its frozen `Case` snapshot.
+  Immutable in the context of that offer. Read it to answer "what was I
+  offered?" Never update it.
+- The **live record** — the `VulnerabilityCase` actively maintained by the
+  actor. Participants join, states transition, embargo terms change. This copy
+  evolves.
+
+These two copies diverge over time **by design**. Do not treat the snapshot as
+the current state of the object, and do not write the snapshot back over the
+live record when refreshing or re-seeding.
+
+**Why recursive dehydration would be wrong.** If `_dehydrate_data` were
+extended to recurse into inline Activity sub-fields, `Accept.object_.object_`
+would become a bare ID string pointing to the *current* `VulnerabilityCase` —
+losing the at-offer-time snapshot. Even if Activities eventually gain
+independent DataLayer records (removing the technical constraint), the semantic
+reason alone prohibits recursive dehydration here.
+
+*Source: CONCERN-2219.*
+
+---
+
 ## Vocabulary Registry Entanglement Across Wire, Core, and DataLayer
 
 The vocabulary registry in `vultron/wire/as2/vocab/` was created before

--- a/plan/history/2608/learning/CONCERN-2219.md
+++ b/plan/history/2608/learning/CONCERN-2219.md
@@ -1,0 +1,49 @@
+---
+source: CONCERN-2219
+timestamp: '2026-08-24T20:44:38.356985+00:00'
+title: Received Activity objects are artifacts — inline sub-field snapshots are intentional
+type: learning
+---
+
+A received Activity is an **artifact** — the exact wire object received is
+worth storing as-is. `_dehydrate_data` in
+`vultron/adapters/driven/db_record.py` deliberately does NOT recursively
+dehydrate the sub-fields of inline Activity objects. This is correct and
+intentional for two reasons:
+
+1. **Technical**: Activities may not have independent DataLayer records, so
+   there is nothing to resolve a bare ID reference back to.
+2. **Semantic (more important)**: The sub-field values form a snapshot of
+   state at receipt time. For a mutable object like `VulnerabilityCase`, the
+   snapshot captures "when you offered me the case, it looked like this" —
+   historical accuracy is the point.
+
+**Two copies, not one.** If an actor receives `Offer(Case)` and extracts the
+case to seed a live DataLayer record, two distinct things exist:
+
+- The **artifact** — stored Offer with frozen Case snapshot. Immutable in the
+  context of that offer. Never write it back over the live record.
+- The **live record** — VulnerabilityCase actively maintained. Evolves over
+  time.
+
+These diverge by design. Confusing them is a landmine.
+
+**No ADR or spec needed**: this is an internal implementation convention, not
+externally-observable behavior (confirmed via `notes/specs-vs-adrs.md`
+decision tree). Documentation belongs in `notes/` and `AGENTS.md`.
+
+**Outcome**: documented in three places:
+
+- `notes/datalayer-design.md` — new section "Received Activity Artifacts:
+  Inline Sub-Field Snapshots Are Intentional"
+- `vultron/adapters/driven/db_record.py` — expanded `_KEEP_INLINE_NESTED_TYPES`
+  comment and `_dehydrate_data` docstring
+- `AGENTS.md` — new pitfall "Do Not Add Recursive Dehydration to Inline
+  Activity Sub-Fields in `_dehydrate_data`"
+
+**Follow-on**: #2545 — "Design: received Activity objects have no enforcement
+of artifact immutability" (Concern, blocked by #2219, parent #2222,
+Schedule=Someday) — no current enforcement that received Activity objects are
+not mutated downstream after storage.
+
+**Docs PR**: <https://github.com/CERTCC/Vultron/pull/2544>

--- a/vultron/adapters/driven/db_record.py
+++ b/vultron/adapters/driven/db_record.py
@@ -89,10 +89,20 @@ _AS_OBJECT_REF_FIELDS: frozenset[str] = frozenset(
 # AS2 Activity ``type_`` strings (transitive + intransitive) plus
 # ``CaseLedgerEntry``.  When a nested ``_AS_OBJECT_REF_FIELDS`` value has one
 # of these types it MUST be kept inline rather than collapsed to a bare ID
-# string: Activities may not have independent DataLayer records (e.g. a
-# reconstituted Offer in the validate-report path, a CaseLedgerEntry inside an
-# Announce envelope), so dehydrating them would make rehydration impossible on
-# read-back and cause MV-09-001 outbox-gate failures.
+# string for two independent reasons:
+#
+# 1. Technical: Activities may not have independent DataLayer records (e.g. a
+#    reconstituted Offer in the validate-report path, a CaseLedgerEntry inside
+#    an Announce envelope), so dehydrating them would make rehydration
+#    impossible on read-back and cause MV-09-001 outbox-gate failures.
+#
+# 2. Semantic (more important): a received Activity is an artifact; its inline
+#    sub-fields are a snapshot of state at receipt time.  An
+#    Accept(Offer(VulnerabilityCase)) captures what was offered at the moment
+#    of acceptance, not the current case state.  This must not be changed even
+#    if Activities eventually gain independent DataLayer records.  See
+#    notes/datalayer-design.md § "Received Activity Artifacts: Inline
+#    Sub-Field Snapshots Are Intentional".
 _KEEP_INLINE_NESTED_TYPES: frozenset[str] = frozenset(
     {e.value for e in as_TransitiveActivityType}
     | {e.value for e in as_IntransitiveActivityType}
@@ -120,6 +130,14 @@ def _dehydrate_data(data: dict[str, Any]) -> dict[str, Any]:
     This ensures that transitive activities (Offer, Create, …) store a URI
     reference to the nested object instead of an inline copy, eliminating
     redundant storage.
+
+    Inline Activity objects and ``CaseLedgerEntry`` instances are kept whole
+    without further recursion into their own sub-fields.  Their nested values
+    are stored as a snapshot of state at write time — intentional artifact
+    semantics.  See ``_KEEP_INLINE_NESTED_TYPES`` and
+    ``notes/datalayer-design.md``
+    § "Received Activity Artifacts: Inline Sub-Field Snapshots Are
+    Intentional" for why this must not be changed to recursive dehydration.
 
     Args:
         data: Serialised (``model_dump(mode="json")``) field dict of a


### PR DESCRIPTION
- Closes #2219

## Summary

Documents the intentional snapshot semantics for inline Activity sub-fields
in `_dehydrate_data`: a received Activity is an artifact and its sub-fields
capture state at receipt time, not live references.

## Changes

- **`notes/datalayer-design.md`**: new section "Received Activity Artifacts:
  Inline Sub-Field Snapshots Are Intentional" explaining the rationale, the
  two-copies pattern (artifact vs. live record), and why recursive dehydration
  would be wrong even if Activities gain independent DataLayer records
- **`vultron/adapters/driven/db_record.py`**: updated `_KEEP_INLINE_NESTED_TYPES`
  comment and `_dehydrate_data` docstring to state both the technical and
  semantic reasons for keeping inline Activity sub-fields intact, with pointer
  to the new notes section
- **`AGENTS.md`**: new pitfall entry warning against adding recursive dehydration
  to inline Activity sub-fields