### PR TITLE
docs: plan issue #2595 — split VFD state machine into vendor-path and deployer-path sub-machines

### DIFF
--- a/docs/adr/0075-split-vfd-state-machine.md
+++ b/docs/adr/0075-split-vfd-state-machine.md
@@ -1,0 +1,100 @@
+---
+status: accepted-provisional
+date: 2026-08-26
+deciders: Allen D. Householder
+consulted: []
+informed: []
+---
+
+# Split Per-Participant VFD Tracking into Separate Vendor-Path and Deployer-Path Sub-Machines
+
+## Context and Problem Statement
+
+The `CS_vfd` sub-machine couples vendor-awareness (`v→V`), fix-readiness
+(`f→F`), and fix-deployment (`d→D`) transitions into a single 4-state chain
+(`vfd → Vfd → VFd → VFD`) for all participants regardless of their CVD role.
+This creates a semantic mismatch: `V` and `F` transitions are only meaningful for
+VENDOR participants (who develop and supply fixes), while `D` transitions are only
+meaningful for DEPLOYER participants (who apply fixes in their own environments).
+
+For a DEPLOYER-only participant the `vfd` field could never advance past `vfd`
+through normal V/F transitions, requiring a workaround: the `CS_vfd.vfd` null
+element doubled as both "initial state" and "not applicable". This workaround
+was addressed at the guard layer (CSB-15-004 causal gate, PR #2593) but left the
+data-model ambiguity in place. See CONCERN-2595 for the full context.
+
+## Decision Drivers
+
+- The `CS_vfd.vfd` "null element" was overloaded: it meant both "vendor unaware,
+  fix not ready, not deployed" (initial state for VENDORs) and "not applicable"
+  (for DEPLOYER-only and non-VFD participants).
+- BT guards compensated for data-model ambiguity rather than preventing
+  structurally impossible states.
+- A participant's permitted transitions should be derivable from its role without
+  runtime guards.
+
+## Considered Options
+
+- **Direction 1** — keep `CS_vfd` monolithic; enforce via guards only
+- **Direction 2** — add a role predicate to `ParticipantStatus` to gate VFD
+  sub-field access at runtime
+- **Direction 3a** — split at the per-participant level into two nullable fields:
+  `vf: VfDimension | None` (vendor path, 3 states) and `d: DDimension | None`
+  (deployer path, 2 states); structural `None` for inapplicable roles
+- **Direction 3b** — split `CS_vfd` into a compound type with optional V/F and
+  optional D parts at the case-aggregate level
+
+## Decision Outcome
+
+Chosen option: **Direction 3a** — split at the per-participant level with two
+nullable fields on `ParticipantStatus`.
+
+Rationale: structural `None` makes role-based inapplicability unrepresentable
+rather than merely rejected at runtime. A DEPLOYER-only participant literally
+cannot have a `vf` value (it is `None`); a VENDOR-only participant cannot have a
+`d` value. This eliminates the guard-compensating pattern for role checks on these
+dimensions. Direction 1 leaves the ambiguity intact. Direction 2 adds runtime
+predicates without removing the ambiguous field. Direction 3b changes the
+case-aggregate CS model, which is orthogonal and unnecessary — the compound
+`CS_vfd` (4 states) at the case level is unchanged.
+
+The implementation is sequenced as three additive+removable tasks:
+
+- #2662 — Add `CS_vf`, `CS_d`, `VfDimension`, `DDimension` (additive)
+- #2663 — Migrate `ParticipantStatus.vfd` to `vf`/`d` fields
+- #2664 — Remove `CS_vfd`, `VfdDimension`, and retired guard nodes
+
+Status is `accepted-provisional` because implementation is not yet complete;
+the spec changes and model_validator contract are the validated direction, but
+the final shape may be refined during #2663.
+
+### Consequences
+
+- Good, because role-based inapplicability becomes structural — no guard needed
+  for "does this participant have a vendor path?"
+- Good, because `ParticipantStatus` construction validates role-dimension
+  invariants at object-creation time, raising `VultronValidationError` on
+  violation rather than silently accepting impossible states.
+- Good, because the case-level `CS_vfd` 4-state enum and `cs_invariants.py`
+  history validity logic are unchanged — the split is per-participant only.
+- Bad, because migration of all `ParticipantStatus.vfd_state` call sites (#2663)
+  is a large mechanical change requiring careful review.
+- Neutral, because the compound CS state (VFD × PXA, 32 members) is unaffected;
+  `CSB-17-001` remains valid.
+
+## Validation
+
+Validated by the `model_validator(mode='after')` on `ParticipantStatus` that
+enforces the role-dimension invariant table (see `notes/case-state-model.md`
+§ "Role-Specific VFD Access"). Implementation tasks #2662–#2664 will add unit
+tests confirming that construction with a violated invariant raises
+`VultronValidationError`.
+
+## More Information
+
+- Planning learning: `plan/history/2608/learning/CONCERN-2595.md`
+- Follow-on concern (fine-grained vendor-deployer dependency tracking): #2665
+- Immediate workaround (guard layer): PR #2593, CONCERN-2595
+
+Generated spec requirements: `specs/cs-behavior.yaml` CSB-15-001, CSB-15-002,
+CSB-15-004, CSB-16-001.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -144,6 +144,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0072 Use a Dedicated `stories:` Field for Spec-to-Story Traceability (Not `relationships:`)](0072-stories-field-for-spec-to-story-traceability.md)
 - [ADR-0073 Give Each Actor Its Own Store; Delete the Unscoped DataLayer](0073-per-actor-storage-isolation.md)
 - [ADR-0074 Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal](0074-wire-activity-artifact-immutability.md)
+- [ADR-0075 Split Per-Participant VFD Tracking into Separate Vendor-Path and Deployer-Path Sub-Machines](0075-split-vfd-state-machine.md) *(provisional)*
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -295,6 +295,7 @@ nav:
       - 'Use a Dedicated stories: Field for Spec-to-Story Traceability': 'adr/0072-stories-field-for-spec-to-story-traceability.md'
       - Give Each Actor Its Own Store; Delete the Unscoped DataLayer: 'adr/0073-per-actor-storage-isolation.md'
       - 'Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal': 'adr/0074-wire-activity-artifact-immutability.md'
+      - 'Split Per-Participant VFD Tracking into Separate Vendor-Path and Deployer-Path Sub-Machines': 'adr/0075-split-vfd-state-machine.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -240,8 +240,9 @@ behavior.
 
 | State dimension | Participant-Specific or Agnostic? | Where tracked |
 |-----------------|----------------------------------|---------------|
-| RM state | **Participant-specific** | `ParticipantStatus.rm_state` |
-| VFD (Vendor Fix Deployment) path | **Participant-specific** (only for Vendors/Deployers) | `ParticipantStatus.vfd_state` |
+| RM state | **Participant-specific** | `ParticipantStatus.rm` |
+| VF (Vendor Awareness / Fix Ready) path | **Participant-specific** (VENDOR role only; `None` for others) | `ParticipantStatus.vf` |
+| D (Fix Deployed) path | **Participant-specific** (DEPLOYER role only; `None` for others) | `ParticipantStatus.d` |
 | EM (Embargo Management) state | **Participant-agnostic** (global per case) | `CaseStatus.em_state` |
 | PXA (Public/Exploit/Attack) sub-state | **Participant-agnostic** (global per case) | `CaseStatus.pxa_state` |
 
@@ -249,8 +250,13 @@ In the Mermaid diagram from `docs/topics/process_models/model_interactions/index
 
 ```text
 Participant-Agnostic: EM ↔ CS_pxa
-Participant-Specific: RM ↔ CS_vfd
+Participant-Specific: RM ↔ CS_vf (vendor path) + CS_d (deployer path)
 ```
+
+The vendor and deployer paths are **structurally separated**: `ParticipantStatus.vf`
+is `None` for non-VENDOR participants, and `ParticipantStatus.d` is `None` for
+non-DEPLOYER participants. A `model_validator` on `ParticipantStatus` enforces both
+directions of this invariant at construction time and raises on violation.
 
 ### Implementation: CaseStatus vs. ParticipantStatus
 
@@ -265,8 +271,11 @@ The canonical Python implementation is in
 
 **`ParticipantStatus`** — participant-specific, one per (actor × case) pair:
 
-- `rm_state: RM` — Report management state (default `RM.START`)
-- `vfd_state: CS_vfd` — Vendor fix path sub-state (default `CS_vfd.vfd`)
+- `rm: RmDimension` — Report management state (default `RM.START`)
+- `vf: VfDimension | None` — Vendor-path sub-state (`CS_vf`: `vf` → `Vf` → `VF`);
+  `None` for non-VENDOR participants (structurally enforced)
+- `d: DDimension | None` — Deployer-path sub-state (`CS_d`: `d` → `D`);
+  `None` for non-DEPLOYER participants (structurally enforced)
 - `actor` — references the participant Actor
 - `context` — references the `VulnerabilityCase`
 - `case_engagement: bool` — whether participant is engaged
@@ -275,20 +284,28 @@ The canonical Python implementation is in
 - `case_status: CaseStatus | None` — optionally embeds the shared case status
 
 Note that `ParticipantStatus` MAY embed a `CaseStatus` for convenience when
-presenting the full participant state as a triple `(rm_state, vfd_state,
-case_status)`, corresponding to the formal protocol's participant state tuple
-`(q^rm, q^em, q^cs)`.
+presenting the full participant state, corresponding to the formal protocol's
+participant state tuple `(q^rm, q^em, q^cs)`.
 
 ### Role-Specific VFD Access
 
-Not all participants have a VFD state:
+The `vf` and `d` fields are structurally assigned by participant role. The
+`model_validator` on `ParticipantStatus` enforces both directions:
 
-- **Vendors**: Have `vfd_state` in `{Vfd, VFd, VFD}` (plus `VFD` only if they
-  also deploy). They enter at `Vfd` (vendor aware) by definition.
-- **Non-Vendor Deployers**: Have `vfd_state` only for the `d → D` transition.
-- **Finders, Reporters, Coordinators**: Do NOT have VFD state. Use the null
-  element `∅` (represented as `CS_vfd.vfd` but semantically "not applicable"
-  for non-vendors — see `vultron/core/states/cs.py`).
+| Role(s) | `vf` | `d` |
+|---------|------|-----|
+| VENDOR only | `VfDimension()` (non-None, required) | `None` (required) |
+| DEPLOYER only | `None` (required) | `DDimension()` (non-None, required) |
+| VENDOR + DEPLOYER | `VfDimension()` (non-None, required) | `DDimension()` (non-None, required) |
+| Finder / Reporter / Coordinator / Observer | `None` (required) | `None` (required) |
+
+Attempting to construct a `ParticipantStatus` that violates this invariant
+raises `VultronValidationError` immediately — it is never silently corrected.
+
+The previous single-field `vfd: VfdDimension` (using `CS_vfd` with 4 states
+`vfd → Vfd → VFd → VFD`) is replaced by these two nullable fields. The old
+`CS_vfd.vfd` "null element" workaround for non-applicable participants is
+superseded by structural `None`.
 
 ### Consequence for Handler Implementation
 
@@ -298,8 +315,9 @@ When handlers process incoming Activities:
   Update `ParticipantStatus.rm_state` for the **sending actor's**
   `CaseParticipant`.
 - **VFD transitions** (e.g., a vendor signaling fix readiness):
-  Update `ParticipantStatus.vfd_state` for the **sending actor's**
-  `CaseParticipant`.
+  Advance `ParticipantStatus.vf` (for VENDOR actors) or `ParticipantStatus.d`
+  (for DEPLOYER actors) on the **sending actor's** `CaseParticipant`. Only the
+  applicable dimension is non-None; the other remains `None` (structural).
 - **EM transitions** (e.g., `accept_embargo`):
   Update `CaseStatus.em_state` — this is **shared** and affects all
   participants.

--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -312,7 +312,7 @@ superseded by structural `None`.
 When handlers process incoming Activities:
 
 - **RM state transitions** (e.g., `engage_case`, `defer_case`):
-  Update `ParticipantStatus.rm_state` for the **sending actor's**
+  Update `ParticipantStatus.rm` for the **sending actor's**
   `CaseParticipant`.
 - **VFD transitions** (e.g., a vendor signaling fix readiness):
   Advance `ParticipantStatus.vf` (for VENDOR actors) or `ParticipantStatus.d`

--- a/plan/history/2608/learning/CONCERN-2595.md
+++ b/plan/history/2608/learning/CONCERN-2595.md
@@ -1,0 +1,64 @@
+---
+source: CONCERN-2595
+timestamp: '2026-08-26T17:19:02.208994+00:00'
+title: Split VFD state machine into vendor-path and deployer-path sub-machines
+type: learning
+---
+
+## Concern
+
+CS_vfd couples the vendor-path (v→V, f→F) and deployer-path (d→D) transitions in a
+single 4-state chain, making the data model ambiguous about which transitions apply
+to a given participant role. The immediate workaround (CSB-15-004 causal gate, #2593)
+addresses the symptom at the guard layer; the structural concern is whether the state
+machine should be split.
+
+## Decision
+
+Split at the per-participant level (Direction 3a). `CS_vfd` / `VfdDimension` are
+replaced by two separate sub-machines:
+
+- **Vendor path** (`CS_vf`, 3 states: `vf` → `Vf` → `VF`): only for VENDOR participants
+- **Deployer path** (`CS_d`, 2 states: `d` → `D`): only for DEPLOYER participants
+
+`ParticipantStatus.vfd` becomes two nullable fields:
+
+- `vf: VfDimension | None = None` — `None` for non-VENDOR participants (structural)
+- `d: DDimension | None = None` — `None` for non-DEPLOYER participants (structural)
+
+A `model_validator(mode='after')` enforces both directions of the role-dimension
+invariant at construction time and raises `VultronValidationError` on violation.
+The old `CS_vfd.vfd` null-element workaround for non-applicable participants is
+superseded by structural `None`.
+
+CSB-15-001 (VENDOR required for f→F) and CSB-15-002 (DEPLOYER required for d→D)
+become structurally enforced at object-construction time rather than BT guard checks.
+CSB-15-004 (d→D only if some vendor has `vf.state=VF`) remains a cross-participant
+BT guard.
+
+Wire format: `vfd_state` removed; replaced by `vf_state: CS_vf | None` and
+`d_state: CS_d | None`. No backward-compat migration shim.
+
+`cs_invariants.py` event-sequence logic is unchanged — V/F events originate from `vf`
+dimension transitions and D events from `d` dimension transitions; the sequence
+constraints remain valid at the case-history level.
+
+## Out of scope
+
+Fine-grained vendor-deployer dependency tracking (which specific vendor does a given
+deployer depend on before they can deploy) is not tracked anywhere. The generic
+CSB-15-004 gate ("some vendor at VF") is the correct bound for now. A follow-on
+Concern is open at #2665.
+
+## Implementation ratchet chain
+
+Three sequenced Task issues (each leaves system green):
+
+- #2662 — Add `CS_vf`, `CS_d`, `VfDimension`, `DDimension` (additive, size:S)
+- #2663 — Split `ParticipantStatus.vfd` into `vf`/`d`, migrate all call sites (size:L)
+- #2664 — Remove `CS_vfd`, `VfdDimension`, retired guard nodes (size:S)
+
+## Reference
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2661>
+Follow-on Concern: #2665

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -1672,35 +1672,38 @@ groups:
     priority: MUST
     kind: protocol
     statement: >-
-      An Actor self-reporting a fix-ready transition (f→F, vfd_state=VFd) via the
+      An Actor self-reporting a fix-ready transition (f→F, vf.state=VF) via the
       trigger path MUST hold CVDRole.VENDOR in the case; the transition MUST be
-      blocked (FAILURE) when CVDRole.VENDOR is absent.
+      blocked (FAILURE) when CVDRole.VENDOR is absent. Under the structural VFD
+      split (Concern #2595), this requirement is enforced at object-construction
+      time: only VENDOR participants have a non-None `vf` dimension, making
+      non-VENDOR actors structurally incapable of advancing the vendor path.
     rationale: >-
       Fix readiness (F event) represents that the actor has produced a fix. Only
       actors who develop or maintain the affected product (Vendors) can produce a
       fix; Deployers operate existing deployments and do not produce fixes. Finders,
       Reporters, and Coordinators likewise MUST NOT self-report fix readiness.
-      Without this guard, non-vendor actors can incorrectly advance their participant
-      VFD state, producing misleading case state records.
+      The structural split (ParticipantStatus.vf is None for non-VENDOR actors)
+      makes this a data-model invariant rather than a BT guard check.
     verification: >-
-      Integration tests in `test/demo/` confirm that the fix-ready trigger returns
-      FAILURE for actors without CVDRole.VENDOR and creates ParticipantStatus
-      with vfd_state=VFd only for VENDOR actors.
+      Unit tests confirm that constructing a ParticipantStatus with CVDRole.VENDOR
+      absent and vf non-None raises VultronValidationError; integration tests confirm
+      that the fix-ready trigger returns FAILURE for actors without CVDRole.VENDOR.
     testable: true
     preconditions:
-    - description: Actor requests vfd_state=VFd via the trigger path
+    - description: Actor requests f→F (vf.state=VF) via the trigger path
     steps:
     - order: 1
       actor: trigger
       action: Check that the requesting actor holds CVDRole.VENDOR in the case
-        participant record
+        participant record (equivalently, that vf is non-None)
       expected: Role check passes for VENDOR; FAILURE returned otherwise
     - order: 2
       actor: trigger
-      action: If role check passes, create ParticipantStatus with vfd_state=VFd
-      expected: Status record created; activity emitted to Case Manager
+      action: If role check passes, advance vf dimension to vf.state=VF
+      expected: ParticipantStatus updated; activity emitted to Case Manager
     postconditions:
-    - description: Only VENDOR actors may record vfd_state=VFd; all others receive FAILURE
+    - description: Only VENDOR actors may record vf.state=VF; all others receive FAILURE
     relationships:
     - rel_type: constrains
       spec_id: CSB-02-001
@@ -1713,36 +1716,39 @@ groups:
     priority: MUST
     kind: protocol
     statement: >-
-      An Actor self-reporting a fix-deployed transition (d→D, vfd_state=VFD) via the
+      An Actor self-reporting a fix-deployed transition (d→D, d.state=D) via the
       trigger path MUST hold CVDRole.DEPLOYER in the case; the transition MUST be blocked
-      (FAILURE) when CVDRole.DEPLOYER is absent.
+      (FAILURE) when CVDRole.DEPLOYER is absent. Under the structural VFD split
+      (Concern #2595), this requirement is enforced at object-construction time: only
+      DEPLOYER participants have a non-None `d` dimension, making non-DEPLOYER actors
+      structurally incapable of advancing the deployer path.
     rationale: >-
       Fix deployment (D event) represents applying a fix in one's own environment.
       Only actors who are responsible for operating deployed instances (Deployers) can
       perform this action. A shipping-product Vendor who does not control downstream
-      deployment holds only CVDRole.VENDOR, not CVDRole.DEPLOYER, and MUST stop at VFd.
-      Without this guard, vendor-only actors reach VFD, misrepresenting the protocol's
-      distinction between fix availability and fix deployment.
+      deployment holds only CVDRole.VENDOR, not CVDRole.DEPLOYER, and has no `d`
+      dimension. The structural split makes this a data-model invariant rather than
+      a BT guard check.
     verification: >-
-      Integration tests in `test/demo/` confirm that the fix-deployed trigger returns
-      FAILURE for actors without CVDRole.DEPLOYER and creates ParticipantStatus
-      with vfd_state=VFD only for DEPLOYER actors.
+      Unit tests confirm that constructing a ParticipantStatus with CVDRole.DEPLOYER
+      absent and d non-None raises VultronValidationError; integration tests confirm
+      that the fix-deployed trigger returns FAILURE for actors without CVDRole.DEPLOYER.
     testable: true
     preconditions:
-    - description: Actor requests vfd_state=VFD via the trigger path
+    - description: Actor requests d→D (d.state=D) via the trigger path
     steps:
     - order: 1
       actor: trigger
       action: Check that the requesting actor holds CVDRole.DEPLOYER in the case
-        participant record
+        participant record (equivalently, that d is non-None)
       expected: Role check passes for DEPLOYER; FAILURE returned for VENDOR-only or
         any other non-DEPLOYER actor
     - order: 2
       actor: trigger
-      action: If role check passes, create ParticipantStatus with vfd_state=VFD
-      expected: Status record created; activity emitted to Case Manager
+      action: If role check passes, advance d dimension to d.state=D
+      expected: ParticipantStatus updated; activity emitted to Case Manager
     postconditions:
-    - description: Only DEPLOYER actors may record vfd_state=VFD; all others receive FAILURE
+    - description: Only DEPLOYER actors may record d.state=D; all others receive FAILURE
     relationships:
     - rel_type: constrains
       spec_id: CSB-03-001
@@ -1778,12 +1784,12 @@ groups:
       expected: Public awareness recorded
     - order: 2
       actor: trigger
-      action: Leave vfd_state unchanged (do not set vfd_state=VFD)
-      expected: vfd_state reflects prior state; D event not triggered by P event
+      action: Leave vf and d dimensions unchanged (do not advance d.state=D)
+      expected: vf and d reflect prior state; D event not triggered by P event
     postconditions:
     - description: >-
-        ParticipantStatus records pxa_state=Pxa; vfd_state is not modified by
-        this trigger; actors wishing to report VFD must call notify-fix-deployed
+        ParticipantStatus records pxa_state=Pxa; vf and d dimensions are not modified by
+        this trigger; actors wishing to report fix deployment must call notify-fix-deployed
         separately (and must hold CVDRole.DEPLOYER per CSB-15-002)
     relationships:
     - rel_type: constrains
@@ -1800,59 +1806,59 @@ groups:
     kind: protocol
     statement: >-
       A DEPLOYER-only actor (holds CVDRole.DEPLOYER but not CVDRole.VENDOR)
-      attempting the d→D transition MUST be permitted to proceed when at least one
-      participant holding CVDRole.VENDOR in the same case has reached VFd state
-      (fix-ready). The DEPLOYER-only actor''s own participant VFD state prior to
-      the transition is vfd; the resulting ParticipantStatus snapshot records
-      vfd_state=VFD, reflecting deployment of an externally-produced fix.
+      attempting the d→D transition MUST be permitted to proceed only when at least
+      one participant holding CVDRole.VENDOR in the same case has reached vf.state=VF
+      (fix-ready). The DEPLOYER-only actor has vf=None (structural) and
+      d=DDimension(state=CS_d.d) prior to the transition; the transition advances
+      d.state to CS_d.D, reflecting deployment of an externally-produced fix.
     rationale: >-
-      A pure Deployer does not develop or supply the fix; V (vendor awareness)
-      and F (fix readiness) transitions carry no semantic meaning for a
-      DEPLOYER-only participant. The causal gate — requiring at least one VENDOR
-      to be at VFd or VFD — captures the real-world dependency: a Deployer can
-      only apply a fix that exists. Checking the DEPLOYER-only participant''s own
-      VFD state (as the existing CheckCSFixNotYetDeployed guard does) permanently
-      blocks d→D because the participant can never reach VFd through normal V and
-      F transitions. The vfd→VFD snapshot is semantically correct for a Deployer:
-      it records that the deployment event occurred; V and F are not separately
-      recorded because they do not apply to this actor.
+      Under the structural VFD split (Concern #2595), a DEPLOYER-only participant
+      has vf=None (structural absence) and d=DDimension (deployer path only). The
+      causal gate — requiring at least one VENDOR participant to have vf.state=VF —
+      captures the real-world dependency: a Deployer can only apply a fix that
+      exists. The previous model required checking the DEPLOYER-only participant''s
+      own vfd_state, which was permanently stuck at vfd because V and F transitions
+      did not apply. The split resolves this cleanly: the deployer''s d dimension
+      starts at CS_d.d and advances to CS_d.D when the causal gate passes; the vf
+      dimension is structurally absent throughout.
+      Note: this constraint is generic — "some VENDOR must be at VF" — because the
+      system does not yet track which specific vendor a given deployer depends on.
+      Finer-grained vendor-deployer dependency tracking is a separate Concern.
     verification: >-
-      Integration tests in `test/demo/` confirm that the fix-deployed trigger returns
-      FAILURE for a DEPLOYER-only actor when no VENDOR participant in the case is at
-      VFd or VFD (causal gate not satisfied), and creates ParticipantStatus with
-      vfd_state=VFD for a DEPLOYER-only actor when at least one VENDOR participant
-      is at VFd or VFD.
+      Integration tests confirm that the fix-deployed trigger returns FAILURE for a
+      DEPLOYER-only actor when no VENDOR participant in the case has vf.state=VF
+      (causal gate not satisfied), and advances d.state=D for a DEPLOYER-only actor
+      when at least one VENDOR participant has vf.state=VF.
     testable: true
     preconditions:
     - description: >-
-        Actor holds CVDRole.DEPLOYER but not CVDRole.VENDOR in the case;
-        at least one other participant holds CVDRole.VENDOR and has VFd or VFD
-        participant VFD state
+        Actor holds CVDRole.DEPLOYER but not CVDRole.VENDOR in the case (vf=None,
+        d=DDimension(state=CS_d.d)); at least one other participant holds
+        CVDRole.VENDOR and has vf.state=VF
     steps:
     - order: 1
       actor: trigger
       action: >-
-        Check that the requesting actor holds CVDRole.DEPLOYER; check that it
-        does not hold CVDRole.VENDOR; check that at least one participant in
-        the case holds CVDRole.VENDOR and has VFd or VFD state (causal gate)
+        Check that the requesting actor holds CVDRole.DEPLOYER and not CVDRole.VENDOR
+        (equivalently, d is non-None and vf is None); check that at least one
+        participant in the case holds CVDRole.VENDOR and has vf.state=VF (causal gate)
       expected: All checks pass; d→D transition allowed
     - order: 2
       actor: trigger
-      action: Create ParticipantStatus with vfd_state=VFD
+      action: Advance d dimension to d.state=D
       expected: >-
-        Status record created with vfd_state=VFD (prior state was vfd);
+        d.state=D (prior state was CS_d.d); vf remains None;
         activity emitted to Case Manager
     postconditions:
     - description: >-
-        DEPLOYER-only participant records vfd_state=VFD; at least one VENDOR
-        participant remains at VFd or VFD in the same case
+        DEPLOYER-only participant records d.state=D (vf=None throughout); at least
+        one VENDOR participant has vf.state=VF in the same case
     relationships:
     - rel_type: refines
       spec_id: CSB-15-002
       note: >-
         CSB-15-002 gates d→D on CVDRole.DEPLOYER; CSB-15-004 adds the causal
-        precondition for DEPLOYER-only actors whose own VFD state never reaches
-        VFd through V and F transitions
+        precondition requiring at least one VENDOR to have vf.state=VF first
     tags:
     - state-machine
     - protocol

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -1764,16 +1764,20 @@ groups:
       The notify-published trigger endpoint MUST set only pxa_state=Pxa in the
       ParticipantStatus record. The D event (fix deployed) is participant-specific
       and distinct from the P event (public awareness); notify-published MUST NOT
-      also modify vfd_state.
+      also advance the d dimension.
     rationale: >-
       Conflating P and D transitions (as notify-published did by setting both
-      vfd_state=VFD and pxa_state=Pxa) causes non-deployer actors (Finders,
-      Reporters, Coordinators) to incorrectly acquire VFD state when they announce
-      public disclosure. The pxa (P event) is participant-agnostic; the VFD (D event)
-      is only valid for DEPLOYER-role actors who have separately completed deployment.
+      d.state=D and pxa_state=Pxa) causes non-deployer actors (Finders,
+      Reporters, Coordinators) to incorrectly acquire deployment state when they
+      announce public disclosure. Under the structural VFD split (Concern #2595),
+      the d dimension is None for non-DEPLOYER participants, making this invariant
+      structural rather than a guard check. The pxa (P event) is participant-agnostic;
+      the D event is only valid for DEPLOYER-role actors who have separately completed
+      deployment.
     verification: >-
       Integration tests in `test/demo/` confirm that notify-published sets only
-      pxa_state=Pxa in the ParticipantStatus record and leaves vfd_state unmodified.
+      pxa_state=Pxa in the ParticipantStatus record and leaves the vf and d
+      dimensions unmodified.
     testable: true
     preconditions:
     - description: Actor calls the notify-published trigger endpoint
@@ -1878,43 +1882,54 @@ groups:
     priority: MUST
     kind: protocol
     statement: >-
-      A BT node or helper that writes a VFD state (CS_vfd) to a ParticipantStatus
-      snapshot MUST validate that the (current_vfd_state → target_vfd_state)
-      transition is permitted by the VFD state machine before persisting.
-      A same-state write is permitted (status confirmation). A backward move or
-      illegal jump (e.g. vfd → VFD skipping Vfd) MUST cause the node to return
-      Status.FAILURE without writing to the DataLayer.
+      A BT node or helper that advances a participant''s vendor-path (vf) or
+      deployer-path (d) dimension in a ParticipantStatus snapshot MUST validate
+      that the (current → target) transition is permitted by the respective
+      sub-machine (CS_vf for vendor path; CS_d for deployer path) before
+      persisting. A same-state write is permitted (status confirmation). A backward
+      move or illegal jump MUST cause the node to return Status.FAILURE without
+      writing to the DataLayer.
     rationale: >-
-      Upstream BT guards (e.g. CheckCSFixNotYetDeployed) are necessary but
-      insufficient: a guard that is too weak, missing, or bypassed allows an
-      invalid VFD state jump to reach the write node unchecked. Validating at
-      the write boundary makes illegal VFD transitions fail-closed regardless
-      of guard coverage. Source: concern #1896, which surfaced when the
-      CheckCSFixNotYetDeployed guard was too weak in issue #1825.
+      Upstream BT guards are necessary but insufficient: a guard that is too weak,
+      missing, or bypassed allows an invalid state jump to reach the write node
+      unchecked. Validating at the write boundary makes illegal transitions
+      fail-closed regardless of guard coverage. Source: concern #1896, which
+      surfaced when the CheckCSFixNotYetDeployed guard was too weak in issue #1825.
+      Under the structural VFD split (Concern #2595), the validation applies
+      independently to each dimension: is_valid_vf_transition() for the vendor
+      path and is_valid_d_transition() for the deployer path. A node that writes
+      both dimensions (VENDOR+DEPLOYER participants) must validate each independently.
       Scope: applies to local write nodes only. The received-wire path
       (add_participant_status_tree) uses a weaker monotonic-forward check
-      intentionally — remote peers may advance through multiple VFD steps
-      between status messages; strict adjacency applies only to local writes.
+      intentionally — remote peers may advance through multiple steps between
+      status messages; strict adjacency applies only to local writes.
     verification: >-
-      A unit test confirms that the VFD write boundary returns Status.FAILURE for
-      illegal jumps (e.g. vfd→VFD skipping Vfd) and that no ParticipantStatus
-      record is persisted for an invalid transition.
+      Unit tests confirm that vf-write and d-write boundaries each return
+      Status.FAILURE for illegal jumps and that no ParticipantStatus record is
+      persisted for an invalid transition on either dimension.
     testable: true
     preconditions:
-    - description: A non-None CS_vfd target state is passed to a ParticipantStatus write node
+    - description: >-
+        A non-None target vf state (for VENDOR path) or d state (for DEPLOYER path)
+        is passed to a ParticipantStatus write node
     steps:
     - order: 1
       actor: write_node
-      action: Read the participant's current VFD state from the DataLayer
-      expected: Current CS_vfd state available
+      action: >-
+        Read the participant''s current vf state (if VENDOR) or d state (if DEPLOYER)
+        from the DataLayer
+      expected: Current dimension state available; absent dimension is None (structural)
     - order: 2
       actor: write_node
       action: >-
-        If target == current, proceed. If is_valid_vfd_transition(current, target)
-        is True, proceed. Otherwise return Status.FAILURE.
+        For each non-None dimension: if target == current, proceed. If
+        is_valid_vf_transition(current, target) [vendor] or
+        is_valid_d_transition(current, target) [deployer] is True, proceed.
+        Otherwise return Status.FAILURE.
       expected: Only valid transitions or same-state writes reach the DataLayer
     postconditions:
-    - description: No ParticipantStatus with an illegal VFD jump is persisted
+    - description: >-
+        No ParticipantStatus with an illegal vf or d state jump is persisted
     relationships:
     - rel_type: implements
       spec_id: SDO-02-004


### PR DESCRIPTION
- Closes #2595

## Summary

Documents the agreed design for splitting `CS_vfd` into separate vendor-path (`CS_vf`: 3 states) and deployer-path (`CS_d`: 2 states) sub-machines, with structural enforcement via nullable `ParticipantStatus` fields and a `model_validator`.

## Changes

- **`notes/case-state-model.md`**: Replace `vfd_state`/`CS_vfd` references with `vf`/`d` split fields; add role-dimension invariant table; update `ParticipantStatus` field list and handler guidance; document structural `None` replacing the old `CS_vfd.vfd` null-element workaround.
- **`specs/cs-behavior.yaml`**: Update CSB-15-001 and CSB-15-002 to reflect structural enforcement (non-VENDOR/non-DEPLOYER actors are now incapable of advancing the path they don't have); rewrite CSB-15-004 for the DEPLOYER-only `d→D` causal gate under the split model (DEPLOYER-only actor starts with `vf=None`, `d=DDimension(state=CS_d.d)`; causal gate checks that at least one VENDOR has `vf.state=VF`); update CSB-15-003 field references.

## Implementation Issues

- #2662 — Add `CS_vf`, `CS_d`, `VfDimension`, `DDimension` alongside existing types (size:S, blocked-by #2595)
- #2663 — Split `ParticipantStatus.vfd` into `vf`/`d` fields and migrate all call sites (size:L, blocked-by #2662)
- #2664 — Remove `CS_vfd`, `VfdDimension` and retired guard nodes (size:S, blocked-by #2663)
- #2665 — [Concern] Per-deployer/per-vendor dependency tracking for fine-grained VF→D causal gate