### PR TITLE
refactor: remove AdvisoryReviewDecision.approved (redundant with Status.FAILURE)

### DIFF
--- a/plan/incoming/learnings/2607-ratchet-ceiling-stale.md
+++ b/plan/incoming/learnings/2607-ratchet-ceiling-stale.md
@@ -1,0 +1,12 @@
+---
+name: 2607-ratchet-ceiling-stale
+description: Pre-existing CI failure on origin/main — spec coverage ratchet ceiling stale (948 > 947)
+metadata:
+  type: project
+---
+
+**Bug #2607**: `test_protocol_spec_coverage_floor` fails on `origin/main` — uncovered count 948 exceeds ceiling 947.
+
+**Why:** A protocol-kind spec was added (or coverage mapping removed) without tightening the ratchet. Discovered during task/1932 validation on 2026-08-25.
+
+**How to apply:** Any PR CI run will show this failure until #2607 is fixed. Note it as pre-existing when filing PRs that hit this failure.

--- a/test/core/behaviors/report/test_publish_artifact_tree.py
+++ b/test/core/behaviors/report/test_publish_artifact_tree.py
@@ -67,18 +67,14 @@ def _marker_factory(label):
 
 
 def test_review_decision_defaults():
-    """Defaults encode the auto-approve path: approved, no revision needed."""
+    """Defaults encode the auto-approve path: no revision needed."""
     d = AdvisoryReviewDecision()
-    assert d.approved is True
     assert d.needs_revision is False
     assert d.feedback == ""
 
 
 def test_review_decision_needs_revision():
-    d = AdvisoryReviewDecision(
-        approved=False, needs_revision=True, feedback="Fix title."
-    )
-    assert d.approved is False
+    d = AdvisoryReviewDecision(needs_revision=True, feedback="Fix title.")
     assert d.needs_revision is True
     assert d.feedback == "Fix title."
 

--- a/vultron/core/behaviors/report/publish_artifact_tree.py
+++ b/vultron/core/behaviors/report/publish_artifact_tree.py
@@ -39,7 +39,7 @@ Tree structure per artifact::
     PublishArtifactBT (Sequence)
     ├── DraftAdvisoryArtifact (Composer)       — writes draft_advisory_artifact key
     ├── ReviewAdvisoryDraft   (Evaluator)      — writes advisory_review_decision key
-    ├── RevisionArm           (Selector)       — optional revision; graceful no-op
+    ├── RevisionArm           (Selector)       — optional; no-op when no revision needed
     │   ├── Sequence(NeedsRevision, ReviseAdvisoryDraft)
     │   └── Inverter(NeedsRevision)
     └── SubmitAdvisoryArtifact (Actuator)      — submits to advisory platform
@@ -98,25 +98,21 @@ class AdvisoryReviewDecision(BaseModel):
     path), the revision arm is a graceful no-op and the pipeline proceeds
     directly to submission.
 
