### PR TITLE
Add ci:main-failure label guard workflow (CISEC-05-005)

### DIFF
--- a/.github/workflows/ci-main-failure-label-guard.yml
+++ b/.github/workflows/ci-main-failure-label-guard.yml
@@ -1,0 +1,28 @@
+# Enforces that the ci:main-failure label is bot-managed.
+# If any actor other than github-actions[bot] applies the label,
+# this workflow removes it immediately to prevent label spoofing
+# that could corrupt the CI failure notification signal.
+# See specs/ci-security.yaml CISEC-05-005.
+
+name: "ci:main-failure label guard"
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  guard:
+    if: github.event.label.name == 'ci:main-failure'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Remove label if not applied by github-actions[bot]
+        if: github.actor != 'github-actions[bot]'
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "ci:main-failure"

--- a/test/ci/test_ci_main_failure_label_guard.py
+++ b/test/ci/test_ci_main_failure_label_guard.py
@@ -55,15 +55,18 @@ def test_guard_workflow_has_issues_write_permission() -> None:
     data = _load()
     # permissions may be at workflow level or job level
     workflow_perms = data.get("permissions", {})
-    if isinstance(workflow_perms, dict):
-        assert (
-            workflow_perms.get("issues") == "write"
-        ), "Workflow-level permissions must include 'issues: write' (CISEC-05-005)."
-        extra = {k: v for k, v in workflow_perms.items() if k != "issues"}
-        assert not extra, (
-            f"Workflow should have minimal permissions (issues: write only). "
-            f"Extra permissions found: {extra}"
-        )
+    assert isinstance(workflow_perms, dict), (
+        "Workflow permissions must be a scoped dict, not a broad string like "
+        "'write-all' (CISEC-05-005)."
+    )
+    assert (
+        workflow_perms.get("issues") == "write"
+    ), "Workflow-level permissions must include 'issues: write' (CISEC-05-005)."
+    extra = {k: v for k, v in workflow_perms.items() if k != "issues"}
+    assert not extra, (
+        f"Workflow should have minimal permissions (issues: write only). "
+        f"Extra permissions found: {extra}"
+    )
 
 
 def test_guard_workflow_filters_to_ci_main_failure_label() -> None:

--- a/test/ci/test_ci_main_failure_label_guard.py
+++ b/test/ci/test_ci_main_failure_label_guard.py
@@ -1,0 +1,92 @@
+"""CI verification test — confirm the ci:main-failure label guard workflow.
+
+Implements CISEC-05-005 from specs/ci-security.yaml: a workflow triggered on
+``issues: labeled`` SHOULD enforce that the ``ci:main-failure`` label is
+bot-managed.  If ``github.actor`` is not ``github-actions[bot]``, the label
+MUST be removed immediately.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+GUARD_WORKFLOW = WORKFLOWS_DIR / "ci-main-failure-label-guard.yml"
+
+_EXPECTED_LABEL = "ci:main-failure"
+_EXPECTED_ACTOR = "github-actions[bot]"
+
+
+def _load() -> dict[str, Any]:
+    return yaml.safe_load(GUARD_WORKFLOW.read_text())  # type: ignore[no-any-return]
+
+
+def test_guard_workflow_exists() -> None:
+    """CISEC-05-005: the label guard workflow file must exist."""
+    assert GUARD_WORKFLOW.exists(), (
+        f"{GUARD_WORKFLOW.name} not found. "
+        "Create .github/workflows/ci-main-failure-label-guard.yml "
+        "per CISEC-05-005."
+    )
+
+
+def test_guard_workflow_triggers_on_issues_labeled() -> None:
+    """CISEC-05-005: workflow must trigger on issues: labeled."""
+    data = _load()
+    on = data.get(True, data.get("on", {}))  # type: ignore[call-overload]
+    assert isinstance(on, dict), "workflow has no 'on:' block"
+    issues_trigger = on.get("issues", {})
+    types = (
+        issues_trigger.get("types", [])
+        if isinstance(issues_trigger, dict)
+        else []
+    )
+    assert (
+        "labeled" in types
+    ), "Workflow must trigger on 'issues: labeled' (CISEC-05-005)."
+
+
+def test_guard_workflow_has_issues_write_permission() -> None:
+    """CISEC-05-005: workflow must have issues: write and no broader permissions."""
+    data = _load()
+    # permissions may be at workflow level or job level
+    workflow_perms = data.get("permissions", {})
+    if isinstance(workflow_perms, dict):
+        assert (
+            workflow_perms.get("issues") == "write"
+        ), "Workflow-level permissions must include 'issues: write' (CISEC-05-005)."
+        extra = {k: v for k, v in workflow_perms.items() if k != "issues"}
+        assert not extra, (
+            f"Workflow should have minimal permissions (issues: write only). "
+            f"Extra permissions found: {extra}"
+        )
+
+
+def test_guard_workflow_filters_to_ci_main_failure_label() -> None:
+    """CISEC-05-005: workflow must filter to the ci:main-failure label."""
+    text = GUARD_WORKFLOW.read_text()
+    assert (
+        _EXPECTED_LABEL in text
+    ), f"Workflow must reference '{_EXPECTED_LABEL}' label (CISEC-05-005)."
+
+
+def test_guard_workflow_checks_actor() -> None:
+    """CISEC-05-005: workflow must guard against non-bot actors."""
+    text = GUARD_WORKFLOW.read_text()
+    assert _EXPECTED_ACTOR in text, (
+        f"Workflow must check github.actor against '{_EXPECTED_ACTOR}' "
+        "(CISEC-05-005)."
+    )
+
+
+def test_guard_workflow_removes_label() -> None:
+    """CISEC-05-005: workflow must remove the label when actor is not bot."""
+    text = GUARD_WORKFLOW.read_text()
+    assert "--remove-label" in text, (
+        "Workflow must use --remove-label to strip the ci:main-failure label "
+        "(CISEC-05-005)."
+    )


### PR DESCRIPTION
- Closes #2440

## Summary

Adds a GitHub Actions workflow that enforces the `ci:main-failure` label is
bot-managed: if `github.actor` is not `github-actions[bot]`, the label is
stripped immediately, preventing label spoofing that could corrupt the CI
failure notification signal (CISEC-05-005).

## Changes

- **`.github/workflows/ci-main-failure-label-guard.yml`**: new workflow
  triggered on `issues: labeled`; job filtered to `ci:main-failure` label;
  strips the label when applied by any non-bot actor; `issues: write`
  permission only; no external `uses:` references
- **`test/ci/test_ci_main_failure_label_guard.py`**: 6 structural tests
  verifying workflow existence, trigger type, permission scope, label filter,
  actor-check expression, and `--remove-label` usage

## Verification

- No external `uses:` references → CISEC-01-001 trivially satisfied
- Permissions limited to `issues: write` per AC
- Pre-commit hooks pass including GitHub Actions workflow lint (`actionlint`)
- 7475 unit tests pass; 1172 integration tests pass
- `black`, `flake8`, `mypy`, `pyright` all clean