### PR TITLE
refactor(behaviors): create _EmitSingleActivityBase and eliminate case-domain emit duplication (CONCERN-2559 Group 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,12 +322,6 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   `__init__.py` MUST re-export all public names. See BTND-07-001, BTND-07-003.
 - **Splits Must Not Produce New God Modules** — submodules ≤500 lines; split
   recursively when they re-accumulate. See CS-18-001 through CS-18-004.
-- **BT Emit Nodes: Inherit Base Classes, Never Reimplement Guard Boilerplate**
-  — before writing any emit, send, or state-transition node, check the
-  domain base-class table and discovery gate in
-  [`vultron/core/behaviors/AGENTS.md`](vultron/core/behaviors/AGENTS.md)
-  § "Compose Before Create". If no base exists for your domain, create it
-  first. See BTND-07-005, BTND-07-009, BTND-07-010.
 - **Peer Broadcast Nodes Must Not Mask Delivery Failure with SUCCESS** —
   see [notes/peer-broadcast-failure-semantics.md](notes/peer-broadcast-failure-semantics.md) BT-14-001.
 - **Negative-Guard Condition Nodes Are a Readability Anti-Pattern** — use

--- a/plan/incoming/learnings/20260825-emit-base-on-success-outside-try.md
+++ b/plan/incoming/learnings/20260825-emit-base-on-success-outside-try.md
@@ -1,0 +1,39 @@
+---
+title: "_EmitSingleActivityBase: _on_success() must live outside the try block"
+type: learning
+timestamp: "2026-08-25"
+source: ISSUE-2582
+signal: design-question
+---
+
+When writing base-class emit nodes that follow the guard+emit+outbox pattern,
+the `_on_success()` hook must be called **outside** the `try/except` block,
+not inside it.
+
+If `_on_success()` is inside the `try`, any exception it raises causes the
+`except` to catch it and return `Status.FAILURE` — even though the outbox
+write (`record_outbox_item`) and `_captured` update have **already committed**.
+The BT parent sees FAILURE and may retry or compensate against a write that
+already landed, producing a duplicate outbox entry or incorrect state.
+
+**Rule for all future `_Emit*Base` classes:**
+
+```python
+try:
+    activity_id, activity_dict = self._call_factory()
+    dl.record_outbox_item(...)
+    if self._captured is not None:
+        self._captured["activity"] = activity_dict
+except Exception as e:
+    ...
+    return Status.FAILURE
+# _on_success OUTSIDE the try
+self._on_success(activity_id, activity_dict)
+return Status.SUCCESS
+```
+
+The `activity_id` / `activity_dict` variables are guaranteed to be in scope
+here because the `except` always returns — Python (and pyright) handle this
+correctly without "possibly unbound" errors.
+
+Follow-up: #2609 (add test for `_on_success` raising after committed write).

--- a/plan/incoming/learnings/20260825-pytrees-class-registry-in-tests.md
+++ b/plan/incoming/learnings/20260825-pytrees-class-registry-in-tests.md
@@ -1,0 +1,31 @@
+---
+title: "py_trees BehaviourWithPorts subclasses must not be defined inside test functions"
+type: learning
+timestamp: "2026-08-25"
+source: ISSUE-2582
+signal: tooling-issue
+---
+
+`py_trees.ports.BehaviourWithPorts.__init_subclass__` registers each subclass
+by its `__name__` in a global class-tag registry. If a BT node class is
+defined **inside a test function or factory method** (dynamically each call),
+py_trees raises:
+
+```text
+UserWarning: Ports class tag '_TestEmitNode' is already registered ...
+  overriding with '_TestEmitNode' (last wins).
+```
+
+Worse, with pytest, this causes a `FAILED` result even on a technically
+passing test when the warning becomes an error.
+
+**Rule**: BT subclasses used in tests must be defined at **module level**
+(or in a class body), never inside a function or closure. Instance-level
+variation is achieved by setting instance attributes (e.g.,
+`node.factory_fn = lambda ...`) rather than creating a new class per test.
+
+This was found when writing `_StubEmitNode` for `TestEmitSingleActivityBase`.
+The fix was to move from a `make_node()` factory (defining a new `_TestEmitNode`
+class on each call) to a single module-level `_StubEmitNode` class whose
+behaviour is controlled via `node.factory_fn` and `node.on_success_fn`
+instance attributes.

--- a/test/core/behaviors/test_helpers.py
+++ b/test/core/behaviors/test_helpers.py
@@ -960,3 +960,45 @@ class TestEmitSingleActivityBase:
 
         assert result.status == Status.FAILURE
         assert "failed" in node.feedback_message
+
+    def test_on_success_raising_after_committed_write_propagates(
+        self, datalayer
+    ):
+        """Exception in _on_success() propagates; outbox write already committed.
+
+        _on_success() runs outside the try/except block (see helpers.py), so
+        a hook that raises is NOT silently swallowed as Status.FAILURE.  The
+        exception bubbles to the BT executor, which is the correct behaviour:
+        it signals an unexpected hook bug rather than masking a committed write
+        as a retryable failure.
+
+        Tracks DEFER from code-review of #2582 / issue #2609.
+        """
+        from unittest.mock import MagicMock
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+        activity_id = "https://example.org/activities/emit-hook-raise"
+        activity_dict = {"id": activity_id}
+        factory = MagicMock(spec=TriggerActivityPort)
+
+        def _factory_fn(self_node):
+            return (activity_id, activity_dict)
+
+        def _raising_hook(self_node, aid, adict):
+            raise RuntimeError("hook exploded after write committed")
+
+        node = _StubEmitNode()
+        node.factory_fn = _factory_fn
+        node.on_success_fn = _raising_hook
+        bridge = BTBridge(datalayer, trigger_activity=factory)
+        result = bridge.execute_with_setup(node, actor_id=_ACTOR_URI)
+
+        # BTBridge catches uncaught exceptions from update() and surfaces them
+        # as result.errors. The key contract being tested: because _on_success()
+        # is OUTSIDE the try block, its exception bypasses the feedback_message
+        # path — result.errors is set rather than feedback_message.
+        assert result.status == Status.FAILURE
+        assert result.errors is not None
+        # feedback_message was NOT set by the normal except path
+        assert "failed" not in (node.feedback_message or "")

--- a/test/core/behaviors/test_helpers.py
+++ b/test/core/behaviors/test_helpers.py
@@ -26,6 +26,7 @@ from vultron.core.behaviors.helpers import (
     ReadObject,
     UpdateObject,
     CreateObject,
+    _EmitSingleActivityBase,
 )
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.models.case import VultronCase
@@ -827,3 +828,135 @@ def test_action_logger_emits_via_caplog(bridge, datalayer, caplog):
     assert any(
         "BT action log message emitted" in r.message for r in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for _EmitSingleActivityBase
+# ---------------------------------------------------------------------------
+
+_ACTOR_URI = "https://example.org/actors/emit-test-actor"
+
+
+class _StubEmitNode(_EmitSingleActivityBase):
+    """Concrete stub — delegates to injected callables set before use."""
+
+    factory_fn = None
+    on_success_fn = None
+
+    def _call_factory(self) -> tuple[str, dict]:
+        if self.factory_fn is None:
+            raise NotImplementedError("no factory_fn set on _StubEmitNode")
+        return self.factory_fn(self)
+
+    def _on_success(self, activity_id: str, activity_dict: dict) -> None:
+        if self.on_success_fn is not None:
+            self.on_success_fn(self, activity_id, activity_dict)
+
+
+class TestEmitSingleActivityBase:
+    """Unit tests for _EmitSingleActivityBase guard+emit+outbox contract."""
+
+    def test_call_factory_raises_not_implemented_on_base(self):
+        """`_call_factory()` raises NotImplementedError when not overridden."""
+        node = _EmitSingleActivityBase.__new__(_EmitSingleActivityBase)
+        with pytest.raises(NotImplementedError):
+            node._call_factory()
+
+    def test_on_success_default_is_noop(self):
+        """`_on_success()` does nothing when not overridden."""
+        node = _EmitSingleActivityBase.__new__(_EmitSingleActivityBase)
+        node._on_success("some-id", {})  # must not raise
+
+    def test_update_fails_when_datalayer_missing(self, datalayer):
+        """Returns FAILURE immediately when DataLayer is not available."""
+        from vultron.core.behaviors.bridge import BTBridge
+
+        node = _StubEmitNode()
+        bridge = BTBridge(datalayer)
+        result = bridge.execute_with_setup(node, actor_id=None)
+        assert result.status == Status.FAILURE
+
+    def test_update_fails_when_factory_missing(self, datalayer):
+        """Returns FAILURE when trigger_activity_factory is not wired."""
+        from vultron.core.behaviors.bridge import BTBridge
+
+        node = _StubEmitNode()
+        bridge = BTBridge(datalayer)
+        result = bridge.execute_with_setup(node, actor_id=_ACTOR_URI)
+        assert result.status == Status.FAILURE
+
+    def test_update_succeeds_and_queues_outbox(self, datalayer):
+        """SUCCESS path: calls factory, queues outbox, returns SUCCESS."""
+        from unittest.mock import MagicMock
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+        activity_id = "https://example.org/activities/emit-001"
+        activity_dict = {"id": activity_id, "type": "Create"}
+        factory = MagicMock(spec=TriggerActivityPort)
+
+        node = _StubEmitNode()
+        node.factory_fn = lambda self_node: (activity_id, activity_dict)
+        bridge = BTBridge(datalayer, trigger_activity=factory)
+        result = bridge.execute_with_setup(node, actor_id=_ACTOR_URI)
+
+        assert result.status == Status.SUCCESS
+
+    def test_update_stores_activity_in_captured(self, datalayer):
+        """When _captured is provided, sets captured['activity'] on success."""
+        from unittest.mock import MagicMock
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+        activity_id = "https://example.org/activities/emit-002"
+        activity_dict = {"id": activity_id, "type": "Accept"}
+        captured: dict = {}
+        factory = MagicMock(spec=TriggerActivityPort)
+
+        node = _StubEmitNode(captured=captured)
+        node.factory_fn = lambda self_node: (activity_id, activity_dict)
+        bridge = BTBridge(datalayer, trigger_activity=factory)
+        bridge.execute_with_setup(node, actor_id=_ACTOR_URI)
+
+        assert captured.get("activity") == activity_dict
+
+    def test_update_calls_on_success_hook(self, datalayer):
+        """_on_success() is called with activity_id and activity_dict on SUCCESS."""
+        from unittest.mock import MagicMock
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+        activity_id = "https://example.org/activities/emit-003"
+        activity_dict = {"id": activity_id}
+        calls: list = []
+        factory = MagicMock(spec=TriggerActivityPort)
+
+        node = _StubEmitNode()
+        node.factory_fn = lambda self_node: (activity_id, activity_dict)
+        node.on_success_fn = lambda self_node, aid, adict: calls.append(
+            (aid, adict)
+        )
+        bridge = BTBridge(datalayer, trigger_activity=factory)
+        result = bridge.execute_with_setup(node, actor_id=_ACTOR_URI)
+
+        assert result.status == Status.SUCCESS
+        assert calls == [(activity_id, activity_dict)]
+
+    def test_update_returns_failure_on_factory_exception(self, datalayer):
+        """Returns FAILURE and sets feedback_message when factory raises."""
+        from unittest.mock import MagicMock
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+        factory = MagicMock(spec=TriggerActivityPort)
+
+        def _raising(self_node):
+            raise RuntimeError("factory exploded")
+
+        node = _StubEmitNode()
+        node.factory_fn = _raising
+        bridge = BTBridge(datalayer, trigger_activity=factory)
+        result = bridge.execute_with_setup(node, actor_id=_ACTOR_URI)
+
+        assert result.status == Status.FAILURE
+        assert "failed" in node.feedback_message

--- a/test/core/behaviors/test_helpers.py
+++ b/test/core/behaviors/test_helpers.py
@@ -15,6 +15,8 @@
 
 """Unit tests for DataLayer-aware BT helper nodes."""
 
+from typing import Callable, Optional
+
 import pytest
 import py_trees
 from py_trees.common import Status
@@ -840,8 +842,10 @@ _ACTOR_URI = "https://example.org/actors/emit-test-actor"
 class _StubEmitNode(_EmitSingleActivityBase):
     """Concrete stub — delegates to injected callables set before use."""
 
-    factory_fn = None
-    on_success_fn = None
+    factory_fn: Optional[Callable[["_StubEmitNode"], tuple[str, dict]]] = None
+    on_success_fn: Optional[Callable[["_StubEmitNode", str, dict], None]] = (
+        None
+    )
 
     def _call_factory(self) -> tuple[str, dict]:
         if self.factory_fn is None:
@@ -873,7 +877,7 @@ class TestEmitSingleActivityBase:
 
         node = _StubEmitNode()
         bridge = BTBridge(datalayer)
-        result = bridge.execute_with_setup(node, actor_id=None)
+        result = bridge.execute_with_setup(node, actor_id=None)  # type: ignore[arg-type]
         assert result.status == Status.FAILURE
 
     def test_update_fails_when_factory_missing(self, datalayer):

--- a/vultron/core/behaviors/AGENTS.md
+++ b/vultron/core/behaviors/AGENTS.md
@@ -149,7 +149,7 @@ package, perform these checks (BTND-07-005, BTND-07-009, BTND-07-010):
    |--------|-----------|------|
    | Report | `_EmitCaseActorReportActivityBase` | `report/nodes/emit.py` |
    | Embargo | `_SendEmbargoActivityBase` | `embargo/nodes/emit.py` |
-   | Participant-status | `_EmitParticipantStatusActivityBase` | `report/nodes/develop_fix.py` *(create if absent)* |
+   | Participant-status | `_EmitParticipantStatusActivityBase` | `report/nodes/develop_fix.py` |
    | Single-activity (invite, ownership, other case domains) | `_EmitSingleActivityBase` | `helpers.py` |
 
    **If no base exists for your domain: create it first, then write the

--- a/vultron/core/behaviors/AGENTS.md
+++ b/vultron/core/behaviors/AGENTS.md
@@ -150,7 +150,7 @@ package, perform these checks (BTND-07-005, BTND-07-009, BTND-07-010):
    | Report | `_EmitCaseActorReportActivityBase` | `report/nodes/emit.py` |
    | Embargo | `_SendEmbargoActivityBase` | `embargo/nodes/emit.py` |
    | Participant-status | `_EmitParticipantStatusActivityBase` | `report/nodes/develop_fix.py` *(create if absent)* |
-   | Single-activity (invite, ownership, other case domains) | `_EmitSingleActivityBase` | `helpers.py` *(create if absent)* |
+   | Single-activity (invite, ownership, other case domains) | `_EmitSingleActivityBase` | `helpers.py` |
 
    **If no base exists for your domain: create it first, then write the
    concrete node.** Do not implement `update()` inline in a concrete node

--- a/vultron/core/behaviors/case/nodes/invite_response.py
+++ b/vultron/core/behaviors/case/nodes/invite_response.py
@@ -27,17 +27,13 @@ Composite subtrees assembling these nodes are defined in
 """
 
 import logging
-from typing import cast
 
-from py_trees.common import Status
-
-from vultron.core.behaviors.helpers import DataLayerActionWithPorts
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.behaviors.helpers import _EmitSingleActivityBase
 
 logger = logging.getLogger(__name__)
 
 
-class EmitAcceptCaseInviteNode(DataLayerActionWithPorts):
+class EmitAcceptCaseInviteNode(_EmitSingleActivityBase):
     """Create Accept(Invite) and queue in the invitee's outbox.
 
     Uses ``trigger_activity_factory.accept_case_invite()`` — the factory
@@ -50,11 +46,10 @@ class EmitAcceptCaseInviteNode(DataLayerActionWithPorts):
         captured: dict | None = None,
         name: str | None = None,
     ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
+        super().__init__(captured=captured, name=name)
         self.invite_id = invite_id
-        self._captured = captured
 
-    def _emit(self) -> tuple[str, dict]:
+    def _call_factory(self) -> tuple[str, dict]:
         assert self.trigger_activity_factory is not None
         assert self.actor_id is not None
         return self.trigger_activity_factory.accept_case_invite(
@@ -62,33 +57,15 @@ class EmitAcceptCaseInviteNode(DataLayerActionWithPorts):
             actor=self.actor_id,
         )
 
-    def update(self) -> Status:
-        if (f := self._require_datalayer_and_actor()) is not None:
-            return f
-        if (f := self._require_factory()) is not None:
-            self.logger.error(self.feedback_message)
-            return f
-
-        try:
-            activity_id, activity_dict = self._emit()
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, activity_id  # type: ignore[arg-type]
-            )
-            if self._captured is not None:
-                self._captured["activity"] = activity_dict
-            self.logger.info(
-                "Actor '%s' accepted case invite '%s'",
-                self.actor_id,
-                self.invite_id,
-            )
-            return Status.SUCCESS
-        except Exception as e:
-            self.feedback_message = f"EmitAcceptCaseInvite failed: {e}"
-            self.logger.error(self.feedback_message)
-            return Status.FAILURE
+    def _on_success(self, activity_id: str, activity_dict: dict) -> None:
+        self.logger.info(
+            "Actor '%s' accepted case invite '%s'",
+            self.actor_id,
+            self.invite_id,
+        )
 
 
-class EmitRejectCaseInviteNode(DataLayerActionWithPorts):
+class EmitRejectCaseInviteNode(_EmitSingleActivityBase):
     """Create Reject(Invite) and queue in the invitee's outbox.
 
     Uses ``trigger_activity_factory.reject_case_invite()`` — the factory
@@ -101,11 +78,10 @@ class EmitRejectCaseInviteNode(DataLayerActionWithPorts):
         captured: dict | None = None,
         name: str | None = None,
     ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
+        super().__init__(captured=captured, name=name)
         self.invite_id = invite_id
-        self._captured = captured
 
-    def _emit(self) -> tuple[str, dict]:
+    def _call_factory(self) -> tuple[str, dict]:
         assert self.trigger_activity_factory is not None
         assert self.actor_id is not None
         return self.trigger_activity_factory.reject_case_invite(
@@ -113,27 +89,9 @@ class EmitRejectCaseInviteNode(DataLayerActionWithPorts):
             actor=self.actor_id,
         )
 
-    def update(self) -> Status:
-        if (f := self._require_datalayer_and_actor()) is not None:
-            return f
-        if (f := self._require_factory()) is not None:
-            self.logger.error(self.feedback_message)
-            return f
-
-        try:
-            activity_id, activity_dict = self._emit()
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, activity_id  # type: ignore[arg-type]
-            )
-            if self._captured is not None:
-                self._captured["activity"] = activity_dict
-            self.logger.info(
-                "Actor '%s' rejected case invite '%s'",
-                self.actor_id,
-                self.invite_id,
-            )
-            return Status.SUCCESS
-        except Exception as e:
-            self.feedback_message = f"EmitRejectCaseInvite failed: {e}"
-            self.logger.error(self.feedback_message)
-            return Status.FAILURE
+    def _on_success(self, activity_id: str, activity_dict: dict) -> None:
+        self.logger.info(
+            "Actor '%s' rejected case invite '%s'",
+            self.actor_id,
+            self.invite_id,
+        )

--- a/vultron/core/behaviors/case/nodes/ownership_transfer.py
+++ b/vultron/core/behaviors/case/nodes/ownership_transfer.py
@@ -34,22 +34,24 @@ BTND-07-003.
 """
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerActionWithPorts
+from vultron.core.behaviors.helpers import (
+    DataLayerActionWithPorts,
+    _EmitSingleActivityBase,
+)
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models._helpers import _as_id
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 from vultron.enums.roles import CVDRole
 
 logger = logging.getLogger(__name__)
 
 
-class EmitOfferCaseOwnershipTransferNode(DataLayerActionWithPorts):
+class EmitOfferCaseOwnershipTransferNode(_EmitSingleActivityBase):
     """Emit ``Offer(VulnerabilityCase)`` (ownership transfer) to ``transferee_id``.
 
     Calls ``trigger_activity_factory.offer_case_ownership_transfer()`` with
@@ -65,13 +67,12 @@ class EmitOfferCaseOwnershipTransferNode(DataLayerActionWithPorts):
         captured: dict | None = None,
         name: str | None = None,
     ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
+        super().__init__(captured=captured, name=name)
         self.case_id = case_id
         self.transferee_id = transferee_id
         self.content = content
-        self._captured = captured
 
-    def _emit(self) -> tuple[str, dict]:
+    def _call_factory(self) -> tuple[str, dict]:
         assert self.trigger_activity_factory is not None
         assert self.actor_id is not None
         assert self.datalayer is not None
@@ -89,36 +90,16 @@ class EmitOfferCaseOwnershipTransferNode(DataLayerActionWithPorts):
             to=case_actor_id,
         )
 
-    def update(self) -> Status:
-        if (f := self._require_datalayer_and_actor()) is not None:
-            return f
-        if (f := self._require_factory()) is not None:
-            self.logger.error(self.feedback_message)
-            return f
-
-        try:
-            activity_id, activity_dict = self._emit()
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, activity_id  # type: ignore[arg-type]
-            )
-            if self._captured is not None:
-                self._captured["activity"] = activity_dict
-            self.logger.info(
-                "Actor '%s' offered case ownership transfer for case '%s' to '%s'",
-                self.actor_id,
-                self.case_id,
-                self.transferee_id,
-            )
-            return Status.SUCCESS
-        except Exception as e:
-            self.feedback_message = (
-                f"EmitOfferCaseOwnershipTransfer failed: {e}"
-            )
-            self.logger.error(self.feedback_message)
-            return Status.FAILURE
+    def _on_success(self, activity_id: str, activity_dict: dict) -> None:
+        self.logger.info(
+            "Actor '%s' offered case ownership transfer for case '%s' to '%s'",
+            self.actor_id,
+            self.case_id,
+            self.transferee_id,
+        )
 
 
-class EmitAcceptCaseOwnershipTransferNode(DataLayerActionWithPorts):
+class EmitAcceptCaseOwnershipTransferNode(_EmitSingleActivityBase):
     """Emit ``Accept(Offer(VulnerabilityCase))`` (ownership transfer) to offerer.
 
     Calls ``trigger_activity_factory.accept_case_ownership_transfer()``
@@ -133,12 +114,11 @@ class EmitAcceptCaseOwnershipTransferNode(DataLayerActionWithPorts):
         captured: dict | None = None,
         name: str | None = None,
     ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
+        super().__init__(captured=captured, name=name)
         self.offer_id = offer_id
         self.case_id = case_id
-        self._captured = captured
 
-    def _emit(self) -> tuple[str, dict]:
+    def _call_factory(self) -> tuple[str, dict]:
         assert self.trigger_activity_factory is not None
         assert self.actor_id is not None
         assert self.datalayer is not None
@@ -154,32 +134,12 @@ class EmitAcceptCaseOwnershipTransferNode(DataLayerActionWithPorts):
             to=case_actor_id,
         )
 
