### PR TITLE
task: add pre-claim gates and shared compose-before-create skill

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -53,6 +53,37 @@ If this fails, stop and investigate before proceeding.
 
 3. Invoke `orient-agent` to load baseline context.
 4. Fetch the issue body and comments.
+
+4.5. **Pre-claim defect verification** — before claiming, verify the
+     described defect still exists on `origin/main` HEAD:
+
+     Search for the specific symptom, anti-pattern, or code path described
+     in the issue body (grep, `git log -S "<key term>" -- <file>`, or
+     graphify query). If the defect cannot be reproduced on `origin/main`,
+     it may have been fixed by a prior PR that lacked a `Closes #N` footer.
+
+     If the defect is absent from `origin/main`:
+
+     1. Post a reference comment identifying any PR that likely fixed it:
+
+        ```bash
+        gh issue comment <N> --repo CERTCC/Vultron --body "$(cat <<'EOF'
+        The described defect is not present on `origin/main`. It appears to
+        have been fixed by #<PR> without a `Closes #N` footer. Closing.
+        EOF
+        )"
+        ```
+
+     2. Close the issue:
+
+        ```bash
+        gh issue close <N> --repo CERTCC/Vultron
+        ```
+
+     3. **Stop.** Do not claim, branch, or investigate further.
+
+     If the defect is confirmed present, proceed to step 5 and claim.
+
 5. Claim the issue:
 
    ```bash
@@ -144,6 +175,12 @@ Ask: **"Proceed with this plan, redirect, or narrow scope?"**
 ## Phase 4 — Implement
 
 Once the plan is confirmed:
+
+0. **Compose-before-create gate (blocking)**: before writing any new code,
+   load `.agents/skills/shared/compose-before-create.md` and apply the
+   per-subsystem search patterns for every subsystem the fix touches (use
+   cases, wire handlers, adapters, demo helpers). If an existing artifact
+   covers the requirement, compose or subclass it — do not re-implement.
 
 1. **Write a failing test first** — confirm it fails before fixing.
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -102,7 +102,38 @@ Invoke the `orient-agent` skill.
    - If any OPEN blockers exist, print blocker numbers/titles and stop.
    - Do not claim, branch, or deepen context when blocked.
 
-6. **Claim the Issue**:
+6. **Pre-claim AC verification gate** — fetch the issue body and verify
+   each acceptance criterion against `origin/main` HEAD before claiming:
+
+   For each `- [ ] AC-N: <text>` item in the issue body, grep or graphify
+   `origin/main` for concrete evidence the AC is already satisfied (e.g.,
+   the described file exists with the required content, the named function
+   or class is present, the referenced behavior is implemented).
+
+   If **all** ACs are confirmed satisfied on `origin/main`:
+
+   1. Post a reference comment on the issue citing the PR(s) that
+      delivered the work:
+
+      ```bash
+      gh issue comment <N> --repo CERTCC/Vultron --body "$(cat <<'EOF'
+      All acceptance criteria are already satisfied on `origin/main` (delivered
+      by #<PR>). Closing without further work.
+      EOF
+      )"
+      ```
+
+   2. Close the issue:
+
+      ```bash
+      gh issue close <N> --repo CERTCC/Vultron
+      ```
+
+   3. **Stop.** Do not claim, branch, or deepen context.
+
+   If any AC is unconfirmed, proceed to step 7 and claim normally.
+
+7. **Claim the Issue**:
 
    ```bash
    bash .agents/skills/shared/claim-issue.sh <N> task <slug>
@@ -110,7 +141,7 @@ Invoke the `orient-agent` skill.
 
    Abort immediately if this exits non-zero.
 
-7. Fetch the issue body and comments. Use the content as implementation
+8. Fetch the issue body and comments. Use the content as implementation
    context throughout Phases 3–5.
 
 ### Phase 3 — Deepen Context
@@ -120,9 +151,16 @@ Invoke `deepen-context` with focus hints derived from the issue body
 
 ### Phase 4 — Verify Before Coding
 
-1. Search `vultron/` and `test/` to confirm the current state.
-2. Do not assume missing functionality; verify in code.
-3. If a blocking prerequisite is discovered, create and wire it:
+1. **Compose-before-create gate (all domain types — blocking)**:
+   Load `.agents/skills/shared/compose-before-create.md` and apply the
+   per-subsystem search patterns for every subsystem the task touches (use
+   cases, wire handlers, adapters, demo helpers). Do not write any new code
+   until this search is complete. If an existing artifact covers the
+   requirement, compose or subclass it — do not re-implement.
+
+2. Search `vultron/` and `test/` to confirm the current state.
+3. Do not assume missing functionality; verify in code.
+4. If a blocking prerequisite is discovered, create and wire it:
 
    ```bash
    NEW_ISSUE=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
