### PR TITLE
feat(ci): add notify-failure composite action and wire CI failure alerting

### DIFF
--- a/.github/actions/notify-failure/action.yml
+++ b/.github/actions/notify-failure/action.yml
@@ -1,0 +1,95 @@
+name: Notify CI failure
+description: >-
+  Files or closes a GitHub Issue for CI failures on push-to-main or
+  scheduled workflows. In "notify" mode, creates a new issue or adds a
+  comment to an existing open one. In "close" mode, closes any open failure
+  issues for this workflow and records recovery. A workflow-specific label
+  combined with ci:main-failure uniquely identifies each workflow's issue
+  (CISEC-05-001, CISEC-05-002, CISEC-05-003).
+
+inputs:
+  mode:
+    description: '"notify" to file/update a failure issue; "close" to close it.'
+    required: true
+  workflow-label:
+    description: >-
+      Workflow-specific label (e.g. ci:workflow-python-app). Combined with
+      ci:main-failure to uniquely identify the failure issue for deduplication
+      and targeted close on recovery (CISEC-05-003).
+    required: true
+  token:
+    description: >-
+      GitHub token with issues:write permission (pass secrets.GITHUB_TOKEN).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure ci:main-failure and workflow-specific labels exist
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ github.repository }}
+        WORKFLOW_LABEL: ${{ inputs.workflow-label }}
+      run: |
+        set -euo pipefail
+        # Idempotent: silently skip if a label already exists.
+        gh label create "ci:main-failure" \
+          --repo "$REPO" \
+          --description "Bot-managed: CI failure on main or scheduled workflow" \
+          --color "d73a4a" 2>/dev/null || true
+        gh label create "$WORKFLOW_LABEL" \
+          --repo "$REPO" \
+          --description "CI failure alert for $WORKFLOW_LABEL" \
+          --color "e4e669" 2>/dev/null || true
+
+    - name: File, update, or close the failure issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ github.repository }}
+        MODE: ${{ inputs.mode }}
+        WORKFLOW_LABEL: ${{ inputs.workflow-label }}
+        WORKFLOW_NAME: ${{ github.workflow }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        REF: ${{ github.ref }}
+      run: |
+        set -euo pipefail
+
+        # Collect all open issue numbers matching both labels.
+        mapfile -t ISSUE_NUMS < <(gh issue list \
+          --repo "$REPO" \
+          --label "ci:main-failure" \
+          --label "$WORKFLOW_LABEL" \
+          --state open \
+          --json number \
+          --jq '.[].number')
+
+        if [ "$MODE" = "notify" ]; then
+          if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+            # Add a comment to the first open failure issue.
+            gh issue comment "${ISSUE_NUMS[0]}" \
+              --repo "$REPO" \
+              --body "CI still failing — [run]($RUN_URL)"
+          else
+            # Create a new failure issue.
+            BODY=$(printf \
+              'The **%s** workflow failed on ref `%s`.\n[View run](%s)\n\nThis issue is closed automatically when the workflow next passes.' \
+              "$WORKFLOW_NAME" "$REF" "$RUN_URL")
+            gh issue create \
+              --repo "$REPO" \
+              --title "CI failure: $WORKFLOW_NAME" \
+              --body "$BODY" \
+              --label "ci:main-failure" \
+              --label "$WORKFLOW_LABEL"
+          fi
+        elif [ "$MODE" = "close" ]; then
+          for NUM in "${ISSUE_NUMS[@]}"; do
+            gh issue close "$NUM" \
+              --repo "$REPO" \
+              --comment "CI is passing again — [run]($RUN_URL)"
+          done
+        else
+          echo "::error::Unknown mode '$MODE'. Expected 'notify' or 'close'." >&2
+          exit 1
+        fi

--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -34,6 +34,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -116,3 +117,18 @@ jobs:
           [ "$MISSING" -eq 0 ]
 
           echo "Scenario matrix OK: $(jq -r length "$FILE") total, ${PR_COUNT} in PR set."
+
+      - name: Notify CI failure
+        if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: notify
+          workflow-label: ci:workflow-actions-lint
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Close CI failure issue
+        if: success() && (github.event_name == 'push' || github.event_name == 'schedule')
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: close
+          workflow-label: ci:workflow-actions-lint
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -290,3 +290,32 @@ jobs:
         env:
           TEST_FILE: ${{ matrix.test_file }}
         run: uv run pytest "$TEST_FILE" -v --tb=short
+
+  # ── Notify: file or close a failure issue on push to main ────────────────
+  notify:
+    name: Notify CI failure
+    runs-on: ubuntu-latest
+    needs: [scenarios, demo, invariant-harness]
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Notify CI failure
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: notify
+          workflow-label: ci:workflow-demo-integration
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Close CI failure issue
+        if: >-
+          !contains(needs.*.result, 'failure') &&
+          !contains(needs.*.result, 'cancelled') &&
+          contains(needs.*.result, 'success')
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: close
+          workflow-label: ci:workflow-demo-integration
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -57,3 +58,18 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+      - name: Notify CI failure
+        if: failure() && github.event_name == 'push'
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: notify
+          workflow-label: ci:workflow-deploy-site
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Close CI failure issue
+        if: success() && github.event_name == 'push'
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: close
+          workflow-label: ci:workflow-deploy-site
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint_md_all.yml
+++ b/.github/workflows/lint_md_all.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,3 +31,17 @@ jobs:
       with:
         globs: "**/*.md"
         config: .markdownlint-cli2.yaml
+    - name: Notify CI failure
+      if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
+      uses: ./.github/actions/notify-failure
+      with:
+        mode: notify
+        workflow-label: ci:workflow-lint-md
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Close CI failure issue
+      if: success() && (github.event_name == 'push' || github.event_name == 'schedule')
+      uses: ./.github/actions/notify-failure
+      with:
+        mode: close
+        workflow-label: ci:workflow-lint-md
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -118,3 +118,29 @@ jobs:
           name: vultron
           path: dist/vultron-*.tar.gz
           retention-days: 14
+
+  # ── Notify: file or close a failure issue on push to main ────────────────
+  notify:
+    name: Notify CI failure
+    runs-on: ubuntu-latest
+    needs: [test, lint-black, lint-flake8, lint-mypy, lint-pyright, build]
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Notify CI failure
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: notify
+          workflow-label: ci:workflow-python-app
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Close CI failure issue
+        if: "!contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')"
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: close
+          workflow-label: ci:workflow-python-app
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quarterly_tag.yml
+++ b/.github/workflows/quarterly_tag.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
 
     steps:
       - name: Checkout repository
@@ -43,3 +44,18 @@ jobs:
             git push origin "$TAG"
             echo "Created and pushed tag: $TAG"
           fi
+
+      - name: Notify CI failure
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: notify
+          workflow-label: ci:workflow-quarterly-tag
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Close CI failure issue
+        if: success() && github.event_name == 'schedule'
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: close
+          workflow-label: ci:workflow-quarterly-tag
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -24,6 +24,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -42,3 +43,17 @@ jobs:
         # PYTHONPATH='' (quoted) is identical in effect to PYTHONPATH= but
         # distinguishable by shellcheck, which flags the bare form as SC1007.
         run: PYTHONPATH='' uv run spec-lint specs/
+      - name: Notify CI failure
+        if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: notify
+          workflow-label: ci:workflow-spec-check
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Close CI failure issue
+        if: success() && (github.event_name == 'push' || github.event_name == 'schedule')
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: close
+          workflow-label: ci:workflow-spec-check
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale_claim_sweeper.yml
+++ b/.github/workflows/stale_claim_sweeper.yml
@@ -25,6 +25,7 @@ jobs:
       REPO: ${{ github.repository }}
 
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Find and flag orphaned claims
         run: |
           set -euo pipefail

--- a/.github/workflows/stale_claim_sweeper.yml
+++ b/.github/workflows/stale_claim_sweeper.yml
@@ -142,3 +142,18 @@ jobs:
           done <<< "$BRANCHES"
 
           echo "=== Sweep complete. Flagged $FLAGGED issue(s). ==="
+
+      - name: Notify CI failure
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: notify
+          workflow-label: ci:workflow-stale-claim-sweeper
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Close CI failure issue
+        if: success() && github.event_name == 'schedule'
+        uses: ./.github/actions/notify-failure
+        with:
+          mode: close
+          workflow-label: ci:workflow-stale-claim-sweeper
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -26,8 +26,6 @@ and fall through to Level 2 (GitHub label search).
 | Test node ID | Issue | Last blocked |
 |---|---|---|
 | `test/bt/test_vultrabot.py::MyTestCase::test_main` | — | 2026-05-05 |
-| `test/core/behaviors/case/test_case_proposal_received_tree.py::TestADR0041Idempotency::test_duplicate_proposal_no_duplicate_participants_or_entries` | #2511 | 2026-08-24 |
-| `test/core/behaviors/sync/test_announce_tree.py::TestAnnounceLogEntryAppliesCloseCase::test_close_case_not_applied_for_other_event_types` | #2511 | 2026-08-24 |
 
 > Note: the two `test_integration_script_scenarios` entries were **hard-broken
 > on `main`, not flaky** — they failed deterministically. #2114 added a test that

--- a/plan/incoming/learnings/20260825-pyyaml-on-key-is-true.md
+++ b/plan/incoming/learnings/20260825-pyyaml-on-key-is-true.md
@@ -1,0 +1,33 @@
+---
+title: PyYAML parses bare `on:` mapping key as Python True, not string "on"
+type: learning
+timestamp: 2026-08-25T00:00:00Z
+source: ISSUE-2184
+signal: concern
+---
+
+PyYAML (which follows YAML 1.1) resolves the bare token `on` as a boolean
+`True` when it appears as a mapping key. A GitHub Actions workflow file that
+begins with `on:` is therefore loaded by `yaml.safe_load()` as
+`{True: {...}, 'name': '...', 'jobs': {...}}` — NOT `{'on': {...}, ...}`.
+
+Any test or tool that reads workflow YAML and queries the trigger block must use:
+
+```python
+on = wf_data.get(True, wf_data.get("on", {}))  # type: ignore[call-overload]
+```
+
+The `# type: ignore[call-overload]` is required because `dict[str, Any]`
+does not accept a `bool` key — but the actual runtime dict has one.
+
+Discovered during PR #2612 (`task/2184-ci-failure-alerting`) while writing
+`test/ci/test_workflow_failure_notification.py`. The fix is applied in that
+file. The existing `test_workflow_sha_pinning.py` never queries trigger type
+and is not affected.
+
+**Risk**: any new test that parses workflow YAML and tries to filter by trigger
+(push-to-main, schedule, etc.) will silently match zero workflows if it uses
+`wf_data.get("on", {})` — and its parametrize fixture will produce an empty
+list, making all parametrized test cases SKIP instead of FAIL. The
+`test_qualifying_workflows_found` assertion in the notification test catches
+this specifically.

--- a/test/ci/test_workflow_failure_notification.py
+++ b/test/ci/test_workflow_failure_notification.py
@@ -1,0 +1,138 @@
+"""CI verification test — confirm every qualifying workflow includes notify-failure.
+
+Implements CISEC-05-004 from specs/ci-security.yaml: every qualifying workflow
+(triggered by push to ``main`` or by a ``schedule`` event) SHOULD include the
+``.github/actions/notify-failure`` composite action step.
+
+A qualifying workflow is one whose ``on:`` trigger includes:
+- ``push`` to the ``main`` branch, OR
+- a ``schedule`` entry.
+
+For each qualifying workflow the test asserts that at least one step across all
+jobs uses ``./.github/actions/notify-failure`` in ``notify`` mode (CISEC-05-001)
+and at least one step uses it in ``close`` mode (CISEC-05-002).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+NOTIFY_FAILURE_USES = "./.github/actions/notify-failure"
+
+
+def _load_workflow(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text())  # type: ignore[no-any-return]
+
+
+def _is_qualifying(wf_data: dict[str, Any]) -> bool:
+    """Return True when the workflow triggers on push-to-main or schedule."""
+    # PyYAML 1.1 parses the bare `on:` key as Python True, not the string "on".
+    on = wf_data.get(True, wf_data.get("on", {}))
+    if not isinstance(on, dict):
+        return False
+    if "schedule" in on:
+        return True
+    push = on.get("push", {})
+    if isinstance(push, dict):
+        branches = push.get("branches", [])
+        if isinstance(branches, list) and "main" in branches:
+            return True
+    return False
+
+
+def _notify_failure_steps(
+    wf_data: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return all steps that reference the notify-failure composite action."""
+    steps = []
+    for job in wf_data.get("jobs", {}).values():
+        for step in job.get("steps", []):
+            if isinstance(step, dict) and step.get("uses", "").startswith(
+                NOTIFY_FAILURE_USES
+            ):
+                steps.append(step)
+    return steps
+
+
+def _qualifying_workflow_files() -> list[Path]:
+    files = []
+    for wf in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        try:
+            data = _load_workflow(wf)
+        except Exception:  # pragma: no cover
+            continue
+        if _is_qualifying(data):
+            files.append(wf)
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Parametrize: one test case per qualifying workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def qualifying_workflows() -> list[Path]:
+    found = _qualifying_workflow_files()
+    assert found, f"No qualifying workflows found under {WORKFLOWS_DIR}"
+    return found
+
+
+def test_qualifying_workflows_found(qualifying_workflows: list[Path]) -> None:
+    """At least one qualifying workflow must exist."""
+    assert len(qualifying_workflows) >= 1
+
+
+@pytest.mark.parametrize(
+    "wf", _qualifying_workflow_files(), ids=lambda p: p.name
+)
+def test_qualifying_workflow_has_notify_step(wf: Path) -> None:
+    """CISEC-05-004/CISEC-05-001: qualifying workflow must have a notify step."""
+    data = _load_workflow(wf)
+    steps = _notify_failure_steps(data)
+    notify_steps = [
+        s for s in steps if s.get("with", {}).get("mode") == "notify"
+    ]
+    assert notify_steps, (
+        f"{wf.name} is a qualifying workflow (push-to-main or schedule) "
+        f"but has no ./.github/actions/notify-failure step with mode: notify. "
+        f"Add the step per CISEC-05-001."
+    )
+
+
+@pytest.mark.parametrize(
+    "wf", _qualifying_workflow_files(), ids=lambda p: p.name
+)
+def test_qualifying_workflow_has_close_step(wf: Path) -> None:
+    """CISEC-05-004/CISEC-05-002: qualifying workflow must have a close step."""
+    data = _load_workflow(wf)
+    steps = _notify_failure_steps(data)
+    close_steps = [
+        s for s in steps if s.get("with", {}).get("mode") == "close"
+    ]
+    assert close_steps, (
+        f"{wf.name} is a qualifying workflow (push-to-main or schedule) "
+        f"but has no ./.github/actions/notify-failure step with mode: close. "
+        f"Add the step per CISEC-05-002."
+    )
+
+
+@pytest.mark.parametrize(
+    "wf", _qualifying_workflow_files(), ids=lambda p: p.name
+)
+def test_qualifying_workflow_notify_step_has_workflow_label(wf: Path) -> None:
+    """CISEC-05-004/CISEC-05-003: each notify step must carry a workflow-label."""
+    data = _load_workflow(wf)
+    steps = _notify_failure_steps(data)
+    for step in steps:
+        label = step.get("with", {}).get("workflow-label", "")
+        assert label, (
+            f"{wf.name}: a ./.github/actions/notify-failure step is missing "
+            f"the workflow-label input (CISEC-05-003)."
+        )

--- a/test/ci/test_workflow_failure_notification.py
+++ b/test/ci/test_workflow_failure_notification.py
@@ -33,7 +33,7 @@ def _load_workflow(path: Path) -> dict[str, Any]:
 def _is_qualifying(wf_data: dict[str, Any]) -> bool:
     """Return True when the workflow triggers on push-to-main or schedule."""
     # PyYAML 1.1 parses the bare `on:` key as Python True, not the string "on".
-    on = wf_data.get(True, wf_data.get("on", {}))
+    on = wf_data.get(True, wf_data.get("on", {}))  # type: ignore[call-overload]
     if not isinstance(on, dict):
         return False
     if "schedule" in on:


### PR DESCRIPTION
- Closes #2184
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Implements CISEC-05-001 through CISEC-05-004: a `notify-failure` composite
action files or closes a GitHub Issue when a push-to-main or scheduled
workflow fails/recovers, using a `ci:main-failure` + workflow-specific label
pair for deduplication (ADR-0055).

## Changes

- **`.github/actions/notify-failure/action.yml`**: New composite action.
  Accepts `mode` (notify/close), `workflow-label`, and `token` inputs. Creates
  workflow-specific labels idempotently, then files a new issue or comments on
  an existing open one (notify mode), or closes open failure issues (close mode).
- **`.github/workflows/python-app.yml`**: Added dedicated `notify` job
  (needs all stage-1/2 jobs, `if: always()`) with `issues: write`.
- **`.github/workflows/demo-integration.yml`**: Added dedicated `notify` job
  (needs scenarios/demo/invariant-harness, `if: always()`) with `issues: write`.
  Close step guards on `contains(needs.*.result, 'success')` to avoid closing
  on Dependabot-skipped runs.
- **`.github/workflows/spec-check.yml`**: Added `issues: write` and
  notify/close steps to `spec-lint` job.
- **`.github/workflows/actions-lint.yml`**: Added `issues: write` and
  notify/close steps to `actionlint` job.
- **`.github/workflows/lint_md_all.yml`**: Added `issues: write` and
  notify/close steps to `lint` job.
- **`.github/workflows/stale_claim_sweeper.yml`**: Added notify/close steps
  (schedule-only guard; already had `issues: write`).
- **`.github/workflows/quarterly_tag.yml`**: Added `issues: write` at
  job-level (job already had `contents: write`) and notify/close steps.
- **`.github/workflows/deploy_site.yml`**: Added `issues: write` and
  notify/close steps for push events (push-to-`publish` branch; beyond-spec
  coverage — not covered by CISEC-05-004 qualifying criteria).
- **`test/ci/test_workflow_failure_notification.py`**: New CISEC-05-004 spec
  test. Parametrizes over all qualifying workflows (push-to-main or schedule);
  asserts each has a notify step, a close step, and a workflow-label input.
  Fixes PyYAML 1.1 boolean key issue (`on:` parsed as Python `True`).
- **`notes/flaky-tests.md`**: Evict stale #2511 entries (issue is now closed).

## Verification

- All 22 new spec tests pass (`test/ci/test_workflow_failure_notification.py`)
- Black, flake8, mypy, pyright clean
- `ci:main-failure` label created in CERTCC/Vultron repo
- All 8 wired workflow YAML files validated by actionlint pre-commit hook