### PR TITLE
feat(cm-24): implement delegated-message contract for ownership-transfer trigger

### DIFF
--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -269,23 +269,28 @@ Recipient receives Activity:
 
 ### Reference Implementation
 
-`SvcInviteActorToCaseUseCase._prepare()` (`triggers/actor.py:146–166`) is the
-canonical reference:
+Use `_prepare_delegated_context()` (`triggers/_helpers.py`) as the canonical
+implementation.  All delegated-emit trigger use cases MUST call this helper
+(CM-24-005).  When the BT tree also needs `case_actor_id` separately (e.g.
+for the `cc:` routing in the invite flow), resolve it with a second
+`_find_case_actor_id()` call after the helper:
 
 ```python
-case_actor_id = _find_case_actor_id(self._dl, self._case.id_)
-self._actor_id = case_actor_id if case_actor_id else owner_id   # CM-24-001/003
-self._case_actor_id = case_actor_id
-self._attributed_to = owner_id if case_actor_id else None        # CM-24-002/003
+# Delegated-message contract (CM-24-001..003)
+self._actor_id, self._attributed_to = _prepare_delegated_context(
+    self._dl, self._case.id_, requesting_actor_id
+)
+# case_actor_id needed separately when BT tree requires it (e.g. invite cc:)
+self._case_actor_id = _find_case_actor_id(self._dl, self._case.id_)
 ```
 
 ### Delegated Flows (Exhaustive)
 
 | Trigger use case | Notes |
 |---|---|
