### PR TITLE
feat(pr-pipeline): execute waits for CI; artifacts preserved on PENDING-CI

### DIFF
--- a/.agents/skills/pr-execute/REFERENCE.md
+++ b/.agents/skills/pr-execute/REFERENCE.md
@@ -39,9 +39,13 @@ Proceed to Phase 6.
      it fails there too.
    - At least one causality check: confirm no line in the PR diff plausibly
      causes the failure.
-4. If pre-existing is proven: create/update a Bug issue with evidence via
+4. If pre-existing is proven: assess whether a fix is straightforward and
+   context is in hand. If yes, fix it now — a pre-existing failure you can
+   resolve is still a failure worth resolving. Only proceed to step 5 if the
+   fix is genuinely non-trivial or requires design work outside this PR's scope.
+5. If deferral is warranted: create/update a Bug issue with evidence via
    `manage-github-issue`; wire structured blockers; post a handoff comment.
-5. If evidence is incomplete: treat as PR-owned and continue debugging.
+6. If evidence is incomplete: treat as PR-owned and continue debugging.
 
 ### Integration Tests Fail ❌
 
@@ -52,9 +56,12 @@ Proceed to Phase 6.
 1. Display failure output (first 50 lines + last 20 for context).
 2. Perform targeted causality checks against the PR diff.
 3. Allow "unrelated/pre-existing" only with clean-base + causality evidence.
-4. If pre-existing is proven: create/update a Bug issue with evidence; wire
+4. If pre-existing is proven: assess whether a fix is straightforward and
+   context is in hand. If yes, fix it now. Only proceed to step 5 if the fix
+   is genuinely non-trivial or requires design work outside this PR's scope.
+5. If deferral is warranted: create/update a Bug issue with evidence; wire
    blockers via `manage-github-issue`; add a handoff comment.
-5. Stop only after recording blocked/unblocked status with linked evidence.
+6. Stop only after recording blocked/unblocked status with linked evidence.
 
 Integration tests can fail due to: missing environment setup, timing issues
 in demo orchestration, architectural breaking changes, or infrastructure
@@ -141,7 +148,7 @@ dead or missing reference is treated as unmanaged debt and triggers a
 Stop and surface to the user if:
 
 - Integration test failure with unclear root cause after causality checks
