### PR TITLE
fix(plan-issue): replace top-down grill-me questions with bottom-up conversation flow

### DIFF
--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -3,15 +3,32 @@ name: grill-me
 description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
 ---
 
-Interview me relentlessly about every aspect of this plan until we reach a
-shared understanding. Walk down each branch of the design tree, resolving
-dependencies between decisions one-by-one. For each question, provide your
-recommended answer.
+Conduct a thorough bottom-up interview about this plan or design until we reach
+shared understanding. Conclusions (scope, acceptance criteria, options,
+recommendation, ADR applicability) should emerge from conversation rather than
+being imposed as a predetermined list of structured questions.
 
-**Ask questions one at a time using the `ask_user` tool.** Never ask questions
-in plain text — always use `ask_user` so the user gets a proper response UI.
-Provide a recommended answer (or a `choices` array with a recommended option
-first) for every question.
+**General pattern:**
 
-If a question can be answered by exploring the codebase, explore the codebase
-instead of asking the user.
+1. **Open with a synthesis brief** — Before asking anything, present what you
+   already know or can infer: what the plan says, what the codebase or context
+   shows about the landscape, and 2–3 plausible directions. Ask whether this
+   reading is accurate before proceeding.
+
+2. **Conversation** — Walk through the problem bottom-up. Ask clarifying
+   questions as understanding builds. If a question can be answered by
+   exploring the codebase, explore the codebase instead of asking. Do not
+   impose a predetermined question structure.
+
+3. **Signal the transition** — When understanding is forming, say so:
+   "I think we're almost there — here's what I have so far. Got more?"
+   Do not declare done unilaterally.
+
+4. **Confirm conclusions** — After the user closes the conversation, propose
+   the full plan as a confirmation block: what to implement, what docs to
+   update, whether an ADR is warranted, recommended option and reasoning.
+   These are proposals to confirm, not a new round of questions.
+
+Use `ask_user` for structured choices when a decision has clear, discrete
+options — it is a tool, not a mandate. Plain conversational replies are
+fine for open-ended clarification.

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -337,7 +337,7 @@ See the loaded companion file for the type-specific completion step:
 - [ ] Issue claimed via `claim-issue.sh` (`plan/<N>-<slug>`) — always (Phase 1b)
 - [ ] `orient-agent` invoked
 - [ ] `deepen-context` invoked with focus hints from the issue
-- [ ] All grill-me branches resolved (shared + type-specific)
+- [ ] Grill-me conversation complete — conclusions confirmed as proposals (scope, ACs, ADR, options)
 - [ ] `deepen-context` re-invoked if new focus areas emerged during grilling
 - [ ] Docs updated — optional for all types (or consciously skipped with a note)
 - [ ] Markdown lint clean (if docs changed)

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -145,23 +145,33 @@ baseline rather than blank-slate context.
 
 ### Phase 4 — Grill-Me Interview (invoke `grill-me`)
 
-Invoke the `grill-me` skill. Resolve every decision branch one at a time
-via `ask_user`, providing a recommendation for each.
+Invoke the `grill-me` skill. The interview is conversation-driven and
+bottom-up — conclusions (scope, ACs, ADR, options, recommendation) emerge
+from the discussion rather than being asked as structured questions.
 
-**Shared base questions (all types):**
+**General pattern (all types):**
 
-1. **Scope** — What is in scope? What is explicitly out of scope?
-2. **Acceptance criteria** — How do we verify this is fully addressed?
-   Drive one GitHub issue per distinct AC cluster. Be exhaustive: if an
-   acceptance criterion is clearly needed but missing from the issue, add
-   it here. Do not produce a plan that leaves obvious ACs out simply
-   because the issue didn't spell them out. Deferring a clearly-needed AC
-   requires explicit user acknowledgment.
-3. **ADR determination** — Apply the `notes/specs-vs-adrs.md` decision tree
-   (MS-11-001 through MS-11-006). Form a recommendation with reasoning.
-   Present for approval before proceeding.
+1. **Open with a synthesis brief** — Before asking anything, present what
+   the research from Phase 3 reveals: what the issue says, what the current
+   codebase/specs show about the landscape, and 2–3 plausible directions.
+   Ask whether this reading is accurate before proceeding.
 
