### PR TITLE
fix: preserve published timestamp in as_CaseActor.from_core

### DIFF
--- a/test/wire/as2/vocab/test_case_actor.py
+++ b/test/wire/as2/vocab/test_case_actor.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""
+Tests for as_CaseActor wire object, including from_core conversions.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import unittest
+from datetime import datetime, timezone
+
+from vultron.core.models.case_actor import CaseActor as CoreCaseActor
+from vultron.wire.as2.vocab.objects.case_actor import as_CaseActor
+
+ACTOR_ID = "https://example.org/case-actors/svc-1"
+CASE_ID = "https://example.org/cases/case-001"
+OWNER_ID = "https://example.org/actors/alice"
+
+
+class TestFromCorePreservesPublished(unittest.TestCase):
+    """from_core must not regenerate published (regression: issue #2554)."""
+
+    _FIXED_TIME = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    def test_as_case_actor_from_core_preserves_published(self):
+        core = CoreCaseActor(
+            id_=ACTOR_ID,
+            context=CASE_ID,
+            attributed_to=OWNER_ID,
+            published=self._FIXED_TIME,
+        )
+        wire = as_CaseActor.from_core(core)
+        self.assertEqual(self._FIXED_TIME, wire.published)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vultron/wire/as2/vocab/objects/case_actor.py
+++ b/vultron/wire/as2/vocab/objects/case_actor.py
@@ -18,7 +18,10 @@ Defines a CaseActor class for the Vultron ActivityStreams Vocabulary.
 
 from vultron.core.models.case_actor import CaseActor as CoreCaseActor
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.base import _scalar_ref_id_or_value
+from vultron.wire.as2.vocab.objects.base import (
+    _scalar_ref_id_or_value,
+    _strip_core_context,
+)
 
 
 class as_CaseActor(as_Service):
@@ -34,12 +37,13 @@ class as_CaseActor(as_Service):
 
     @classmethod
     def from_core(cls, core_obj: CoreCaseActor) -> "as_CaseActor":
-        return cls(
-            id_=core_obj.id_,
-            name=core_obj.name,
-            attributed_to=core_obj.attributed_to,
-            context=core_obj.context,
-        )
+        data = core_obj.model_dump(mode="json")
+        _strip_core_context(data)
+        # VultronOutbox is core-internal tracking; as_Actor.outbox expects
+        # an as_OrderedCollection — drop it so the actor's inbox/outbox URIs
+        # are auto-derived from id_ by the as_Actor model validator instead.
+        data.pop("outbox", None)
+        return cls.model_validate(data)
 
     def to_core(self) -> CoreCaseActor:
         return CoreCaseActor.model_validate(


### PR DESCRIPTION
- Closes #2554
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

`as_CaseActor.from_core` built its data dict manually, omitting `published`. Since `as_Object.published` has `default_factory=now_utc`, every `render()` call generated a fresh current timestamp instead of preserving the core object's value. This is the same root cause fixed for `as_CaseStatus` and `as_ParticipantStatus` in #2511.

## Changes

- **`vultron/wire/as2/vocab/objects/case_actor.py`**: Refactored `from_core` to use `core_obj.model_dump(mode="json")` + `_strip_core_context` + `cls.model_validate(data)`. `VultronOutbox` is popped before `model_validate` because it is core-internal tracking state with a structure incompatible with `as_OrderedCollection`; `as_Actor` auto-derives inbox/outbox URIs from `id_`.
- **`test/wire/as2/vocab/test_case_actor.py`**: New file with `test_as_case_actor_from_core_preserves_published` confirming the fix.

## Verification

- 7288 unit tests pass (1 new)
- 1172 integration tests pass
- Black, flake8, mypy, pyright clean