-- 2+ consecutive test failures after fix attempts
+- CI loop reaches 4 iterations with the same failure persisting (see Phase 5 eject condition in SKILL.md)
 - Test output suggests missing context (env vars, setup, infrastructure)
 - Error suggests architectural issue (breaking change to core logic)
 - A merge conflict whose correct resolution is genuinely unclear (see
@@ -159,7 +166,7 @@ explicit blocked/unblocked status.
 
 ### Why sync runs late
 
-The branch is synced in Phase 4 — after all fixes and CI remediation, before the
+The branch is synced in Phase 5 (CI loop, Step 2) — after all fixes, before the
 test suite. Three reasons:
 
 1. **Execute's own fixes can create conflicts.** A fix touching the same lines a
@@ -277,7 +284,7 @@ File: `.claude/pr-{number}-execute.json`
   "pr_number": 1234,
   "timestamp": "2026-01-01T00:00:00Z",
   "integration_tests_run": true,
-  "final_ci_status": "passing",
+  "final_ci_status": "passing",  // "passing" | "failing" | "timeout"
   "merge_state": {
     "base_ref": "main",
     "synced": true,
@@ -357,7 +364,7 @@ cannot produce a READY-TO-MERGE verdict.
 **Issues filed**: <M>
 **Deferred (awaiting your input)**: <K>
 **Tests run**: unit only / unit + integration
-**CI status after push**: ✅ passing / ❌ failing / ⏳ pending
+**CI status**: ✅ passing / ❌ failing / ⏳ timed out
 **Base sync**: ✅ merged `<base_ref>` @ `def5678` — <N> conflicts resolved / ✅ already current / ❌ conflicts unresolved
 
 ---
@@ -401,5 +408,5 @@ _Omit this section entirely when the merge was clean._
 ---
 
 *Execute artifact: `.claude/pr-<number>-execute.json`*
-*Next step: run `/pr-verify` or wait for CI, then `/pr-ship` will continue automatically.*
+*Next step: run `/pr-verify`, or `/pr-ship` will continue automatically.*
 ```

--- a/.agents/skills/pr-execute/SKILL.md
+++ b/.agents/skills/pr-execute/SKILL.md
@@ -17,11 +17,14 @@ Execute consumes the closed finding list from `pr-triage` and processes it in
 one batch pass. No new discovery happens here. The finding set is fixed at the
 start; execute either resolves each item or records why it was skipped.
 
-**One exception to "no new discovery"**: the base-sync in Phase 4 re-reads merge
-state from git rather than trusting triage's snapshot. Conflicts are a moving
-target — execute's own fixes in Phases 2–3 can create them, and another PR can
-land on the base branch mid-run. Sync runs *after* all code mutation and
-*before* the test suite, so tests validate the actually-mergeable tree.
+Execute's exit criterion is **CI green**: it does not hand off to pr-verify until
+the branch is synced, tests pass locally, and all CI checks have completed
+successfully (or the 4-iteration cap is reached).
+
+**One exception to "no new discovery"**: the CI loop (Phase 5) re-reads CI state
+and merge state from live sources rather than trusting triage's snapshots. CI
+failures and conflicts are moving targets — execute's own fixes can create them,
+and other PRs can land on the base branch mid-run.
 
 ## Quick Start
 
@@ -52,7 +55,7 @@ Run /pr-triage first (or /pr-ship to run the full pipeline).
 4. Extract `pr_metadata.domains` and invoke `deepen-context` with those hints
    to load the same domain context that triage used.
 5. Check `pr_metadata.needs_integration_tests` — determines test scope in Phase 5.
-6. Note `pr_metadata.base_ref` — Phase 4 syncs against this branch, not
+6. Note `pr_metadata.base_ref` — Phase 5 syncs against this branch, not
    necessarily `main`.
 
 ### Phase 2 — Apply fix-now Fixes
@@ -60,7 +63,7 @@ Run /pr-triage first (or /pr-ship to run the full pipeline).
 For each finding where `decision_outcome` is `fix-now` or `fix-now-expand-scope`
 and `severity` is `FAIL` or `IMPROVE`:
 
-> Note: findings with `severity: NEW-ISSUE` are handled exclusively in Phase 6,
+> Note: findings with `severity: NEW-ISSUE` are handled exclusively in Phase 3,
 > regardless of their `decision_outcome`. Do not process them here.
 
 1. Apply the fix (edit files as needed).
@@ -76,131 +79,11 @@ and `severity` is `FAIL` or `IMPROVE`:
    ```
 
 4. Record `commit_ref` (short SHA) for each finding addressed in this commit.
-5. Push the branch: `git push` — CI must see the new commits before Phase 5.
 
-### Phase 3 — CI Remediation
+**Do not push yet.** All pushes happen inside the CI loop (Phase 5) so that
+every push includes the sync commit and passes local tests first.
 
-For findings from triage's Phase 11 (CI failures) in the triage artifact:
-
-1. Fetch current CI failure logs: `gh run list --branch <head_ref> --limit 1`
-   then `gh run view <run-id> --log-failed`.
-2. Parse failure output — identify root causes (lint, type errors, test failures).
-3. Fix lint/type/format failures directly (these are always branch-owned).
-4. For test failures: apply the branch-ownership rule from [REFERENCE.md](REFERENCE.md)
-   § "Test Failure Rules" before classifying anything as pre-existing.
-5. Run `uv run black <changed files>` before committing — mirroring Phase 2.
-6. Commit CI fixes separately from Phase 2 fixes:
-
-   ```text
-   fix(ci): resolve CI failures — <summary>
-
-   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
-   ```
-
-7. Push the branch: `git push`.
-8. Record `commit_ref` for each CI finding addressed.
-
-### Phase 4 — Sync With Base and Resolve Conflicts
-
-Runs after every code mutation (Phases 2–3) and before the test suite, so a
-conflict introduced by execute's own fixes is caught and the tests exercise the
-post-merge tree.
-
-1. Re-read merge state — do not trust `pr_metadata` from triage:
-
-   ```bash
-   bash .agents/skills/shared/merge-state.sh <number>
-   ```
-
-2. Sync the branch with its **actual base** (`pr_metadata.base_ref`, which is
-   not always `main`):
-
-   ```bash
-   bash .agents/skills/shared/sync-with-main.sh <base_ref>
-   ```
-
-   | Exit | Meaning | Action |
-   |---|---|---|
-   | `0` | Already current, or merged cleanly | Go to step 5 |
-   | `1` | Conflicts left in the worktree | Resolve them (step 3) |
-   | `2` | Unexpected error (dirty tree, merge in progress) | Stop and report; do not force anything |
-
-3. Resolve each conflicted path per [REFERENCE.md](REFERENCE.md) § "Conflict
-   Resolution Rules". Read both sides before editing. Never resolve by
-   wholesale `--ours`/`--theirs` on a file you have not read.
-
-4. Stage and commit the resolution:
-
-   ```bash
-   uv run black <changed files>
-   git add <resolved files>
-   git commit --no-edit
-   ```
-
-   Then verify no markers survived anywhere in the tree:
-
-   ```bash
-   git grep -nE '^(<<<<<<<|>>>>>>>) ' -- . && echo "MARKERS PRESENT — do not push"
-   ```
-
-   Match only the `<<<<<<<` and `>>>>>>>` markers, each followed by a space — a
-   bare `=======` row is a valid markdown setext heading underline and
-   false-positives constantly in this repo.
-
-5. Push: `git push` (a merge never needs `--force`; if git demands a force-push,
-   stop — something rewrote history and that needs a human).
-
-6. Confirm the result with `merge-state.sh <number>` again. If it still reports
-   `CONFLICTING`, record the merge-state finding as `outcome: skipped` with the
-   reason, and stop the pipeline — do not proceed to a verdict.
-
-7. Record the outcome for the Phase 12 merge-state finding(s) from triage, and
-   populate the `merge_state` block of the execute artifact.
-
-**If the PR is a draft with a `needs-rebase` label** (`create-pr` opens these
-when it cannot freshen a branch): once the sync succeeds and tests pass in
-Phase 5, remove the label and undraft it:
-
-```bash
-gh pr ready <number>
-gh pr edit <number> --remove-label needs-rebase
-```
-
-### Phase 5 — Run Test Suite
-
-Based on `pr_metadata.needs_integration_tests`:
-
-**Unit tests only** (flag is false):
-
-```bash
-uv run pytest --tb=short 2>&1 | tail -20
-```
-
-**Full suite** (flag is true):
-
-```bash
-uv run pytest --tb=short 2>&1 | tail -20
-uv run pytest integration_tests/ -v 2>&1 | tail -40
-```
-
-If tests fail: apply the rules from [REFERENCE.md](REFERENCE.md) § "Test Failure
-Rules". Fix branch-owned failures and re-run. If failure is proven pre-existing,
-file a Bug issue with evidence via `manage-github-issue`, wire structured blockers,
-and record the finding outcome as `skipped` with a `skip_reason` referencing the
-issue number.
-
-After tests pass, also run the xfail ratchet per
-[REFERENCE.md](REFERENCE.md) § "xfail Ratchet" — scan `XFAIL` output lines
-and verify each references a live open issue.
-
-Do not proceed to Phase 6 until tests pass or all remaining failures are
-documented as pre-existing with linked Bug issues.
-
-> If fixing a test failure here required new commits, re-run
-> `merge-state.sh <number>` before Phase 6 — a push can race a base-branch
-> merge. If it now reports `CONFLICTING`, return to Phase 4.
-
-### Phase 6 — Handle NEW-ISSUE Findings
+### Phase 3 — Handle NEW-ISSUE Findings
 
 For each finding with `severity: NEW-ISSUE`:
 
@@ -218,7 +101,7 @@ For each finding with `severity: NEW-ISSUE`:
 2. Add to Project #24.
 3. Record as `outcome: filed` with `issue_number`.
 
-### Phase 7 — Resolve Review Thread Comments
+### Phase 4 — Resolve Review Thread Comments
 
 For each unresolved review comment on the PR (fetched via
 `gh api repos/CERTCC/Vultron/pulls/<number>/comments`):
@@ -232,9 +115,144 @@ Match each comment to the finding(s) it corresponds to. Then per
 
 Do not mark a comment resolved unless the code actually addresses it.
 
-### Phase 8 — Emit Artifact and Post Comment
+### Phase 5 — CI Loop
 
-1. Build the execute artifact in memory throughout Phases 2–7; write it only now.
+This phase owns syncing, testing, pushing, and CI wait. It loops until CI is
+green or the cap is reached. **Maximum 4 iterations.** One iteration = one full
+Sync → Test → Push → Wait cycle.
+
+#### Step 1 — Apply CI fixes
+
+*Iteration 1*: apply any CI-failure findings from the triage artifact (triage
+Phase 11). Fix lint/type/format failures directly. For test failures, apply Test
+Failure Rules from [REFERENCE.md](REFERENCE.md).
+
+*Subsequent iterations*: apply fixes for failures found in the previous
+iteration's CI wait result. Fetch logs first:
+
+```bash
+gh run list --branch <head_ref> --limit 1
+gh run view <run-id> --log-failed
+```
+
+**Repeated-failure rule**: if the same CI failure appears in two consecutive
+iterations:
+
+1. Apply Test Failure Rules from [REFERENCE.md](REFERENCE.md) to determine
+   whether it is pre-existing.
+2. Before filing or deferring: assess whether a fix is straightforward and
+   context is in hand. If yes, fix it now — a pre-existing failure you can
+   resolve is still a failure worth resolving.
+3. Only file a bug issue and record `outcome: skipped` if the fix is genuinely
+   non-trivial or requires design work outside this PR's scope.
+
+Commit CI fixes separately from Phase 2 fixes:
+
+```text
+fix(ci): resolve CI failures — <summary>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+Record `commit_ref` for each CI finding addressed.
+
+#### Step 2 — Sync with base
+
+```bash
+bash .agents/skills/shared/sync-with-main.sh <base_ref>
+```
+
+| Exit | Meaning | Action |
+|---|---|---|
+| `0` | Already current, or merged cleanly | Continue to Step 3 |
+| `1` | Conflicts left in the worktree | Resolve them (see below) |
+| `2` | Unexpected error (dirty tree, merge in progress) | Stop and report; do not force anything |
+
+Resolve each conflicted path per [REFERENCE.md](REFERENCE.md) § "Conflict
+Resolution Rules". Read both sides before editing. Never resolve by
+wholesale `--ours`/`--theirs` on a file you have not read.
+
+```bash
+uv run black <changed files>
+git add <resolved files>
+git commit --no-edit
+```
+
+Verify no markers survived:
+
+```bash
+git grep -nE '^(<<<<<<<|>>>>>>>) ' -- . && echo "MARKERS PRESENT — do not push" || echo "clean"
+```
+
+If `sync-with-main.sh` still reports `CONFLICTING` after resolution, record
+the merge-state finding as `outcome: skipped` with the conflicted paths and stop
+— do not push.
+
+#### Step 3 — Run local tests
+
+```bash
+uv run pytest --tb=short 2>&1 | tail -20
+```
+
+If `pr_metadata.needs_integration_tests` is true, also run:
+
+```bash
+uv run pytest integration_tests/ -v 2>&1 | tail -40
+```
+
+If tests fail: fix branch-owned failures per [REFERENCE.md](REFERENCE.md)
+§ "Test Failure Rules", then **restart this iteration from Step 2** — always
+re-sync after a fix so the pushed commit includes both the fix and a clean merge.
+Do not push failing code.
+
+After tests pass, run the xfail ratchet per [REFERENCE.md](REFERENCE.md)
+§ "xfail Ratchet".
+
+#### Step 4 — Push
+
+```bash
+git push
+```
+
+If git demands a force-push, stop — something rewrote history and that needs
+a human.
+
+#### Step 5 — Wait for CI
+
+```bash
+bash .agents/skills/shared/wait-for-ci.sh <number>
+```
+
+| Exit | Meaning | Action |
+|---|---|---|
+| `0` | All checks passed | CI is green — proceed to "On CI green" below |
+| `1` | One or more checks failed | Start next iteration with the failures as input |
+| `2` | Timed out (10 min) | Record `final_ci_status: "timeout"`; exit loop |
+
+**On CI green**:
+
+1. Run `merge-state.sh <number>`. If it now reports `CONFLICTING`, return to
+   Step 2 — a push can race a base-branch merge.
+
+2. If the PR is a draft with a `needs-rebase` label, undraft it:
+
+   ```bash
+   gh pr ready <number>
+
+   gh pr edit <number> --remove-label needs-rebase
+   ```
+
+3. Record `final_ci_status: "passing"`. Populate the `merge_state` block.
+4. Exit the loop.
+
+**On iteration 4 failure (eject)**:
+
+Record `final_ci_status: "failing"`. List the unresolved CI failures. Run
+`merge-state.sh <number>` and populate the `merge_state` block. Exit the loop.
+
+### Phase 6 — Emit Artifact and Post Comment
+
+1. Build the execute artifact in memory throughout Phases 2–5; write it only now.
    Write `.claude/pr-{number}-execute.json` per the schema in [REFERENCE.md](REFERENCE.md).
 2. Render the execute summary comment (format in [REFERENCE.md](REFERENCE.md)
    § "Execute Comment Format").

--- a/.agents/skills/pr-ship/SKILL.md
+++ b/.agents/skills/pr-ship/SKILL.md
@@ -66,6 +66,7 @@ Before running any phase, check for existing artifacts:
 | Both artifacts exist AND last verify verdict was GAPS-FOUND | Delete `.claude/pr-{N}-execute.json`; re-run execute then verify |
 | Both artifacts exist AND last verify verdict was CONFLICTS-FOUND | Delete `.claude/pr-{N}-execute.json`; re-run execute then verify — execute Phase 4 owns the resolution |
 | Both artifacts exist AND last verify verdict was PENDING-MERGE-CHECK | Skip triage and execute; re-run verify only (GitHub just needed time) |
+| Both artifacts exist AND last verify verdict was PENDING-CI | Skip triage and execute; re-run verify only (CI timed out last run; try again now) |
 | Verify ran and cleaned up (no artifacts) | Pipeline already completed; report last comment URL if available |
 
 When resuming, print which phase is being skipped and why.
@@ -212,9 +213,10 @@ delete `.claude/pr-{N}-execute.json` and re-run `/pr-ship` — execute Phase 4 w
 sync and resolve. If a re-run lands on the same conflict twice, stop and hand it
 to the user; the resolution needs judgment the pipeline does not have.
 
-If `PENDING-CI`: print the PR URL and note that CI is still running. Re-run
-`/pr-ship` (or `/pr-verify`) after CI completes to get the final verdict and
-clean up artifacts.
+If `PENDING-CI`: CI timed out during verify's 10-minute wait (or a race
+condition re-triggered CI after execute finished). Print the PR URL and note
+that CI is still running. Artifacts are preserved. Re-run `/pr-ship` (or
+`/pr-verify`) after CI completes to get the final verdict.
 
 If `PENDING-MERGE-CHECK`: GitHub had not finished computing mergeability. Wait a
 moment and re-run `/pr-verify` — no execute re-run is needed.
@@ -229,8 +231,7 @@ If any step fails (unexpected error, not a structured stop):
 - Do NOT clean up artifacts — they preserve the work done up to the failure
   point for manual inspection or resume.
 
-Artifacts are only cleaned up by `pr-verify` on a successful `READY-TO-MERGE`
-or `PENDING-CI` verdict.
+Artifacts are only cleaned up by `pr-verify` on a `READY-TO-MERGE` verdict.
 
 ## Where Merge Conflicts Are Handled
 

--- a/.agents/skills/pr-ship/SKILL.md
+++ b/.agents/skills/pr-ship/SKILL.md
@@ -64,7 +64,7 @@ Before running any phase, check for existing artifacts:
 | `pr-{N}-triage.json` exists, `pr-{N}-execute.json` absent | Skip triage; start at execute |
 | Both artifacts exist AND last verify verdict was not GAPS-FOUND / CONFLICTS-FOUND | Skip triage and execute; start at verify |
 | Both artifacts exist AND last verify verdict was GAPS-FOUND | Delete `.claude/pr-{N}-execute.json`; re-run execute then verify |
-| Both artifacts exist AND last verify verdict was CONFLICTS-FOUND | Delete `.claude/pr-{N}-execute.json`; re-run execute then verify — execute Phase 4 owns the resolution |
+| Both artifacts exist AND last verify verdict was CONFLICTS-FOUND | Delete `.claude/pr-{N}-execute.json`; re-run execute then verify — execute Phase 5 (CI Loop) owns the resolution |
 | Both artifacts exist AND last verify verdict was PENDING-MERGE-CHECK | Skip triage and execute; re-run verify only (GitHub just needed time) |
 | Both artifacts exist AND last verify verdict was PENDING-CI | Skip triage and execute; re-run verify only (CI timed out last run; try again now) |
 | Verify ran and cleaned up (no artifacts) | Pipeline already completed; report last comment URL if available |
@@ -102,7 +102,7 @@ Create a PR first, then re-run /pr-ship.
 
 Print the base branch and merge state alongside the PR title. Do **not** stop on
 a conflicting or draft PR — resolving conflicts is exactly what the pipeline is
-for. `pr-execute` Phase 4 syncs and resolves; `pr-verify` Phase 2 gates the
+for. `pr-execute` Phase 5 (CI Loop) syncs and resolves; `pr-verify` Phase 2 gates the
 verdict. A conflicted PR at this point is a normal input, not an error.
 
 If the PR is a draft carrying the `needs-rebase` label, note that `create-pr`
@@ -158,7 +158,7 @@ If execute stops due to a blocking test failure (pre-existing with linked Bug
 issue): report the blocked status and stop pr-ship. The user must resolve the
 blocker before re-running.
 
-If execute stops because a merge conflict could not be resolved safely (Phase 4):
+If execute stops because a merge conflict could not be resolved safely (Phase 5, CI Loop):
 report the conflicting paths and stop. Do not skip ahead to verify — an
 unresolved conflict is a hard stop, and running verify would only restate it.
 
@@ -209,7 +209,7 @@ If `GAPS-FOUND`: print which findings are unresolved. To retry:
    artifact and re-run execute before verify.
 
 If `CONFLICTS-FOUND`: print the conflicting paths from verify's comment, then
-delete `.claude/pr-{N}-execute.json` and re-run `/pr-ship` — execute Phase 4 will
+delete `.claude/pr-{N}-execute.json` and re-run `/pr-ship` — execute Phase 5 (CI Loop) will
 sync and resolve. If a re-run lands on the same conflict twice, stop and hand it
 to the user; the resolution needs judgment the pipeline does not have.
 
@@ -241,7 +241,7 @@ the pipeline runs:
 | Phase | Check | Role |
 |---|---|---|
 | `pr-triage` Phase 12 | Read merge state, emit a FAIL finding | Early warning; recorded in `pr_metadata` |
-| `pr-execute` Phase 4 | Sync with base, resolve conflicts, re-verify | The only phase that **fixes** conflicts. Runs after all other mutation so execute's own fixes are included, and before the test suite so tests see the merged tree |
+| `pr-execute` Phase 5 (CI Loop) | Sync with base, resolve conflicts, re-verify | The only phase that **fixes** conflicts. Runs after all other mutation so execute's own fixes are included, and before the test suite so tests see the merged tree |
 | `pr-verify` Phase 2 | Live re-check as a hard gate | The **authoritative** answer. Blocks `READY-TO-MERGE` |
 
 Execute resolves rather than verify because verify is a read-only reporter by

--- a/.agents/skills/pr-verify/REFERENCE.md
+++ b/.agents/skills/pr-verify/REFERENCE.md
@@ -94,7 +94,7 @@ headline the user needs.
 | Verdict | Next step | Artifacts |
 |---|---|---|
 | `READY-TO-MERGE` | Merge | Cleaned up |
-| `PENDING-CI` | Re-run `/pr-verify` after CI finishes | Cleaned up |
+| `PENDING-CI` | Re-run `/pr-verify` after CI finishes | Preserved |
 | `PENDING-MERGE-CHECK` | Re-run `/pr-verify` in a minute — GitHub is still computing | Preserved |
 | `CONFLICTS-FOUND` | Delete the execute artifact, re-run `/pr-execute` (Phase 4 resolves) | Preserved |
 | `GAPS-FOUND` | Fix manually, or delete the execute artifact and re-run `/pr-execute` | Preserved |

--- a/.agents/skills/pr-verify/SKILL.md
+++ b/.agents/skills/pr-verify/SKILL.md
@@ -124,8 +124,21 @@ cannot be ready to merge no matter what those checks find.
    `UNVERIFIED-CI-FAILING` and set overall verdict to `GAPS-FOUND` — the code
    changes may be correct but CI must be green before the PR can be considered
    ready.
-4. If CI is pending: note it; proceed with spot-checks but mark overall verdict
-   as `PENDING-CI`.
+4. If CI is pending: wait for completion before proceeding:
+
+   ```bash
+   bash .agents/skills/shared/wait-for-ci.sh <number>
+   ```
+
+   | Exit | Meaning | Action |
+   |---|---|---|
+   | `0` | All checks passed | Proceed with CI green |
+   | `1` | One or more checks failed | Mark all findings `UNVERIFIED-CI-FAILING`; set verdict to `GAPS-FOUND` |
+   | `2` | Timed out (10 min) | Note it; proceed with spot-checks; set overall verdict to `PENDING-CI` |
+
+   A `PENDING-CI` verdict here is a fallback for a genuine race condition (CI
+   re-triggered after execute finished, or unusually slow CI). Under normal
+   operation execute already waited for CI, so this path should be rare.
 
 ### Phase 4 — Spot-Verify FAIL Findings
 
@@ -186,11 +199,10 @@ See [REFERENCE.md](REFERENCE.md) § "Verify Comment Format" for the template.
 
 ### Phase 7 — Cleanup
 
-Only runs if overall verdict is `READY-TO-MERGE` or `PENDING-CI` (i.e., no
-gaps that require re-running execute).
+Only runs if overall verdict is `READY-TO-MERGE`.
 
-Do **not** clean up on `CONFLICTS-FOUND` or `PENDING-MERGE-CHECK` — both need
-another execute pass, which needs the triage artifact.
+Do **not** clean up on `PENDING-CI`, `CONFLICTS-FOUND`, or `PENDING-MERGE-CHECK`
+— all three may need a follow-up pass, which needs the artifacts.
 
 1. Delete `.claude/pr-{number}-triage.json`
 2. Delete `.claude/pr-{number}-execute.json`
@@ -198,11 +210,12 @@ another execute pass, which needs the triage artifact.
 
    ```text
    Artifacts cleaned up.
-   PR #N is READY-TO-MERGE / PENDING-CI.
+   PR #N is READY-TO-MERGE.
    ```
 
-If verdict is `GAPS-FOUND`, `CONFLICTS-FOUND`, or `PENDING-MERGE-CHECK`: do NOT
-delete artifacts. The user or a retry of `/pr-execute` will need them.
+If verdict is `PENDING-CI`, `GAPS-FOUND`, `CONFLICTS-FOUND`, or
+`PENDING-MERGE-CHECK`: do NOT delete artifacts. The user or a retry of
+`/pr-verify` or `/pr-execute` will need them.
 
 ## This Skill Does Not Fix
 

--- a/.agents/skills/shared/wait-for-ci.sh
+++ b/.agents/skills/shared/wait-for-ci.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# wait-for-ci.sh — poll gh pr checks until all checks complete or timeout.
+#
+# Usage: bash .agents/skills/shared/wait-for-ci.sh [<pr-number>]
+#
+# Emits one JSON object on stdout when all checks have completed:
+#   {"total":N,"passing":M,"failing":K,"checks":[...]}
+#
+# Exit codes:
+#   0 — all checks completed and passed (bucket: pass or skipping)
+#   1 — one or more checks failed or were cancelled (bucket: fail or cancel)
+#   2 — timed out before all checks completed, or gh error
+#
+# Environment:
+#   WAIT_CI_TIMEOUT_MINUTES  — max minutes to wait (default: 10)
+#   WAIT_CI_SLEEP            — seconds between polls (default: 30)
+set -uo pipefail
+
+TIMEOUT_MINUTES=${WAIT_CI_TIMEOUT_MINUTES:-10}
+SLEEP=${WAIT_CI_SLEEP:-30}
+MAX_ATTEMPTS=$(( TIMEOUT_MINUTES * 60 / SLEEP ))
+
+PR_ARG=()
+if [ "$#" -gt 0 ] && [ -n "${1:-}" ]; then
+  PR_ARG=("$1")
+fi
+
+for i in $(seq 1 "$MAX_ATTEMPTS"); do
+  if ! JSON=$(gh pr checks "${PR_ARG[@]+"${PR_ARG[@]}"}" --json name,bucket,state,startedAt,completedAt 2>&1); then
+    echo "❌ wait-for-ci: gh pr checks failed: $JSON" >&2
+    exit 2
+  fi
+
+  TOTAL=$(printf '%s' "$JSON" | jq 'length')
+  PENDING=$(printf '%s' "$JSON" | jq '[.[] | select(.bucket == "pending")] | length')
+  FAILING=$(printf '%s' "$JSON" | jq '[.[] | select(.bucket | IN("fail","cancel"))] | length')
+
+  if [ "$TOTAL" -eq 0 ]; then
+    echo "… wait-for-ci: no checks found yet (attempt $i/$MAX_ATTEMPTS)" >&2
+    if [ "$i" -lt "$MAX_ATTEMPTS" ]; then sleep "$SLEEP"; fi
+    continue
+  fi
+
+  if [ "$PENDING" -eq 0 ]; then
+    PASSING=$(( TOTAL - FAILING ))
+    printf '%s' "$JSON" | jq -c --argjson passing "$PASSING" --argjson failing "$FAILING" '{
+      total: length,
+      passing: $passing,
+      failing: $failing,
+      checks: .
+    }'
+    if [ "$FAILING" -gt 0 ]; then
+      printf '%s' "$JSON" | jq -r '.[] | select(.bucket | IN("fail","cancel")) | "  ❌ \(.name)"' >&2
+      exit 1
+    fi
+    exit 0
+  fi
+
+  echo "… wait-for-ci: $PENDING/$TOTAL check(s) still running (attempt $i/$MAX_ATTEMPTS)" >&2
+  if [ "$i" -lt "$MAX_ATTEMPTS" ]; then sleep "$SLEEP"; fi
+done
+
+echo "⚠ wait-for-ci: timed out after ${TIMEOUT_MINUTES} minutes." >&2
+exit 2


### PR DESCRIPTION
## Summary

- **`wait-for-ci.sh`** (new shared script): polls `gh pr checks` every 30s, exits 0/1/2 for pass/fail/timeout (10-min cap)
- **`pr-execute`** restructured from 8 phases to 6: the old Sync, Test, CI-remediation, and Push phases are consolidated into a single **CI loop** (Phase 5, max 4 iterations). No push happens until after sync and local tests pass. The loop exits when CI is green, times out, or the cap is hit.
- **Pre-existing failures** now require a fixability assessment before deferring — if the fix is straightforward and context is in hand, fix it.
- **`pr-verify`** Phase 3 calls `wait-for-ci.sh` when CI is pending instead of immediately emitting `PENDING-CI`. `PENDING-CI` is now a true timeout fallback.
- **`pr-verify`** Phase 7 only cleans up artifacts on `READY-TO-MERGE` (previously also cleaned up on `PENDING-CI`, forcing a full re-triage on the next run).
- **`pr-ship`** resume table gains an explicit `PENDING-CI` row (skip to verify).

## Changes

- **`.agents/skills/shared/wait-for-ci.sh`**: new script; polls `gh pr checks --json name,bucket` every 30s; exit 0 all pass, exit 1 any fail, exit 2 timeout
- **`.agents/skills/pr-execute/SKILL.md`**: restructured 8→6 phases; NEW-ISSUE and review-thread phases moved before the CI loop; Sync/Test/Push/Wait consolidated into Phase 5 CI loop; no push until local tests pass on merged tree
- **`.agents/skills/pr-execute/REFERENCE.md`**: test failure rules add fixability assessment before deferring pre-existing failures; phase reference updated; CI status field updated
- **`.agents/skills/pr-verify/SKILL.md`**: Phase 3 waits for CI via `wait-for-ci.sh`; Phase 7 only cleans up on `READY-TO-MERGE`
- **`.agents/skills/pr-verify/REFERENCE.md`**: PENDING-CI retry row: artifacts preserved (was "cleaned up")
- **`.agents/skills/pr-ship/SKILL.md`**: resume table gains PENDING-CI row; all stale "Phase 4" conflict-resolution references updated to Phase 5 (CI Loop)

## Test plan

- [ ] Run `/pr-ship` on a PR where CI is still in-flight when verify starts — confirm it waits rather than returning `PENDING-CI`
- [ ] Run `/pr-ship` on a PR with a CI failure — confirm execute loops, fixes, and re-runs CI before handing off to verify
- [ ] Simulate a timeout (set `WAIT_CI_TIMEOUT_MINUTES=1`) — confirm `PENDING-CI` verdict is emitted and artifacts are preserved
- [ ] Re-run `/pr-ship` after a `PENDING-CI` — confirm it skips to verify without re-triaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)