-    def update(self) -> Status:
-        if (f := self._require_datalayer_and_actor()) is not None:
-            return f
-        if (f := self._require_factory()) is not None:
-            self.logger.error(self.feedback_message)
-            return f
-
-        try:
-            activity_id, activity_dict = self._emit()
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, activity_id  # type: ignore[arg-type]
-            )
-            if self._captured is not None:
-                self._captured["activity"] = activity_dict
-            self.logger.info(
-                "Actor '%s' accepted case ownership transfer offer '%s'",
-                self.actor_id,
-                self.offer_id,
-            )
-            return Status.SUCCESS
-        except Exception as e:
-            self.feedback_message = (
-                f"EmitAcceptCaseOwnershipTransfer failed: {e}"
-            )
-            self.logger.error(self.feedback_message)
-            return Status.FAILURE
+    def _on_success(self, activity_id: str, activity_dict: dict) -> None:
+        self.logger.info(
+            "Actor '%s' accepted case ownership transfer offer '%s'",
+            self.actor_id,
+            self.offer_id,
+        )
 
 
 class AcceptCaseOwnershipTransferNode(DataLayerActionWithPorts):

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -596,12 +596,12 @@ class _EmitSingleActivityBase(DataLayerActionWithPorts):
             )
             if self._captured is not None:
                 self._captured["activity"] = activity_dict