@@ -135,7 +173,7 @@ Invoke `deepen-context` with focus hints derived from the issue body
 
    Record the dependency as a learning file in `plan/incoming/learnings/` and stop.
 
-4. If more than one prerequisite is required, or the work is non-trivial,
+5. If more than one prerequisite is required, or the work is non-trivial,
    create a learning file in `plan/incoming/learnings/` and stop.
 
 ### Phase 5 — Implement

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -110,6 +110,9 @@ Invoke the `orient-agent` skill.
    the described file exists with the required content, the named function
    or class is present, the referenced behavior is implemented).
 
+   If **no** `- [ ] AC-N:` items are found in the issue body (prose-format
+   or free-form ACs), skip this gate and proceed directly to step 7.
+
    If **all** ACs are confirmed satisfied on `origin/main`:
 
    1. Post a reference comment on the issue citing the PR(s) that
@@ -141,8 +144,9 @@ Invoke the `orient-agent` skill.
 
    Abort immediately if this exits non-zero.
 
-8. Fetch the issue body and comments. Use the content as implementation
-   context throughout Phases 3–5.
+8. Fetch the issue body and comments (including any comments not yet
+   loaded in step 6). Use the full content as implementation context
+   throughout Phases 3–5.
 
 ### Phase 3 — Deepen Context
 

--- a/.agents/skills/shared/compose-before-create.md
+++ b/.agents/skills/shared/compose-before-create.md
@@ -57,8 +57,20 @@ Demo helpers are strictly DRY — reuse `receiver_engages_case()`,
 inlining their bodies in a new scenario. See `vultron/demo/AGENTS.md`
 § "Extract Before Reuse" and DEMOMA-17-001.
 
-## BT Domain
+## BT Domain (`vultron/core/behaviors/`)
 
-For behavior tree nodes, see `vultron/core/behaviors/AGENTS.md`
-§ "Compose Before Create: Node Discovery Gate" for the domain base-class
-table and the AC-1 compliance requirements specific to BT work.
+For behavior tree nodes, run these searches first, then consult
+`vultron/core/behaviors/AGENTS.md` § "Compose Before Create: Node Discovery
+Gate" for the domain base-class table and AC-1 compliance requirements.
+
+**Node inventory** — search for existing nodes whose protocol state, domain,
+or semantic action overlaps with what you are about to implement:
+
+```bash
+grep -r "<target state value or action name>" vultron/core/behaviors/<domain>/nodes/
+graphify query "<action name or protocol state>"
+```
+
+If a match exists, compose or subclass — do not re-implement. After
+completing this inventory, apply the base-class and AC-1 checks from
+`vultron/core/behaviors/AGENTS.md`.

--- a/.agents/skills/shared/compose-before-create.md
+++ b/.agents/skills/shared/compose-before-create.md
@@ -1,0 +1,64 @@
+# Compose Before Create
+
+Before writing any new class or function, confirm that the functionality
+does not already exist in the codebase. Implementing a duplicate is always
+worse than composing from or subclassing what already exists.
+
+## Principle
+
+Search the target subsystem for classes or functions whose names,
+docstrings, or semantics overlap with the code you are about to write. If a
+match exists, compose or subclass — do not re-implement. If the task spans
+multiple subsystems, search each one.
+
+## Per-Subsystem Search Patterns
+
+### Use cases (`vultron/core/use_cases/`)
+
+```bash
+grep -rn "<semantic keyword>" vultron/core/use_cases/
+graphify query "<use case action or message type>"
+```
+
+A match in `handlers/` or `triggers/` means the protocol action is already
+wired. Reuse the existing use case rather than writing a parallel handler.
+
+### Wire handlers (`vultron/wire/as2/`)
+
+```bash
+grep -rn "<message type or pattern name>" vultron/wire/as2/
+graphify query "<wire activity type>"
+```
+
+A match in `extractor.py` or `patterns/` means the wire pattern is already
+registered. Extend an existing entry when semantics overlap; do not create a
+competing pattern for the same activity structure.
+
+### Adapters (`vultron/adapters/`)
+
+```bash
+grep -rn "<port name or adapter action>" vultron/adapters/
+graphify query "<adapter keyword>"
+```
+
+Confirm the port contract before implementing. A port method already defined
+in `vultron/core/ports/` with a stub in `vultron/adapters/driven/` should be
+extended, not shadowed.
+
+### Demo helpers (`vultron/demo/helpers/`)
+
+```bash
+grep -rn "<helper name or scenario action>" vultron/demo/helpers/
+graphify query "<demo action>"
+```
+
+Demo helpers are strictly DRY — reuse `receiver_engages_case()`,
+`run_direct_path_rm_triage()`, and similar shared helpers rather than
+inlining their bodies in a new scenario. See `vultron/demo/AGENTS.md`
+§ "Extract Before Reuse" and DEMOMA-17-001.
+
+## BT Domain
+
+For behavior tree nodes, see `vultron/core/behaviors/AGENTS.md`
+§ "Compose Before Create: Node Discovery Gate" for the domain base-class
+table and the AC-1 compliance requirements specific to BT work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -603,8 +603,10 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   *Source: CONCERN-2413*
 - **Verify Issue ACs Against Current Code Before Starting** — an issue may already
   be fully implemented by a prior PR that did not include a `Closes #N` footer.
