### PR TITLE
docs: ADR-0078 retire CVDRole.FINDER — Reporter is the protocol-salient role

### DIFF
--- a/docs/adr/0078-retire-finder-role.md
+++ b/docs/adr/0078-retire-finder-role.md
@@ -1,0 +1,123 @@
+---
+status: accepted
+date: 2026-08-26
+deciders: Allen D. Householder
+consulted: CERTCC/Vultron contributors
+informed: Vultron protocol working group
+lint_suppress: [status_prose_contradiction]
+---
+
+# Retire `CVDRole.FINDER` — Reporter Is the Protocol-Salient Role
+
+## Context and Problem Statement
+
+The Vultron protocol models multi-party CVD as a Communicating Hierarchical State
+Machine. Each Participant runs a process, and $N$ is the count of unique
+Participants. The formal protocol definition (Brand & Zafiropulo,
+`docs/reference/formal_protocol/index.md`) characterised the participant pool as
+"Finders, Vendors, Coordinators, Deployers, and Others."
+
+The draft Vultron Protocol Spec (PR #2078, §7.3.1) provisionally listed `Finder`
+as a protocol role while deferring its finalisation pending this ADR. The note
+read:
+
+> **Finder** still requires an ADR before the removal can be treated as normative.
+
+Separately, `CVDRole.FINDER` is present in the implementation enum
+(`vultron/enums/roles.py`), and convenience subclasses `FinderParticipant` and
+`FinderReporterParticipant` exist in `vultron/core/models/case_participant.py`.
+
+The question this ADR answers: should Finder be a distinct, protocol-recognised
+role, or should it be retired?
+
+## Decision Drivers
+
+- **Protocol neutrality**: The protocol cares about who *reports* a
+  vulnerability, not about who *found* it. A Finder who reports their own
+  finding acts as a Reporter. A Finder who asks someone else to report acts as
+  a source of information for that Reporter. Neither interaction requires a
+  dedicated protocol role.
+- **Formal model alignment**: The $N$ definition in
+  `docs/reference/formal_protocol/index.md` already uses the formula
+  $N = |Reporters \cup Vendors \cup Coordinators \cup Deployers \cup Others|$
+  — not Finders. The prose description that said "Finder" was already
+  inconsistent with the formula. The formula is correct.
+- **Role simplicity**: Fewer roles reduces the combinatorial surface of role
+  stacking (CM-26). A role that adds no protocol obligations and can always be
+  expressed via another role is a source of confusion for implementers.
+- **Circulation blocker**: PR #2078 identified the missing ADR as a blocker for
+  external circulation of the draft spec. Resolving it unblocks the spec.
+
+## Considered Options
+
+1. **Retain `CVDRole.FINDER` as a distinct protocol role** — keep the current
+   status quo, add normative requirements for Finder behaviour.
+2. **Retire `CVDRole.FINDER`; record discoverer identity as report metadata** —
+   remove Finder from the CVD role taxonomy. Any actor that discovers and reports
+   a vulnerability holds the `REPORTER` role. An actor that discovers but does not
+   report may be credited in the Report's free-text fields or in case Notes.
+3. **Retain `CVDRole.FINDER` as a non-normative annotation** — keep the value in
+   the enum as an informational tag only, with no protocol obligations or
+   permissions associated with it.
+
+## Decision Outcome
+
+Chosen option: **Retire `CVDRole.FINDER`** (option 2), because:
+
+- Nothing in the protocol state machines (RM, EM, CS, PEC) distinguishes a
+  Finder from a Reporter. A Finder that enters the protocol is a Reporter.
+  Adding normative requirements for Finder (option 1) would require inventing
+  protocol obligations that do not exist in the specification's source material.
+- Option 3 (non-normative annotation) retains the implementation surface and
+  all the confusion it creates while providing no protocol value in return.
+- The formal $N$ formula already expresses the correct model; the prose
+  description of "Finders" in `docs/reference/formal_protocol/index.md` was an
+  artefact of earlier CERT/CC CVD terminology and is inconsistent with the
+  formula itself. Aligning the prose with the formula is the minimal correct fix.
+- The "Note on Reporter" already in draft §7.3.1 captures the relationship
+  precisely: the protocol is concerned with who reported, not who found.
+
+**Normative scope of this decision:**
+
+- `CVDRole.FINDER` is **retired** from the Vultron CVD role taxonomy.
+- The discoverer of a vulnerability SHOULD be recorded in the Report content or
+  in case Notes; it is metadata, not a protocol role.
+- The formal protocol process count $N$ is defined over Reporters, Vendors,
+  Coordinators, Deployers, and Others (the formula already in place).
+- An actor who discovers and reports a vulnerability simultaneously holds
+  `CVDRole.REPORTER`. There is no separate "Finder-Reporter" combined role;
+  `REPORTER` is sufficient.
+
+### Consequences
+
+- Good, because the formal $N$ definition and the role taxonomy are now
+  consistent with each other.
+- Good, because role stacking complexity (CM-26) is reduced by one role.
+- Good, because the draft spec §7.3.1 provisional marker is removed and Open
+  Question #5 is resolved, unblocking external circulation.
+- Neutral, because the implementation change (removing `CVDRole.FINDER` from
+  `vultron/enums/roles.py`, retiring `FinderParticipant` and
+  `FinderReporterParticipant`) is a follow-on task; the enum value is retained in
+  the code until that task ships. Wire actors in demo scenarios that hold the
+  "Finder" conceptual role hold `CVDRole.REPORTER` (or `CVDRole.REPORTER` +
+  `CVDRole.OBSERVER`) in practice.
+- Watch out: code and specs that reference `CVDRole.FINDER` directly must be
+  updated in the follow-on task. Until that task ships, `CVDRole.FINDER` remains
+  a valid (if deprecated) wire value and implementers may encounter it in stored
+  data.
+
+## Validation
+
+- Spec: no new spec entries are generated by this ADR; the existing role taxonomy
+  in `specs/participant-role-management.yaml` and `specs/case-management.yaml`
+  will be updated in the follow-on implementation task to remove FINDER references.
+- Draft spec: §7.3.1 provisional note removed; Open Question #5 struck.
+- Formal protocol doc: prose description updated from "Finder" to "Reporter".
+- ADR index updated.
+
+## More Information
+
+Related issues: #2102 (this ADR, circulation blocker), #2078 (draft spec PR).
+Follow-on implementation task: remove `CVDRole.FINDER` from the enum and retire
+`FinderParticipant` / `FinderReporterParticipant`; update all spec entries and
+code that reference `CVDRole.FINDER`.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -145,6 +145,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0073 Give Each Actor Its Own Store; Delete the Unscoped DataLayer](0073-per-actor-storage-isolation.md)
 - [ADR-0074 Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal](0074-wire-activity-artifact-immutability.md)
 - [ADR-0075 Split Per-Participant VFD Tracking into Separate Vendor-Path and Deployer-Path Sub-Machines](0075-split-vfd-state-machine.md) *(provisional)*
