### PR TITLE
docs: plan issue #1238 — VC demo scenario (vendor-as-finder)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -926,6 +926,18 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   new rules edition require N separate factory changes instead of one.
   See BTND-05-007, ADR-0071.
   *Source: CONCERN-2108*
+- **Adding a `kind: protocol` Spec Without Coverage Raises the Ratchet — Never Raise the Ceiling** —
+  the protocol-spec coverage ratchet (`test_protocol_spec_coverage_floor` in
+  `test/architecture/test_spec_coverage_ratchet.py`, ceiling = `MAX_UNCOVERED_PROTOCOL_SPECS`)
+  counts uncovered `kind: protocol` specs immediately. If no test carries
+  `@pytest.mark.spec("SPEC-ID")`, the uncovered count rises above the ceiling and CI fails.
+  The ceiling comment says "never raise it." Pattern for a spec whose implementation does not yet
+  exist: write a test asserting the not-yet-implemented behavior → mark it
+  `@pytest.mark.xfail(strict=True, reason="SPEC-ID: <short description>. Tracked by Bug #N.")`
+  and `@pytest.mark.spec("SPEC-ID")`. Do NOT add a stub class — use an existing node or
+  assertion that fails for the right reason. The xfail auto-promotes to passing once the feature
+  lands and the `reason=` links the test back to the implementation issue.
+  *Source: ISSUE-2606*
 
 ---
 

--- a/plan/history/2608/idea/IDEA-1238.md
+++ b/plan/history/2608/idea/IDEA-1238.md
@@ -1,0 +1,43 @@
+---
+source: IDEA-1238
+timestamp: '2026-08-25T19:02:11.786109+00:00'
+title: 'Demo scenario: vendor-as-finder — VC (vendor self-reports, coordinator joins
+  as observer)'
+type: idea
+---
+
+Planned the VC demo scenario from GitHub issue #1238. The scenario exercises
+Vendor self-discovering a vulnerability (no external Finder), using the standard
+`reporter_submits_report` helper with Vendor in both reporter and receiver slots,
+creating a case as `CVDRole.VENDOR + CASE_OWNER`, inviting Coordinator as
+`CVDRole.OBSERVER`, Coordinator signing the embargo to become SIGNATORY, only
+Vendor following the VFD fix path, and both participants reaching `RM.CLOSED`.
+
+## Outcome
+
+- Added DEMOMA-24 group (6 specs: DEMOMA-24-001 through DEMOMA-24-006) to
+  `specs/multi-actor-demo.yaml` covering container topology, self-reporting
+  mechanics, Coordinator-as-OBSERVER invite/accept, Vendor-only VFD path,
+  final state, and CI/test obligations
+- Added DEMOMA-16-014 specifying the VC scenario's required case-actor event
+  types (`invite_actor_to_case`, `accept_invite_actor_to_case` beyond universals)
+- Added `vc` row to `vultron/demo/scenario/README.md`
+- Created implementation issue #2591 as child of epic #1279, blocked-by #1238
+
+## Key design decisions
+
+- **Self-reporting**: Vendor uses `reporter_submits_report` unchanged with self
+  as both reporter and receiver — no protocol bypass, no special mechanism
+- **Observer role only**: Coordinator holds `CVDRole.OBSERVER` (not COORDINATOR);
+  renamed from `CVDRole.OTHER` in ADR-0057
+- **Embargo SIGNATORY required**: absent embargo participation, OBSERVER sees
+  nothing — Coordinator must sign embargo via Invite/Accept (CM-25)
+- **VFD path**: only Vendor (CVDRole.VENDOR) follows vfd→Vfd→VFd→VFD; Coordinator
+  tracks pxa state only (CM-26)
+- **Containers**: existing `vendor` + `coordinator` containers; Vendor self-hosts
+  CaseActor (`VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL=http://vendor:7999/api/v2`)
+
+## References
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2590>
+Implementation: #2591

--- a/plan/history/2608/idea/IDEA-1238.md
+++ b/plan/history/2608/idea/IDEA-1238.md
@@ -34,8 +34,10 @@ Vendor following the VFD fix path, and both participants reaching `RM.CLOSED`.
   nothing — Coordinator must sign embargo via Invite/Accept (CM-25)
 - **VFD path**: only Vendor (CVDRole.VENDOR) follows vfd→Vfd→VFd→VFD; Coordinator
   tracks pxa state only (CM-26)
