### PR TITLE
docs: plan issue #2092 — sentinel PXA authority model and conservative gate defaults

### DIFF
--- a/docs/adr/0025-call-out-point-abstraction-layer.md
+++ b/docs/adr/0025-call-out-point-abstraction-layer.md
@@ -214,6 +214,15 @@ There are three logical backend modes:
 Deterministic is the default everywhere. The p=0.5 tie-breaking direction is
 `AlwaysSucceed` (happy-path forward progress).
 
+**Security-significant gate exception (ADR-0076):** For call-out points whose
+permissive default enables unilateral state change or embargo consequences —
+e.g., `CaseOwnerApprovesStatusUpdate` in `StatusAdoptionGate` and
+`EmbargoTeardownAuthorizationGate` — the DETERMINISTIC default MUST be
+`RequireCaseOwnerApproval`, not `AlwaysSucceed`, regardless of stochastic p.
+The ceiling/floor rule applies only to simulation-domain nodes where a
+permissive default is a prototype-stage convenience, not a security risk.
+See `notes/call-out-configuration.md` and RSH-07.
+
 ### Domain bundle dataclasses
 
 Individual per-node factory kwargs on tree builders are replaced by a single

--- a/docs/adr/0046-received-status-authorization.md
+++ b/docs/adr/0046-received-status-authorization.md
@@ -66,8 +66,10 @@ without coupling the trees directly: when StatusAdoptionGate passes, the CaseAct
   policy decision that could be misconfigured
 - Good: side-effects (teardown) only execute after canonical state is written,
   preserving write-before-side-effect ordering
-- Good: both seams default to `AlwaysSucceed`, so existing behavior is
-  unchanged until real backends are wired in
+- Good: both seams default to `RequireCaseOwnerApproval`, making the
+  conservative posture the out-of-the-box behavior; permissive behavior
+  (e.g., `AlwaysSucceed` for trusted-participant or demo deployments) requires
+  explicit operator configuration (RSH-07-003, ADR-0076)
 - Neutral: two new call-out fields add bundle surface area; addressed by a
   single `StatusAuthorizationCallOutBundle` (StatusAdoptionGate and EmbargoTeardownAuthorizationGate)
 - Bad: the self-addressed `Add(CaseStatus)` introduces an internal loopback;
@@ -84,7 +86,7 @@ claim), before any canonicalization.
 ```text
 StatusAdoptionGate (Fallback)
 ├─ CheckIsCaseOwnerNode            ← hard bypass: CASE_OWNER = gospel
-└─ CaseOwnerApprovesStatusUpdate   ← Evaluator call-out (AlwaysSucceed default)
+└─ CaseOwnerApprovesStatusUpdate   ← Evaluator call-out (RequireCaseOwnerApproval default)
 ```
 
 If the gate passes, `EmitAddCaseStatusToSelfNode` emits a self-addressed
@@ -95,7 +97,7 @@ If the gate passes, `EmitAddCaseStatusToSelfNode` emits a self-addressed
 Positioned after `AppendCaseStatusToCaseNode`.
 
 ```text
-EmbargoTeardownAuthorizationGate (Evaluator call-out, AlwaysSucceed default)
+EmbargoTeardownAuthorizationGate (Evaluator call-out, RequireCaseOwnerApproval default)
 ThreatTerminationBranchNode    ← fires teardown on CS.P OR CS.X OR CS.A
 ```
 