+- [ADR-0078 Retire `CVDRole.FINDER` — Reporter Is the Protocol-Salient Role](0078-retire-finder-role.md)
 
 ## Proposed ADRs
 

--- a/docs/reference/draft-vultron-spec.md
+++ b/docs/reference/draft-vultron-spec.md
@@ -1198,13 +1198,6 @@ completing a role assignment (§6.6.1). The full capability prerequisites per
 role are under active specification; see `docs/reference/vultron-taxonomy.md`
 §"Open Ideas."
 
-!!! note "Finder role: still provisional"
-    **Finder** still requires an ADR before the removal can be treated as normative.
-    The formal protocol definition this document builds on (§3.1, §3.4) defines
-    the process count over Finders, Vendors, Coordinators, Deployers, and Others.
-    `CVDRole.FINDER` exists in the current implementation and is retained until
-    the ADR is written.
-
 !!! note "Note on Reporter"
     Reporters are most often also the discoverer of the vulnerability, but
     the protocol is concerned with who reported it, not who found it. The
@@ -1546,12 +1539,11 @@ implementation. Other implementations are not required to use this structure.
    participants. Tracked in issue #2068.
 4. **Background material depth** — How much CVD domain background belongs here
    vs. a companion "CVD Concepts" document?
-5. **Finder removal ADR** — Decision to drop the Finder role needs an ADR before
-   the spec circulates. Rationale: Reporter is the protocol-salient role; Finder
-   identity may be recorded in the report or case Notes but has no protocol effect.
-   Note the reach: `docs/reference/formal_protocol/index.md` defines the process
-   count $N$ over Finders, Vendors, Coordinators, Deployers, and Others, and §3.1
-   and §3.4 build on that definition. Marked provisional in §7.3.1.
+5. ~~**Finder removal ADR**~~ — Resolved. ADR-0078
+   (`docs/adr/0078-retire-finder-role.md`) retires `CVDRole.FINDER`; Reporter is
+   the protocol-salient role. Finder identity is metadata, not a protocol role.
+   Formal protocol $N$ definition updated. Implementation (enum removal) tracked
+   separately.
 6. ~~**Observer rename ADR**~~ — Resolved. ADR-0057
    (`docs/adr/0057-observer-participant-role.md`) decided the rename and Observer
    semantics (CM-25, CM-26). Implementation (code rename) tracked separately.