-**Type-specific questions:** see the loaded companion file.
+2. **Conversation** — Walk through the problem bottom-up. Ask clarifying
+   questions as understanding builds. Do not impose a predetermined question
+   structure. Scope, ACs, and ADR applicability are conclusions to confirm,
+   not questions to ask.
+
+3. **Signal the transition** — When understanding is forming, say so:
+   "I think we're almost there — here's what I have so far. Got more?"
+   Do not declare done unilaterally.
+
+4. **Confirm conclusions** — After the user closes the conversation, propose
+   the full plan as a confirmation block: what to implement, what docs to
+   update, whether an ADR is warranted. These are proposals to confirm, not
+   a new round of questions.
+
+**Type-specific opening and conversation guidance:** see the loaded
+companion file.
 
 Do **not** write anything until grill-me is complete.
 

--- a/.agents/skills/plan-issue/concern.md
+++ b/.agents/skills/plan-issue/concern.md
@@ -1,17 +1,41 @@
 # Plan Issue — Concern path
 
-## Grill-Me Interview (additional questions beyond shared base)
+## Grill-Me Interview
 
-After resolving the shared base questions (scope, AC clusters, ADR
-determination), also cover:
+**Opening brief** — Before asking anything, synthesize what Phase 3
+research reveals about this concern. Present:
 
-1. **Root cause** — What is actually broken, risky, or missing?
-2. **Impact** — What fails or degrades if left unaddressed?
-3. **Options** — 2–3 ways to address this concern.
-4. **Recommended approach** — Which option and why.
-5. **Spec/notes gaps** — Does this concern reveal missing requirements or
-   design decisions? Which file(s) should be added or changed?
-6. **AGENTS.md gap** — Is there a recurring implementation pitfall to capture?
+- What the issue says
+- Whether the concern still applies as written, has narrowed/shifted, or
+  appears to have already been addressed by subsequent work
+- Your read on what is actually broken, risky, or missing right now
+- 2–3 plausible directions for addressing (or recharacterizing) it
+
+**"Nothing there" path** — If the concern appears stale or already
+resolved, say so explicitly rather than running the full ceremony: "I'm
+not finding an actionable problem here because [reason]. However, I
+noticed [X] nearby that could be recharacterized as [narrower/different
+concern]." Offer: (a) close as resolved, (b) recharacterize and continue,
+(c) override and proceed anyway. Confirm before abandoning work.
+
+**Conversation** — Walk through the concern bottom-up. Ask clarifying
+questions as understanding builds. The following topics should emerge
+naturally from the discussion — do not ask them as sequential structured
+questions:
+
+- The actual root cause and what is broken, risky, or missing
+- Impact if left unaddressed
+- Options to address it and which is recommended
+- Whether this reveals missing specs, notes, or design decisions
+- Whether a recurring agent pitfall belongs in `AGENTS.md`
+- Scope, acceptance criteria, and ADR applicability
+
+Signal the transition with "I think we're almost there — here's what I
+have so far. Got more?" rather than declaring done unilaterally.
+
+**Confirm conclusions** — After the conversation closes, propose the full
+plan: what to implement, which docs to update, whether an ADR is warranted.
+These are proposals to confirm, not new questions.
 
 ## Docs Output
 

--- a/.agents/skills/plan-issue/epic.md
+++ b/.agents/skills/plan-issue/epic.md
@@ -2,21 +2,25 @@
 
 ## Phase A — Validate the Epic
 
-Before decomposing, validate the Epic against current understanding. Cover:
+Before decomposing, research the Epic against the current codebase and
+present a validation brief — do not ask the user to answer these questions;
+answer them yourself first, then confirm.
 
-1. **Currency check** — What do we know now that wasn't known when this Epic
-   was written? Has adjacent work (e.g., related Epics, merged PRs, new specs)
-   changed what this Epic should cover or how it should be scoped?
-2. **Codebase audit** — Have any of this Epic's ACs been partially or fully
-   addressed already? Search `vultron/` and `test/` before answering.
-3. **AC refinement** — Should any ACs be dropped, rewritten, or added in light
-   of current understanding?
-4. **Hierarchy check** — Does the Epic still belong under its current parent, or
+Research and present findings on:
+
+1. **Currency** — What has changed since this Epic was written? Adjacent
+   Epics, merged PRs, new specs that affect scope or approach.
+2. **Codebase audit** — Which of this Epic's ACs (if any) have been
+   partially or fully addressed already? Search `vultron/` and `test/`.
+3. **AC gaps** — ACs that should be added or rewritten in light of current
+   understanding.
+4. **Hierarchy** — Does the Epic still belong under its current parent, or
    has the project structure shifted?