-- **Containers**: existing `vendor` + `coordinator` containers; Vendor self-hosts
-  CaseActor (`VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL=http://vendor:7999/api/v2`)
+- **Containers**: existing `vendor` + `coordinator` + `case-actor` containers;
+  Vendor points to the shared CaseActor service
+  (`VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL=http://case-actor:7999/api/v2`)
+  per DEMOMA-24-001
 
 ## References
 

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -3446,17 +3446,19 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The VC scenario MUST involve exactly two actor identities — Vendor and
-      Coordinator — each with its own isolated DataLayer and separate container.
-      The Vendor container MUST serve as its own CaseActor host
-      (`VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL=http://vendor:7999/api/v2`); no
-      dedicated third CaseActor container is required.
+      The VC scenario MUST involve three actor identities — Vendor, Coordinator,
+      and CaseActor — each with its own isolated DataLayer and separate container.
+      The CaseActor MUST run as a separate actor identity on the dedicated
+      `case-actor` container (not co-located on the Vendor container), and
+      `docker-compose-multi-actor.yml` MUST configure Vendor with
+      `VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL=http://case-actor:7999/api/v2`.
     rationale: >-
-      VC is the minimal vendor-self-discovers scenario: no external Finder, no
-      dedicated CaseActor container. Vendor self-hosts CaseActor (CP-08-003),
-      which is the correct configuration in `docker-compose-multi-actor.yml`
-      for the vendor container. Using the two existing containers (vendor,
-      coordinator) avoids introducing new Docker infrastructure.
+      Using the shared `case-actor` container for Vendor-owned cases matches the
+      topology used by other scenarios where a non-Coordinator actor holds
+      CASE_OWNER, keeps the CaseActor identity consistent across scenarios, and
+      exercises true multi-container message delivery. All three containers
+      (vendor, coordinator, case-actor) already exist in
+      `docker-compose-multi-actor.yml`; no new infrastructure is required.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-01-001

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -2255,6 +2255,27 @@ groups:
     rationale: >-
       These counts verify that every actor who received an invitation explicitly
       accepted, and that the ADR-0026 approval path was exercised.