--- a/docs/reference/formal_protocol/index.md
+++ b/docs/reference/formal_protocol/index.md
@@ -73,7 +73,7 @@ We detail each of these below or in subsequent pages:
 ## Number of Processes
 
 The processes we are concerned with represent the different Participants
-in their roles (Finder, Vendor, Coordinator, Deployer, and Other). Each
+in their roles (Reporter, Vendor, Coordinator, Deployer, and Observer). Each
 Participant has their own process, but Participants might take on
 multiple roles in a given case.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -296,6 +296,7 @@ nav:
       - Give Each Actor Its Own Store; Delete the Unscoped DataLayer: 'adr/0073-per-actor-storage-isolation.md'
       - 'Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal': 'adr/0074-wire-activity-artifact-immutability.md'
       - 'Split Per-Participant VFD Tracking into Separate Vendor-Path and Deployer-Path Sub-Machines': 'adr/0075-split-vfd-state-machine.md'
+      - "Retire CVDRole.FINDER — Reporter Is the Protocol-Salient Role": 'adr/0078-retire-finder-role.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'


### PR DESCRIPTION
- Closes #2102

## Summary

Writes ADR-0078 to record the decision to retire `CVDRole.FINDER` from the
Vultron CVD role taxonomy. Reporter is the protocol-salient role; Finder
identity is metadata (stored in the Report or case Notes), not a protocol role.
Removes the draft spec §7.3.1 provisional note and strikes Open Question #5,
unblocking external circulation of the draft spec.

## Changes

- **`docs/adr/0078-retire-finder-role.md`**: new ADR recording the decision,
  considered options, rationale, and follow-on scope
- **`docs/adr/index.md`**: index entry for ADR-0078
- **`mkdocs.yml`**: nav entry for ADR-0078
- **`docs/reference/formal_protocol/index.md`**: align prose description of
  participant roles with the formal $N$ formula — "Reporter, Vendor, Coordinator,
  Deployer, and Observer" (the formula already used Reporters; the prose said
  Finders, which was inconsistent)
- **`docs/reference/draft-vultron-spec.md`**: remove §7.3.1 "Finder role: still
  provisional" note; strike Open Question #5 as resolved by ADR-0078

## Follow-on

Issue #2677 tracks the implementation task: remove `CVDRole.FINDER` from the
enum, retire `FinderParticipant`/`FinderReporterParticipant`, and update all
spec and code references.