### PR TITLE
docs: plan issue #2559 — BT DRY violations and AC-1 embargo canonical channel

### DIFF
--- a/plan/history/2608/learning/CONCERN-2559.md
+++ b/plan/history/2608/learning/CONCERN-2559.md
@@ -1,0 +1,58 @@
+---
+source: CONCERN-2559
+timestamp: '2026-08-25T16:58:49.936392+00:00'
+title: '9 BT DRY violations in vultron/core/behaviors/: copied logic creates multi-site
+  bug surface and AC-1 violations'
+type: learning
+---
+
+Identified 9 DRY violations across `vultron/core/behaviors/` grouped into 3
+implementation clusters. Each cluster shares overlapping file context and is
+tracked as a separate impl issue, all blocked-by CONCERN-2559 and sub-issues
+of epic #2558.
+
+## Group 1 — Embargo AC-1 violations (impl: #2583, size:M)
+
+V1 and V7: two sites bypass `ReadEmStateNode`/`WriteEmStateNode` and read/write
+`case.current_status.em` inline. AC-1 of issue #1474 mandates all EM state
+access go through the canonical nodes.
+
+- `embargo/nodes/teardown.py` — `ApplyEmbargoTeardownNode.update()` reads
+  `case.current_status.em.state` directly; fix: delegate to
+  `ClearActiveEmbargoNode` + `ResetParticipantConsentNode`, preserving the
+  existing blackboard `activity` port.
+- `case/nodes/embargo.py` — inline `EmDimension(state=EM.ACTIVE)` write.
+- `embargo/nodes/lifecycle.py` — inline `EmDimension(state=EM.ACTIVE)` write.
+
+## Group 2 — Report-phase dedup (impl: #2581, size:L)
+
+V2, V3, V6, B2: four near-identical `update()` blocks in the report-phase nodes.
+
+- Extract `_TransitionRMtoReportPhaseState(target: RM)` base from
+  `rm_transitions.py`; `TransitionRMtoInvalid` and `TransitionRMtoClosed`
+  become thin subclasses.
+- Extract `_EmitParticipantStatusActivityBase` for `EmitCFActivity` /
+  `EmitCDActivity` in `develop_fix.py` / `deploy_fix.py`.
+- Extract `_CheckParticipantRMStateBase` or factory for `CheckRMStateAccepted`
+  / `RMinStateDeferred`.
+- Unify `CheckRMStateValid` / `CheckRMStateReceivedOrInvalid` condition logic
+  (`conditions.py`).
+
+## Group 3 — Case-domain emit base (impl: #2582, size:L)
+
+V4, V5, B1: `invite_response.py` and `ownership_transfer.py` each contain 2–3
+`update()` methods with identical guard+emit+outbox patterns.
+
+- Create `_EmitSingleActivityBase` in `helpers.py`; concrete nodes override
+  only `_call_factory()` and `_on_success()`.
+- Move "BT Emit Nodes" pitfall from root `AGENTS.md` to
+  `vultron/core/behaviors/AGENTS.md` once the base class exists to reference.
+
+## Docs outcome
+
+PR #2580 adds `## EM State Reads and Writes Must Use Canonical Nodes` section
+to `vultron/core/behaviors/AGENTS.md` with a concrete `ReadEmStateNode`
+delegation code pattern, complementing the existing AC-1 bullet in the
+"Compose Before Create: Node Discovery Gate" section.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2580>

--- a/vultron/core/behaviors/AGENTS.md
+++ b/vultron/core/behaviors/AGENTS.md
@@ -167,6 +167,36 @@ it. Specs: BTND-07-005, BTND-07-009, BTND-07-010, BTC-01-001.
 
 ---
 
+## EM State Reads and Writes Must Use Canonical Nodes
+
+**Never read or write `case.current_status.em` inline inside a BT node.**
+All EM state reads MUST go through `ReadEmStateNode`; all writes through
+`WriteEmStateNode`. Both live in
+`vultron/core/behaviors/embargo/nodes/em_state.py`.
+
+Direct field access (`case.current_status.em.state`) bypasses the canonical
+channel: the read or write is invisible to the BT audit trail and creates
+paths where state can diverge from what the canonical nodes report.
+`ReadEmStateNode` was introduced specifically to centralize this read (AC-1,
+issue #1474).
+
+**Pattern for reading EM state in an action node:**
+
+```python
+result_out: dict[str, object] = {}
+read_node = ReadEmStateNode(case_id=case_id, result_out=result_out)
+read_node.datalayer = self.datalayer
+if read_node.update() != Status.SUCCESS:
+    self.feedback_message = read_node.feedback_message
+    return Status.FAILURE
+current_em = result_out["em_before"]
+assert isinstance(current_em, EM)
+```
+
+Source: CONCERN-2559
+
+---
+
 ## See Also
 
 - `notes/bt-integration.md` — architecture decisions, actor isolation,


### PR DESCRIPTION
- Closes #2559

## Summary

Adds EM canonical channel pitfall to `vultron/core/behaviors/AGENTS.md`,
documenting that all EM state reads/writes in BT nodes must go through
`ReadEmStateNode` / `WriteEmStateNode` (AC-1, CONCERN-2559). Complements the
existing "Compose Before Create" section's AC-1 compliance bullet with a
concrete code pattern.

## Changes

- **`vultron/core/behaviors/AGENTS.md`**: New section "EM State Reads and Writes
  Must Use Canonical Nodes" — concrete code pattern for delegating EM state reads
  to `ReadEmStateNode`, inline alongside the "Compose Before Create: Node Discovery
  Gate" section. Source: CONCERN-2559.

## Implementation Issues

- #2581 — extract report-phase dedup base classes (size:L)
- #2582 — create `_EmitSingleActivityBase` for case-domain emit nodes (size:L)
- #2583 — fix inline EM state reads/writes (embargo AC-1, size:M)