-    The ``approved`` field is metadata for the ``ReviewAdvisoryDraft``
-    backend to record its decision.  The pipeline does not gate submission on
-    it — a backend that needs to block submission without requesting edits
-    (e.g. a legal hold) MUST return ``Status.FAILURE`` from ``update()`` so
-    the Sequence fails.  Gating submission on ``approved=False`` is tracked
-    as a follow-on design question (see AC-4 in issue #1312).
+    To block submission for any reason (legal hold, compliance failure,
+    editorial rejection) the backend MUST return ``Status.FAILURE`` from
+    ``update()`` — that is the universal BT blocking idiom (BT-18-007).
+    There is no separate approval flag: FAILURE is both necessary and
+    sufficient to stop the pipeline.
 
-    The default instance (``approved=True``, ``needs_revision=False``) encodes
-    the auto-approve path used when no real review agent is available (AC-3).
+    The default instance (``needs_revision=False``) encodes the auto-approve
+    path used when no real review agent is available (AC-3, ADR-0030).
 
     Attributes:
-        approved: Informational flag indicating the Evaluator's approval
-            decision.  Not read by the pipeline tree.
         needs_revision: Whether the draft requires revision before submission.
             When ``True``, the optional ``ReviseAdvisoryDraft`` Composer runs.
         feedback: Human-readable or machine-generated review feedback.
     """
 
-    approved: bool = True
     needs_revision: bool = False
     feedback: str = ""
 
@@ -265,7 +261,7 @@ def create_publish_artifact_tree(
         PublishArtifactBT (Sequence)
         ├── DraftAdvisoryArtifact (Composer)
         ├── ReviewAdvisoryDraft   (Evaluator)
-        ├── RevisionArm           (Selector — optional; no-op when approved)
+        ├── RevisionArm           (Selector — optional; no-op when no revision needed)
         │   ├── Sequence(NeedsRevision, ReviseAdvisoryDraft)
         │   └── Inverter(NeedsRevision)
         └── SubmitAdvisoryArtifact (Actuator)
@@ -320,7 +316,7 @@ def create_publish_artifact_tree(
         ],
     )
     needs_revision_skip = py_trees.decorators.Inverter(
-        name=f"SkipRevisionIfApproved{suffix}",
+        name=f"SkipRevisionArm{suffix}",
         child=_NeedsRevisionGate(name=f"NeedsRevisionSkip{suffix}"),
     )
     revision_arm = py_trees.composites.Selector(

--- a/vultron/demo/fuzzer/report_management/publication.py
+++ b/vultron/demo/fuzzer/report_management/publication.py
@@ -432,12 +432,13 @@ class ReviewAdvisoryDraft(EvaluatorCallOutPoint, AlwaysSucceed):
     Semantic function:
         Action — review the drafted advisory artifact and produce an
         :class:`~vultron.core.behaviors.report.publish_artifact_tree.
-        AdvisoryReviewDecision` record indicating approval status and
-        whether revision is required.  The default fuzzer implementation
-        always approves (``needs_revision=False``) so the pipeline
-        functions end-to-end before a real review agent is available
-        (AC-3, ADR-0030).  A real backend may involve human editorial
-        review, automated QA checks, or both.
+        AdvisoryReviewDecision` record indicating whether revision is
+        required.  The default fuzzer implementation always succeeds with
+        ``needs_revision=False`` so the pipeline functions end-to-end
+        before a real review agent is available (AC-3, ADR-0030).  A real
+        backend may involve human editorial review, automated QA checks, or
+        both; to block submission for any reason it MUST return
+        ``Status.FAILURE`` (BT-18-007).
 
     Blackboard contract (BT-18-001):
       Input keys:  draft_advisory_artifact: str  (reads the Composer output)


### PR DESCRIPTION
- Closes #1932

## Summary

Removes the `approved: bool = True` field from `AdvisoryReviewDecision` — it was redundant with the BT blocking idiom (BT-18-007) and created an implementer trap where setting `approved=False` would be silently ignored while `Status.FAILURE` is what actually blocks the pipeline.

## Changes

- **`vultron/core/behaviors/report/publish_artifact_tree.py`**: Removed `approved` field from `AdvisoryReviewDecision`; updated class docstring to document BT-18-007 blocking idiom; renamed `SkipRevisionIfApproved{suffix}` → `SkipRevisionArm{suffix}` to remove stale semantics from node names
- **`test/core/behaviors/report/test_publish_artifact_tree.py`**: Updated `test_review_decision_defaults` and `test_review_decision_needs_revision` to remove `approved` references
- **`vultron/demo/fuzzer/report_management/publication.py`**: Updated `ReviewAdvisoryDraft` docstring to remove approval-status language and add BT-18-007 blocking reference

## Verification

- All unit tests pass (2 updated, 0 new)
- Black, flake8, mypy, pyright clean
- [x] AC-1: Removed `approved: bool = True` from `AdvisoryReviewDecision`
- [x] AC-2: Updated `AdvisoryReviewDecision` docstring — backend MUST use `Status.FAILURE` (BT-18-007)
- [x] AC-3: Updated `test_review_decision_defaults` — removed `assert d.approved is True`
- [x] AC-4: Updated `test_review_decision_needs_revision` — removed `approved=False` from constructor
- [x] AC-5: Renamed `SkipRevisionIfApproved{suffix}` → `SkipRevisionArm{suffix}` in `create_publish_artifact_tree`
- [x] AC-6: All linters clean; tests pass (except pre-existing #2607)
- Note: `test_protocol_spec_coverage_floor` fails with 948 > 947 — pre-existing on `origin/main`, unrelated to this change, tracked in #2607