### PR TITLE
feat(bt-nodes): add _EmitParticipantStatusActivityBase; refactor EmitCF/CDActivity

### DIFF
--- a/plan/incoming/learnings/20260825-freshen-branch-ambiguous-origin-main.md
+++ b/plan/incoming/learnings/20260825-freshen-branch-ambiguous-origin-main.md
@@ -1,0 +1,21 @@
+---
+title: "freshen-branch.sh misreports 'already rooted' when origin/main ref is ambiguous"
+type: learning
+timestamp: "2026-08-25"
+source: ISSUE-2572
+signal: tooling-issue
+---
+
+`freshen-branch.sh` uses `origin/main` as the upstream ref. When a local branch named
+`origin/main` exists alongside the remote-tracking ref `refs/remotes/origin/main`, git
+reports `warning: refname 'origin/main' is ambiguous` and resolves to the local branch.
+
+This caused the script to report "Branch already rooted at origin/main — nothing to do"
+even though the task branch was one merge-commit behind the true `refs/remotes/origin/main`
+tip. The workaround was a manual `git rebase refs/remotes/origin/main`.
+
+The fix should update `freshen-branch.sh` (and any other skill script that references
+`origin/main`) to use the unambiguous form `refs/remotes/origin/main` throughout.
+
+**How to reproduce**: have a local branch named `origin/main` in the repo and run
+`freshen-branch.sh` while the task branch is behind remote main.

--- a/test/core/behaviors/report/test_deploy_fix_tree.py
+++ b/test/core/behaviors/report/test_deploy_fix_tree.py
@@ -52,6 +52,7 @@ from vultron.core.behaviors.report.nodes.deploy_fix import (
     TransitionCStoFixDeployed,
 )
 from vultron.core.behaviors.report.nodes.develop_fix import (
+    _EmitParticipantStatusActivityBase,
     CheckRMStateAccepted,
 )
 from vultron.core.models.case_participant import CaseParticipant
