### PR TITLE
docs: plan CONCERN-2545 — wire Activity artifact immutability

### DIFF
--- a/docs/adr/0074-wire-activity-artifact-immutability.md
+++ b/docs/adr/0074-wire-activity-artifact-immutability.md
@@ -1,0 +1,123 @@
+---
+status: accepted
+date: 2026-08-26
+deciders: ahouseholder
+consulted: notes/wire-artifact-immutability.md, notes/datalayer-design.md, notes/activity-factories.md, notes/core-wire-rendering-port.md, docs/adr/0017-domain-wire-object-separation.md, docs/adr/0064-core-branch-validate-assignment.md, docs/adr/0073-per-actor-storage-isolation.md
+informed: specs/vocabulary-model.yaml
+---
+
+# Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal
+
+## Context and Problem Statement
+
+Wire Activity objects (subclasses of `as_Object`) are used for two distinct
+purposes that have conflicting mutability requirements:
+
+1. **Inbound**: a received Activity is an artifact — it captures the wire state
+   at receipt time. It is stored as `CaseLedgerEntry.payloadSnapshot` and
+   replicated to other participants via `Announce(CaseLedgerEntry)`. Mutating
+   it before ledger storage breaks replication fidelity: other actors reconstruct
+   their local state from the replicated form, so they would see a different
+   representation than what was originally received.
+
+2. **Outbound**: a factory-constructed Activity is an artifact — it captures
+   exactly what was sent. The same object must serve as both the delivery payload
+   and the `payloadSnapshot` in the ledger entry. Adapter enrichment after the
+   factory seals the blob creates a gap: the ledger records one form while the
+   recipient receives another, breaking the accountability invariant.
+
+Currently nothing in the type system prevents mutation. `as_Object` uses
+`ConfigDict(validate_assignment=False)` (ADR-0064) to stay lenient for inbound
+AS2 data, but has no `frozen=True`. Downstream code can and does mutate Activity
+objects in place — three mutation sites in `outbox_delivery.py` overwrite
+`outbound_activity.object_` after the ledger entry has already been written.
+
+## Decision Drivers
+
+- **Ledger integrity**: `CaseLedgerEntry.payloadSnapshot` must be identical to
+  the delivered payload. Post-factory mutation creates a permanent divergence.
+- **Replication fidelity**: other actors reconstruct state from the replicated
+  `payloadSnapshot`. If the frozen artifact is mutated before ledger storage,
+  replications propagate the mutated form.
+- **Type-level enforcement**: "do not mutate" as a convention enforced only by
+  documentation is insufficient; the type system should raise `TypeError` on
+  accidental mutation during development and testing.
+- **Orthogonality**: `validate_assignment=False` (wire branch leniency,
+  ARCH-12-002) and `frozen=True` (post-construction immutability) are
+  independent properties that can coexist. ADR-0064 established the former;
+  this ADR establishes the latter.
+
+## Considered Options
+
+1. **Full `frozen=True` on `as_Object` + A/B split for inbound routing**
+2. **Per-field freeze** — mark only `payloadSnapshot`-bound fields as frozen
+3. **Mutable Activities with a documentation-only immutability convention**
+
+## Decision Outcome
+
+Chosen option: **"Full `frozen=True` + A/B split"**, because it is the only
+option that enforces the invariant at the type level for both the inbound and
+outbound pipelines.
+
+### Inbound: A/B split
+
+Two distinct objects serve the two needs of the inbound pipeline:
+
+- **A — the frozen artifact**: the wire Activity exactly as received. Frozen
+  at the moment of receipt, before any rehydration or routing logic touches it.
+  Stored as `CaseLedgerEntry.payloadSnapshot`. Replicated unchanged.
+- **B — the hydrated routing copy**: a separately constructed object with
+  bare-string references resolved to full objects. Produced independently from
+  A — not by mutating A. Used for semantic dispatch and use-case execution.
+  Never stored in the ledger.
+
+A is never modified to produce B. If rehydration fails, A remains intact.
+
+### Outbound: frozen blob pipeline
+
+1. **Factory** (`vultron/wire/as2/factories/`) constructs the wire object
+   fully populated and returns a frozen blob.
+2. **Port** (`TriggerActivityPort` / `SyncActivityPort`) returns the frozen
+   blob to core — not a `model_dump()` dict.
+3. **Core** uses the exact same blob for both `CaseLedgerEntry.payloadSnapshot`
+   and outbox delivery.
+4. **Adapter** delivers the blob unchanged — no enrichment, no expansion.
+
+The factory is solely responsible for completeness. Adapter enrichment
+compensates for an incomplete factory and creates a ledger/delivery gap.
+
+### Consequences
+
+- Good, because mutation of received Activities raises `TypeError` immediately
+  during development, rather than corrupting ledger entries silently in
+  production.
+- Good, because the ledger entry and delivery payload are guaranteed identical
+  — the accountability invariant becomes structurally enforced.
+- Good, because `frozen=True` and `validate_assignment=False` are orthogonal;
+  no change to the wire branch's lenient field-type policy is required.
+- Bad, because any code that currently mutates wire Activity objects in place
+  must be refactored — three known mutation sites in `outbox_delivery.py` and
+  one in `EmitInviteActorToCaseNode._emit()`.
+- Bad, because `TriggerActivityPort` methods must change their return type
+  from `dict[str, Any]` to a frozen wire object, requiring callers to be
+  updated.
+
+## Validation
+
+- `test/architecture/test_wire_artifact_immutability.py`: xfail tests for
+  VM-08-002 and VM-08-003; promote to passing once implementation is complete.
+- `specs/vocabulary-model.yaml` VM-08-002 and VM-08-003 (MUST-level requirements).
+
+## More Information
+
+Implementation tracked in:
+
+- #2652 — add `frozen=True` to wire branch `as_Object` + ratchet test
+- #2653 — redesign `TriggerActivityPort` to return frozen wire blob (size:L)
+- #2654 — remove `_drop_bare_inline_refs` from emit nodes (blocked by #2653)
+- #2655 — remove `outbox_delivery.py` enrichment mutations (blocked by #2653)
+- #2656 — A/B split in inbox pipeline (blocked by #2652)
+
+Source: CONCERN-2545. Design rationale: `notes/wire-artifact-immutability.md`.
+
+Generated spec requirements: `specs/vocabulary-model.yaml` VM-08-002, VM-08-003.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -143,6 +143,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0071 CVE Eligibility: Reference Baseline over Normative Citation or Implementation-Defined](0071-cna-eligibility-reference-baseline.md)
 - [ADR-0072 Use a Dedicated `stories:` Field for Spec-to-Story Traceability (Not `relationships:`)](0072-stories-field-for-spec-to-story-traceability.md)
 - [ADR-0073 Give Each Actor Its Own Store; Delete the Unscoped DataLayer](0073-per-actor-storage-isolation.md)