-| `SvcInviteActorToCaseUseCase` | ✅ reference — correct |
-| `SvcOfferCaseOwnershipTransferUseCase` | ❌ as of CONCERN-2170 — tracked in #2173 |
-| Other delegated-emit trigger use cases | audit scope of the CM-24 impl issue |
+| `SvcInviteActorToCaseUseCase` | ✅ uses `_prepare_delegated_context()` |
+| `SvcOfferCaseOwnershipTransferUseCase` | ✅ fixed in #2173 |
+| Other trigger use cases | audit complete — no other delegated-emit callsites |
 
 ### Shared-Helper Requirement (CM-24-005)
 

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -1304,7 +1304,7 @@ class TestSvcAcceptCaseOwnershipTransferUseCase:
     def test_accept_to_field_is_case_actor(self):
         """Accept activity must be addressed to the CaseActor (CM-21-006 / ADR-0053).
 
-        ``EmitAcceptCaseOwnershipTransferNode._emit()`` calls
+        ``EmitAcceptCaseOwnershipTransferNode._call_factory()`` calls
         ``_resolve_case_manager_id`` and sets ``to=[case_actor_id]``.
         This test seeds a case with a CASE_MANAGER participant and verifies
         the emitted ``to`` field carries the case actor URI.

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -1042,6 +1042,85 @@ class TestSvcOfferCaseOwnershipTransferUseCase:
                 dl, request, trigger_activity=TriggerActivityAdapter(dl)
             ).execute()
 
+    def test_offer_uses_case_actor_as_sender_when_present(self):
+        """CM-24-001/002: when a CaseActor Service exists, the Offer actor
+        MUST be the CaseActor ID and attributedTo MUST be the offering actor ID.
+        """
+        owner, dl = _make_actor_dl("Vendor")
+        transferee, _ = _make_actor_dl("Coordinator")
+        dl.create(transferee)
+        case = as_VulnerabilityCase(
+            attributed_to=owner.id_, name="Test Case", content="Content"
+        )
+        dl.create(case)
+
+        # Register a CaseActor Service via the legacy path used by _find_case_actor_id
+        case_actor = as_Service(
+            id_=f"{owner.id_}/case-actor",
+            context=case.id_,
+            name="CaseActorService",
+        )
+        dl.create(case_actor)
+
+        from vultron.core.use_cases.triggers.actor import (
+            SvcOfferCaseOwnershipTransferUseCase,
+        )
+        from vultron.core.use_cases.triggers.requests import (
+            OfferCaseOwnershipTransferTriggerRequest,
+        )
+
+        request = OfferCaseOwnershipTransferTriggerRequest(
+            actor_id=owner.id_,
+            case_id=case.id_,
+            transferee_id=transferee.id_,
+        )
+        result = SvcOfferCaseOwnershipTransferUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        activity_data = result["activity"]
+        assert activity_data["type"] == "Offer"
+        # CM-24-001: Offer actor MUST be the CaseActor, not the offering actor
+        assert activity_data["actor"] == case_actor.id_
+        # CM-24-002: offering actor attribution MUST be preserved
+        assert activity_data.get("attributedTo") == owner.id_
+        # The activity must be in the CaseActor's outbox (CM-24-004)
+        case_actor_outbox = dl.clone_for_actor(case_actor.id_).outbox_list()
+        assert activity_data["id"] in case_actor_outbox
+
+    def test_offer_falls_back_to_requesting_actor_when_no_case_actor(self):
+        """CM-24-003: when no CaseActor exists, the Offer actor is the offering
+        actor and attributedTo is absent."""
+        owner, dl = _make_actor_dl("Vendor")
+        transferee, _ = _make_actor_dl("Coordinator")
+        dl.create(transferee)
+        case = as_VulnerabilityCase(
+            attributed_to=owner.id_, name="Test Case", content="Content"
+        )
+        dl.create(case)
+
+        from vultron.core.use_cases.triggers.actor import (
+            SvcOfferCaseOwnershipTransferUseCase,
+        )
+        from vultron.core.use_cases.triggers.requests import (
+            OfferCaseOwnershipTransferTriggerRequest,
+        )
+
+        request = OfferCaseOwnershipTransferTriggerRequest(
+            actor_id=owner.id_,
+            case_id=case.id_,
+            transferee_id=transferee.id_,
+        )
+        result = SvcOfferCaseOwnershipTransferUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        activity_data = result["activity"]
+        assert activity_data["type"] == "Offer"
+        # CM-24-003: falls back to requesting actor when no CaseActor
+        assert activity_data["actor"] == owner.id_
+        assert activity_data.get("attributedTo") is None
+
 
 class TestSvcAcceptCaseOwnershipTransferUseCase:
     """Tests for the accept-case-ownership-transfer trigger use case (TRIG-11-002)."""

--- a/vultron/core/behaviors/case/actor_trigger_trees.py
+++ b/vultron/core/behaviors/case/actor_trigger_trees.py
@@ -220,17 +220,19 @@ def offer_case_ownership_transfer_trigger_bt(
     case_id: str,
     transferee_id: str,
     content: str | None = None,
+    attributed_to: str | None = None,
     captured: dict | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Return the trigger-side BT for the offer-case-ownership-transfer workflow.
 
     Emits ``Offer(VulnerabilityCase)`` (ownership transfer variant) from the
-    offering actor to ``transferee_id`` (TRIG-11-001).
+    CaseActor's identity on behalf of the offering actor (CM-24-001, TRIG-11-001).
 
     Args:
         case_id: ID of the VulnerabilityCase whose ownership is being offered.
         transferee_id: Actor URI of the intended new owner.
         content: Optional human-readable message included in the offer.
+        attributed_to: Offering actor URI for delegated-message attribution (CM-24-002).
         captured: Optional dict; ``captured["activity"]`` is set on success.
 
     Returns:
@@ -244,6 +246,7 @@ def offer_case_ownership_transfer_trigger_bt(
                 case_id=case_id,
                 transferee_id=transferee_id,
                 content=content,
+                attributed_to=attributed_to,
                 captured=captured,
             ),
         ],

--- a/vultron/core/behaviors/case/nodes/ownership_transfer.py
+++ b/vultron/core/behaviors/case/nodes/ownership_transfer.py
@@ -64,6 +64,7 @@ class EmitOfferCaseOwnershipTransferNode(_EmitSingleActivityBase):
         case_id: str,
         transferee_id: str,
         content: str | None = None,
+        attributed_to: str | None = None,
         captured: dict | None = None,
         name: str | None = None,
     ) -> None:
@@ -71,6 +72,7 @@ class EmitOfferCaseOwnershipTransferNode(_EmitSingleActivityBase):
         self.case_id = case_id
         self.transferee_id = transferee_id
         self.content = content
+        self.attributed_to = attributed_to
 
     def _call_factory(self) -> tuple[str, dict]:
         assert self.trigger_activity_factory is not None
@@ -88,6 +90,7 @@ class EmitOfferCaseOwnershipTransferNode(_EmitSingleActivityBase):
             transferee_id=self.transferee_id,
             content=self.content,
             to=case_actor_id,
+            attributed_to=self.attributed_to,
         )
 
     def _on_success(self, activity_id: str, activity_dict: dict) -> None:

--- a/vultron/core/use_cases/triggers/_helpers.py
+++ b/vultron/core/use_cases/triggers/_helpers.py
@@ -30,6 +30,7 @@ from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
 )
 from vultron.core.ports.trigger_activity import TriggerActivityPort
+from vultron.core.use_cases._helpers import _find_case_actor_id
 from vultron.errors import VultronNotFoundError, VultronValidationError
 
 logger = logging.getLogger(__name__)
@@ -168,3 +169,22 @@ def send_case_actor_activity(
         raise VultronValidationError(
             f"{failure_label} failed: {BTBridge.get_failure_reason(tree)}"
         )
+
+
+def _prepare_delegated_context(
+    dl: CasePersistence,
+    case_id: str,
+    requesting_actor_id: str,
+) -> tuple[str, str | None]:
+    """Return (actor_id, attributed_to) for a CaseActor-delegated trigger.
+
+    Implements the delegated-message contract (CM-24-001 through CM-24-003):
+    when a CaseActor is present, the activity MUST be sent under the
+    CaseActor's identity (actor_id) with the requesting actor recorded in
+    attributed_to.  When no CaseActor exists the requesting actor sends
+    directly and attributed_to is None.
+    """
+    case_actor_id = _find_case_actor_id(dl, case_id)
+    actor_id = case_actor_id if case_actor_id else requesting_actor_id
+    attributed_to = requesting_actor_id if case_actor_id else None
+    return actor_id, attributed_to

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -37,6 +37,7 @@ from vultron.core.models._helpers import _as_id
 from vultron.core.use_cases._helpers import _find_case_actor_id
 from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
+    _prepare_delegated_context,
     resolve_actor,
     resolve_case,
 )
@@ -257,13 +258,13 @@ class SvcOfferCaseOwnershipTransferUseCase(SvcBTTriggerBase):
     """Offer case ownership to another actor (trigger-side path).
 
     Emits ``Offer(VulnerabilityCase)`` (ownership transfer variant) from the