+  - id: DEMOMA-16-014
+    priority: MUST
+    kind: project
+    statement: >-
+      The VC scenario expected-event-types list MUST include
+      `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
+      to the universal types (DEMOMA-16-001), because Vendor invites
+      Coordinator into the case as `CVDRole.OBSERVER` and Coordinator
+      explicitly accepts via the `accept-case-invite` trigger.
+    rationale: >-
+      Vendor is CASE_OWNER from self-reporting, so Vendor drives the direct
+      `invite-actor-to-case` trigger (no suggest/approve chain). Coordinator
+      accepts and becomes SIGNATORY by accepting the embargo. No
+      `offer_case_participant` or `accept_actor_recommendation` events are
+      expected because there is no second-level recommendation in this
+      two-actor scenario.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+    - rel_type: refines
+      spec_id: DEMOMA-24-001
 
 - id: DEMOMA-18
   title: In-Process Fuzz Simulation Scenario
@@ -3417,3 +3438,167 @@ groups:
       spec_id: DEMOCI-10-004
     tags:
     - demo
+
+- id: DEMOMA-24
+  title: VC Scenario (Vendor self-reports; Coordinator joins as Observer)
+  specs:
+  - id: DEMOMA-24-001
+    priority: MUST
+    kind: project
+    statement: >-
+      The VC scenario MUST involve exactly two actor identities — Vendor and
+      Coordinator — each with its own isolated DataLayer and separate container.
+      The Vendor container MUST serve as its own CaseActor host
+      (`VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL=http://vendor:7999/api/v2`); no
+      dedicated third CaseActor container is required.
+    rationale: >-
+      VC is the minimal vendor-self-discovers scenario: no external Finder, no
+      dedicated CaseActor container. Vendor self-hosts CaseActor (CP-08-003),
+      which is the correct configuration in `docker-compose-multi-actor.yml`
+      for the vendor container. Using the two existing containers (vendor,
+      coordinator) avoids introducing new Docker infrastructure.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+    tags:
+    - demo
+  - id: DEMOMA-24-002
+    priority: MUST
+    kind: project
+    statement: >-
+      In the VC scenario, Vendor MUST submit the initial vulnerability report to
+      its own inbox using `reporter_submits_report` with Vendor in BOTH the
+      reporter and receiver slots. No external Finder actor exists; there are no
+      interactions outside the protocol. Vendor then validates the report
+      (RM→RECEIVED→VALID) and engages the case (RM→ACCEPTED→case created),
+      becoming CASE_OWNER with `CVDRole.VENDOR + CVDRole.CASE_OWNER`.
+    rationale: >-
+      Vendor-as-finder means the discoverer and the responsible fixer are the
+      same actor. Using `reporter_submits_report` unchanged ensures the standard
+      RM intake path is exercised rather than a shortcut; the only difference
+      from a normal report submission is that the reporter and receiver share an
+      identity. This matches "THERE ARE NO INTERACTIONS OUTSIDE THE PROTOCOL":
+      no ad-hoc case injection or create-case trigger bypass.
+    steps:
+    - order: 1
+      actor: vendor
+      action: POST submit-report trigger directed at self (vendor inbox)
+      expected: Report delivered to Vendor inbox via standard HTTP delivery path
+    - order: 2
+      actor: vendor
+      action: BT processes inbound report; RM transitions RECEIVED→VALID
+      expected: Report validated; RM state VALID
+    - order: 3
+      actor: vendor
+      action: BT engages case; RM transitions VALID→ACCEPTED
+      expected: >-
+        VulnerabilityCase created on Vendor/CaseActor; Vendor holds
+        CVDRole.VENDOR + CVDRole.CASE_OWNER; default embargo initialized
+        EM.ACTIVE (EP-04-001)
+    relationships:
+    - rel_type: refines
+      spec_id: CM-02-001
+    - rel_type: refines
+      spec_id: EP-04-001
+    tags:
+    - demo
+  - id: DEMOMA-24-003
+    priority: MUST
+    kind: project
+    statement: >-
+      Vendor MUST invite Coordinator into the case using the
+      `invite-actor-to-case` trigger. Coordinator's case role MUST be
+      `CVDRole.OBSERVER` only — NOT `CVDRole.COORDINATOR`. Coordinator MUST
+      accept the invitation via the `accept-case-invite` trigger and MUST
+      become an embargo SIGNATORY, which is the prerequisite for receiving
+      case-content announcements as an Observer (CM-25, CM-26).
+    rationale: >-
+      An OBSERVER who is not a SIGNATORY receives no case updates per the
+      embargo semantics ("absent embargo participation OBSERVER sees nothing").
+      The Invite/Accept exchange (CM-25) is the correct admission mechanism
+      regardless of role. Coordinator's role is explicitly limited to OBSERVER:
+      assigning CVDRole.COORDINATOR here would be semantically incorrect because
+      the Vendor, not the Coordinator, owns the case and drives coordination.
+    steps:
+    - order: 1
+      actor: vendor
+      action: POST invite-actor-to-case trigger for Coordinator with OBSERVER role
+      expected: Invite(Actor, Case) sent to Coordinator inbox
+    - order: 2
+      actor: demo_script
+      action: Poll Coordinator DataLayer until Invite(Actor, Case) is visible
+      expected: Invitation record present in Coordinator replica
+    - order: 3
+      actor: coordinator
+      action: POST accept-case-invite trigger directed to CaseActor
+      expected: >-
+        Coordinator transitions to SIGNATORY with CVDRole.OBSERVER;
+        CaseActor emits Announce(VulnerabilityCase) to seed Coordinator replica
+    adr:
+    - ADR-0057
+    relationships:
+    - rel_type: refines
+      spec_id: CM-25-001
+    - rel_type: refines
+      spec_id: CM-26-001
+    tags:
+    - demo
+  - id: DEMOMA-24-004
+    priority: MUST
+    kind: project
+    statement: >-
+      In the VC scenario, only Vendor MUST follow the VFD fix-deployment path
+      (vfd → Vfd → VFd → VFD). Coordinator, holding only `CVDRole.OBSERVER`,
+      MUST NOT be driven through VFD steps. Coordinator tracks pxa state
+      updates only (public-awareness transitions shared with all SIGNATORY
+      participants).
+    rationale: >-
+      VFD obligations attach to `CVDRole.VENDOR` and `CVDRole.DEPLOYER` per
+      CM-26. OBSERVER carries no VFD obligations unless the actor also holds
+      VENDOR or DEPLOYER. Driving Coordinator through VFD triggers in this
+      scenario would incorrectly exercise a code path that the OBSERVER role
+      is not supposed to activate.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-26-001
+    tags:
+    - demo
+  - id: DEMOMA-24-005
+    priority: MUST
+    kind: project
+    statement: >-
+      The VC scenario MUST reach a final state in which both Vendor and
+      Coordinator have transitioned to RM.CLOSED. Vendor MUST reach VFDPxa
+      CS with EM.EXITED. Coordinator MUST reach pxa CS with EM.EXITED
+      (Observer-only state; no VFD suffix). The scenario verifies LedgerFanout
+      replica convergence for the Coordinator replica against the authoritative
+      Vendor/CaseActor state after each major protocol event.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-03-002
+    - rel_type: refines
+      spec_id: EP-04-001
+    tags:
+    - demo
+  - id: DEMOMA-24-006
+    priority: MUST
+    kind: project
+    statement: >-
+      The implementation of the VC scenario MUST add a dedicated parallel CI
+      job (`DEMO=vc`) to `.github/workflows/demo-integration.yml` in the same
+      PR, and MUST ship a dedicated per-scenario case-ledger invariant test
+      file (`test/ci/invariants/test_vc_invariants.py`) built on the shared
+      invariant library. The test MUST assert the event-type list from
+      DEMOMA-16-014 and the pxa-only final state for Coordinator.
+    lint_suppress:
+    - phantom_path_ref
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-03-002
+    - rel_type: refines
+      spec_id: DEMOCI-03-003
+    - rel_type: refines
+      spec_id: DEMOMA-16-014
+    tags:
+    - demo
+    - testing

