### PR TITLE
docs: plan issue #2560 — add BT node discovery gate to build skill and behaviors AGENTS.md

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -169,7 +169,7 @@ on what "done" means — loaded by `orient-agent` in Phase 1.
       existing base class whose `update()` frame covers the same
       guard+emit+outbox or guard+transition+log pattern. Consult the domain
       base-class table in
-      [`vultron/core/behaviors/AGENTS.md`](../../vultron/core/behaviors/AGENTS.md).
+      [`vultron/core/behaviors/AGENTS.md`](../../../vultron/core/behaviors/AGENTS.md).
       If a matching base exists, subclass it. If none exists for your domain,
       create it first, then write the concrete node.
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -152,6 +152,39 @@ on what "done" means — loaded by `orient-agent` in Phase 1.
 3. Add or update tests for every new or changed behavior. A behavior with no
    test is not done.
 4. Reuse existing helpers and keep the implementation DRY.
+
+   **If this task creates or modifies a BT node (required — BTC-01-001,
+   BTND-07-005):**
+
+   a. **Node inventory**: grep `vultron/core/behaviors/` for existing node
+      classes whose protocol state, domain, or semantic action overlaps with
+      what you are about to implement. Search for the target state value, the
+      action name, and the affected domain (e.g. `"RM.CLOSED"`,
+      `"EM.EXITED"`, `"active_embargo = None"`, `"add_participant_status"`).
+      If a matching node exists, compose or delegate from it — do not
+      re-implement.
+
+   b. **Base-class check (BTND-07-009, BTND-07-010)**: for any emit, send,
+      or state-transition node, check `vultron/core/behaviors/` for an
+      existing base class whose `update()` frame covers the same
+      guard+emit+outbox or guard+transition+log pattern. Consult the domain
+      base-class table in
+      [`vultron/core/behaviors/AGENTS.md`](../../vultron/core/behaviors/AGENTS.md).
+      If a matching base exists, subclass it. If none exists for your domain,
+      create it first, then write the concrete node.
+
+   c. **Sibling-domain scan**: check peer trees in sibling modules for the
+      same trigger condition appearing more than once. A shared trigger (e.g.
+      `IsRemoveEmbargoEvent` appearing in two trees) signals a shared behavior
+      need that should be a single composed subtree, not two parallel
+      implementations.
+
+   d. **AC-1 compliance gate**: any node that reads EM/RM/CS state MUST do
+      so through the appropriate `Read*StateNode`. Any node that writes
+      EM/RM/CS state MUST do so through `Write*StateNode`. Inline reads
+      (e.g. `case.current_status.em.state`) and inline writes are AC-1
+      violations regardless of context and must be caught before review.
+
 5. Sub-agents may help, but main-agent validation is mandatory.
 6. **Pattern-change checklist** — run this before opening the PR:
    - If this PR retires a method or establishes a new pattern, grep

--- a/.agents/skills/deepen-context/SKILL.md
+++ b/.agents/skills/deepen-context/SKILL.md
@@ -102,6 +102,18 @@ text. Do not grep blindly when `graphify query` will orient you first.
 If no graph exists, fall back to searching `vultron/` and `test/` directly.
 Do not assert missing functionality without evidence from code search.
 
+**BT integration focus hint — pre-coding gate (BTC-01-001, BTND-07-005):**
+When the task creates or modifies a BT node, the codebase scan is a
+**blocking pre-coding step**, not background reading. Before reading the
+target file, enumerate `vultron/core/behaviors/<domain>/nodes/` for classes
+whose names or docstrings overlap with the feature you are about to
+implement. The `notes/bt-composability.md` decision table row "Simulator
+lookup mandatory? → Yes — MUST check before implementing" means an active
+check is required: find the simulator counterpart in `vultron/bt/`, confirm
+the current behavior, and verify that no existing core-behaviors node already
+implements the same semantics before writing new code. Reading the note
+without doing the inventory does not satisfy BTC-01-001.
+
 ## Notes
 
 - Focus hints come from the calling skill after it has selected and read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,9 +323,11 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **Splits Must Not Produce New God Modules** — submodules ≤500 lines; split
   recursively when they re-accumulate. See CS-18-001 through CS-18-004.
 - **BT Emit Nodes: Inherit Base Classes, Never Reimplement Guard Boilerplate**