@@ -155,6 +156,15 @@ def _seed_status(
         if isinstance(participant, CaseParticipant):
             participant.participant_statuses.append(status)
             bt_scenario.dl.save(participant)
+
+
+# ---------------------------------------------------------------------------
+# _EmitParticipantStatusActivityBase hierarchy (BTND-07-005)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_cd_activity_subclasses_base():
+    assert issubclass(EmitCDActivity, _EmitParticipantStatusActivityBase)
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/report/test_develop_fix_tree.py
+++ b/test/core/behaviors/report/test_develop_fix_tree.py
@@ -39,6 +39,7 @@ from vultron.core.behaviors.report.develop_fix_tree import (
     create_develop_fix_tree,
 )
 from vultron.core.behaviors.report.nodes.develop_fix import (
+    _EmitParticipantStatusActivityBase,
     CheckCSFixNotYetReady,
     CheckIsVendorRoleNode,
     CheckRMStateAccepted,
@@ -548,6 +549,21 @@ class TestTransitionCStoFixReady:
         ]
         assert detail, "Expected the node's own detail line"
         assert all(r.levelno == logging.DEBUG for r in detail)
+
+
+# ---------------------------------------------------------------------------
+# _EmitParticipantStatusActivityBase hierarchy (BTND-07-005)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_cf_activity_subclasses_base():
+    assert issubclass(EmitCFActivity, _EmitParticipantStatusActivityBase)
+
+
+def test_emit_participant_status_base_in_all():
+    import vultron.core.behaviors.report.nodes.develop_fix as mod
+
+    assert "_EmitParticipantStatusActivityBase" in mod.__all__
 
 
 CASE_MANAGER_ACTOR_ID = "https://example.org/actors/case-manager-001"

--- a/vultron/core/behaviors/report/nodes/__init__.py
+++ b/vultron/core/behaviors/report/nodes/__init__.py
@@ -55,6 +55,7 @@ from vultron.core.behaviors.report.nodes.deploy_fix import (
     TransitionCStoFixDeployed,
 )
 from vultron.core.behaviors.report.nodes.develop_fix import (
+    _EmitParticipantStatusActivityBase,
     CheckCSFixNotYetReady,
     CheckIsVendorRoleNode,
     CheckRMStateAccepted,
@@ -104,6 +105,7 @@ __all__ = [
     "TransitionParticipantRMtoAccepted",
     "TransitionParticipantRMtoDeferred",
     # develop_fix
+    "_EmitParticipantStatusActivityBase",
     "CheckIsVendorRoleNode",
     "CheckCSFixNotYetReady",
     "CheckRMStateAccepted",

--- a/vultron/core/behaviors/report/nodes/deploy_fix.py
+++ b/vultron/core/behaviors/report/nodes/deploy_fix.py
@@ -34,25 +34,23 @@ Notes: ``notes/bt-fuzzer-rm-fix.md``.
 """
 
 import logging
-from typing import cast
 
 from py_trees.common import Status
 from py_trees.ports import NoDataAvailable, PortInformation
 
 from vultron.core.behaviors.case.nodes.participant.common import (
-    resolve_case_manager_id,
     resolve_participant_state_from_dl,
 )
 from vultron.core.behaviors.helpers import (
     DataLayerActionWithPorts,
     DataLayerConditionWithPorts,
 )
+from vultron.core.behaviors.report.nodes.develop_fix import (
+    _EmitParticipantStatusActivityBase,
+)
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.dimensions import VfdDimension
-from vultron.core.ports.case_persistence import (
-    CaseOutboxPersistence,
-    CasePersistence,
-)
+from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
 
@@ -395,7 +393,7 @@ class TransitionCStoFixDeployed(DataLayerActionWithPorts):
             return Status.FAILURE
 
 
-class EmitCDActivity(DataLayerActionWithPorts):
+class EmitCDActivity(_EmitParticipantStatusActivityBase):
     """Emit a CD (Fix Deployed) ``Add(ParticipantStatus)`` to the Case Actor.
 
     Calls ``trigger_activity_factory.add_participant_status_to_participant``
@@ -407,86 +405,9 @@ class EmitCDActivity(DataLayerActionWithPorts):
     activities to the Case Actor (CASE_MANAGER) so the CaseActor can commit
     a canonical ledger entry.
 
-    Per AC-5 (issue #1825); mirrors ``EmitCFActivity`` from ``develop_fix.py``.
+    Per AC-5 (issue #1825); uses ``_EmitParticipantStatusActivityBase`` from
+    ``develop_fix.py`` (BTND-07-005).
     """
-
-    def __init__(
-        self,
-        case_id: str,
-        actor_id: str,
-        result_out: dict,
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self._case_id = case_id
-        self._actor_id = actor_id
-        self._result_out = result_out
-
-    def update(self) -> Status:
-        if (f := self._require_datalayer()) is not None:
-            return f
-        if (f := self._require_factory()) is not None:
-            self.logger.warning(
-                "%s: no TriggerActivityPort — cannot emit CD activity",
-                self.name,
-            )
-            return f
-
-        assert self.datalayer is not None
-        assert self.trigger_activity_factory is not None
-
-        status_id = self._result_out.get("status_id")
-        participant_id = self._result_out.get("participant_id")
-        if not status_id or not participant_id:
-            self.feedback_message = (
-                "status_id or participant_id missing from result_out"
-                " — TransitionCStoFixDeployed must precede EmitCDActivity"
-            )
-            self.logger.error("%s: %s", self.name, self.feedback_message)
-            return Status.FAILURE
-
-        case = self.datalayer.read(self._case_id)
-        if not isinstance(case, VulnerabilityCase):
-            self.logger.warning(
-                "%s: case '%s' not found", self.name, self._case_id
-            )
-            return Status.FAILURE
-
-        case_manager_id = resolve_case_manager_id(case, self.datalayer)
-        if not case_manager_id:
-            self.feedback_message = (
-                f"No CASE_MANAGER found for case '{self._case_id}'"
-            )
-            self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return Status.FAILURE
-
-        # When actor IS the case manager (single-actor scenario) to=None means
-        # the activity is self-addressed; no external delivery needed.
-        to = [case_manager_id] if case_manager_id != self._actor_id else None
-
-        try:
-            activity_id = self.trigger_activity_factory.add_participant_status_to_participant(
-                status_id=status_id,
-                participant_id=participant_id,
-                actor=self._actor_id,
-                to=to,
-            )
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self._actor_id, activity_id
-            )
-            self.logger.info(
-                "%s: CD activity '%s' emitted for actor '%s' in case '%s'",
-                self.name,
-                activity_id,
-                self._actor_id,
-                self._case_id,
-            )
-            return Status.SUCCESS
-        except Exception as e:
-            self.logger.error(
-                "%s: Error emitting CD activity: %s", self.name, e
-            )
-            return Status.FAILURE
 
 
 __all__ = [

--- a/vultron/core/behaviors/report/nodes/develop_fix.py
+++ b/vultron/core/behaviors/report/nodes/develop_fix.py
@@ -366,19 +366,13 @@ class TransitionCStoFixReady(DataLayerActionWithPorts):
             return Status.FAILURE
 
 
-class EmitCFActivity(DataLayerActionWithPorts):
-    """Emit a CF (Fix Readiness) ``Add(ParticipantStatus)`` to the Case Actor.
+class _EmitParticipantStatusActivityBase(DataLayerActionWithPorts):
+    """Shared guard+factory-dispatch+outbox-write skeleton for
+    ``Add(ParticipantStatus)`` trigger activities (BTND-07-005).
 
-    Calls ``trigger_activity_factory.add_participant_status_to_participant``
-    with the status and participant IDs written to *result_out* by
-    :class:`TransitionCStoFixReady` and queues the resulting activity ID
-    via ``record_outbox_item``.
-
-    Per ADR-0021 CLP-10-001: trigger trees MUST address fix-readiness
-    activities to the Case Actor (CASE_MANAGER) so the CaseActor can
-    commit a canonical ledger entry.
-
-    Per AC-7 (issue #1812).
+    Subclasses provide only a constructor docstring; all protocol logic
+    lives here.  The ``result_out`` dict must be populated by the preceding
+    ``TransitionCStoFix*`` node (keys: ``status_id``, ``participant_id``).
     """
 
     def __init__(
@@ -398,7 +392,7 @@ class EmitCFActivity(DataLayerActionWithPorts):
             return f
         if (f := self._require_factory()) is not None:
             self.logger.warning(
-                "%s: no TriggerActivityPort — cannot emit CF activity",
+                "%s: no TriggerActivityPort — cannot emit participant-status activity",
                 self.name,
             )
             return f
@@ -411,7 +405,7 @@ class EmitCFActivity(DataLayerActionWithPorts):
         if not status_id or not participant_id:
             self.feedback_message = (
                 "status_id or participant_id missing from result_out"
-                " — TransitionCStoFixReady must precede EmitCFActivity"
+                f" — a TransitionCS node must precede {self.__class__.__name__}"
             )
             self.logger.error("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
@@ -446,21 +440,39 @@ class EmitCFActivity(DataLayerActionWithPorts):
                 self._actor_id, activity_id
             )
             self.logger.info(
-                "%s: CF activity '%s' emitted for actor '%s' in case '%s'",
-                self.name,
-                activity_id,
+                "Actor '%s' emitted %s for case '%s'",
                 self._actor_id,
+                self.__class__.__name__,
                 self._case_id,
             )
             return Status.SUCCESS
         except Exception as e:
             self.logger.error(
-                "%s: Error emitting CF activity: %s", self.name, e
+                "%s: Error emitting participant-status activity: %s",
+                self.name,
+                e,
             )
             return Status.FAILURE
 
 
+class EmitCFActivity(_EmitParticipantStatusActivityBase):
+    """Emit a CF (Fix Readiness) ``Add(ParticipantStatus)`` to the Case Actor.
+
+    Calls ``trigger_activity_factory.add_participant_status_to_participant``
+    with the status and participant IDs written to *result_out* by
+    :class:`TransitionCStoFixReady` and queues the resulting activity ID
+    via ``record_outbox_item``.
+
+    Per ADR-0021 CLP-10-001: trigger trees MUST address fix-readiness
+    activities to the Case Actor (CASE_MANAGER) so the CaseActor can
+    commit a canonical ledger entry.
+
+    Per AC-7 (issue #1812).
+    """
+
+
 __all__ = [
+    "_EmitParticipantStatusActivityBase",
     "CheckIsVendorRoleNode",
     "CheckCSFixNotYetReady",
     "CheckRMStateAccepted",


### PR DESCRIPTION
- Closes #2572

## Summary

Creates `_EmitParticipantStatusActivityBase` in `report/nodes/develop_fix.py` and refactors both `EmitCFActivity` and `EmitCDActivity` to subclass it, eliminating ~60 lines of duplicated `update()` logic.

## Changes

- **`vultron/core/behaviors/report/nodes/develop_fix.py`**: adds `_EmitParticipantStatusActivityBase` with the shared guard + factory-dispatch + outbox-write skeleton; `EmitCFActivity` becomes a docstring-only subclass; base exported in `__all__`
- **`vultron/core/behaviors/report/nodes/deploy_fix.py`**: `EmitCDActivity` subclasses `_EmitParticipantStatusActivityBase`; removes unused `cast`, `CaseOutboxPersistence`, `resolve_case_manager_id` imports
- **`test/.../test_develop_fix_tree.py`**: hierarchy + `__all__` tests
- **`test/.../test_deploy_fix_tree.py`**: hierarchy test for `EmitCDActivity`

## Verification

- 78 develop/deploy_fix tests pass; full unit suite 4501 passed
- Integration suite exit 0; black, flake8, mypy clean