--- a/test/core/behaviors/case/nodes/test_vfd_role_guards.py
+++ b/test/core/behaviors/case/nodes/test_vfd_role_guards.py
@@ -398,6 +398,40 @@ def test_not_sole_observer_failure_when_case_missing(
     assert result.status == Status.FAILURE
 
 
+# ---------------------------------------------------------------------------
+# CSB-15-004: DEPLOYER-only d→D causal gate (not yet implemented)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "CSB-15-004: CheckDeployerRoleNode does not yet enforce the VFd causal gate. "
+        "A DEPLOYER-only actor MUST be blocked (FAILURE) when no VENDOR participant "
+        "in the case has reached VFd. Tracked by Bug #2606."
+    ),
+)
+@pytest.mark.spec("CSB-15-004")
+def test_deployer_only_blocked_when_no_vendor_at_vfd(
+    bt_scenario: BTTestScenario,
+    case_with_vendor_and_deployer: VultronCase,
+) -> None:
+    """DEPLOYER-only d→D MUST be FAILURE when no VENDOR has reached VFd (CSB-15-004).
+
+    The fixture seeds a VENDOR participant at default vfd state (not VFd).
+    The causal gate MUST return FAILURE. Currently xfails: CheckDeployerRoleNode
+    returns SUCCESS for any DEPLOYER without checking the VENDOR's VFd state.
+    """
+    result = bt_scenario.run(
+        CheckDeployerRoleNode(
+            case_id=case_with_vendor_and_deployer.id_,
+            actor_id=DEPLOYER_ACTOR_ID,
+        ),
+        actor_id=DEPLOYER_ACTOR_ID,
+    )
+    assert result.status == Status.FAILURE
+
+
 def test_not_sole_observer_failure_when_actor_not_in_case(
     bt_scenario: BTTestScenario,
     observer_participant: VultronParticipant,

--- a/vultron/demo/scenario/README.md
+++ b/vultron/demo/scenario/README.md
@@ -33,6 +33,7 @@ illustrate individual message semantics in isolation.
 | `fcvcv`           | `fcvcv_demo.py`           | FCVCV (Finder + Coordinator + Vendor + Coordinator2) full lifecycle |
 | `fcv`             | `fcv_demo.py`             | FCV (Finder + Coordinator + Vendor) full VFDPxa lifecycle           |
 | `fcv-reject`      | `fcv_reject_demo.py`      | FCV with Vendor rejecting the case invitation (RM rejection)        |
+| `vc`              | `vc_demo.py`              | VC (Vendor self-discovers, Coordinator joins as Observer)           |
 
 ## Running scenario demos
 


### PR DESCRIPTION
- Closes #1238

## Summary

Plans the VC demo scenario (Vendor self-discovers vulnerability, Coordinator
joins as Observer) by adding spec group DEMOMA-24 and event-type entry
DEMOMA-16-014 to `specs/multi-actor-demo.yaml`, and registering the new
`vc` sub-command in the scenario README.

## Changes

- **`specs/multi-actor-demo.yaml`**: Add DEMOMA-24 group (6 specs) covering
  container topology, Vendor self-reporting via `reporter_submits_report`
  with self as reporter+receiver, Coordinator-as-OBSERVER invite/accept
  with mandatory embargo SIGNATORY, Vendor-only VFD path, final-state
  requirements, and CI/test file obligations; add DEMOMA-16-014 specifying
  the VC scenario's required case-actor event types
  (`invite_actor_to_case`, `accept_invite_actor_to_case` beyond universals)
- **`vultron/demo/scenario/README.md`**: Add `vc` row pointing to
  `vc_demo.py`

## Implementation Issues

- #2591