-  — use `_EmitCaseActorReportActivityBase` (report domain) or
-  `_SendEmbargoActivityBase` (embargo domain); override only `_call_factory()`
-  and the three hook methods. See BTND-07-005.
+  — before writing any emit, send, or state-transition node, check the
+  domain base-class table and discovery gate in
+  [`vultron/core/behaviors/AGENTS.md`](vultron/core/behaviors/AGENTS.md)
+  § "Compose Before Create". If no base exists for your domain, create it
+  first. See BTND-07-005, BTND-07-009, BTND-07-010.
 - **Peer Broadcast Nodes Must Not Mask Delivery Failure with SUCCESS** —
   see [notes/peer-broadcast-failure-semantics.md](notes/peer-broadcast-failure-semantics.md) BT-14-001.
 - **Negative-Guard Condition Nodes Are a Readability Anti-Pattern** — use

--- a/plan/history/2608/learning/CONCERN-2560.md
+++ b/plan/history/2608/learning/CONCERN-2560.md
@@ -1,0 +1,12 @@
+---
+source: CONCERN-2560
+timestamp: '2026-08-25T16:20:15.880815+00:00'
+title: 'Build skill lacks BT node discovery gate: compose before create is documented
+  but never enforced as a workflow step'
+type: learning
+---
+
+See issue #2560 body for full concern text.
+
+**Resolved**: 2026-08-25 — implementation tracked in #2572.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2570>.

--- a/vultron/core/behaviors/AGENTS.md
+++ b/vultron/core/behaviors/AGENTS.md
@@ -132,6 +132,41 @@ not sufficient without the persist. See `notes/participant-embargo-consent.md`
 
 ---
 
+## Compose Before Create: Node Discovery Gate
+
+Before writing any new BT emit, send, or state-transition node in this
+package, perform these checks (BTND-07-005, BTND-07-009, BTND-07-010):
+
+1. **Inventory existing nodes**: grep `vultron/core/behaviors/<domain>/nodes/`
+   for classes with overlapping protocol state, domain, or action semantics.
+   If a match exists, compose or subclass — do not re-implement.
+
+2. **Use the domain base class**: for emit/send nodes, subclass the
+   appropriate base from the table below and override only `_call_factory()`
+   and the hook methods. Do not write a new `update()` from scratch.
+
+   | Domain | Base class | File |
+   |--------|-----------|------|
+   | Report | `_EmitCaseActorReportActivityBase` | `report/nodes/emit.py` |
+   | Embargo | `_SendEmbargoActivityBase` | `embargo/nodes/emit.py` |
+   | Participant-status | `_EmitParticipantStatusActivityBase` | `report/nodes/develop_fix.py` *(create if absent)* |
+   | Single-activity (invite, ownership, other case domains) | `_EmitSingleActivityBase` | `helpers.py` *(create if absent)* |
+
+   **If no base exists for your domain: create it first, then write the
+   concrete node.** Do not implement `update()` inline in a concrete node
+   class unless you have confirmed no existing base covers your
+   guard+emit+outbox pattern.
+
+3. **AC-1 compliance**: any node reading EM/RM/CS state MUST go through
+   `Read*StateNode`; any node writing it MUST go through `Write*StateNode`.
+   Inline reads/writes are AC-1 violations.
+
+See `vultron/core/behaviors/AGENTS.md` (this file) whenever you are about
+to add a node in this package — the build skill's Phase 4 gate references
+it. Specs: BTND-07-005, BTND-07-009, BTND-07-010, BTC-01-001.
+
+---
+
 ## See Also
 
 - `notes/bt-integration.md` — architecture decisions, actor isolation,


### PR DESCRIPTION
- Closes #2560

## Summary

Converts the "compose before create" principle from background reading into an
active, blocking workflow gate in three places: the build skill's pre-coding
phase, the deepen-context skill's BT integration scan, and the directory-level
AGENTS.md closest to where BT nodes are written.

## Changes

- **`.agents/skills/build/SKILL.md`**: Phase 4 item 4 gains a four-step BT
  node discovery sub-section — node inventory grep, domain base-class lookup,
  sibling-domain scan, and AC-1 compliance gate — required whenever a task
  creates or modifies a BT node (BTC-01-001, BTND-07-005)
- **`.agents/skills/deepen-context/SKILL.md`**: Step 4 BT integration block
  gains an explicit paragraph framing the codebase scan as a blocking
  pre-coding gate, not background reading; references BTC-01-001 and
  BTND-07-005
- **`vultron/core/behaviors/AGENTS.md`**: new "Compose Before Create" section
  with four-row domain base-class table, "create first" directive, and AC-1
  compliance reminder (BTND-07-009, BTND-07-010); this is the file the build
  skill now points agents to during the base-class check
- **`AGENTS.md`**: BT emit-nodes pitfall updated to point to the directory-level
  AGENTS.md for the full discovery gate instead of listing bases inline; keeps
  root AGENTS.md lean per routing policy

## Implementation Issues

- #2572