-            self._on_success(activity_id, activity_dict)
-            return Status.SUCCESS
         except Exception as e:
             self.feedback_message = f"{self.__class__.__name__} failed: {e}"
             self.logger.error(self.feedback_message)
             return Status.FAILURE
+        self._on_success(activity_id, activity_dict)
+        return Status.SUCCESS
 
 
 class FindParticipantByActorIdNode(DataLayerConditionWithPorts):

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -541,6 +541,69 @@ class DataLayerActionWithPorts(BehaviourWithPorts):
         )
 
 
+class _EmitSingleActivityBase(DataLayerActionWithPorts):
+    """Base class for emit nodes that create one activity and queue it in the actor's outbox.
+
+    Subclasses override ``_call_factory()`` (required) to invoke the
+    appropriate ``TriggerActivityPort`` method and return
+    ``(activity_id, activity_dict)``.  The optional ``_on_success()`` hook
+    is called after a successful outbox write and is useful for domain-specific
+    log messages.
+
+    When *captured* is provided, ``captured["activity"]`` is set to the
+    serialised activity dict on success, avoiding a follow-up ``dl.read()``
+    (AC-1, AC-2, DL-06-001).
+
+    Implements BTND-07-005, BTND-07-009, BTND-07-010.
+    """
+
+    def __init__(
+        self,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._captured = captured
+
+    def _call_factory(self) -> tuple[str, dict]:
+        """Invoke the trigger-activity factory.  Subclasses must implement this.
+
+        Returns:
+            ``(activity_id, activity_dict)``
+
+        Raises:
+            NotImplementedError: Subclasses must implement this method.
+        """
+        raise NotImplementedError
+
+    def _on_success(self, activity_id: str, activity_dict: dict) -> None:
+        """Optional hook called after a successful outbox write.
+
+        Override in concrete nodes to emit domain-specific log messages or
+        post-emit side-effects.  The default implementation is a no-op.
+        """
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        if (f := self._require_factory()) is not None:
+            self.logger.error(self.feedback_message)
+            return f
+        try:
+            activity_id, activity_dict = self._call_factory()
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity_id  # type: ignore[arg-type]
+            )
+            if self._captured is not None:
+                self._captured["activity"] = activity_dict
+            self._on_success(activity_id, activity_dict)
+            return Status.SUCCESS
+        except Exception as e:
+            self.feedback_message = f"{self.__class__.__name__} failed: {e}"
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
+
+
 class FindParticipantByActorIdNode(DataLayerConditionWithPorts):
     """
     Resolve and store a case participant by actor ID.


### PR DESCRIPTION
- Closes #2582
- Closes #2609

## Summary

Creates `_EmitSingleActivityBase` in `helpers.py` and refactors 4 case-domain emit nodes to inherit from it, eliminating the identical guard+emit+outbox `update()` boilerplate that was duplicated across `invite_response.py` and `ownership_transfer.py` (CONCERN-2559 DRY violations V4, V5, B1).

## Changes

- **`vultron/core/behaviors/helpers.py`**: Add `_EmitSingleActivityBase`; concrete nodes override `_call_factory()` (required) and `_on_success()` (optional hook); `_on_success()` called outside the try block so hook exceptions do not mask committed outbox writes
- **`vultron/core/behaviors/case/nodes/invite_response.py`**: `EmitAcceptCaseInviteNode` and `EmitRejectCaseInviteNode` now inherit `_EmitSingleActivityBase`; `update()` removed; `_emit()` renamed `_call_factory()`; logging moved to `_on_success()`
- **`vultron/core/behaviors/case/nodes/ownership_transfer.py`**: `EmitOfferCaseOwnershipTransferNode` and `EmitAcceptCaseOwnershipTransferNode` refactored similarly; `AcceptCaseOwnershipTransferNode` intentionally unchanged (no emit pattern); unused `cast`/`CaseOutboxPersistence` imports removed
- **`vultron/core/behaviors/AGENTS.md`**: Remove `*(create if absent)*` from `_EmitSingleActivityBase` table row
- **`AGENTS.md`**: Remove now-redundant `BT Emit Nodes` pitfall entry (full guidance in `vultron/core/behaviors/AGENTS.md § "Compose Before Create"`)
- **`test/core/behaviors/test_helpers.py`**: 9 new unit tests for `_EmitSingleActivityBase`, including contract test for `_on_success()` raising after committed write (#2609)

## Audit result (AC-4)

`suggest_actor/emit.py` and `status/nodes/lifecycle.py` were audited — neither matches the guard+emit+outbox pattern (ledger commits, soft failures, blackboard reads). No change.

## Verification

- 9 new tests; all existing tests pass
- `TestEmitOwnershipTransferNodes` routing tests pass unchanged
- Pre-existing failure: `test_protocol_spec_coverage_floor` (ratchet at 948 vs 947 ceiling — unrelated to this PR)
- black, flake8, mypy, pyright all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)