-    requesting actor to ``transferee_id`` (TRIG-11-001).
+    CaseActor's identity on behalf of the offering actor (CM-24-001, TRIG-11-001).
     """
 
     def _prepare(self) -> None:
         request = cast(OfferCaseOwnershipTransferTriggerRequest, self._request)
         actor = resolve_actor(request.actor_id, self._dl)
-        self._actor_id = actor.id_
+        offering_actor_id = actor.id_
         self._case = resolve_case(request.case_id, self._dl)
 
         if self._dl.read(request.transferee_id) is None:
@@ -272,11 +273,17 @@ class SvcOfferCaseOwnershipTransferUseCase(SvcBTTriggerBase):
         self._transferee_id = request.transferee_id
         self._content = request.content
 
+        # Delegated-message contract: emit from CaseActor identity (CM-24-001..003)
+        self._actor_id, self._attributed_to = _prepare_delegated_context(
+            self._dl, self._case.id_, offering_actor_id
+        )
+
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return offer_case_ownership_transfer_trigger_bt(
             case_id=self._case.id_,
             transferee_id=self._transferee_id,
             content=self._content,
+            attributed_to=self._attributed_to,
             captured=self._captured,
         )
 

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -155,14 +155,13 @@ class SvcInviteActorToCaseUseCase(SvcBTTriggerBase):
         self._invitee_id = request.invitee_id
         self._suggested_roles = request.roles
 
-        case_actor_id = _find_case_actor_id(self._dl, self._case.id_)
-        self._actor_id = case_actor_id if case_actor_id else owner_id
-        # When case_actor_id is None (no dedicated CaseActor), the Invite is
-        # sent without cc: so no self-delivery occurs and no CaseLedgerEntry
-        # is committed — by design (ADR-0021: no CaseActor → no canonical
-        # ledger).
-        self._case_actor_id = case_actor_id
-        self._attributed_to = owner_id if case_actor_id else None
+        # Delegated-message contract (CM-24-001..003)
+        self._actor_id, self._attributed_to = _prepare_delegated_context(
+            self._dl, self._case.id_, owner_id
+        )
+        # case_actor_id also needed for invite BT routing (ADR-0021: no
+        # CaseActor → no cc: → no self-delivery → no CaseLedgerEntry commit)
+        self._case_actor_id = _find_case_actor_id(self._dl, self._case.id_)
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return invite_actor_to_case_trigger_bt(


### PR DESCRIPTION
- Closes #2173
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Implements the CM-24 delegated-message contract for `SvcOfferCaseOwnershipTransferUseCase`: when a CaseActor is present, the `Offer` activity is sent under the CaseActor's identity (`actor=`) with the requesting actor recorded in `attributed_to=`, per CM-24-001 through CM-24-003.

## Changes

- **`vultron/core/use_cases/triggers/_helpers.py`**: Adds `_prepare_delegated_context(dl, case_id, requesting_actor_id)` shared helper — resolves the CaseActor and returns `(actor_id, attributed_to)` per the delegated-message contract (CM-24-001..003). Falls back to requesting-actor identity when no CaseActor exists.
- **`vultron/core/use_cases/triggers/actor.py`**: Migrates `SvcOfferCaseOwnershipTransferUseCase._prepare()` to use the new helper; threads `attributed_to` into `_build_tree()`.
- **`vultron/core/behaviors/case/actor_trigger_trees.py`**: Adds `attributed_to: str | None = None` param to `offer_case_ownership_transfer_trigger_bt()` and passes it to the node.
- **`vultron/core/behaviors/case/nodes/ownership_transfer.py`**: Adds `attributed_to` to `EmitOfferCaseOwnershipTransferNode.__init__()` and passes it to the factory in `_call_factory()`.
- **`test/core/use_cases/triggers/test_actor_triggers.py`**: Two new tests — `test_offer_uses_case_actor_as_sender_when_present` (CM-24-001/002/004) and `test_offer_falls_back_to_requesting_actor_when_no_case_actor` (CM-24-003).

## Verification

- All unit tests pass (2 new), integration suite passes (only pre-existing XFAILs)
- Black, flake8, mypy, pyright clean