### PR TITLE
docs: resolve OQ#2 in draft-vultron-spec, write ADR-0077, confirm single-hub normative

### DIFF
--- a/docs/adr/0077-ledger-replication-companion-spec.md
+++ b/docs/adr/0077-ledger-replication-companion-spec.md
@@ -1,0 +1,83 @@
+---
+status: accepted
+date: 2026-08-26
+deciders: ahouseholder
+consulted: notes/sync-ledger-replication.md, docs/reference/draft-vultron-spec.md
+informed: Vultron implementers, external reviewers
+---
+
+# Scope Ledger Replication Mechanics to a Companion Spec; Single-Hub Fan-Out Is Normative
+
+## Context and Problem Statement
+
+`docs/reference/draft-vultron-spec.md` §7.2 requires Hosting capability set
+implementations to replicate the canonical case ledger to participant actors
+via `Announce(CaseLedgerEntry)`. Open Question #2 asked whether the detailed
+replication mechanics (hash-chaining, gap detection, ordering guarantees,
+consensus) belong inside that RFC or in a separate companion document.
+
+Leaving this unresolved blocked external circulation: reviewers reading the RFC
+would find a normative obligation to replicate but no specification of how. The
+RFC must either specify the mechanics inline or explicitly scope them out with a
+forward reference. Silently leaving replication unspecified is not an option.
+
+## Decision Drivers
+
+- The Hosting capability set's obligation to replicate the ledger is stable and
+  belongs in the RFC regardless of where the mechanics are specified.
+- The replication mechanics (hash-chain construction, gap detection, out-of-order
+  buffering, rejection and replay) are technically precise and lengthy; including
+  them inline would make the RFC too long and operationally focused for its
+  intended audience.
+- The RFC should be circulatable for review without waiting for the full
+  replication spec to be complete.
+- Single-hub (one CaseActor, single-writer) with fan-out to participants is the
+  current normative model; distributed consensus (multi-node Raft-style CaseActor
+  cluster) is a future extension that need not block the RFC or the initial
+  companion spec.
+
+## Considered Options
+
+1. **Include full replication mechanics inline in the main RFC** — normative and
+   visible, but makes the RFC unwieldy and mixes implementation-level detail with
+   protocol-level semantics.
+2. **Companion document** — the RFC states the normative model and obligation;
+   a separate `draft-vultron-replication-spec.md` specifies the mechanics.
+3. **Scope out entirely** — the RFC acknowledges replication is required but
+   defers all specification to future work, with no companion doc.
+
+## Decision Outcome
+
+Chosen option: **"Companion document"**, because it lets the RFC circulate at
+the right level of abstraction while giving the replication mechanics room to
+be precise and complete without blocking the main spec.
+
+The RFC retains the normative obligation: Hosting implementations MUST replicate
+the canonical case ledger to participant actors. The normative replication model
+is **single-hub / single-writer + fan-out**: one CaseActor holds exclusive write
+authority, appends to the hash-chained canonical log, and replicates entries to
+participant actors via `Announce(CaseLedgerEntry)`.
+
+Distributed consensus (Raft-style multi-node CaseActor cluster) is a future
+extension, out of scope for both the main RFC and the initial companion spec.
+It is documented as a forward-compatible design path in
+`notes/sync-ledger-replication.md`.
+
+### Consequences
+
+- Good, because the RFC can circulate without blocking on replication spec
+  completeness — reviewers see the normative model and a forward reference.
+- Good, because the companion document can be precise and complete without
+  forcing the RFC to carry that weight.
+- Good, because the normative model (single-hub / fan-out) is now explicit in
+  the RFC, closing the ambiguity that was blocking circulation.
+- Neutral, because two documents must now be kept consistent — when SYNC spec
+  requirements change, the companion document MUST be updated.
+
+## More Information
+
+Companion document: `docs/reference/draft-vultron-replication-spec.md`
+(tracked in issue #2495).
+
+Source issue: CONCERN-2106 — "ledger replication scope (RFC vs companion spec)".
+Design rationale: `notes/sync-ledger-replication.md` § "Document Boundary".

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -145,6 +145,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0073 Give Each Actor Its Own Store; Delete the Unscoped DataLayer](0073-per-actor-storage-isolation.md)
 - [ADR-0074 Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal](0074-wire-activity-artifact-immutability.md)
 - [ADR-0075 Split Per-Participant VFD Tracking into Separate Vendor-Path and Deployer-Path Sub-Machines](0075-split-vfd-state-machine.md) *(provisional)*
+- [ADR-0077 Scope Ledger Replication Mechanics to a Companion Spec; Single-Hub Fan-Out Is Normative](0077-ledger-replication-companion-spec.md)
 
 ## Proposed ADRs
 

--- a/docs/reference/draft-vultron-spec.md
+++ b/docs/reference/draft-vultron-spec.md
@@ -1149,11 +1149,14 @@ It is separable from the Authority capability set.
 - MUST deliver full case content only when the §6.4.7 gate is satisfied
 
 !!! note "Ledger replication scope"