-  Check current `main` against all ACs before writing any code; if satisfied, close
-  the issue with a reference comment instead. *Sources: ISSUE-1510, ISSUE-1484*
+  The build and bugfix skills each enforce a pre-claim gate for this; see the
+  "Pre-claim AC verification gate" step in `.agents/skills/build/SKILL.md` Phase 2
+  and the "Pre-claim defect verification" step in `.agents/skills/bugfix/SKILL.md`
+  Phase 1. *Sources: ISSUE-1510, ISSUE-1484*
 - **Docs/Learn PRs That Fix a Bug Must Include `Closes #N`** — when a docs PR
   fixes a bug as a side effect, the closing footer is the only thing that
   closes the issue automatically. Without it the issue stays OPEN after merge.
@@ -880,11 +882,12 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   convert the field to a `>-` block scalar and use apostrophes freely.
   *Source: ISSUE-2393*
 - **Always Verify Every Acceptance Criterion Against `origin/main` Before
-  Implementing** — check each stated defect and AC in the issue body against
-  current `origin/main` HEAD before writing any code. A prior PR may have
-  partially fixed the issue without a `Closes #N` footer, leaving the issue
-  open but the code already changed. Implement only what is still broken.
-  *Source: ISSUE-1467, ISSUE-2290*
+  Implementing** — a prior PR may have partially satisfied an issue without a
+  `Closes #N` footer. Implement only what is still unmet. The pre-claim gates
+  in the build and bugfix skills enforce this check before branching; see
+  `.agents/skills/build/SKILL.md` Phase 2 § "Pre-claim AC verification gate"
+  and `.agents/skills/bugfix/SKILL.md` Phase 1 § "Pre-claim defect
+  verification". *Source: ISSUE-1467, ISSUE-2290*
 - **Sub-Agent Spec Splits: Re-Run the Violation Detection Script After the
   Parallel Pass** — after parallel sub-agents split compound spec requirements,
   re-run the compound-statement detection script. Agents frequently add new

--- a/plan/incoming/learnings/20260826-issue-type-null-fallback.md
+++ b/plan/incoming/learnings/20260826-issue-type-null-fallback.md
@@ -1,0 +1,22 @@
+---
+title: "issueType: null in GraphQL requires content-based fallback"
+type: learning
+timestamp: "2026-08-26"
+source: ISSUE-2643
+signal: process-issue
+---
+
+Issues #2643 and #2644 both returned `issueType: null` from the
+`query-issue-type.sh` GraphQL query. The `work-issue` routing skill says
+to stop on unrecognized types, but the issues clearly belonged to the
+Task/Feature path based on their body structure (AC-N acceptance criteria,
+implementation-focused summary).
+
+When `issueType` is null, inspect the issue body before stopping: presence
+of `- [ ] AC-N:` items and an implementation-focused Summary section reliably
+identifies Task-type issues. Proceed with the Task routing path rather than
+halting on the null.
+
+This is distinct from a genuinely unrecognized type (e.g., a string value
+not in the supported set). A null type signals "no type set in GitHub" — it
+does not signal an unsupported type.

--- a/vultron/core/behaviors/AGENTS.md
+++ b/vultron/core/behaviors/AGENTS.md
@@ -135,9 +135,10 @@ not sufficient without the persist. See `notes/participant-embargo-consent.md`
 ## Compose Before Create: Node Discovery Gate
 
 Before writing any new BT emit, send, or state-transition node in this
