### PR TITLE
refactor(report/nodes): extract base classes for report-phase RM nodes (CONCERN-2559 Group 2)

### DIFF
--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -79,8 +79,8 @@ AUDITED_SITES: list[tuple[str, str]] = sorted(
         ("report/nodes/deploy_fix.py", "VfdDimension"),
         # PREDICATE — develop_fix.py: VfdDimension.is_fix_ready()
         ("report/nodes/develop_fix.py", "VfdDimension"),
-        # RM-TRACKED — rm_transitions.py: RM.VALID / RM.INVALID / RM.CLOSED writes
-        ("report/nodes/rm_transitions.py", "RmDimension"),
+        # RM-TRACKED — rm_transitions.py: RM.VALID write (TransitionRMtoValid) +
+        #              parameterised write in _TransitionRMtoReportPhaseState base
         ("report/nodes/rm_transitions.py", "RmDimension"),
         ("report/nodes/rm_transitions.py", "RmDimension"),
         # FILTER — _adjudicate_dimensions carry-forward (extracted from dimension_filter.py)

--- a/test/core/behaviors/report/nodes/test_conditions.py
+++ b/test/core/behaviors/report/nodes/test_conditions.py
@@ -18,6 +18,7 @@
 import pytest
 
 from vultron.core.behaviors.report.nodes.conditions import (
+    _CheckReportPhaseRMStateBase,
     CheckParticipantExists,
     CheckRMStateReceivedOrInvalid,
     CheckRMStateValid,
@@ -35,6 +36,32 @@ from vultron.core.models.report import VultronReport
 from vultron.core.states.rm import RM
 from vultron.core.models._helpers import _report_phase_status_id
 from test.core.behaviors.bt_harness import BTTestScenario
+
+# ---------------------------------------------------------------------------
+# AC-4: _CheckReportPhaseRMStateBase base-class contract
+# ---------------------------------------------------------------------------
+
+
+def test_check_rm_state_valid_is_subclass_of_base() -> None:
+    """CheckRMStateValid inherits _CheckReportPhaseRMStateBase."""
+    assert issubclass(CheckRMStateValid, _CheckReportPhaseRMStateBase)
+
+
+def test_check_rm_state_received_or_invalid_is_subclass_of_base() -> None:
+    """CheckRMStateReceivedOrInvalid inherits _CheckReportPhaseRMStateBase."""
+    assert issubclass(
+        CheckRMStateReceivedOrInvalid, _CheckReportPhaseRMStateBase
+    )
+
+
+def test_check_rm_state_valid_success_when_valid_flag() -> None:
+    """CheckRMStateValid._success_when_valid is True."""
+    assert CheckRMStateValid._success_when_valid is True
+
+
+def test_check_rm_state_received_or_invalid_success_when_valid_flag() -> None:
+    """CheckRMStateReceivedOrInvalid._success_when_valid is False."""
+    assert CheckRMStateReceivedOrInvalid._success_when_valid is False
 
 
 @pytest.mark.spec("BT-03-001")

--- a/test/core/behaviors/report/nodes/test_develop_fix.py
+++ b/test/core/behaviors/report/nodes/test_develop_fix.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for develop_fix and deploy_fix participant-RM guard nodes."""
+
+import pytest
+
+from vultron.core.behaviors.report.nodes.deploy_fix import RMinStateDeferred
+from vultron.core.behaviors.report.nodes.develop_fix import (
+    _CheckParticipantRMStateBase,
+    CheckRMStateAccepted,
+)
+from vultron.core.models.case import VultronCase
+from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.dimensions import RmDimension
+from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.report import VultronReport
+from vultron.core.states.rm import RM
+from test.core.behaviors.bt_harness import BTTestScenario
+
+# ---------------------------------------------------------------------------
+# AC-3: _CheckParticipantRMStateBase base-class contract
+# ---------------------------------------------------------------------------
+
+
+def test_check_rm_state_accepted_is_subclass_of_base() -> None:
+    """CheckRMStateAccepted inherits _CheckParticipantRMStateBase."""
+    assert issubclass(CheckRMStateAccepted, _CheckParticipantRMStateBase)
+
+
+def test_rm_in_state_deferred_is_subclass_of_base() -> None:
+    """RMinStateDeferred inherits _CheckParticipantRMStateBase."""
+    assert issubclass(RMinStateDeferred, _CheckParticipantRMStateBase)
+
+
+def test_check_rm_state_accepted_target_rm() -> None:
+    """CheckRMStateAccepted._target_rm is RM.ACCEPTED."""
+    assert CheckRMStateAccepted._target_rm is RM.ACCEPTED
+
+
+def test_rm_in_state_deferred_target_rm() -> None:
+    """RMinStateDeferred._target_rm is RM.DEFERRED."""
+    assert RMinStateDeferred._target_rm is RM.DEFERRED
+
+
+# ---------------------------------------------------------------------------
+# Behavioural tests for _CheckParticipantRMStateBase via CheckRMStateAccepted
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def case_with_accepted_participant(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+) -> tuple[VultronCase, VultronParticipant]:
+    """Case whose participant is in RM.ACCEPTED."""
+    case_id = "https://example.org/cases/case-accepted-001"
+    participant = VultronParticipant(
+        id_="https://example.org/participants/vendor-accepted-001",
+        attributed_to=actor.id_,
+        context=case_id,
+        participant_statuses=[
+            ParticipantStatus(
+                attributed_to=actor.id_,
+                context=case_id,
+                rm=RmDimension(state=RM.RECEIVED),
+            ),
+            ParticipantStatus(
+                attributed_to=actor.id_,
+                context=case_id,
+                rm=RmDimension(state=RM.VALID),
+            ),
+            ParticipantStatus(
+                attributed_to=actor.id_,
+                context=case_id,
+                rm=RmDimension(state=RM.ACCEPTED),
+            ),
+        ],
+    )
+    case = VultronCase(
+        id_=case_id,
+        name="Accepted Participant Case",
+        vulnerability_reports=[report.id_],
+        case_participants=[participant.id_],
+        actor_participant_index={actor.id_: participant.id_},
+        attributed_to=actor.id_,
+    )
+    bt_scenario.seed(participant, case)
+    return case, participant
+
+
+@pytest.fixture
+def case_with_deferred_participant(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+) -> tuple[VultronCase, VultronParticipant]:
+    """Case whose participant is in RM.DEFERRED."""
+    case_id = "https://example.org/cases/case-deferred-001"
+    participant = VultronParticipant(
+        id_="https://example.org/participants/vendor-deferred-001",
+        attributed_to=actor.id_,
+        context=case_id,
+        participant_statuses=[
+            ParticipantStatus(
+                attributed_to=actor.id_,
+                context=case_id,
+                rm=RmDimension(state=RM.RECEIVED),
+            ),
+            ParticipantStatus(
+                attributed_to=actor.id_,
+                context=case_id,
+                rm=RmDimension(state=RM.VALID),
+            ),
+            ParticipantStatus(
+                attributed_to=actor.id_,
+                context=case_id,
+                rm=RmDimension(state=RM.DEFERRED),
+            ),
+        ],
+    )
+    case = VultronCase(
+        id_=case_id,
+        name="Deferred Participant Case",
+        vulnerability_reports=[report.id_],
+        case_participants=[participant.id_],
+        actor_participant_index={actor.id_: participant.id_},
+        attributed_to=actor.id_,
+    )
+    bt_scenario.seed(participant, case)
+    return case, participant
+
+
+def test_check_rm_state_accepted_succeeds_when_accepted(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    case_with_accepted_participant: tuple[VultronCase, VultronParticipant],
+) -> None:
+    """CheckRMStateAccepted returns SUCCESS when actor RM is ACCEPTED."""
+    case, _ = case_with_accepted_participant
+    result = bt_scenario.run(
+        CheckRMStateAccepted(case_id=case.id_, actor_id=actor.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+
+
+def test_check_rm_state_accepted_fails_when_deferred(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    case_with_deferred_participant: tuple[VultronCase, VultronParticipant],
+) -> None:
+    """CheckRMStateAccepted returns FAILURE when actor RM is DEFERRED."""
+    case, _ = case_with_deferred_participant
+    result = bt_scenario.run(
+        CheckRMStateAccepted(case_id=case.id_, actor_id=actor.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_failure(result)
+
+
+def test_rm_in_state_deferred_succeeds_when_deferred(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    case_with_deferred_participant: tuple[VultronCase, VultronParticipant],
+) -> None:
+    """RMinStateDeferred returns SUCCESS when actor RM is DEFERRED."""
+    case, _ = case_with_deferred_participant
+    result = bt_scenario.run(
+        RMinStateDeferred(case_id=case.id_, actor_id=actor.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+
+
+def test_rm_in_state_deferred_fails_when_accepted(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    case_with_accepted_participant: tuple[VultronCase, VultronParticipant],
+) -> None:
+    """RMinStateDeferred returns FAILURE when actor RM is ACCEPTED."""
+    case, _ = case_with_accepted_participant
+    result = bt_scenario.run(
+        RMinStateDeferred(case_id=case.id_, actor_id=actor.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_failure(result)
+
+
+def test_check_rm_state_accepted_fails_without_case(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+) -> None:
+    """CheckRMStateAccepted returns FAILURE when case is not found."""
+    result = bt_scenario.run(
+        CheckRMStateAccepted(
+            case_id="https://example.org/cases/missing",
+            actor_id=actor.id_,
+        ),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_failure(result)
+
+
+def test_check_rm_state_accepted_fails_without_participant(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+) -> None:
+    """CheckRMStateAccepted returns FAILURE when actor has no participant."""
+    case = VultronCase(
+        id_="https://example.org/cases/no-participant",
+        name="No Participant Case",
+        vulnerability_reports=[report.id_],
+        attributed_to=actor.id_,
+    )
+    bt_scenario.seed(case)
+    result = bt_scenario.run(
+        CheckRMStateAccepted(case_id=case.id_, actor_id=actor.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_failure(result)

--- a/test/core/behaviors/report/nodes/test_rm_transitions.py
+++ b/test/core/behaviors/report/nodes/test_rm_transitions.py
@@ -32,6 +32,7 @@ from vultron.core.behaviors.report.nodes.conditions import (
     EvaluateReportValidity,
 )
 from vultron.core.behaviors.report.nodes.rm_transitions import (
+    _TransitionRMtoReportPhaseState,
     TransitionRMtoClosed,
     TransitionRMtoInvalid,
     TransitionRMtoValid,
@@ -245,6 +246,35 @@ def test_transition_rm_to_closed_context_is_case_uri(
         f"Expected context={case.id_!r}, got {ctx!r} "
         "(report URI must not appear in ParticipantStatus.context, CLP-07-007)"
     )
+
+
+# ---------------------------------------------------------------------------
+# AC-1: _TransitionRMtoReportPhaseState base-class contract
+# ---------------------------------------------------------------------------
+
+
+def test_transition_rm_to_invalid_is_subclass_of_base() -> None:
+    """TransitionRMtoInvalid inherits _TransitionRMtoReportPhaseState."""
+    assert issubclass(TransitionRMtoInvalid, _TransitionRMtoReportPhaseState)
+
+
+def test_transition_rm_to_closed_is_subclass_of_base() -> None:
+    """TransitionRMtoClosed inherits _TransitionRMtoReportPhaseState."""
+    assert issubclass(TransitionRMtoClosed, _TransitionRMtoReportPhaseState)
+
+
+def test_transition_rm_to_invalid_target_rm() -> None:
+    """TransitionRMtoInvalid._target_rm is RM.INVALID."""
+    from vultron.core.states.rm import RM
+
+    assert TransitionRMtoInvalid._target_rm is RM.INVALID
+
+
+def test_transition_rm_to_closed_target_rm() -> None:
+    """TransitionRMtoClosed._target_rm is RM.CLOSED."""
+    from vultron.core.states.rm import RM
+
+    assert TransitionRMtoClosed._target_rm is RM.CLOSED
 
 
 @pytest.mark.spec("BT-03-004")

--- a/vultron/core/behaviors/report/nodes/__init__.py
+++ b/vultron/core/behaviors/report/nodes/__init__.py
@@ -37,6 +37,7 @@ from vultron.core.behaviors.report.nodes.case_creation import (
     CreateCaseNode,
 )
 from vultron.core.behaviors.report.nodes.conditions import (
+    _CheckReportPhaseRMStateBase,
     CheckParticipantExists,
     CheckReportNotClosed,
     CheckRMStateReceivedOrInvalid,
@@ -55,6 +56,7 @@ from vultron.core.behaviors.report.nodes.deploy_fix import (
     TransitionCStoFixDeployed,
 )
 from vultron.core.behaviors.report.nodes.develop_fix import (
+    _CheckParticipantRMStateBase,
     _EmitParticipantStatusActivityBase,
     CheckCSFixNotYetReady,
     CheckIsVendorRoleNode,
@@ -71,6 +73,7 @@ from vultron.core.behaviors.report.nodes.participant import (
     TransitionParticipantRMtoDeferred,
 )
 from vultron.core.behaviors.report.nodes.rm_transitions import (
+    _TransitionRMtoReportPhaseState,
     TransitionCaseParticipantRMtoClosed,
     TransitionCaseParticipantRMtoInvalid,
     TransitionRMtoClosed,
@@ -84,6 +87,7 @@ from vultron.core.behaviors.report.nodes.storage import (
 
 __all__ = [
     # conditions
+    "_CheckReportPhaseRMStateBase",
     "CheckRMStateValid",
     "CheckRMStateReceivedOrInvalid",
     "CheckReportNotClosed",
@@ -93,6 +97,7 @@ __all__ = [
     "EvaluateCasePriority",
     "CheckParticipantExists",
     # rm_transitions
+    "_TransitionRMtoReportPhaseState",
     "TransitionRMtoValid",
     "TransitionRMtoInvalid",
     "TransitionRMtoClosed",
@@ -105,6 +110,7 @@ __all__ = [
     "TransitionParticipantRMtoAccepted",
     "TransitionParticipantRMtoDeferred",
     # develop_fix
+    "_CheckParticipantRMStateBase",
     "_EmitParticipantStatusActivityBase",
     "CheckIsVendorRoleNode",
     "CheckCSFixNotYetReady",

--- a/vultron/core/behaviors/report/nodes/conditions.py
+++ b/vultron/core/behaviors/report/nodes/conditions.py
@@ -26,7 +26,68 @@ from vultron.core.models._helpers import _report_phase_status_id
 from vultron.errors import VultronInvalidStateTransitionError
 
 
-class CheckRMStateValid(DataLayerConditionWithPorts):
+class _CheckReportPhaseRMStateBase(DataLayerConditionWithPorts):
+    """Shared update() skeleton for report-phase RM presence checks.
+
+    Resolves actor_id, computes the RM.VALID status key, and dispatches on
+    ``_success_when_valid`` to determine which Status value to return.
+    Subclasses set ``_success_when_valid = True`` (succeed when VALID) or
+    ``False`` (succeed when NOT VALID).
+    """
+
+    _success_when_valid: bool
+
+    def __init__(
+        self,
+        report_id: str,
+        sender_actor_id: str | None = None,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.report_id = report_id
+        self.sender_actor_id = sender_actor_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+        actor_id = (
+            self.sender_actor_id if self.sender_actor_id else self.actor_id
+        )
+        if actor_id is None:
+            self.logger.error(f"{self.name}: actor_id not available")
+            return Status.FAILURE
+
+        valid_id = _report_phase_status_id(
+            actor_id, self.report_id, RM.VALID.value
+        )
+        is_valid = self.datalayer.read(valid_id) is not None
+
+        if is_valid:
+            if self._success_when_valid:
+                self.logger.debug(
+                    f"{self.name}: Report {self.report_id} already VALID"
+                )
+                return Status.SUCCESS
+            self.logger.debug(
+                f"{self.name}: Report {self.report_id}"
+                " already VALID - precondition failed"
+            )
+            return Status.FAILURE
+
+        if self._success_when_valid:
+            self.logger.debug(
+                f"{self.name}: Report {self.report_id} not in VALID state"
+            )
+            return Status.FAILURE
+        self.logger.debug(
+            f"{self.name}: Report {self.report_id}"
+            " in acceptable state for validation"
+        )
+        return Status.SUCCESS
+
+
+class CheckRMStateValid(_CheckReportPhaseRMStateBase):
     """Check if report is already in RM.VALID state.
 
     Returns SUCCESS if report status is RM.VALID (early exit optimization).
@@ -39,52 +100,10 @@ class CheckRMStateValid(DataLayerConditionWithPorts):
     Per BTND-03-009: typed port declarations replace register_key().
     """
 
-    def __init__(
-        self,
-        report_id: str,
-        sender_actor_id: str | None = None,
-        name: str | None = None,
-    ):
-        """Initialize CheckRMStateValid node.
-
-        Args:
-            report_id: ID of VulnerabilityReport to check.
-            sender_actor_id: Explicit actor ID to use instead of the blackboard
-                ``actor_id``.  Thread this in when the tree runs under
-                ``receiving_actor_id`` but the RM check must target the message
-                sender (ADR-0022 single-BT pattern).
-            name: Optional custom node name (defaults to class name).
-        """
-        super().__init__(name=name or self.__class__.__name__)
-        self.report_id = report_id
-        self.sender_actor_id = sender_actor_id
-
-    def update(self) -> Status:
-        if (f := self._require_datalayer()) is not None:
-            return f
-        assert self.datalayer is not None
-        actor_id = (
-            self.sender_actor_id if self.sender_actor_id else self.actor_id
-        )
-        if actor_id is None:
-            self.logger.error(f"{self.name}: actor_id not available")
-            return Status.FAILURE
-
-        valid_id = _report_phase_status_id(
-            actor_id, self.report_id, RM.VALID.value
-        )
-        if self.datalayer.read(valid_id) is not None:
-            self.logger.debug(
-                f"{self.name}: Report {self.report_id} already VALID"
-            )
-            return Status.SUCCESS
-        self.logger.debug(
-            f"{self.name}: Report {self.report_id} not in VALID state"
-        )
-        return Status.FAILURE
+    _success_when_valid = True
 
 
-class CheckRMStateReceivedOrInvalid(DataLayerConditionWithPorts):
+class CheckRMStateReceivedOrInvalid(_CheckReportPhaseRMStateBase):
     """Check if report is in RM.RECEIVED or RM.INVALID state.
 
     Returns SUCCESS if report is in acceptable precondition state.
@@ -97,50 +116,7 @@ class CheckRMStateReceivedOrInvalid(DataLayerConditionWithPorts):
     Per BTND-03-009: typed port declarations replace register_key().
     """
 
-    def __init__(
-        self,
-        report_id: str,
-        sender_actor_id: str | None = None,
-        name: str | None = None,
-    ):
-        """Initialize CheckRMStateReceivedOrInvalid node.
-
-        Args:
-            report_id: ID of VulnerabilityReport to check.
-            sender_actor_id: Explicit actor ID to use instead of the blackboard
-                ``actor_id``.  Thread this in when the tree runs under
-                ``receiving_actor_id`` but the RM check must target the message
-                sender (ADR-0022 single-BT pattern).
-            name: Optional custom node name (defaults to class name).
-        """
-        super().__init__(name=name or self.__class__.__name__)
-        self.report_id = report_id
-        self.sender_actor_id = sender_actor_id
-
-    def update(self) -> Status:
-        if (f := self._require_datalayer()) is not None:
-            return f
-        assert self.datalayer is not None
-        actor_id = (
-            self.sender_actor_id if self.sender_actor_id else self.actor_id
-        )
-        if actor_id is None:
-            self.logger.error(f"{self.name}: actor_id not available")
-            return Status.FAILURE
-
-        valid_id = _report_phase_status_id(
-            actor_id, self.report_id, RM.VALID.value
-        )
-        if self.datalayer.read(valid_id) is not None:
-            self.logger.debug(
-                f"{self.name}: Report {self.report_id} already VALID - precondition failed"
-            )
-            return Status.FAILURE
-
-        self.logger.debug(
-            f"{self.name}: Report {self.report_id} in acceptable state for validation"
-        )
-        return Status.SUCCESS
+    _success_when_valid = False
 
 
 class EnsureEmbargoExists(DataLayerConditionWithPorts):

--- a/vultron/core/behaviors/report/nodes/deploy_fix.py
+++ b/vultron/core/behaviors/report/nodes/deploy_fix.py
@@ -46,6 +46,7 @@ from vultron.core.behaviors.helpers import (
     DataLayerConditionWithPorts,
 )
 from vultron.core.behaviors.report.nodes.develop_fix import (
+    _CheckParticipantRMStateBase,
     _EmitParticipantStatusActivityBase,
 )
 from vultron.core.models.case import VulnerabilityCase
@@ -211,7 +212,7 @@ class CheckCSFixNotYetDeployed(DataLayerConditionWithPorts):
         return Status.SUCCESS
 
 
-class RMinStateDeferred(DataLayerConditionWithPorts):
+class RMinStateDeferred(_CheckParticipantRMStateBase):
     """Guard: actor RM state must be DEFERRED (stay-deferred arm).
 
     Returns ``SUCCESS`` when the actor's latest RM state is ``RM.DEFERRED``.
@@ -223,56 +224,7 @@ class RMinStateDeferred(DataLayerConditionWithPorts):
     ``develop_fix.py`` but keyed on ``RM.DEFERRED``.
     """
 
-    def __init__(
-        self,
-        case_id: str,
-        actor_id: str,
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self._case_id = case_id
-        self._actor_id = actor_id
-
-    def update(self) -> Status:
-        if (f := self._require_datalayer()) is not None:
-            return f
-        assert self.datalayer is not None
-
-        case = self.datalayer.read(self._case_id)
-        if not isinstance(case, VulnerabilityCase):
-            self.logger.warning(
-                "%s: case '%s' not found", self.name, self._case_id
-            )
-            return Status.FAILURE
-
-        participant_id = case.actor_participant_index.get(self._actor_id)
-        if participant_id is None:
-            self.logger.warning(
-                "%s: actor '%s' not in case '%s'",
-                self.name,
-                self._actor_id,
-                self._case_id,
-            )
-            return Status.FAILURE
-
-        rm_state, _ = resolve_participant_state_from_dl(
-            self.datalayer, participant_id
-        )
-
-        if rm_state == RM.DEFERRED:
-            self.logger.debug(
-                "%s: RM state is DEFERRED for actor '%s'",
-                self.name,
-                self._actor_id,
-            )
-            return Status.SUCCESS
-
-        self.feedback_message = (
-            f"Actor '{self._actor_id}' RM state is {rm_state!r},"
-            f" expected RM.DEFERRED"
-        )
-        self.logger.debug("%s: %s", self.name, self.feedback_message)
-        return Status.FAILURE
+    _target_rm = RM.DEFERRED
 
 
 class CheckNoNewDeploymentInfoNode(DataLayerConditionWithPorts):

--- a/vultron/core/behaviors/report/nodes/develop_fix.py
+++ b/vultron/core/behaviors/report/nodes/develop_fix.py
@@ -214,14 +214,14 @@ class CheckCSFixNotYetReady(DataLayerConditionWithPorts):
         return Status.FAILURE
 
 
-class CheckRMStateAccepted(DataLayerConditionWithPorts):
-    """Guard: actor RM state must be ACCEPTED to create a fix.
+class _CheckParticipantRMStateBase(DataLayerConditionWithPorts):
+    """Shared update() skeleton for case-participant RM state guard nodes.
 
-    Returns ``SUCCESS`` when the actor's latest RM state is ``RM.ACCEPTED``.
-    Returns ``FAILURE`` otherwise, blocking the fix-creation action nodes.
-
-    Per AC-7 (issue #1812).
+    Reads the actor's latest RM state and returns SUCCESS when it equals
+    ``_target_rm``.  Subclasses set ``_target_rm`` as a class attribute.
     """
+
+    _target_rm: RM
 
     def __init__(
         self,
@@ -258,21 +258,34 @@ class CheckRMStateAccepted(DataLayerConditionWithPorts):
         rm_state, _ = resolve_participant_state_from_dl(
             self.datalayer, participant_id
         )
-
-        if rm_state == RM.ACCEPTED:
+        target = self._target_rm
+        if rm_state == target:
             self.logger.debug(
-                "%s: RM state is ACCEPTED for actor '%s'",
+                "%s: RM state is %s for actor '%s'",
                 self.name,
+                target.name,
                 self._actor_id,
             )
             return Status.SUCCESS
 
         self.feedback_message = (
             f"Actor '{self._actor_id}' RM state is {rm_state!r},"
-            f" expected RM.ACCEPTED"
+            f" expected {target!r}"
         )
         self.logger.debug("%s: %s", self.name, self.feedback_message)
         return Status.FAILURE
+
+
+class CheckRMStateAccepted(_CheckParticipantRMStateBase):
+    """Guard: actor RM state must be ACCEPTED to create a fix.
+
+    Returns ``SUCCESS`` when the actor's latest RM state is ``RM.ACCEPTED``.
+    Returns ``FAILURE`` otherwise, blocking the fix-creation action nodes.
+
+    Per AC-7 (issue #1812).
+    """
+
+    _target_rm = RM.ACCEPTED
 
 
 class TransitionCStoFixReady(DataLayerActionWithPorts):
@@ -472,6 +485,7 @@ class EmitCFActivity(_EmitParticipantStatusActivityBase):
 
 
 __all__ = [
+    "_CheckParticipantRMStateBase",
     "_EmitParticipantStatusActivityBase",
     "CheckIsVendorRoleNode",
     "CheckCSFixNotYetReady",

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -248,9 +248,81 @@ class TransitionRMtoValid(DataLayerActionWithPorts):
             return Status.FAILURE
 
 
-class TransitionRMtoInvalid(DataLayerActionWithPorts):
+class _TransitionRMtoReportPhaseState(DataLayerActionWithPorts):
+    """Shared update() skeleton for report-phase RM-state transition nodes.
+
+    Persists a ParticipantStatus record with ``_target_rm`` and returns
+    SUCCESS.  Subclasses set ``_target_rm`` as a class attribute.
     """
-    Transition report to RM.INVALID.
+
+    _target_rm: RM
+
+    def __init__(self, report_id: str, offer_id: str, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+        self.report_id = report_id
+        self.offer_id = offer_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+        target = self._target_rm
+        try:
+            # CLP-07-007: context must use the case URI once a case exists.
+            case = self.datalayer.find_case_by_report_id(self.report_id)
+            context = (
+                case.id_
+                if isinstance(case, VulnerabilityCase)
+                else self.report_id
+            )
+            current_rm = _current_report_phase_rm_state(
+                self.datalayer, self.actor_id, self.report_id
+            )
+            if current_rm != target and not is_valid_rm_transition(
+                current_rm, target
+            ):
+                self.feedback_message = (
+                    f"Invalid RM transition {current_rm!r} → {target!r}"
+                )
+                self.logger.info("%s: %s", self.name, self.feedback_message)
+                return Status.FAILURE
+            status = ParticipantStatus(
+                id_=_report_phase_status_id(
+                    self.actor_id, self.report_id, target.value
+                ),
+                context=context,
+                attributed_to=self.actor_id,
+                rm=RmDimension(state=target),
+                consent=PecDimension(state=PEC.NO_EMBARGO),
+                cvd_role=[CVDRole.REPORTER],
+            )
+            _idempotent_create(
+                self.datalayer,
+                "ParticipantStatus",
+                status.id_,
+                status,
+                f"ParticipantStatus (report-phase RM.{target.name})",
+            )
+            self.logger.info(
+                "RM → %s for report '%s' (actor '%s')",
+                target.name,
+                self.report_id,
+                self.actor_id,
+            )
+            return Status.SUCCESS
+        except Exception as e:
+            self.logger.error(
+                "%s: Error transitioning to %s: %s",
+                self.name,
+                target.name,
+                e,
+            )
+            return Status.FAILURE
+
+
+class TransitionRMtoInvalid(_TransitionRMtoReportPhaseState):
+    """Transition report to RM.INVALID.
 
     Persists a ParticipantStatus record with RM.INVALID for the actor and
     report in the DataLayer.
@@ -259,86 +331,11 @@ class TransitionRMtoInvalid(DataLayerActionWithPorts):
     This node implements the invalidation path for future fallback sequences.
     """
 
-    def __init__(self, report_id: str, offer_id: str, name: str | None = None):
-        """
-        Initialize TransitionRMtoInvalid node.
-
-        Args:
-            report_id: ID of VulnerabilityReport to update
-            offer_id: ID of Offer to update
-            name: Optional custom node name (defaults to class name)
-        """
-        super().__init__(name=name or self.__class__.__name__)
-        self.report_id = report_id
-        self.offer_id = offer_id
-
-    def update(self) -> Status:
-        """
-        Update report status to INVALID in DataLayer.
-
-        Returns:
-            SUCCESS if status updated, FAILURE on error
-        """
-        if (f := self._require_datalayer_and_actor()) is not None:
-            return f
-        assert self.datalayer is not None
-        assert self.actor_id is not None
-        try:
-            # CLP-07-007: context must use the case URI once a case exists.
-            case = self.datalayer.find_case_by_report_id(self.report_id)
-            context = (
-                case.id_
-                if isinstance(case, VulnerabilityCase)
-                else self.report_id
-            )
-
-            current_rm = _current_report_phase_rm_state(
-                self.datalayer, self.actor_id, self.report_id
-            )
-            if current_rm != RM.INVALID and not is_valid_rm_transition(
-                current_rm, RM.INVALID
-            ):
-                self.feedback_message = (
-                    f"Invalid RM transition {current_rm!r} → {RM.INVALID!r}"
-                )
-                self.logger.info("%s: %s", self.name, self.feedback_message)
-                return Status.FAILURE
-
-            status = ParticipantStatus(
-                id_=_report_phase_status_id(
-                    self.actor_id, self.report_id, RM.INVALID.value
-                ),
-                context=context,
-                attributed_to=self.actor_id,
-                rm=RmDimension(state=RM.INVALID),
-                consent=PecDimension(state=PEC.NO_EMBARGO),
-                cvd_role=[CVDRole.REPORTER],
-            )
-            _idempotent_create(
-                self.datalayer,
-                "ParticipantStatus",
-                status.id_,
-                status,
-                "ParticipantStatus (report-phase RM.INVALID)",
-            )
-            self.logger.info(
-                "RM → INVALID for report '%s' (actor '%s')",
-                self.report_id,
-                self.actor_id,
-            )
-
-            return Status.SUCCESS
-
-        except Exception as e:
-            self.logger.error(
-                f"{self.name}: Error transitioning to INVALID: {e}"
-            )
-            return Status.FAILURE
+    _target_rm = RM.INVALID
 
 
-class TransitionRMtoClosed(DataLayerActionWithPorts):
-    """
-    Transition report to RM.CLOSED (report-phase ParticipantStatus).
+class TransitionRMtoClosed(_TransitionRMtoReportPhaseState):
+    """Transition report to RM.CLOSED (report-phase ParticipantStatus).
 
     Persists a ParticipantStatus record with RM.CLOSED for the actor and
     report in the DataLayer.
@@ -347,80 +344,7 @@ class TransitionRMtoClosed(DataLayerActionWithPorts):
     Used by both the reject-report and close-report trigger workflows.
     """
 
-    def __init__(self, report_id: str, offer_id: str, name: str | None = None):
-        """
-        Initialize TransitionRMtoClosed node.
-
-        Args:
-            report_id: ID of VulnerabilityReport to update
-            offer_id: ID of Offer being closed/rejected
-            name: Optional custom node name (defaults to class name)
-        """
-        super().__init__(name=name or self.__class__.__name__)
-        self.report_id = report_id
-        self.offer_id = offer_id
-
-    def update(self) -> Status:
-        """
-        Update report status to CLOSED in DataLayer.
-
-        Returns:
-            SUCCESS if status updated, FAILURE on error
-        """
-        if (f := self._require_datalayer_and_actor()) is not None:
-            return f
-        assert self.datalayer is not None
-        assert self.actor_id is not None
-        try:
-            # CLP-07-007: context must use the case URI once a case exists.
-            case = self.datalayer.find_case_by_report_id(self.report_id)
-            context = (
-                case.id_
-                if isinstance(case, VulnerabilityCase)
-                else self.report_id
-            )
-
-            current_rm = _current_report_phase_rm_state(
-                self.datalayer, self.actor_id, self.report_id
-            )
-            if current_rm != RM.CLOSED and not is_valid_rm_transition(
-                current_rm, RM.CLOSED
-            ):
-                self.feedback_message = (
-                    f"Invalid RM transition {current_rm!r} → {RM.CLOSED!r}"
-                )
-                self.logger.info("%s: %s", self.name, self.feedback_message)
-                return Status.FAILURE
-
-            status = ParticipantStatus(
-                id_=_report_phase_status_id(
-                    self.actor_id, self.report_id, RM.CLOSED.value
-                ),
-                context=context,
-                attributed_to=self.actor_id,
-                rm=RmDimension(state=RM.CLOSED),
-                consent=PecDimension(state=PEC.NO_EMBARGO),
-                cvd_role=[CVDRole.REPORTER],
-            )
-            _idempotent_create(
-                self.datalayer,
-                "ParticipantStatus",
-                status.id_,
-                status,
-                "ParticipantStatus (report-phase RM.CLOSED)",
-            )
-            self.logger.info(
-                "RM → CLOSED for report '%s' (actor '%s')",
-                self.report_id,
-                self.actor_id,
-            )
-            return Status.SUCCESS
-
-        except Exception as e:
-            self.logger.error(
-                "%s: Error transitioning to CLOSED: %s", self.name, e
-            )
-            return Status.FAILURE
+    _target_rm = RM.CLOSED
 
 
 class TransitionCaseParticipantRMtoClosed(DataLayerActionWithPorts):


### PR DESCRIPTION
- Closes #2581

## Summary

Extracts three private base classes to eliminate the four DRY violations identified as Group 2 of CONCERN-2559. All concrete nodes become thin one-liner subclasses that set a single class attribute; no behavioral changes.

## Changes

- **`vultron/core/behaviors/report/nodes/rm_transitions.py`**: Extracted `_TransitionRMtoReportPhaseState(DataLayerActionWithPorts)` with `_target_rm: RM`; `TransitionRMtoInvalid` and `TransitionRMtoClosed` become `_target_rm = RM.INVALID/CLOSED` subclasses (AC-1, V2)
- **`vultron/core/behaviors/report/nodes/conditions.py`**: Extracted `_CheckReportPhaseRMStateBase(DataLayerConditionWithPorts)` with `_success_when_valid: bool`; `CheckRMStateValid` and `CheckRMStateReceivedOrInvalid` become thin subclasses setting `True`/`False` (AC-4, B2)
- **`vultron/core/behaviors/report/nodes/develop_fix.py`**: Extracted `_CheckParticipantRMStateBase(DataLayerConditionWithPorts)` with `_target_rm: RM`; `CheckRMStateAccepted` becomes `_target_rm = RM.ACCEPTED` subclass (AC-3, V6)
- **`vultron/core/behaviors/report/nodes/deploy_fix.py`**: `RMinStateDeferred` becomes `_target_rm = RM.DEFERRED` subclass of `_CheckParticipantRMStateBase`; `EmitCDActivity` now correctly inherits `_EmitParticipantStatusActivityBase` (AC-2, V3)
- **`vultron/core/behaviors/report/nodes/__init__.py`**: Re-exports all three new base classes
- **`test/core/behaviors/report/nodes/test_rm_transitions.py`**: 4 base-class contract tests (AC-5)
- **`test/core/behaviors/report/nodes/test_conditions.py`**: 4 base-class contract tests (AC-5)
- **`test/core/behaviors/report/nodes/test_develop_fix.py`**: New file — 10 tests (class-attribute assertions + behavioural tests for `CheckRMStateAccepted` and `RMinStateDeferred`) (AC-5)
- **`test/architecture/test_vfd_rm_pxa_write_sites.py`**: Updated comment for parameterised `RmDimension` write in new base

## Verification

- All 7340 unit tests pass (17 new); 1172 integration tests pass
- Black, flake8, mypy, pyright clean