+- [ADR-0074 Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal](0074-wire-activity-artifact-immutability.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -294,6 +294,7 @@ nav:
       - 'CVE Eligibility: Reference Baseline over Normative Citation or Implementation-Defined': 'adr/0071-cna-eligibility-reference-baseline.md'
       - 'Use a Dedicated stories: Field for Spec-to-Story Traceability': 'adr/0072-stories-field-for-spec-to-story-traceability.md'
       - Give Each Actor Its Own Store; Delete the Unscoped DataLayer: 'adr/0073-per-actor-storage-isolation.md'
+      - 'Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal': 'adr/0074-wire-activity-artifact-immutability.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/README.md
+++ b/notes/README.md
@@ -100,6 +100,19 @@ rules are in `vultron/core/ports/AGENTS.md`.
 resolving which store a read or write belongs to, rehydration of nested
 objects, or storage record migration.
 
+**`wire-artifact-immutability.md`**
+Design principle for wire Activity immutability: received artifacts MUST be
+frozen at receipt (A/B split — A = frozen ledger snapshot, B = separately
+constructed hydrated routing copy); emitted blobs MUST be frozen by the factory
+and used unchanged as both `payloadSnapshot` and delivery payload; ports are
+dumb relays (no adapter enrichment). Covers the orthogonality of lenient field
+types (`validate_assignment=False`) and post-construction immutability
+(`frozen=True`). Spec requirements: `VM-08-002`, `VM-08-003`.
+**Load when**: implementing or reviewing the inbound pipeline (inbox freeze
+point), outbound factory/port interfaces (`TriggerActivityPort`,
+`SyncActivityPort`), `CaseLedgerEntry.payloadSnapshot` construction, or
+auditing `outbox_delivery.py` for enrichment mutations. Source: CONCERN-2545.
+
 **`vultron/wire/as2/factories/AGENTS.md`**
 Factory-function operating rules for outbound Vultron protocol activities.
 See `notes/activity-factories.md` for the full design rationale and inventory.

--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -425,7 +425,9 @@ losing the at-offer-time snapshot. Even if Activities eventually gain
 independent DataLayer records (removing the technical constraint), the semantic
 reason alone prohibits recursive dehydration here.
 
-*Source: CONCERN-2219.*
+*Source: CONCERN-2219. See also `notes/wire-artifact-immutability.md` for the
+full design (A/B split, `frozen=True` enforcement, outbound blob pipeline, and
+VM-08-002/003 spec requirements).*
 
 ---
 

--- a/notes/wire-artifact-immutability.md
+++ b/notes/wire-artifact-immutability.md
@@ -108,6 +108,8 @@ event, breaking the accountability invariant.
 
 ## ADR Cross-references
 
+- **ADR-0074**: wire Activity artifact immutability — the decision record for
+  this design principle (frozen=True on wire branch, A/B split, dumb-relay ports).
 - **ADR-0017**: two-branch hierarchy (`VultronBase` shared root, core branch
   strict, wire branch lenient). Wire branch flexibility does not preclude wire
   branch immutability.

--- a/notes/wire-artifact-immutability.md
+++ b/notes/wire-artifact-immutability.md
@@ -1,0 +1,126 @@
+---
+title: Wire Artifact Immutability
+status: active
+---
+
+# Wire Artifact Immutability
+
+Wire Activities that arrive or depart are **artifacts** — immutable evidence of
+what was received or sent. This note codifies the design principle and its
+consequences for both the inbound and outbound pipelines.
+
+Source: CONCERN-2545.
+
+---
+
+## The Principle
+
+A wire Activity is immutable once it is complete:
+
+- **Received**: frozen at the moment of receipt, before any rehydration or
+  routing logic touches it.
+- **Emitted**: frozen at the moment the factory seals it, before it is handed
+  to any port or adapter.
+
+Flexibility and immutability are **orthogonal**. A wire model can allow
+optional fields, `Any`-typed sub-fields, and string-as-reference values (all
+required by the lenient wire branch per ARCH-12-002) while simultaneously
+preventing post-construction mutation via `ConfigDict(frozen=True)`. The
+`validate_assignment=False` exemption on `as_Object` (ADR-0064) affects
+type-checking on field writes — it does not preclude `frozen=True`, which
+raises `TypeError` on any attribute assignment regardless of type.
+
+---
+
+## Inbound: A/B Split
+
+Routing and use-case execution often need a more hydrated form than raw wire
+data. Two distinct objects serve these two needs:
+
+- **A — the frozen artifact**: the wire Activity exactly as received. Never
+  mutated. Stored as `CaseLedgerEntry.payloadSnapshot`. Replicated to other
+  participants via `Announce(CaseLedgerEntry)` so they can reconstruct local
+  state from the same evidence.
+
+- **B — the hydrated routing copy**: a separately constructed object with
+  bare-string references resolved to full objects. Produced independently from
+  A — not by mutating A. Used for semantic dispatch and use-case execution.
+  Not stored in the ledger.
+
+A is never modified to produce B. If rehydration fails and B cannot be
+produced, A remains intact and untouched.
+
+**Replication fidelity**: other actors receive A via `Announce(CaseLedgerEntry)`
+and reconstruct their own B locally. If A were mutated before ledger storage,
+replication would propagate the mutated form, and other actors could not
+reconstruct the original received state.
+
+---
+
+## Outbound: Frozen Blob Pipeline
+
+The canonical outbound pipeline:
+
+1. **Core** builds or requests a domain object representing the activity.
+2. **Factory** (`vultron/wire/as2/factories/`) constructs the wire object,
+   fully populated (case stub with embargo enrichment, all required fields).
+   The result is a frozen wire blob.
+3. **Port interface** (`TriggerActivityPort` / `SyncActivityPort`) returns the
+   frozen blob — not a `model_dump()` dict — to core. Core must not import wire
+   types; the blob is opaque at the port boundary (raw JSON or an opaque bytes
+   value).
+4. **Core** receives `(activity_id, frozen_blob)`. It uses the **exact same
+   blob** for:
+   - `CaseLedgerEntry.payloadSnapshot` — what was recorded
+   - Outbox delivery payload — what was sent
+5. **Port/adapter** delivers the blob as-is. No enrichment, no expansion of
+   bare refs, no hydration of inline objects. The adapter is a **dumb relay**.
+
+The ledger entry is written only after successful delivery — see the causal
+ordering concern (CONCERN-2546).
+
+### Current gaps (as of CONCERN-2545)
+
+- `TriggerActivityAdapter` returns `model_dump()` dict, not a frozen blob.
+- `EmitInviteActorToCaseNode._emit()` derives `payload_snapshot` via
+  `_drop_bare_inline_refs(activity_dict)` — the snapshot is not the exact
+  emitted form.
+- Three mutation sites in `outbox_delivery.py` (lines 166, 236, 257) overwrite
+  `outbound_activity.object_` after the ledger entry has been written.
+
+These gaps are tracked as implementation tasks under CONCERN-2545.
+
+---
+
+## Why "Ports Are Dumb Relays"
+
+The factory is responsible for producing a complete, self-contained wire blob.
+Adapter code that enriches an outbound activity (expanding refs, hydrating
+inline objects) is compensating for an incomplete factory — the enrichment
+belongs at construction time, not delivery time.
+
+Moving enrichment into the adapter creates an integrity gap: the ledger records
+the pre-enrichment blob while the recipient receives the post-enrichment one.
+Recipients and replicants therefore see different representations of the same
+event, breaking the accountability invariant.
+
+---
+
+## ADR Cross-references
+
+- **ADR-0017**: two-branch hierarchy (`VultronBase` shared root, core branch
+  strict, wire branch lenient). Wire branch flexibility does not preclude wire
+  branch immutability.
+- **ADR-0064**: `validate_assignment=False` on wire branch — exempts wire
+  branch from post-construction type validation. Orthogonal to `frozen=True`.
+- **ADR-0073**: per-actor DataLayer isolation — each actor's artifact store
+  holds only what that actor received, preserving each actor's independent view.
+
+## Related Notes
+
+- `notes/datalayer-design.md` — "Received Activity Artifacts" section:
+  rationale for non-recursive dehydration of inline Activity sub-fields.
+- `notes/core-wire-rendering-port.md` — `WireRenderPort` driven seam: how core
+  obtains wire-shaped JSON without importing wire types.
+- `notes/activity-factories.md` — factory function inventory and construction
+  patterns.

--- a/plan/history/2608/learning/CONCERN-2545.md
+++ b/plan/history/2608/learning/CONCERN-2545.md
@@ -1,0 +1,43 @@
+---
+source: CONCERN-2545
+timestamp: '2026-08-26T16:06:46.415294+00:00'
+title: Wire Activity artifact immutability — design
+type: learning
+---
+
+Planned and documented the wire Activity artifact immutability design for CONCERN-2545.
+
+## Key design decisions
+
+**Inbound (A/B split):**
+
+- A received wire Activity is a frozen artifact — it MUST NOT be mutated after construction.
+- A (raw artifact) goes to `CaseLedgerEntry.payloadSnapshot` and is replicated via `Announce(CaseLedgerEntry)`.
+- B (hydrated routing copy) is produced independently for dispatch and use-case execution.
+- Field-type leniency (`validate_assignment=False`, ARCH-12-002) and post-construction immutability (`frozen=True`) are orthogonal properties — both MUST hold simultaneously.
+
+**Outbound (frozen blob pipeline):**
+
+- Factory produces a complete, frozen wire blob.
+- Port interface returns the exact blob to core (not `model_dump()` dict).
+- Core uses the same blob as both `payloadSnapshot` and delivery payload — no derivation.
+- Ports are dumb relays; completeness belongs in the factory.
+
+## Current gaps identified
+
+- `TriggerActivityAdapter` returns `model_dump()` dict, not frozen blob.
+- `EmitInviteActorToCaseNode._emit()` derives snapshot via `_drop_bare_inline_refs()` — not the exact emitted form.
+- Three `outbound_activity.object_` mutation sites in `outbox_delivery.py` (lines 166, 236, 257) fire after ledger entry is written.
+
+## Surfaced adjacent concern
+
+Ledger entry is written BEFORE wire delivery (causal ordering inversion) — tracked as CONCERN-2657.
+The frozen-blob design (VM-08-003) is a prerequisite for the delivery-confirmed ledger write.
+
+## Outputs
+
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/2651>
+- Spec requirements: `specs/vocabulary-model.yaml` VM-08-002 (received artifact frozen), VM-08-003 (emitted blob unchanged)
+- Design note: `notes/wire-artifact-immutability.md`
+- Impl issues: #2652 (frozen=True + ratchet), #2653 (port interface, size:L), #2654 (remove _drop_bare_inline_refs), #2655 (outbox delivery audit), #2656 (A/B inbox split)
+- New concern: #2657 (causal ordering inversion — ledger before delivery)

--- a/specs/vocabulary-model.yaml
+++ b/specs/vocabulary-model.yaml
@@ -305,6 +305,8 @@ groups:
       Inspection of the inbox pipeline confirms that received wire Activity objects are
       constructed once and not modified before being passed to `CaseLedgerEntry.payloadSnapshot`.
       A hydrated routing copy (B) is produced separately from the original artifact (A).
+    adr:
+    - ADR-0074
     relationships:
     - rel_type: refines
       spec_id: VM-08-001
@@ -326,6 +328,8 @@ groups:
       Inspection of outbound emit nodes confirms that `payload_snapshot` is set to the exact
       blob returned by the factory port, without further transformation. Outbox delivery
       passes the blob through unchanged — no `object_` mutation sites remain.
+    adr:
+    - ADR-0074
     relationships:
     - rel_type: refines
       spec_id: VM-08-001

--- a/specs/vocabulary-model.yaml
+++ b/specs/vocabulary-model.yaml
@@ -288,6 +288,49 @@ groups:
     kind: protocol
     statement: Objects intended to be static once created (e.g., vocabulary registry entries, canonical example objects) SHOULD
       use immutable (frozen) configuration so that any attempt to modify them at runtime raises an exception
+  - id: VM-08-002
+    priority: MUST
+    kind: protocol
+    statement: >-
+      A received wire Activity MUST be treated as a frozen artifact from the moment of receipt.
+      It MUST NOT be mutated after construction. If a more hydrated form is required for routing
+      or use-case execution, it MUST be produced as a separate object; the original received
+      artifact MUST remain unmodified.
+    rationale: >-
+      The received artifact is the evidence of what arrived. It is stored as
+      `CaseLedgerEntry.payloadSnapshot` and replicated to other participants via
+      `Announce(CaseLedgerEntry)`. Mutating before storage breaks replication fidelity.
+      Field-type leniency (ARCH-12-002) and post-construction immutability are orthogonal.
+    verification: >-
+      Inspection of the inbox pipeline confirms that received wire Activity objects are
+      constructed once and not modified before being passed to `CaseLedgerEntry.payloadSnapshot`.
+      A hydrated routing copy (B) is produced separately from the original artifact (A).
+    relationships:
+    - rel_type: refines
+      spec_id: VM-08-001
+    lint_suppress:
+    - missing_story_reference
+  - id: VM-08-003
+    priority: MUST
+    kind: protocol
+    statement: >-
+      An emitted wire Activity blob MUST be produced by the factory as a complete, frozen object
+      before being handed to any port or adapter. The exact blob returned to core MUST be used
+      as both the delivery payload and `CaseLedgerEntry.payloadSnapshot`. No port or adapter
+      MAY enrich, mutate, or re-derive the blob after it leaves the factory.
+    rationale: >-
+      Ledger integrity requires that what is recorded and what is delivered are identical.
+      Adapter enrichment creates a gap where the ledger records one form and the recipient
+      receives another. The factory is solely responsible for completeness; ports relay only.
+    verification: >-
+      Inspection of outbound emit nodes confirms that `payload_snapshot` is set to the exact
+      blob returned by the factory port, without further transformation. Outbox delivery
+      passes the blob through unchanged — no `object_` mutation sites remain.
+    relationships:
+    - rel_type: refines
+      spec_id: VM-08-001
+    lint_suppress:
+    - missing_story_reference
 - id: VM-09
   title: Unknown Message Handling
   specs:

--- a/test/architecture/test_wire_artifact_immutability.py
+++ b/test/architecture/test_wire_artifact_immutability.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Architecture ratchet: wire Activity artifact immutability (VM-08-002, VM-08-003).
+
+Both tests are xfail(strict=True) — they assert the desired end state and will
+auto-promote to passing once the implementation issues are resolved.
+
+- VM-08-002 → #2652 (add frozen=True to wire branch + ratchet test)
+- VM-08-003 → #2653 (redesign TriggerActivityPort to return frozen wire blob)
+"""
+
+import typing
+
+import pytest
+
+
+@pytest.mark.spec("VM-08-002")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "VM-08-002: as_Object lacks frozen=True; received wire Activities can be "
+        "mutated after construction. Implement frozen wire branch via #2652. "
+        "When #2652 lands, as_Object.model_config['frozen'] becomes True, this "
+        "test XPASSes, and the xfail marker should be removed."
+    ),
+)
+def test_wire_activity_base_is_frozen():
+    """as_Object.model_config must have frozen=True (VM-08-002)."""
+    from vultron.wire.as2.vocab.base.objects.base import as_Object
+
+    assert as_Object.model_config.get("frozen") is True
+
+
+@pytest.mark.spec("VM-08-003")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "VM-08-003: TriggerActivityPort.submit_report returns dict[str, Any], "
+        "not a frozen wire blob. Port interface must be redesigned via #2653. "
+        "When #2653 lands, the second element of the return tuple becomes a "
+        "wire object type, get_origin returns None, and this test XPASSes."
+    ),
+)
+def test_trigger_activity_port_returns_wire_blob_not_dict():
+    """TriggerActivityPort activity methods must return frozen wire blobs, not dicts (VM-08-003)."""
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+    hints = typing.get_type_hints(TriggerActivityPort.submit_report)
+    return_type = hints.get("return")
+    assert (
+        return_type is not None
+    ), "submit_report must have a return type annotation"
+    type_args = typing.get_args(return_type)
+    assert (
+        len(type_args) == 2
+    ), "return type must be a 2-tuple (activity_id, payload)"
+    payload_type = type_args[1]
+    # Currently dict[str, Any]: get_origin returns dict → assertion fails (xfail).
+    # After #2653, payload_type is a frozen wire object: get_origin returns None → passes.
+    assert typing.get_origin(payload_type) is not dict


### PR DESCRIPTION
- Closes #2545
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Design documentation and spec requirements for wire Activity artifact
immutability: received activities are frozen at receipt (A/B split), emitted
blobs are frozen by the factory and used unchanged for both ledger snapshot and
delivery (ports are dumb relays).

## Changes

- **`notes/wire-artifact-immutability.md`**: new design note covering the
  inbound A/B split principle, outbound frozen blob pipeline, orthogonality
  of field-type flexibility vs post-construction immutability, current code
  gaps, and ADR cross-references
- **`specs/vocabulary-model.yaml`**: add VM-08-002 (received artifact MUST be
  frozen at receipt; hydrated copy produced independently) and VM-08-003
  (emitted blob MUST be used unchanged as `payloadSnapshot` and delivery
  payload; no port/adapter enrichment)
- **`notes/datalayer-design.md`**: forward-reference to new notes file from
  the existing "Received Activity Artifacts" section
- **`notes/README.md`**: index entry for new notes file

## Implementation Issues

- #2652 add `frozen=True` to wire branch + ratchet test
- #2653 redesign `TriggerActivityPort` to return frozen blob (size:L)
- #2654 remove `_drop_bare_inline_refs` from emit nodes (blocked by #2653)
- #2655 remove outbox_delivery enrichment mutations after factory audit (blocked by #2653)
- #2656 A/B split in inbox pipeline (blocked by #2652)