### PR TITLE
test: add parametrised SE-07-006 phrase render regression tests

### DIFF
--- a/plan/incoming/learnings/20260825-se07-trailing-dash-three-more-phrases.md
+++ b/plan/incoming/learnings/20260825-se07-trailing-dash-three-more-phrases.md
@@ -1,0 +1,25 @@
+---
+title: "SE-07-006 render test discovered 3 more trailing-dash phrases"
+type: learning
+timestamp: "2026-08-25"
+source: ISSUE-1905
+signal: concern
+---
+
+While implementing the parametrised SE-07-006 behavioural render test (#1905),
+`test_event_phrase_render_no_dangling_output` found three additional phrases that
+produce trailing em-dashes when called through `event_phrase()`:
+
+| Semantic type | Phrase | event_phrase() output |
+|---|---|---|
+| OFFER_CASE_PARTICIPANT | `'{actor} offered case participation to {object}'` | `'— offered case participation to —'` |
+| OFFER_CASE_OWNERSHIP_TRANSFER | `'{actor} offered case ownership to {object}'` | `'— offered case ownership to —'` |
+| ADD_PARTICIPANT_STATUS_TO_PARTICIPANT | `'{actor} updated the participant status for {object}'` | `'— updated the participant status for —'` |
+
+Root cause: `event_phrase()` uses `defaultdict(lambda: "—")`, so any phrase
+ending with a slot reference always ends with `"—"`.
+
+These are the same class of bug as #2150 (SUBMIT_REPORT / `{target}`).
+
+Tracked in GitHub issue #2615. All three marked `xfail(strict=True)` in
+`test/test_semantic_registry.py` pending a fix.

--- a/test/test_semantic_registry.py
+++ b/test/test_semantic_registry.py
@@ -316,3 +316,75 @@ def test_no_phrase_uses_unknown_slots(entry):
         f"{entry.semantics.name}: phrase={entry.phrase!r} uses unknown "
         f"slot(s) {sorted(unknown)}. Valid names: {sorted(all_known)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# SE-07-006 — parametrised behavioural render check (AC-2, AC-4)
+# ---------------------------------------------------------------------------
+
+
+_TRAILING_DASH_XFAIL_REASONS = {
+    MessageSemantics.SUBMIT_REPORT: (
+        "SE-07-006: SUBMIT_REPORT phrase ends with {target}; "
+        "event_phrase() fills it with '—', producing trailing dash. "
+        "Tracked in #2150."
+    ),
+    MessageSemantics.OFFER_CASE_PARTICIPANT: (
+        "SE-07-006: OFFER_CASE_PARTICIPANT phrase ends with {object}; "
+        "event_phrase() fills it with '—', producing trailing dash. "
+        "Tracked in #2615."
+    ),
+    MessageSemantics.OFFER_CASE_OWNERSHIP_TRANSFER: (
+        "SE-07-006: OFFER_CASE_OWNERSHIP_TRANSFER phrase ends with {object}; "
+        "event_phrase() fills it with '—', producing trailing dash. "
+        "Tracked in #2615."
+    ),
+    MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT: (
+        "SE-07-006: ADD_PARTICIPANT_STATUS_TO_PARTICIPANT phrase ends with {object}; "
+        "event_phrase() fills it with '—', producing trailing dash. "
+        "Tracked in #2615."
+    ),
+}
+
+
+@pytest.mark.spec("SE-07-006")
+@pytest.mark.parametrize(
+    "entry",
+    [
+        (
+            pytest.param(
+                e,
+                id=e.semantics.name,
+                marks=[
+                    pytest.mark.xfail(
+                        strict=True,
+                        reason=_TRAILING_DASH_XFAIL_REASONS[e.semantics],
+                    )
+                ],
+            )
+            if e.semantics in _TRAILING_DASH_XFAIL_REASONS
+            else pytest.param(e, id=e.semantics.name)
+        )
+        for e in SEMANTIC_REGISTRY
+    ],
+)
+def test_event_phrase_render_no_dangling_output(entry):
+    """Parametrised: event_phrase() must not produce trailing em-dash or leave
+    un-substituted ``{slot}`` markers for any semantic type (SE-07-006, AC-2, AC-4).
+
+    Calls the real runtime render function — unlike the SE-07-004 defaultdict
+    test, which fills every slot (including reserved ones), masking the class of
+    bug where a phrase references a slot the runtime never populates.
+    """
+    import re
+
+    from vultron.demo.report import event_phrase
+
+    _slot_re = re.compile(r"\{(\w+)\}")
+    result = event_phrase(entry.semantics.value)
+    assert not result.endswith(
+        "—"
+    ), f"{entry.semantics.name}: event_phrase() ends with '—': {result!r}"
+    assert not _slot_re.search(
+        result
+    ), f"{entry.semantics.name}: event_phrase() left un-substituted slot: {result!r}"


### PR DESCRIPTION
- Closes #1905

## Summary

Adds a fully-parametrised SE-07-006 behavioural render test that calls `event_phrase()` for every entry in `SEMANTIC_REGISTRY` (49 entries) and asserts: (a) the rendered output does not end with a trailing `"—"`, and (b) no un-substituted `{slot}` markers remain.

## Changes

- **`test/test_semantic_registry.py`**: added `_TRAILING_DASH_XFAIL_REASONS` dict and `test_event_phrase_render_no_dangling_output` (parametrised over full `SEMANTIC_REGISTRY`, `@pytest.mark.spec("SE-07-006")`).
  - `SUBMIT_REPORT` xfail → tracked in #2150 (pre-existing)
  - `OFFER_CASE_PARTICIPANT`, `OFFER_CASE_OWNERSHIP_TRANSFER`, `ADD_PARTICIPANT_STATUS_TO_PARTICIPANT` xfail → newly discovered, tracked in #2615

## Acceptance criteria

- AC-1 ✅ pre-existing: `test_no_phrase_uses_unpopulated_slots` / `test_no_phrase_uses_unknown_slots`
- AC-2 ✅ new: `test_event_phrase_render_no_dangling_output` calls `event_phrase()` for each entry and asserts (a) no trailing `"—"` and (b) no dangling `{slot}`
- AC-3 ✅ pre-existing: `test_create_case_proposal_phrase_has_no_target_slot` retained as the model
- AC-4 ✅ new test is parametrised over the full registry

## Side-effects

While closing #1905 the new test discovered three previously undetected trailing-dash bugs beyond the known SUBMIT_REPORT case. These are tracked in the newly-created #2615 and marked `xfail(strict=True)`.

## Verification

- `uv run pytest test/test_semantic_registry.py` — 213 passed, 4 xfailed
- `uv run pytest --tb=short` (full unit suite) — 7412 passed, 5 xfailed
- `uv run pytest -m integration --tb=short` — 1172 passed, 3 xfailed
- `uv run black`, `flake8`, `mypy`, `pyright` clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)