### PR TITLE
ops(docker): skip .venv in dev-stage chown to speed up build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -167,7 +167,11 @@ RUN su - vscode -c "curl -fsSL https://claude.ai/install.sh | bash"
 
 # /app is owned by root from the earlier COPY and git steps; hand it to vscode so
 # the git reset in poststart.sh doesn't fail on dubious-ownership checks.
-RUN chown -R vscode:vscode /app
+# Exclude .venv — inherited from dep-layer as root-owned, contains thousands of
+# files, and is bind-mounted over at runtime. World-readable/executable via root's
+# default umask (022) so vscode can run Python without owning them.
+RUN chown vscode:vscode /app \
+    && find /app -mindepth 1 -maxdepth 1 ! -name '.venv' -exec chown -R vscode:vscode {} +
 
 WORKDIR /app
 USER vscode


### PR DESCRIPTION
## Summary

- Replaces `chown -R vscode:vscode /app` with a `find`-based command that recurses into everything under `/app` except `.venv`
- `.venv` is inherited from `dep-layer` as root-owned and contains thousands of files — it was the source of the ~53 s build penalty
- `.venv` files remain world-readable/executable (root umask 022), so `vscode` can run Python without owning them; the directory is also bind-mounted over at runtime

## Test plan

- [ ] Rebuild the dev image and confirm the `chown` step completes in a few seconds rather than ~53 s
- [ ] Start a devcontainer slot and confirm `git status` / `poststart.sh` git reset runs without dubious-ownership errors
- [ ] Confirm Python / `uv run` work normally inside the container

Closes #2649

🤖 Generated with [Claude Code](https://claude.com/claude-code)