--- a/docs/adr/0076-security-significant-gates-default-require-case-owner-approval.md
+++ b/docs/adr/0076-security-significant-gates-default-require-case-owner-approval.md
@@ -1,0 +1,138 @@
+---
+status: accepted
+date: 2026-08-26
+deciders: Allen D. Householder
+consulted: Claude Sonnet 4.6
+informed: []
+---
+
+# Security-Significant Call-Out Gates Default to `RequireCaseOwnerApproval`
+
+## Context and Problem Statement
+
+The two-gate authorization model (ADR-0046) places a configurable Evaluator
+call-out at `StatusAdoptionGate` (`CaseOwnerApprovesStatusUpdate`) and at
+`EmbargoTeardownAuthorizationGate`. Both gates defaulted to `AlwaysSucceed`,
+inheriting the ADR-0025 ceiling/floor rule that maps a stochastic node with
+`p ≥ 0.5` to `AlwaysSucceed` in DETERMINISTIC mode.
+
+CONCERN-2092 identified that this default creates a protocol-exploitable
+channel: any admitted participant — including a hostile or malfunctioning
+Observer admitted as a sentinel — can post `Add(ParticipantStatus)` carrying
+PXA state changes (`CS.P`, `CS.X`, `CS.A`) and, without any Case Owner
+confirmation, force PXA adoption as canonical case state and trigger embargo
+teardown. The current answer to "what prevents this?" is "don't deploy with
+the default" — a configuration posture, not a protocol guarantee.
+
+The design question is: **what should the default backend be for
+security-significant Evaluator call-out gates, and should that default be
+implemented as a reusable pattern?**
+
+## Decision Drivers
+
+- A permissive default for gates that control unilateral state change or
+  embargo consequences is a protocol-level security risk, not just an
+  inconvenience
+- The same approval pattern recurs: status adoption, invitation suggestions,
+  embargo proposals, and other protocol actions all benefit from a
+  Case Owner approval gate
+- Existing AS2 `Offer`/`Accept`/`Reject` vocabulary is sufficient for the
+  round-trip — no new message types are needed
+- The ADR-0025 ceiling/floor rule was designed for simulation-domain fuzzer
+  nodes where permissive defaults are a prototype-stage convenience; it does
+  not apply where permissiveness creates an exploitable channel
+- Reusable tree factory reduces per-gate implementation cost and ensures
+  consistent semantics across all approval flows
+
+## Considered Options
+
+1. **Keep `AlwaysSucceed` as default** — permissive; production hardening is
+   opt-in configuration. No code change; conservative posture requires explicit
+   operator action.
+2. **`AlwaysFail` as default** — conservative but semantically wrong: no
+   non-owner PXA assertion would ever be adopted, making the gate a permanent
+   block rather than a configurable approval seam.
+3. **`RequireCaseOwnerApproval` as default** — conservative and correct:
+   non-owner assertions require explicit Case Owner confirmation via an
+   Offer/Accept/Reject round-trip before adoption. Permissive behavior is an
+   explicit operator opt-in.
+
+## Decision Outcome
+
+Chosen option: **`RequireCaseOwnerApproval` as default** (option 3), because
+it provides a meaningful conservative default — the Case Owner must explicitly
+approve — while using existing AS2 vocabulary, being composable with any
+policy, and making permissive behavior a visible, documented operator choice.
+
+`RequireCaseOwnerApproval` is defined as a reusable Evaluator call-out
+backend that:
+
+- Sends an `Offer` activity to the Case Owner carrying the pending action as
+  the object
+- Waits for an `Accept` or `Reject` in reply using existing AS2
+  `Accept`/`Reject` vocabulary
+- Returns `SUCCESS` on `Accept`, `FAILURE` on `Reject` or timeout
+
+The backend is implemented as a shared tree factory with parameters for the
+subject and the CaseActor context, composable into any Evaluator call-out
+seam that requires Case Owner approval.
+
+**Capability shape:** Evaluator — the call-out answers a yes/no question
+("is this action approved?"). The internal Offer/Accept/Reject mechanics are
+an implementation detail of the default backend, not a property of the seam.
+
+**Scope of the conservative-default rule:** This decision establishes a
+project-wide exception to ADR-0025's ceiling/floor rule. For any call-out
+point whose permissive default enables unilateral state change or embargo
+consequences, the DETERMINISTIC default MUST sit at the floor (most
+restrictive semantically-correct backend), not the ceiling. ADR-0025 is
+amended in-place to reflect this exception.
+
+**Valid alternative backends (all MAY):** `AlwaysSucceed` (trusted
+participants, demo deployments), `AlwaysFail` (reject all non-owner
+assertions), role-differentiated policy (Vendor treated differently from
+Observer), probabilistic approval (stochastic simulation), and any other
+`CallOutBackendFactory`-conformant implementation. None requires a framework
+change — each is a different factory injected into the same bundle field.
+
+### Consequences
+
+- Good: the conservative posture requires no configuration; permissive
+  behavior is an explicit operator choice with documented consequences
+- Good: existing AS2 vocabulary is reused; no new wire message types are
+  introduced
+- Good: the same `RequireCaseOwnerApproval` factory is composable across
+  status adoption, invitation suggestions, embargo proposals, and similar
+  flows — one pattern, not many bespoke implementations
+- Neutral: demo and trusted-participant deployments must explicitly configure
+  `AlwaysSucceed` (or equivalent); this is intentional — permissiveness is
+  visible in the code rather than inherited from an implicit default
+- Neutral: tests that relied on the `AlwaysSucceed` default must be updated
+  to either explicitly configure a permissive bundle or exercise the approval
+  flow; this is the correct test behavior
+- Bad: existing demo scenarios that relied on `AlwaysSucceed` implicitly will
+  fail until updated to configure the permissive backend explicitly
+
+## Validation
+
+- `StatusAuthorizationCallOutBundle` fields default to `RequireCaseOwnerApproval`
+  (not `AlwaysSucceed`)
+- Tests for `add_participant_status_bt` and `add_case_status_bt` that exercise
+  the non-owner path must pass a permissive bundle explicitly; tests that
+  exercise the conservative path use the default
+- Architecture boundary test (`test_core_no_demo_imports.py`) continues to
+  pass after the new backend is added
+
+## More Information
+
+- CONCERN-2092: sentinel actors admitted as Observers can force embargo
+  teardown via PXA assertions — the source concern
+- ADR-0025 (amended): call-out point factory injection and ceiling/floor rule;
+  the security-significant gate exception is added in-place
+- ADR-0046 (amended): two-gate authorization model; Consequences updated to
+  reflect conservative default
+- `notes/received-status-authorization.md`: two-gate design and bundle defaults
+- `notes/call-out-configuration.md`: three-mode model and ceiling/floor rule
+
+Generated spec requirements: `specs/received-status-handling.yaml`
+RSH-07-001 through RSH-07-003.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -145,6 +145,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0073 Give Each Actor Its Own Store; Delete the Unscoped DataLayer](0073-per-actor-storage-isolation.md)
 - [ADR-0074 Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal](0074-wire-activity-artifact-immutability.md)
 - [ADR-0075 Split Per-Participant VFD Tracking into Separate Vendor-Path and Deployer-Path Sub-Machines](0075-split-vfd-state-machine.md) *(provisional)*
