### PR TITLE
docs: plan issue #2397 — spec-to-story bidirectional traceability

### DIFF
--- a/plan/history/2608/learning/CONCERN-2397.md
+++ b/plan/history/2608/learning/CONCERN-2397.md
@@ -1,0 +1,26 @@
+---
+source: CONCERN-2397
+timestamp: '2026-08-25T17:12:42.105054+00:00'
+title: spec-to-story traceability is one-way — specs don't back-reference user stories
+type: learning
+---
+
+## Concern
+
+Traceability between user stories and spec requirements is one-way: `docs/reference/user_stories/traceability.md` maps stories → specs, but spec YAML files do not back-reference the user stories that motivated them. This means a requirement cannot be traced back to its stakeholder need without consulting the traceability matrix, and the matrix is a manually-maintained document that drifts.
+
+## Surface Symptom vs. Underlying Problem
+
+**Surface symptom:** Spec requirements have no `relationships:` entries of type `satisfies` pointing to user story IDs. The `traceability.md` matrix is the only artifact linking stories to requirements, and it lives outside the spec files themselves.
+
+**Underlying problem:** Without bidirectional traceability, it is not possible to answer "which stakeholder need does this requirement serve?" from the spec alone. This violates the NASA requirements validation criterion for bidirectional traceability to baselined stakeholder expectations. It also means that when a user story is updated or a new story is added, there is no automated way to identify which requirements need review. The traceability matrix is a snapshot that will drift.
+
+## Resolved
+
+2026-08-25 — implementation tracked in #2585. Docs PR: <https://github.com/CERTCC/Vultron/pull/2584>. Spec: `specs/spec-registry.yaml` (SR-11-001 through SR-11-004).
+
+## Design decisions
+
+- **Separate `stories:` field** (not `relationships:`): story IDs are not in the spec registry index, so using `relationships:` would cause hard lint errors from `validate_cross_references()`. A dedicated `stories: list[StoryIdStr]` field with its own Pydantic type avoids this without polluting the cross-reference graph.
+- **No rename** of story IDs: renaming `story_2022_NNN` → `STORY-22-NNN` was considered (it would match `SpecIdStr`) but is unnecessary since a separate field with its own `StoryIdStr` type is used.
+- **Lint tiers**: `kind: protocol` + `priority: MUST` with no stories → hard error (CI-blocking, suppressible); SHOULD/MAY → advisory warning. Rationale: MUST-level protocol specs are the strongest obligations; SHOULD/MAY story coverage is aspirational.

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -539,3 +539,70 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: SR-10-001
+- id: SR-11
+  title: Story Traceability
+  specs:
+  - id: SR-11-001
+    priority: MUST
+    kind: project
+    statement: >-
+      `StatementSpec` MUST support an optional `stories` field containing a non-empty
+      list of `StoryIdStr` values (pattern `^story_\d{4}_\d{3}$`), identifying the
+      user stories that motivated the requirement. The field MUST be subject to the
+      `_nonempty_if_present` validator.
+    rationale: >-
+      Bidirectional traceability between requirements and stakeholder user stories is a
+      NASA systems engineering criterion. Without back-references in spec files, tracing
+      "which stakeholder need does this requirement serve?" requires consulting the
+      manually-maintained `docs/reference/user_stories/traceability.md` matrix, which
+      drifts as specs evolve. Embedding story references in the spec files makes the
+      spec the authoritative source and enables automated change-impact analysis.
+    tags:
+    - documentation
+    - tooling
+  - id: SR-11-002
+    priority: MUST
+    kind: project
+    statement: >-
+      Story ID strings used in `stories:` fields MUST conform to the pattern
+      `^story_\d{4}_\d{3}$` (e.g. `story_2022_001`). The `StoryIdStr` type in
+      `vultron/metadata/specs/schema.py` MUST enforce this constraint via Pydantic
+      `StringConstraints`.
+    relationships:
+    - rel_type: refines
+      spec_id: SR-11-001
+    tags:
+    - documentation
+    - tooling
+  - id: SR-11-003
+    priority: MUST
+    kind: process
+    statement: >-
+      The spec linter MUST flag as a hard error any `kind: protocol` spec with
+      `priority: MUST` that has no `stories:` entry. This check MUST be suppressible
+      per-spec via `lint_suppress: [missing_story_reference]`.
+    rationale: >-
+      Protocol-level MUST requirements represent the strongest normative obligations
+      in the spec corpus. Making story coverage a hard-error gate for this tier ensures
+      every binding protocol requirement can be traced back to at least one stakeholder
+      need. Suppressibility preserves an escape hatch for implementation-detail MUSTs
+      with no direct story antecedent.
+    relationships:
+    - rel_type: refines
+      spec_id: SR-11-001
+    tags:
+    - documentation
+    - tooling
+  - id: SR-11-004
+    priority: SHOULD
+    kind: process
+    statement: >-
+      The spec linter SHOULD emit an advisory warning for any `kind: protocol` spec
+      with `priority: SHOULD` or `priority: MAY` that has no `stories:` entry. This
+      check SHOULD be suppressible per-spec via `lint_suppress: [missing_story_reference]`.
+    relationships:
+    - rel_type: refines
+      spec_id: SR-11-003
+    tags:
+    - documentation
+    - tooling


### PR DESCRIPTION
- Closes #2397
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Adds SR-11 (Story Traceability) group to `specs/spec-registry.yaml`, formalising the design decisions from planning CONCERN-2397 on bidirectional spec-to-story traceability.

## Changes

- **`specs/spec-registry.yaml`**: new SR-11 group with four requirements — `StoryIdStr` type and `stories:` field on `StatementSpec` (SR-11-001/002), linter hard-error for `kind:protocol` MUST specs with no story reference (SR-11-003), and advisory warning for SHOULD/MAY (SR-11-004)

## Implementation Issues

- #2585