-package, run the compose-before-create procedure from
-`.agents/skills/shared/compose-before-create.md`, then apply these
-BT-specific checks (BTND-07-005, BTND-07-009, BTND-07-010):
+package, run the BT Domain section of
+`.agents/skills/shared/compose-before-create.md` (node inventory grep,
+then return here), then apply these BT-specific checks
+(BTND-07-005, BTND-07-009, BTND-07-010):
 
 1. **Use the domain base class**: for emit/send nodes, subclass the
    appropriate base from the table below and override only `_call_factory()`

--- a/vultron/core/behaviors/AGENTS.md
+++ b/vultron/core/behaviors/AGENTS.md
@@ -135,13 +135,11 @@ not sufficient without the persist. See `notes/participant-embargo-consent.md`
 ## Compose Before Create: Node Discovery Gate
 
 Before writing any new BT emit, send, or state-transition node in this
-package, perform these checks (BTND-07-005, BTND-07-009, BTND-07-010):
+package, run the compose-before-create procedure from
+`.agents/skills/shared/compose-before-create.md`, then apply these
+BT-specific checks (BTND-07-005, BTND-07-009, BTND-07-010):
 
-1. **Inventory existing nodes**: grep `vultron/core/behaviors/<domain>/nodes/`
-   for classes with overlapping protocol state, domain, or action semantics.
-   If a match exists, compose or subclass — do not re-implement.
-
-2. **Use the domain base class**: for emit/send nodes, subclass the
+1. **Use the domain base class**: for emit/send nodes, subclass the
    appropriate base from the table below and override only `_call_factory()`
    and the hook methods. Do not write a new `update()` from scratch.
 
@@ -157,13 +155,11 @@ package, perform these checks (BTND-07-005, BTND-07-009, BTND-07-010):
    class unless you have confirmed no existing base covers your
    guard+emit+outbox pattern.
 
-3. **AC-1 compliance**: any node reading EM/RM/CS state MUST go through
+2. **AC-1 compliance**: any node reading EM/RM/CS state MUST go through
    `Read*StateNode`; any node writing it MUST go through `Write*StateNode`.
    Inline reads/writes are AC-1 violations.
 
-See `vultron/core/behaviors/AGENTS.md` (this file) whenever you are about
-to add a node in this package — the build skill's Phase 4 gate references
-it. Specs: BTND-07-005, BTND-07-009, BTND-07-010, BTC-01-001.
+Specs: BTND-07-005, BTND-07-009, BTND-07-010, BTC-01-001.
 
 ---
 


### PR DESCRIPTION
- Closes #2643
- Closes #2644

## Summary

Adds two pre-claim gates that prevent agents from claiming issues that are
already satisfied or already fixed on `origin/main`, and generalizes the
compose-before-create DRY principle from BT-only to all domain subsystems.

## Changes

- **`.agents/skills/build/SKILL.md`**: Phase 2 gains a new step 6
  "Pre-claim AC verification gate" — fetches issue body, checks each
  `- [ ] AC-N:` item against `origin/main` HEAD, closes issue with reference
  comment if all ACs are already satisfied. Phase 4 gains a compose-before-create
  gate as step 1 (blocking, all domain types). Step 8 clarifies it supersedes
  the step-6 partial fetch.
- **`.agents/skills/bugfix/SKILL.md`**: Phase 1 gains step 4.5 "Pre-claim
  defect verification" — confirms described defect still exists on
  `origin/main`; closes issue if absent. Phase 4 (Implement) gains step 0
  compose-before-create gate before writing any new code.
- **`.agents/skills/shared/compose-before-create.md`** (new): general DRY
  principle + per-subsystem search patterns for use cases (`vultron/core/use_cases/`),
  wire handlers (`vultron/wire/as2/`), adapters (`vultron/adapters/`), demo
  helpers (`vultron/demo/helpers/`), and BT nodes (with node inventory grep).
- **`vultron/core/behaviors/AGENTS.md`**: "Compose Before Create" section
  — 4-step workflow procedure replaced with pointer to shared file; domain
  base-class table retained; entry point made explicit ("run BT Domain section
  of compose-before-create.md, then return here").
- **`AGENTS.md`**: both "Verify Issue ACs" pitfall entries updated to point
  to the skill gates rather than describing the procedure inline.

## Verification

- All 7807 unit tests pass (0 new — skill/doc only change)
- Integration tests pass (0 Python changed)
- Black, flake8, mypy, pyright clean
- markdownlint clean