### PR TITLE
ops(devcontainer): cap each slot container at 3 CPU cores

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -98,6 +98,7 @@ DOCKER_ARGS=(
     --name "$CONTAINER_NAME"
     --hostname "$CONTAINER_NAME"
     --env-file "$ENV_FILE"
+    --cpus "${SLOT_CPUS:-3}"
     -e LANG=C.UTF-8
     -e LC_ALL=C.UTF-8
     -e TERM=xterm-256color


### PR DESCRIPTION
## Summary

Add `--cpus "${SLOT_CPUS:-3}"` to the `docker run` call in `start-dev.sh` so that a runaway agent in one devcontainer slot cannot consume all host CPU and starve the other containers running concurrently.

## Changes

- **`start-dev.sh`**: add `--cpus "${SLOT_CPUS:-3}"` to `DOCKER_ARGS` before the `docker run` call. The cap is kernel-enforced via Linux CFS quota (`--cpu-period`/`--cpu-quota`), not a soft weight — throttling is hard. Default is 3 cores; override at launch with `SLOT_CPUS=2 ./start-dev.sh <slot>`.

## Context

With 7 devcontainers on a 20-core host, one agent spawning many parallel processes could consume all available CPU, causing test-suite timeouts in the other slots. The fix limits blast radius to at most 3 cores per slot (overcommit ratio 7×3=21 on 20 cores is intentional — CFS only throttles a container when it actually hits its quota simultaneously with others).