+- [ADR-0076 Security-Significant Call-Out Gates Default to `RequireCaseOwnerApproval`](0076-security-significant-gates-default-require-case-owner-approval.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -296,6 +296,7 @@ nav:
       - Give Each Actor Its Own Store; Delete the Unscoped DataLayer: 'adr/0073-per-actor-storage-isolation.md'
       - 'Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal': 'adr/0074-wire-activity-artifact-immutability.md'
       - 'Split Per-Participant VFD Tracking into Separate Vendor-Path and Deployer-Path Sub-Machines': 'adr/0075-split-vfd-state-machine.md'
+      - Security-Significant Call-Out Gates Default to RequireCaseOwnerApproval: 'adr/0076-security-significant-gates-default-require-case-owner-approval.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -65,6 +65,15 @@ use of the deterministic bundle is a **happy-path demonstration** in which the
 protocol makes forward progress. Scenarios that need to exercise failure paths
 should use a pessimistic bundle or inject an explicit `AlwaysFail` factory.
 
+**Security-significant gate exception (ADR-0076, ADR-0025 amended):** For
+call-out points whose permissive default enables unilateral state change or
+embargo consequences — e.g., `CaseOwnerApprovesStatusUpdate` in
+`StatusAdoptionGate` and `EmbargoTeardownAuthorizationGate` — the
+DETERMINISTIC default MUST be `RequireCaseOwnerApproval`, not `AlwaysSucceed`,
+regardless of stochastic p. The ceiling/floor rule applies only to
+simulation-domain nodes where permissiveness is a prototype-stage convenience.
+See RSH-07-001 and RSH-07-002.
+
 Currently there are four `p=0.5` nodes (all default to `AlwaysSucceed`):
 
 | Node | Domain | Rationale |

--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -175,9 +175,11 @@ structural skip: if `CheckIsCaseOwnerNode` succeeds, the approval call-out is
 never reached.
 
 For all other senders, the `CaseOwnerApprovesStatusUpdate` Evaluator call-out
-provides the hook. In the prototype it defaults to `AlwaysSucceed` (all status
-updates are adopted automatically). A production implementation can replace
-this with a real policy engine or human-in-the-loop step.
+provides the hook. The default backend is `RequireCaseOwnerApproval` — an
+Evaluator that performs an Offer/Accept/Reject round-trip with the Case Owner
+before allowing the assertion to be adopted as canonical. A permissive backend
+(e.g., `AlwaysSucceed`) MAY be configured for trusted-participant or demo
+deployments but MUST be explicitly configured (RSH-07-003, ADR-0076).
 
 ### Self-addressed `Add(CaseStatus)` pattern
 
@@ -298,13 +300,24 @@ authorized.
 
 ## Call-Out Bundle
 
-A new `StatusAuthorizationCallOutBundle` covers both gates:
+A `StatusAuthorizationCallOutBundle` covers both gates:
 
 ```python
 @dataclass(frozen=True)
 class StatusAuthorizationCallOutBundle:
-    status_adoption_gate_factory: CallOutBackendFactory = ...  # AlwaysSucceed
-    embargo_teardown_authorization_gate_factory: CallOutBackendFactory = ...   # AlwaysSucceed
+    status_adoption_gate_factory: CallOutBackendFactory = ...  # RequireCaseOwnerApproval
+    embargo_teardown_authorization_gate_factory: CallOutBackendFactory = ...  # RequireCaseOwnerApproval
+```
+
+Both fields default to `RequireCaseOwnerApproval` (RSH-07-001, RSH-07-002,
+ADR-0076). Demo and trusted-participant deployments that need automated
+adoption MUST explicitly configure a permissive backend — e.g.:
+
+```python
+STATUS_AUTHORIZATION_PERMISSIVE = StatusAuthorizationCallOutBundle(
+    status_adoption_gate_factory=lambda n: AlwaysSucceed(n),
+    embargo_teardown_authorization_gate_factory=lambda n: AlwaysSucceed(n),
+)
 ```
 
 Placed in `vultron/core/behaviors/call_out/bundles/status_authorization.py`

--- a/plan/history/2608/learning/CONCERN-2092.md
+++ b/plan/history/2608/learning/CONCERN-2092.md
@@ -1,0 +1,48 @@
+---
+source: CONCERN-2092
+timestamp: '2026-08-26T18:21:02.322500+00:00'
+title: sentinel PXA authority model — conservative gate defaults for StatusAdoptionGate
+  and EmbargoTeardownAuthorizationGate
+type: learning
+---
+
+## Concern
+
+CONCERN-2092 identified that `StatusAdoptionGate` and `EmbargoTeardownAuthorizationGate`
+both defaulted to `AlwaysSucceed`, creating a protocol-exploitable channel: a hostile or
+malfunctioning sentinel actor admitted as OBSERVER could force PXA state adoption and
+embargo teardown without Case Owner approval.
+
+## Decision
+
+Flip both gate defaults from `AlwaysSucceed` to `RequireCaseOwnerApproval` — an Evaluator
+that performs an Offer/Accept/Reject round-trip with the Case Owner using existing AS2
+vocabulary. Permissive backends (e.g., `AlwaysSucceed`) remain valid MAY configurations
+for trusted-participant or demo deployments but MUST be explicitly configured.
+
+`RequireCaseOwnerApproval` is the default because:
+
+- The opposite of "always allow" is not "always block" — it is "ask the owner"
+- The pattern recurs across status updates, invitation suggestions, and embargo proposals
+- A reusable tree factory with parameters should be designed (impl issue #2676)
+
+## Key artifacts
+
+- ADR-0076: `Security-Significant Call-Out Gates Default to RequireCaseOwnerApproval`
+  — new ADR establishing the project-wide exception to ADR-0025's ceiling/floor rule
+- ADR-0025 amended in-place: security-significant gate exception paragraph added
+- ADR-0046 revised in-place: Consequences section and gate definition blocks updated
+- Specs RSH-07-001..003 added to `specs/received-status-handling.yaml`
+- RSH-02-002 flipped from MUST be `AlwaysSucceed` → MUST be `RequireCaseOwnerApproval`
+- Notes `received-status-authorization.md` and `call-out-configuration.md` updated
+
+## Implementation
+
+- #2675 (size:M): Flip `StatusAuthorizationCallOutBundle` defaults + add `RequireCaseOwnerApproval` tree factory
+- #2676 (size:L): Audit all call-out gates for security-significant permissive defaults and flip them
+
+Both wired as sub-issues of epic #1935 (Protocol authority & lifecycle semantics).
+
+## PR
+
+<https://github.com/CERTCC/Vultron/pull/2674>

--- a/specs/received-status-handling.yaml
+++ b/specs/received-status-handling.yaml
@@ -110,13 +110,24 @@ groups:
     priority: MUST
     kind: protocol
     statement: >
-      The default backend for `EmbargoTeardownAuthorizationGate` MUST be `AlwaysSucceed`,
-      preserving existing behavior until a real policy engine is wired in.
+      The default backend for `EmbargoTeardownAuthorizationGate` MUST be
+      `RequireCaseOwnerApproval` — an Evaluator that performs an
+      Offer/Accept/Reject round-trip with the Case Owner before permitting
+      teardown side-effects. A permissive backend (e.g., `AlwaysSucceed`) MAY
+      be configured for trusted-participant or demo deployments but MUST be
+      explicitly configured. See RSH-07.
     rationale: >
-      Prototype-stage default per ADR-0025 ceiling/floor rule. Changing the
-      default would alter existing demo behavior.
+      Conservative default for a security-significant gate per ADR-0025
+      (security-significant gate exception) and ADR-0076. The prior default
+      of `AlwaysSucceed` was a prototype-stage convenience; production-ready
+      posture requires explicit operator opt-in for permissive behavior.
+      Belt-and-suspenders: even though `StatusAdoptionGate` (RSH-07-001) has
+      already obtained Case Owner approval before the self-addressed
+      `Add(CaseStatus)` arrives here, an operator constructing
+      `add_case_status_tree` outside the self-addressed pattern would otherwise
+      inherit a permissive teardown gate with no explicit opt-in.
     verification: Inspection of `vultron/core/behaviors/status/` confirms the default backend for
-      `EmbargoTeardownAuthorizationGate` is `AlwaysSucceed`, preserving existing demo behavior.
+      `EmbargoTeardownAuthorizationGate` is `RequireCaseOwnerApproval`, not `AlwaysSucceed`.
 
     lint_suppress:
     - missing_story_reference
@@ -651,3 +662,69 @@ groups:
     - story_2022_039
     - story_2022_074
     - story_2022_077
+
+- id: RSH-07
+  title: Conservative Default Authorization Policy for Status Gates
+  description: >
+    Both StatusAdoptionGate and EmbargoTeardownAuthorizationGate MUST default to
+    `RequireCaseOwnerApproval` — an Evaluator that performs an Offer/Accept/Reject
+    round-trip with the Case Owner before allowing PXA assertion adoption or
+    embargo teardown side-effects. Permissive backends are valid but MUST be
+    explicitly configured.
+    Derived from CONCERN-2092 and ADR-0076.
+  specs:
+  - id: RSH-07-001
+    priority: MUST
+    kind: protocol
+    statement: >
+      The default backend for the `CaseOwnerApprovesStatusUpdate` Evaluator
+      call-out in `StatusAdoptionGate` MUST be `RequireCaseOwnerApproval` —
+      an Evaluator that sends an `Offer` to the Case Owner and waits for
+      `Accept` or `Reject` before allowing the PXA assertion to be adopted
+      as canonical case state.
+    rationale: >
+      A permissive default (e.g., `AlwaysSucceed`) means any admitted
+      participant — including a hostile or malfunctioning Observer admitted
+      as a sentinel — can force PXA adoption and thereby trigger embargo
+      teardown without any Case Owner confirmation. The default posture must
+      be conservative; permissive behavior requires explicit opt-in. See ADR-0076.
+    verification: >
+      Inspection of `StatusAuthorizationCallOutBundle` confirms
+      `status_adoption_gate_factory` defaults to `RequireCaseOwnerApproval`,
+      not `AlwaysSucceed`.
+    lint_suppress:
+    - missing_story_reference
+  - id: RSH-07-002
+    priority: MUST
+    kind: protocol
+    statement: >
+      The default backend for `EmbargoTeardownAuthorizationGate` MUST be
+      `RequireCaseOwnerApproval`. See also RSH-02-002.
+    rationale: >
+      Belt-and-suspenders: both gates default conservatively. See RSH-02-002
+      rationale and ADR-0076 for full justification.
+    verification: >
+      Inspection of `StatusAuthorizationCallOutBundle` confirms
+      `embargo_teardown_authorization_gate_factory` defaults to
+      `RequireCaseOwnerApproval`, not `AlwaysSucceed`.
+    lint_suppress:
+    - missing_story_reference
+  - id: RSH-07-003
+    priority: MAY
+    kind: protocol
+    statement: >
+      An implementation MAY configure a permissive backend (e.g.,
+      `AlwaysSucceed`) for `CaseOwnerApprovesStatusUpdate` or
+      `EmbargoTeardownAuthorizationGate` in deployments where all admitted
+      participants are trusted and the operational overhead of Case Owner
+      approval is unacceptable. Any such configuration MUST be explicit and
+      documented.
+    rationale: >
+      Demo and trusted-participant deployments legitimately need automated
+      sentinel behavior without ceremony. The conservative posture applies by
+      default; permissive is an explicit operator choice with documented
+      consequences. Other valid alternative backends include role-differentiated
+      policy, probabilistic approval, and any `CallOutBackendFactory`-conformant
+      implementation. See ADR-0076.
+    lint_suppress:
+    - missing_story_reference


### PR DESCRIPTION
- Closes #2092

## Summary

Resolves CONCERN-2092 by specifying that `StatusAdoptionGate` and
`EmbargoTeardownAuthorizationGate` MUST default to `RequireCaseOwnerApproval`
rather than `AlwaysSucceed`, making the conservative posture the out-of-the-box
behavior and permissive behavior an explicit operator opt-in.

## Changes

- **`docs/adr/0076-security-significant-gates-default-require-case-owner-approval.md`**:
  New ADR. Establishes `RequireCaseOwnerApproval` (Offer/Accept/Reject
  round-trip using existing AS2 vocab) as the conservative default Evaluator
  backend for security-significant call-out gates. Documents the reusable
  tree factory, valid alternative backends (all MAY), and the capability
  shape (Evaluator).
- **`docs/adr/0025-call-out-point-abstraction-layer.md`**: Revised in-place.
  Adds security-significant gate exception to the ceiling/floor rule.
- **`docs/adr/0046-received-status-authorization.md`**: Revised in-place.
  Updates Consequences section and gate definition blocks to reflect
  conservative default posture.
- **`docs/adr/index.md`** and **`mkdocs.yml`**: Add ADR-0076 entry.
- **`specs/received-status-handling.yaml`**: Update RSH-02-002 (flip default
  from AlwaysSucceed to RequireCaseOwnerApproval); add RSH-07 group
  (RSH-07-001 through RSH-07-003) specifying the conservative default policy
  for both gates.
- **`notes/received-status-authorization.md`**: Update CASE_OWNER gospel-bypass
  rationale and Call-Out Bundle section to reflect new defaults.
- **`notes/call-out-configuration.md`**: Annotate ceiling/floor rule with
  security-significant gate exception.

## Implementation Issues
- #2675
- #2676