### PR TITLE
ops(skills): capture pytest output to temp files; ban re-runs for more output

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -212,8 +212,8 @@ that clearly belongs with it, apply the following:
    ```bash
    uv run black vultron/ test/
    uv run flake8 vultron/ test/ && uv run mypy && uv run pyright
-   uv run pytest --tb=short 2>&1 | tail -5
-   uv run pytest -m integration --tb=short 2>&1 | tail -5
+   uv run pytest --tb=short 2>&1 | tee /tmp/pytest-unit.log | tail -5
+   uv run pytest -m integration --tb=short 2>&1 | tee /tmp/pytest-integration.log | tail -5
    ```
 
    Both suites must pass. The first command covers the unit suite (integration

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -161,8 +161,8 @@ before proceeding. Do not open a PR with lint failures.
 ```bash
 uv run black vultron/ test/
 uv run flake8 vultron/ test/ && uv run mypy && uv run pyright
-uv run pytest --tb=short 2>&1 | tail -5
-uv run pytest -m integration --tb=short 2>&1 | tail -5
+uv run pytest --tb=short 2>&1 | tee /tmp/pytest-unit.log | tail -5
+uv run pytest -m integration --tb=short 2>&1 | tee /tmp/pytest-integration.log | tail -5
 ```
 
 Both suites must pass. The first pytest command covers the unit suite

--- a/.agents/skills/pr-comprehensive-fix/SKILL.md
+++ b/.agents/skills/pr-comprehensive-fix/SKILL.md
@@ -70,7 +70,7 @@ If proceeding, invoke sub-skills in order:
 
 Based on Step 1 decision point:
 
-- **Unit only**: `uv run pytest --tb=short 2>&1 | tail -5`
+- **Unit only**: `uv run pytest --tb=short 2>&1 | tee /tmp/pytest-unit.log | tail -5`
 - **Full (unit + integration)**: Run both unit and integration test suites
 
 If tests fail:

--- a/.agents/skills/pr-comprehensive-fix/TESTING-LOGIC.md
+++ b/.agents/skills/pr-comprehensive-fix/TESTING-LOGIC.md
@@ -46,7 +46,7 @@ needs_integration = any(
 **Commands**:
 
 1. `uv run pytest --tb=short 2>&1 | tee /tmp/pytest-unit.log | tail -5` (all unit tests)
-2. `uv run pytest integration_tests/ -v` (integration test suite)
+2. `uv run pytest integration_tests/ -v 2>&1 | tee /tmp/pytest-integration.log` (integration test suite)
 
 **When**: Demo, adapters, behavior trees, or use-cases modified
 

--- a/.agents/skills/pr-comprehensive-fix/TESTING-LOGIC.md
+++ b/.agents/skills/pr-comprehensive-fix/TESTING-LOGIC.md
@@ -35,7 +35,7 @@ needs_integration = any(
 
 ### Unit Tests Only (default)
 
-**Command**: `uv run pytest --tb=short 2>&1 | tail -5`
+**Command**: `uv run pytest --tb=short 2>&1 | tee /tmp/pytest-unit.log | tail -5`
 
 **When**: Changes are localized (single module, no core/demo/adapter impact)
 
@@ -45,12 +45,14 @@ needs_integration = any(
 
 **Commands**:
 
-1. `uv run pytest --tb=short 2>&1 | tail -5` (all unit tests)
+1. `uv run pytest --tb=short 2>&1 | tee /tmp/pytest-unit.log | tail -5` (all unit tests)
 2. `uv run pytest integration_tests/ -v` (integration test suite)
 
 **When**: Demo, adapters, behavior trees, or use-cases modified
 
 **Expected output**: Full test summary from both suites
+
+Full pytest output is written to `/tmp/pytest-unit.log` (and `/tmp/pytest-integration.log` for the integration suite). **Never re-run the test suite to get more output** — grep or read those files instead.
 
 ## Interpreting Test Results
 

--- a/.agents/skills/pr-execute/SKILL.md
+++ b/.agents/skills/pr-execute/SKILL.md
@@ -191,14 +191,17 @@ the merge-state finding as `outcome: skipped` with the conflicted paths and stop
 #### Step 3 — Run local tests
 
 ```bash
-uv run pytest --tb=short 2>&1 | tail -20
+uv run pytest --tb=short 2>&1 | tee /tmp/pytest-unit.log | tail -20
 ```
 
 If `pr_metadata.needs_integration_tests` is true, also run:
 
 ```bash
-uv run pytest integration_tests/ -v 2>&1 | tail -40
+uv run pytest integration_tests/ -v 2>&1 | tee /tmp/pytest-integration.log | tail -40
 ```
+
+**If the tail output is insufficient**, grep or read `/tmp/pytest-unit.log` or
+`/tmp/pytest-integration.log` — **do not re-run the test suite for more output**.
 
 If tests fail: fix branch-owned failures per [REFERENCE.md](REFERENCE.md)
 § "Test Failure Rules", then **restart this iteration from Step 2** — always

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -8,7 +8,7 @@ tags:
   - ci
 shell: "zsh"
 commands:
-  - "uv run pytest --tb=short 2>&1 | tail -5"
+  - "uv run pytest --tb=short 2>&1 | tee /tmp/last-test-run.log | tail -5"
 inputs:
   - name: repo_root
     description: "Repository root"
@@ -22,17 +22,17 @@ outputs:
 
 | Suite | Command |
 |---|---|
-| Unit (default) | `uv run pytest --tb=short 2>&1 \| tail -5` |
-| Integration | `uv run pytest -m integration --tb=short 2>&1 \| tail -5` |
-| All | `uv run pytest -m "" --tb=short 2>&1 \| tail -5` |
+| Unit (default) | `uv run pytest --tb=short 2>&1 \| tee /tmp/last-test-run.log \| tail -5` |
+| Integration | `uv run pytest -m integration --tb=short 2>&1 \| tee /tmp/last-test-run.log \| tail -5` |
+| All | `uv run pytest -m "" --tb=short 2>&1 \| tee /tmp/last-test-run.log \| tail -5` |
 
 ## Pre-PR Validation (build and create-pr)
 
 Run **both** suites before opening a PR:
 
 ```bash
-uv run pytest --tb=short 2>&1 | tail -5
-uv run pytest -m integration --tb=short 2>&1 | tail -5
+uv run pytest --tb=short 2>&1 | tee /tmp/pytest-unit.log | tail -5
+uv run pytest -m integration --tb=short 2>&1 | tee /tmp/pytest-integration.log | tail -5
 ```
 
 The first command covers the unit suite (integration tests excluded by
@@ -47,3 +47,4 @@ tests must not reach a non-draft PR.
 - `filterwarnings = ["error"]` in `pyproject.toml` — warnings are test errors; fix root cause, do not suppress.
 - Integration tests are excluded from the default interactive run; always run `-m integration` explicitly in pre-PR validation.
 - Treat all failures as branch-owned by default; clean-base proof is required before classifying as pre-existing.
+- **Never re-run the test suite to get more output.** Full pytest output is written to `/tmp/last-test-run.log` (or `/tmp/pytest-unit.log` / `/tmp/pytest-integration.log` when both suites run). Read or grep those files instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Agents MUST follow these rules when generating, modifying, or reviewing code.
 - Use-Case Protocol: `__init__(dl, request)` + `execute() -> None`; routing via
   `USE_CASE_MAP` key lookup.
 - ASGI entrypoint: `vultron.adapters.driving.fastapi.main:app`.
-- Tests: `uv run pytest --tb=short 2>&1 | tail -5` — run once. See
+- Tests: `uv run pytest --tb=short 2>&1 | tee /tmp/last-test-run.log | tail -5` — run once. See
   `.agents/skills/run-tests/SKILL.md`.
 
 Quick gotchas: specific patterns before general; always `rehydrate()` before


### PR DESCRIPTION
## Summary

All pytest invocations in the skill suite now pipe through `tee` to persist full output in `/tmp` log files. Agents that need more detail than the tail shows must read/grep those files instead of re-running the test suite.

## Changes

- **`.agents/skills/run-tests/SKILL.md`**: all three suite commands pipe through `tee /tmp/last-test-run.log`; pre-PR validation uses named unit/integration files; added constraint banning re-runs for more output
- **`.agents/skills/pr-execute/SKILL.md`**: Step 3 uses `tee /tmp/pytest-unit.log` and `tee /tmp/pytest-integration.log`; explicit "do not re-run" rule added inline
- **`.agents/skills/build/SKILL.md`**: Phase 6 validate commands use named tee files
- **`.agents/skills/create-pr/SKILL.md`**: Phase 3 implementation commands use named tee files
- **`.agents/skills/pr-comprehensive-fix/SKILL.md`** and **`TESTING-LOGIC.md`**: same tee pattern; "never re-run" rule added to test execution section