### PR TITLE
fix(embargo-ac1): eliminate inline EM state reads/writes — embargo AC-1 violations (Group 1 of CONCERN-2559)

### DIFF
--- a/test/core/behaviors/case/nodes/test_embargo.py
+++ b/test/core/behaviors/case/nodes/test_embargo.py
@@ -289,6 +289,53 @@ class TestInitializeDefaultEmbargoNode:
         ]
 
 
+class TestAttachEmbargoToCaseNodeAC1:
+    """AC-1 regression for AttachEmbargoToCaseNode (issue #2583)."""
+
+    def test_em_write_delegates_to_write_em_state_node(
+        self,
+        bt_scenario: BTTestScenario,
+        actor_id: str,
+        case_obj: VultronCase,
+    ) -> None:
+        """AC-1 (issue #2583): EM write is delegated to WriteEmStateNode.
+
+        When WriteEmStateNode.update() is patched to return FAILURE the
+        node must propagate FAILURE — proving the inline write was replaced
+        by delegation.
+        """
+        from unittest.mock import patch
+
+        from vultron.core.behaviors.embargo.nodes.em_state import (
+            WriteEmStateNode,
+        )
+
+        embargo = EmbargoEvent(
+            end_time=datetime.now(tz=timezone.utc) + timedelta(days=1),
+            context=case_obj.id_,
+        )
+        bt_scenario.dl.create(embargo)
+
+        bt_scenario.run(
+            CreateCaseOwnerParticipant(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+
+        with patch.object(
+            WriteEmStateNode, "update", return_value=Status.FAILURE
+        ):
+            result = bt_scenario.run(
+                AttachEmbargoToCaseNode(),
+                actor_id=actor_id,
+                case_id=case_obj.id_,
+                default_embargo_id=embargo.id_,
+                default_embargo_initialized=True,
+            )
+
+        assert result.status == Status.FAILURE
+
+
 class TestSeedOwnerAsSignatoryNode:
     """SeedOwnerAsSignatoryNode is idempotent when participant is already SIGNATORY."""
 

--- a/test/core/behaviors/case/nodes/test_embargo.py
+++ b/test/core/behaviors/case/nodes/test_embargo.py
@@ -292,6 +292,7 @@ class TestInitializeDefaultEmbargoNode:
 class TestAttachEmbargoToCaseNodeAC1:
     """AC-1 regression for AttachEmbargoToCaseNode (issue #2583)."""
 
+    @pytest.mark.spec("EMB-18-001")
     def test_em_write_delegates_to_write_em_state_node(
         self,
         bt_scenario: BTTestScenario,

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -622,6 +622,7 @@ class TestSetEmbargoActiveNode:
         updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em.state == EM.ACTIVE
 
+    @pytest.mark.spec("EMB-18-001")
     def test_em_write_goes_through_write_em_state_node(self):
         """AC-1 (issue #2583): _apply_transition delegates EM write to WriteEmStateNode.
 

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -621,3 +621,37 @@ class TestSetEmbargoActiveNode:
         assert any("state-sync override" in r.message for r in caplog.records)
         updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em.state == EM.ACTIVE
+
+    def test_em_write_goes_through_write_em_state_node(self):
+        """AC-1 (issue #2583): _apply_transition delegates EM write to WriteEmStateNode.
+
+        Patch WriteEmStateNode.update() (autospec) to return SUCCESS and confirm
+        it is invoked during the PROPOSED → ACTIVE transition, proving that the
+        EM write goes through the canonical node rather than inline mutation.
+        """
+        from unittest.mock import patch
+
+        from vultron.core.behaviors.embargo.nodes.em_state import (
+            WriteEmStateNode,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = make_case_and_embargo("sea-ac1", em_state=EM.PROPOSED)
+        case.active_embargo = None
+        dl.create(case)
+
+        _setup_blackboard_simple(dl)
+        node = SetEmbargoActiveNode(case_id=case.id_, embargo_id=embargo.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        with patch.object(
+            WriteEmStateNode,
+            "update",
+            autospec=True,
+            return_value=py_trees.common.Status.SUCCESS,
+        ) as mock_update:
+            bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert mock_update.called, "WriteEmStateNode.update() was never called"

--- a/test/core/behaviors/embargo/nodes/test_teardown.py
+++ b/test/core/behaviors/embargo/nodes/test_teardown.py
@@ -510,6 +510,34 @@ class TestApplyEmbargoTeardownNode:
 
         assert node.status == py_trees.common.Status.SUCCESS
 
+    def test_delegates_em_write_to_clear_active_embargo_node(self):
+        """AC-1 (issue #2583): EM write is delegated to ClearActiveEmbargoNode.
+
+        When ClearActiveEmbargoNode.update() is patched to return FAILURE the
+        EM state is not mutated and the node still returns SUCCESS (sync
+        context graceful fallback).  This proves the inline write was
+        replaced by delegation.
+        """
+        from py_trees.common import Status as BtStatus
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("ac1-del", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        setup_blackboard(dl)
+        node = ApplyEmbargoTeardownNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        with patch.object(
+            ClearActiveEmbargoNode, "update", return_value=BtStatus.FAILURE
+        ):
+            bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        unchanged = cast(VulnerabilityCase, dl.read(case.id_))
+        assert unchanged.current_status.em.state == EM.ACTIVE
+
 
 class TestRemoveFromProposedEmbargoesNode:
     """Tests for RemoveFromProposedEmbargoesNode."""

--- a/test/core/behaviors/embargo/nodes/test_teardown.py
+++ b/test/core/behaviors/embargo/nodes/test_teardown.py
@@ -510,6 +510,7 @@ class TestApplyEmbargoTeardownNode:
 
         assert node.status == py_trees.common.Status.SUCCESS
 
+    @pytest.mark.spec("EMB-18-001")
     def test_delegates_em_write_to_clear_active_embargo_node(self):
         """AC-1 (issue #2583): EM write is delegated to ClearActiveEmbargoNode.
 

--- a/vultron/core/behaviors/case/nodes/embargo.py
+++ b/vultron/core/behaviors/case/nodes/embargo.py
@@ -34,6 +34,7 @@ from datetime import datetime, timedelta, timezone
 import isodate  # type: ignore[import-untyped]
 from py_trees.common import Status
 
+from vultron.core.behaviors.embargo.nodes.em_state import WriteEmStateNode
 from vultron.core.behaviors.helpers import (
     DataLayerActionWithPorts,
     PortInformation,
@@ -47,7 +48,6 @@ from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
     TransitionMode,
 )
-from vultron.core.models.dimensions import EmDimension
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC, PEC_Trigger
 from vultron.core.models._helpers import _as_id
@@ -382,8 +382,16 @@ class AttachEmbargoToCaseNode(DataLayerActionWithPorts):
         active_embargo_id = _as_id(stored_case.active_embargo)
         if active_embargo_id is None:
             stored_case.active_embargo = embargo_id
-            stored_case.current_status.em = EmDimension(state=EM.ACTIVE)
             self.datalayer.save(stored_case)
+            # AC-1: delegate EM state write to WriteEmStateNode.
+            result_out: dict[str, object] = {"em_after": EM.ACTIVE}
+            write_node = WriteEmStateNode(
+                case_id=case_id, result_out=result_out
+            )
+            write_node.datalayer = self.datalayer
+            if write_node.update() != Status.SUCCESS:
+                self.feedback_message = write_node.feedback_message
+                return Status.FAILURE
             self.logger.info(
                 "Attached embargo '%s' to case '%s' as active_embargo",
                 embargo_id,

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -37,7 +37,6 @@ from vultron.core.behaviors.helpers import (
 )
 from vultron.core.behaviors.narrative_log import log_em_transition
 from vultron.core.models.case import VulnerabilityCase
-from vultron.core.models.dimensions import EmDimension
 from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
     EmbargoLifecycleResult,
@@ -384,9 +383,22 @@ class SetEmbargoActiveNode(DataLayerActionWithPorts):
                 self.case_id,
             )
         case.set_embargo(self.embargo_id)
-        case.current_status.em = EmDimension(state=EM.ACTIVE)
         assert self.datalayer is not None
         self.datalayer.save(case)
+        # AC-1: delegate EM state write to WriteEmStateNode.
+        result_out: dict[str, object] = {"em_after": EM.ACTIVE}
+        write_node = WriteEmStateNode(
+            case_id=self.case_id, result_out=result_out
+        )
+        write_node.datalayer = self.datalayer
+        if write_node.update() != Status.SUCCESS:
+            self.logger.warning(
+                "%s: Failed to write EM state for case '%s': %s",
+                self.name,
+                self.case_id,
+                write_node.feedback_message,
+            )
+            return
         self.feedback_message = (
             f"Activated embargo '{self.embargo_id}' on case"
             f" '{self.case_id}' (EM {current_em} → ACTIVE)"

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -239,48 +239,23 @@ class ApplyEmbargoTeardownNode(DataLayerActionWithPorts):
             entry = _require_log_entry(self._activity, self.name)
             case_id = entry.case_id
 
-        case = self.datalayer.read(case_id)
-        if not isinstance(case, VulnerabilityCase):
-            self.feedback_message = f"Case '{case_id}' not found"
-            self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return Status.SUCCESS
-
-        current_em = case.current_status.em.state
-
-        if current_em == EM.EXITED:
+        # AC-1: delegate EM state read/write to canonical nodes.
+        clear_node = ClearActiveEmbargoNode(case_id=case_id)
+        clear_node.datalayer = self.datalayer
+        clear_node.actor_id = self.actor_id
+        if clear_node.update() != Status.SUCCESS:
             self.feedback_message = (
-                f"Case '{case_id}' EM already EXITED — idempotent no-op"
+                f"Case '{case_id}' not found — teardown skipped"
             )
             self.logger.info("%s: %s", self.name, self.feedback_message)
             return Status.SUCCESS
 
-        if not is_valid_em_transition(current_em, EM.EXITED):
-            self.logger.warning(
-                "%s: EM transition %s → EXITED is not a standard machine"
-                " transition for case '%s'; applying state-sync override",
-                self.name,
-                current_em,
-                case_id,
-            )
+        reset_node = ResetParticipantConsentNode(case_id=case_id)
+        reset_node.datalayer = self.datalayer
+        reset_node.update()
 
-        case.current_status.em = EmDimension(state=EM.EXITED)
-        case.active_embargo = None
-        reset_case_participant_embargo_consent(self.datalayer, case)
-        self.datalayer.save(case)
-
-        self.feedback_message = (
-            f"Embargo teardown applied on case '{case_id}'"
-            f" (EM {current_em} → EXITED)"
-        )
+        self.feedback_message = f"Embargo teardown applied on case '{case_id}'"
         self.logger.debug("%s: %s", self.name, self.feedback_message)
-        # SL-04-001/SL-04-006: embargo teardown is a protocol milestone.
-        log_em_transition(
-            self.logger,
-            self.actor_id or "<unknown>",
-            case_id,
-            current_em,
-            EM.EXITED,
-        )
         return Status.SUCCESS
 
 


### PR DESCRIPTION
- Closes #2583
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Eliminates the three remaining AC-1 violations in embargo BT nodes where `case.current_status.em` was read or written inline instead of using `ReadEmStateNode`/`WriteEmStateNode`, completing Group 1 of CONCERN-2559.

## Changes

- **`vultron/core/behaviors/embargo/nodes/teardown.py`**: `ApplyEmbargoTeardownNode.update()` refactored to delegate to `ClearActiveEmbargoNode` + `ResetParticipantConsentNode`. Removed inline `case.current_status.em.state` read and `EmDimension(state=EM.EXITED)` write. Missing-case path still returns SUCCESS (sync context).
- **`vultron/core/behaviors/case/nodes/embargo.py`**: `AttachEmbargoToCaseNode.update()` replaces `stored_case.current_status.em = EmDimension(state=EM.ACTIVE)` with `WriteEmStateNode` delegation (saves `active_embargo` first, then delegates EM write). Added `WriteEmStateNode` import; removed now-unused `EmDimension` import.
- **`vultron/core/behaviors/embargo/nodes/lifecycle.py`**: `SetEmbargoActiveNode._apply_transition()` replaces `case.current_status.em = EmDimension(state=EM.ACTIVE)` with `WriteEmStateNode` delegation. Removed unused `EmDimension` import.
- **`test/core/behaviors/embargo/nodes/test_teardown.py`**: Added `test_delegates_em_write_to_clear_active_embargo_node` — patches `ClearActiveEmbargoNode.update` to FAILURE, verifies EM unchanged and node still returns SUCCESS.
- **`test/core/behaviors/embargo/nodes/test_lifecycle.py`**: Added `test_em_write_goes_through_write_em_state_node` — patches `WriteEmStateNode.update` (autospec) and asserts it was called during PROPOSED → ACTIVE transition.
- **`test/core/behaviors/case/nodes/test_embargo.py`**: Added `TestAttachEmbargoToCaseNodeAC1.test_em_write_delegates_to_write_em_state_node` — patches `WriteEmStateNode.update` to FAILURE and verifies FAILURE propagates.

## Verification

- All 67 targeted tests pass (64 pre-existing + 3 new regression tests)
- Full unit suite: 7342 passed, 1 pre-existing ratchet failure (`test_protocol_spec_coverage_floor` already failing on `origin/main` at 948 > 947)
- Integration suite: 1172 passed
- Black, flake8, mypy, pyright clean