-5. **Description/title gaps** — Should the Epic title or body be updated to
-   reflect the validated understanding? Draft proposed edits if so.
+5. **Title/body gaps** — Proposed edits to the Epic title or body if the
+   validated understanding differs from what is written.
 
-Apply any agreed Epic title/body edits before proceeding to Phase B:
+Present all findings as a brief, ask for confirmation or correction, and
+apply any agreed Epic title/body edits before proceeding to Phase B:
 
 ```bash
 gh issue edit "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
@@ -26,7 +30,11 @@ gh issue edit "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
 
 ## Phase B — Decompose into Tasks
 
-After validating the Epic, decompose it. Cover:
+After validating the Epic, propose a decomposition. Present a draft task
+breakdown — boundaries, sequencing, AC coverage — and ask "does this look
+right, or should we adjust?" rather than asking each question in sequence.
+
+The decomposition should cover:
 
 1. **Decomposition boundaries** — What is one Task vs. two? Avoid both
    over-splitting (trivial Tasks) and under-splitting (Tasks too large to
@@ -35,6 +43,10 @@ After validating the Epic, decompose it. Cover:
    `blocked-by` relationships.
 3. **AC inheritance** — Which of the Epic's ACs map to which Tasks? Every AC
    must be covered by at least one Task.
+
+Signal when the decomposition is stable: "I think we're almost there —
+here's the full task breakdown. Got more?" rather than declaring done
+unilaterally.
 
 ## Docs Output (optional)
 

--- a/.agents/skills/plan-issue/idea.md
+++ b/.agents/skills/plan-issue/idea.md
@@ -1,13 +1,32 @@
 # Plan Issue — Idea path
 
-## Grill-Me Interview (additional questions beyond shared base)
+## Grill-Me Interview
 
-After resolving the shared base questions (scope, AC clusters, ADR
-determination), also cover:
+**Opening brief** — Before asking anything, synthesize what Phase 3
+research reveals about this idea. Present:
 
-1. **Spec scope** — What requirements should be captured in `specs/`?
-2. **Design decisions** — What alternatives were considered? Which is recommended?
-3. **Notes scope** — What implementation guidance should be documented in `notes/`?
+- What the issue says
+- What the current codebase and specs show about the landscape this idea
+  lands in — existing patterns, adjacent work, open questions
+- Your read on what the idea is trying to achieve
+- 2–3 plausible directions for implementing or scoping it
+
+**Conversation** — Walk through the idea bottom-up. Ask clarifying
+questions as understanding builds. The following topics should emerge
+naturally from the discussion — do not ask them as sequential structured
+questions:
+
+- What requirements should be captured in `specs/`
+- What alternatives were considered and which is recommended
+- What implementation guidance belongs in `notes/`
+- Scope, acceptance criteria, and ADR applicability
+
+Signal the transition with "I think we're almost there — here's what I
+have so far. Got more?" rather than declaring done unilaterally.
+
+**Confirm conclusions** — After the conversation closes, propose the full
+plan: what to implement, which docs to update, whether an ADR is warranted.
+These are proposals to confirm, not new questions.
 
 ## Docs Output
 


### PR DESCRIPTION
## Summary

Restructures the grill-me interview phase for all plan-issue types (Ideas, Concerns, Epics) so the agent opens with a synthesis brief rather than asking structured questions (scope, ACs, ADR) that can only be answered *after* the conversation — not before it.

## Changes

- **`.agents/skills/plan-issue/SKILL.md`**: Replaced shared base questions (scope, ACs, ADR determination) with a general conversation pattern: open with synthesis brief → bottom-up discussion → "almost there" transition signal → confirm conclusions as proposals
- **`.agents/skills/plan-issue/concern.md`**: Added opening brief instruction, "nothing there" path (recharacterize or close with confirmation), bottom-up conversation guidance, and closing confirmation block. Root cause, impact, scope, ACs, ADR all moved from interrogation order to "emerge from discussion"
- **`.agents/skills/plan-issue/idea.md`**: Same pattern — opening brief grounded in Phase 3 research, bottom-up conversation, transition signal, confirm conclusions
- **`.agents/skills/plan-issue/epic.md`**: Phase A revised so agent researches and presents validation findings as a brief rather than asking the user to answer them; Phase B revised to propose a draft decomposition and ask for confirmation rather than sequential questions