-    Whether the full ledger replication protocol belongs in this specification or
-    in a companion document is unresolved (see Open Questions). The Hosting
-    requirement above is stable regardless: a Case Actor host must replicate the
-    ledger. What may move is the *detailed* replication mechanics — ordering,
-    hash-chaining, gap recovery — not the obligation.
+    The detailed replication mechanics (hash-chaining, gap detection, ordering
+    guarantees) are specified in a companion document,
+    `docs/reference/draft-vultron-replication-spec.md`, not in this RFC. See
+    ADR-0077. The single-hub / single-writer + fan-out model is the normative
+    replication architecture: one Case Actor holds exclusive write authority and
+    replicates entries to participant actors via `Announce(CaseLedgerEntry)`.
+    Distributed consensus (multi-node CaseActor cluster) is a future extension
+    out of scope for this RFC.
 
 - *Source: `specs/sync-ledger-replication.yaml`; `specs/case-management.yaml`;
   `specs/received-status-handling.yaml`; `specs/vultron-protocol-spec.yaml` VP-17-001*
@@ -1537,9 +1540,10 @@ implementation. Other implementations are not required to use this structure.
    `https://certcc.github.io/Vultron/ns`; the JSON-LD context document is at
    `https://certcc.github.io/Vultron/ns/context.jsonld`. See §4.5 and ADR-0069.
    A permanent namespace URI may be registered in a future version.
-2. **Sync/replication** — Is the ledger replication protocol in scope for this
-   RFC, or a separate companion spec? The Hosting capability set obligation to
-   replicate is stable either way (§7.2); what may move is the detailed mechanics.
+2. ~~**Sync/replication**~~ — Resolved. Replication mechanics belong in a
+   companion document, not this RFC; the normative model (single-hub /
+   single-writer + fan-out) is stated in §7.2. See ADR-0077 and
+   `docs/reference/draft-vultron-replication-spec.md` (tracked in #2495).
 3. ~~**ActivityPub vs. bare AS2**~~ — Resolved for this version. §4.1 states the
    current normative floor as AS2 vocabulary only, with an informative note that
    a future version is expected to require full ActivityPub conformance for all

--- a/docs/reference/draft-vultron-spec.md
+++ b/docs/reference/draft-vultron-spec.md
@@ -1151,8 +1151,8 @@ It is separable from the Authority capability set.
 !!! note "Ledger replication scope"
     The detailed replication mechanics (hash-chaining, gap detection, ordering
     guarantees) are specified in a companion document,
-    `docs/reference/draft-vultron-replication-spec.md`, not in this RFC. See
-    ADR-0077. The single-hub / single-writer + fan-out model is the normative
+    `docs/reference/draft-vultron-replication-spec.md` (forthcoming, tracked in
+    #2495), not in this RFC. See ADR-0077. The single-hub / single-writer + fan-out model is the normative
     replication architecture: one Case Actor holds exclusive write authority and
     replicates entries to participant actors via `Announce(CaseLedgerEntry)`.
     Distributed consensus (multi-node CaseActor cluster) is a future extension

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -296,6 +296,7 @@ nav:
       - Give Each Actor Its Own Store; Delete the Unscoped DataLayer: 'adr/0073-per-actor-storage-isolation.md'
       - 'Treat Wire Activities as Immutable Artifacts; Freeze at Receipt and at Factory Seal': 'adr/0074-wire-activity-artifact-immutability.md'
       - 'Split Per-Participant VFD Tracking into Separate Vendor-Path and Deployer-Path Sub-Machines': 'adr/0075-split-vfd-state-machine.md'
+      - 'Scope Ledger Replication Mechanics to a Companion Spec; Single-Hub Fan-Out Is Normative': 'adr/0077-ledger-replication-companion-spec.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/sync-ledger-replication.md
+++ b/notes/sync-ledger-replication.md
@@ -621,7 +621,7 @@ reader-friendly rendering, not an independent source of truth.
 
 The document-boundary decision — why the replication mechanics live in a
 companion document rather than the main RFC — is recorded in
-`docs/adr/0069-ledger-replication-companion-spec.md` (tracked in issue #2494).
+`docs/adr/0077-ledger-replication-companion-spec.md` (tracked in issue #2494).
 
 ## Related
 


### PR DESCRIPTION
- Closes #2494

## Summary

Resolves Open Question #2 in the draft Vultron protocol RFC by documenting
the replication-scope decision as ADR-0077 and updating §7.2 to state the
normative single-hub / fan-out model explicitly.

## Changes

- **`docs/adr/0077-ledger-replication-companion-spec.md`**: New ADR
  recording the document-boundary decision from issue #2106: replication
  mechanics belong in a companion spec (not the main RFC); single-hub /
  single-writer + fan-out is the normative model; distributed consensus is
  a future extension.
- **`docs/reference/draft-vultron-spec.md`**: Replaced the unresolved
  `!!! note "Ledger replication scope"` in §7.2 with a scoping statement
  citing ADR-0077 and the companion spec path; marked Open Question #2 as
  resolved with ~~strikethrough~~ and forward references to ADR-0077 and
  `draft-vultron-replication-spec.md` (#2495).
- **`notes/sync-ledger-replication.md`**: Fixed stale ADR number in the
  "Document Boundary" section (the originally planned `0069` was claimed by
  the namespace-URI ADR before this branch landed; corrected to `0077`).
- **`docs/adr/index.md`** and **`mkdocs.yml`**: Added ADR-0077 nav and
  index entries.