### PR TITLE
fix(demo): replace hardcoded *_ACTOR_ID constants with dynamic actor.id_ in wait_for_case_participants

### DIFF
--- a/test/architecture/test_demo_wait_for_participants_uses_dynamic_ids.py
+++ b/test/architecture/test_demo_wait_for_participants_uses_dynamic_ids.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Architecture invariant: ``wait_for_case_participants`` must receive dynamic actor IDs.
+
+``wait_for_case_participants`` changed from count-based to identity-based in
+PR #2625.  Its ``expected_actor_ids`` parameter is checked against
+``actor_participant_index.keys()``, which stores the actual IDs assigned when
+actors were seeded.  Passing hardcoded ``*_ACTOR_ID`` module-level string
+constants instead of the live ``actor.id_`` attributes causes the identity
+check to diverge from the stored keys whenever the server derives an ID that
+differs from the constant — producing a 15-second timeout and CI failure.
+
+The fix is always to use ``{actor_obj.id_, other_obj.id_}`` (attributes of the
+objects returned by the seeding helpers), not ``{FINDER_ACTOR_ID, VENDOR_ACTOR_ID}``.
+
+Issue: #2628
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from test.architecture import _corpus
+
+_SCENARIO_DIR = _corpus.REPO_ROOT / "vultron" / "demo" / "scenario"
+
+_SCENARIO_TREES = {
+    path: tree
+    for path, tree in _corpus.files_mentioning(
+        "wait_for_case_participants", under=_SCENARIO_DIR
+    )
+    if path.name != "__init__.py"
+}
+
+
+def _hardcoded_actor_id_violations(
+    tree: ast.AST,
+) -> list[tuple[int, str]]:
+    """Return ``(line, name)`` for each hardcoded ``*_ACTOR_ID`` constant found
+    inside ``expected_actor_ids`` of a ``wait_for_case_participants`` call.
+
+    A violation is a ``Name`` node whose identifier ends with ``_ACTOR_ID``
+    (e.g., ``FINDER_ACTOR_ID``, ``C1_ACTOR_ID``).  The correct form is an
+    ``Attribute`` access such as ``finder.id_`` or ``c1.id_``.
+    """
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        callee = (
+            func.attr
+            if isinstance(func, ast.Attribute)
+            else getattr(func, "id", "")
+        )
+        if callee != "wait_for_case_participants":
+            continue
+        for kw in node.keywords:
+            if kw.arg != "expected_actor_ids":
+                continue
+            val = kw.value
+            if not isinstance(val, ast.Set):
+                continue
+            for elt in val.elts:
+                if isinstance(elt, ast.Name) and elt.id.endswith("_ACTOR_ID"):
+                    violations.append((node.lineno, elt.id))
+    return violations
+
+
+@pytest.mark.parametrize(
+    "scenario", sorted(_SCENARIO_TREES), ids=lambda p: p.name
+)
+def test_wait_for_case_participants_uses_dynamic_actor_ids(scenario: Path):
+    """``expected_actor_ids`` must use live actor object ``.id_`` attributes.
+
+    Hardcoded ``*_ACTOR_ID`` string constants diverge from server-derived IDs
+    and cause a 15-second timeout in the Demo Integration CI tier (issue #2628).
+    Use ``{seeded_actor.id_, other_actor.id_}`` instead.
+    """
+    violations = _hardcoded_actor_id_violations(_SCENARIO_TREES[scenario])
+    assert not violations, (
+        f"{scenario.relative_to(_corpus.REPO_ROOT)} passes hardcoded"
+        f" constants to wait_for_case_participants expected_actor_ids:"
+        f" {violations}. Replace with actor_obj.id_ attributes from the"
+        " seeded actor objects (issue #2628)."
+    )
+
+
+def test_the_check_can_actually_fail():
+    """Guard: the detector must flag a genuine hardcoded-constant violation."""
+    sample = _corpus.parse_inline(
+        "FINDER_ACTOR_ID = 'http://finder:7999/api/v2/actors/finder'\n"
+        "VENDOR_ACTOR_ID = 'http://vendor:7999/api/v2/actors/vendor'\n"
+        "wait_for_case_participants(\n"
+        "    vendor_client=vendor_client,\n"
+        "    case_id=case.id_,\n"
+        "    expected_actor_ids={FINDER_ACTOR_ID, VENDOR_ACTOR_ID},\n"
+        ")\n"
+    )
+    violations = _hardcoded_actor_id_violations(sample)
+    assert len(violations) == 2
+    names = {name for _, name in violations}
+    assert names == {"FINDER_ACTOR_ID", "VENDOR_ACTOR_ID"}

--- a/test/demo/test_fccv_handoff_demo.py
+++ b/test/demo/test_fccv_handoff_demo.py
@@ -858,6 +858,7 @@ class TestFinderCaseReplicaWaitBeforeVendorTriage:
         offer = MagicMock()
         report = MagicMock()
         finder = self._actor("urn:test:finder")
+        c1 = self._actor("urn:test:c1")
         invite = MagicMock()
         invite.id_ = "urn:test:invite"
         # Matches the case_actor_id passed below: the phase now asserts the
@@ -922,6 +923,7 @@ class TestFinderCaseReplicaWaitBeforeVendorTriage:
                 offer=offer,
                 report=report,
                 finder=finder,
+                c1=c1,
             )
 
         assert (

--- a/test/demo/test_fcvcv_demo.py
+++ b/test/demo/test_fcvcv_demo.py
@@ -280,6 +280,7 @@ class TestFinderCaseReplicaWaitBeforeV2Triage(_Helpers):
                 offer=MagicMock(id_="urn:test:offer"),
                 report=MagicMock(),
                 finder=self._actor("urn:test:finder"),
+                v1=self._actor("urn:test:v1"),
             )
 
         assert (

--- a/test/demo/test_issue_2361_2337_replication_timeout.py
+++ b/test/demo/test_issue_2361_2337_replication_timeout.py
@@ -186,6 +186,9 @@ def test_fcvcv_sync_verification_uses_gate_not_check_for_ledger_coverage(
         c1=c1,
         finder=finder,
         case=case,
+        v1=MagicMock(),
+        c2_in_c2=MagicMock(),
+        v2=MagicMock(),
     )
 
     failures = demo_utils._demo_failures
@@ -267,6 +270,9 @@ def test_fcvcv_sync_verification_non_v2_timeout_is_at_least_30s(monkeypatch):
         c1=c1,
         finder=finder,
         case=case,
+        v1=MagicMock(),
+        c2_in_c2=MagicMock(),
+        v2=MagicMock(),
     )
 
     finder_timeout = timeouts_by_client_id.get(id(finder_client))

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -232,7 +232,7 @@ def _phase_report_submission(
     wait_for_case_participants(
         vendor_client=c1_client,
         case_id=case.id_,
-        expected_actor_ids={FINDER_ACTOR_ID, C1_ACTOR_ID},
+        expected_actor_ids={finder.id_, c1.id_},
     )
 
     # C1 invites C2 with CVDRole.COORDINATOR (not CASE_MANAGER).
@@ -278,7 +278,7 @@ def _phase_report_submission(
     wait_for_case_participants(
         vendor_client=c1_client,
         case_id=case.id_,
-        expected_actor_ids={FINDER_ACTOR_ID, C1_ACTOR_ID, C2_ACTOR_ID},
+        expected_actor_ids={finder.id_, c1.id_, c2.id_},
     )
 
     with demo_check(
@@ -412,10 +412,10 @@ def _phase_c2_suggests_vendor(
         vendor_client=c1_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            C1_ACTOR_ID,
-            C2_ACTOR_ID,
-            VENDOR_ACTOR_ID,
+            finder.id_,
+            c1_in_c1.id_,
+            c2_in_c2.id_,
+            vendor.id_,
         },
         timeout_seconds=PARTICIPANT_JOIN_TIMEOUT,
     )
@@ -453,6 +453,8 @@ def _phase_sync_verification(
     c1: as_Actor,
     finder: as_Actor,
     case: as_VulnerabilityCase,
+    c2_in_c2: as_Actor,
+    vendor: as_Actor,
 ) -> None:
     """Verify LedgerFanout replication for Finder, C2, and Vendor replicas."""
     logger.info("─" * 80)
@@ -496,10 +498,10 @@ def _phase_sync_verification(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_actor_ids={
-                FINDER_ACTOR_ID,
-                C1_ACTOR_ID,
-                C2_ACTOR_ID,
-                VENDOR_ACTOR_ID,
+                finder.id_,
+                c1.id_,
+                c2_in_c2.id_,
+                vendor.id_,
             },
             timeout_seconds=p_timeout,
         )
@@ -969,6 +971,8 @@ def run_fccv_extension_demo(
             c1,
             finder,
             case,
+            c2_in_c2,
+            vendor,
         )
         _phase_notes_exchange(
             finder_client=finder_client,

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -230,7 +230,7 @@ def _phase_report_submission(
     wait_for_case_participants(
         vendor_client=c1_client,
         case_id=case.id_,
-        expected_actor_ids={FINDER_ACTOR_ID, C1_ACTOR_ID},
+        expected_actor_ids={finder.id_, c1.id_},
     )
 
     case = as_VulnerabilityCase.model_validate(
@@ -257,6 +257,7 @@ def _phase_ownership_handoff(
     c2: as_Actor,
     c2_in_c2: as_Actor,
     case: as_VulnerabilityCase,
+    finder: as_Actor,
 ) -> as_VulnerabilityCase:
     """C1 invites C2 then transfers case ownership to C2.
 
@@ -312,7 +313,7 @@ def _phase_ownership_handoff(
     wait_for_case_participants(
         vendor_client=c1_client,
         case_id=case.id_,
-        expected_actor_ids={FINDER_ACTOR_ID, C1_ACTOR_ID, C2_ACTOR_ID},
+        expected_actor_ids={finder.id_, c1.id_, c2.id_},
     )
     logger.info("C2 has joined the case")
 
@@ -418,6 +419,7 @@ def _phase_c2_invites_vendor(
     offer: as_Offer,
     report: as_VulnerabilityReport,
     finder: as_Actor,
+    c1: as_Actor,
 ) -> None:
     """C2 (new CASE_OWNER) invites Vendor and Vendor joins the case (AC-2)."""
     logger.info("─" * 80)
@@ -497,10 +499,10 @@ def _phase_c2_invites_vendor(
         vendor_client=c1_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            C1_ACTOR_ID,
-            C2_ACTOR_ID,
-            VENDOR_ACTOR_ID,
+            finder.id_,
+            c1.id_,
+            c2.id_,
+            vendor.id_,
         },
         timeout_seconds=LATE_JOINER_TIMEOUT,
     )
@@ -584,10 +586,10 @@ def _phase_sync_verification(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_actor_ids={
-                FINDER_ACTOR_ID,
-                C1_ACTOR_ID,
-                C2_ACTOR_ID,
-                VENDOR_ACTOR_ID,
+                finder.id_,
+                c1.id_,
+                c2.id_,
+                vendor.id_,
             },
             timeout_seconds=p_timeout,
         )
@@ -1057,6 +1059,7 @@ def run_fccv_handoff_demo(
             c2=c2,
             c2_in_c2=c2_in_c2,
             case=case,
+            finder=finder,
         )
 
         _phase_c2_invites_vendor(
@@ -1073,6 +1076,7 @@ def run_fccv_handoff_demo(
             offer=offer,
             report=report,
             finder=finder,
+            c1=c1,
         )
 
         # Verify case active now that all participants have joined.

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -218,7 +218,7 @@ def _phase_report_submission(
     wait_for_case_participants(
         vendor_client=coordinator_client,
         case_id=case.id_,
-        expected_actor_ids={FINDER_ACTOR_ID, COORDINATOR_ACTOR_ID},
+        expected_actor_ids={finder.id_, coordinator.id_},
     )
 
     with demo_check("M1: ≥3 participants, EM.ACTIVE, Finder has replica"):
@@ -314,9 +314,9 @@ def _phase_invite_vendor(
         vendor_client=coordinator_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            COORDINATOR_ACTOR_ID,
-            VENDOR_ACTOR_ID,
+            finder.id_,
+            coordinator_in_coordinator.id_,
+            vendor.id_,
         },
         timeout_seconds=PARTICIPANT_JOIN_TIMEOUT,
     )
@@ -355,6 +355,7 @@ def _phase_sync_verification(
     finder: as_Actor,
     coordinator: as_Actor,
     case: as_VulnerabilityCase,
+    vendor: as_Actor,
 ) -> None:
     """Verify LedgerFanout replication for Finder and Vendor replicas."""
     logger.info("─" * 80)
@@ -399,9 +400,9 @@ def _phase_sync_verification(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_actor_ids={
-                FINDER_ACTOR_ID,
-                COORDINATOR_ACTOR_ID,
-                VENDOR_ACTOR_ID,
+                finder.id_,
+                coordinator.id_,
+                vendor.id_,
             },
             timeout_seconds=p_timeout,
         )
@@ -813,6 +814,7 @@ def run_fcv_demo(
             finder=finder,
             coordinator=coordinator,
             case=case,
+            vendor=vendor_obj,
         )
 
         _phase_notes_exchange(

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -241,7 +241,7 @@ def _phase_report_submission(
     wait_for_case_participants(
         vendor_client=c1_client,
         case_id=case.id_,
-        expected_actor_ids={FINDER_ACTOR_ID, C1_ACTOR_ID},
+        expected_actor_ids={finder.id_, c1.id_},
     )
 
     with demo_check(
@@ -352,10 +352,10 @@ def _phase_report_submission(
         vendor_client=c1_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            C1_ACTOR_ID,
-            V1_ACTOR_ID,
-            C2_ACTOR_ID,
+            finder.id_,
+            c1_in_c1.id_,
+            v1.id_,
+            c2_in_c2.id_,
         },
     )
 
@@ -399,6 +399,7 @@ def _phase_c2_suggests_v2(
     offer: as_Offer,
     report: as_VulnerabilityReport,
     finder: as_Actor,
+    v1: as_Actor,
 ) -> None:
     """C2 suggests V2 via ADR-0026; C1 approves; V2 joins (DEMOMA-19-009)."""
     logger.info("─" * 80)
@@ -488,11 +489,11 @@ def _phase_c2_suggests_v2(
         vendor_client=c1_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            C1_ACTOR_ID,
-            V1_ACTOR_ID,
-            C2_ACTOR_ID,
-            V2_ACTOR_ID,
+            finder.id_,
+            c1_in_c1.id_,
+            v1.id_,
+            c2_in_c2.id_,
+            v2.id_,
         },
         timeout_seconds=LATE_JOINER_TIMEOUT,
     )
@@ -529,6 +530,9 @@ def _phase_sync_verification(
     c1: as_Actor,
     finder: as_Actor,
     case: as_VulnerabilityCase,
+    v1: as_Actor,
+    c2_in_c2: as_Actor,
+    v2: as_Actor,
 ) -> None:
     """Verify LedgerFanout replication for all participant replicas."""
     logger.info("─" * 80)
@@ -573,11 +577,11 @@ def _phase_sync_verification(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_actor_ids={
-                FINDER_ACTOR_ID,
-                C1_ACTOR_ID,
-                V1_ACTOR_ID,
-                C2_ACTOR_ID,
-                V2_ACTOR_ID,
+                finder.id_,
+                c1.id_,
+                v1.id_,
+                c2_in_c2.id_,
+                v2.id_,
             },
             timeout_seconds=p_timeout,
         )
@@ -1137,6 +1141,7 @@ def run_fcvcv_demo(
             offer=offer,
             report=report,
             finder=finder,
+            v1=v1,
         )
 
         v2_in_v2 = get_actor_by_id(v2_client, v2.id_)
@@ -1151,6 +1156,9 @@ def run_fcvcv_demo(
             c1,
             finder,
             case,
+            v1,
+            c2_in_c2,
+            v2,
         )
         _phase_notes_exchange(
             finder_client=finder_client,

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -217,7 +217,7 @@ def _phase_report_submission(
     wait_for_case_participants(
         vendor_client=vendor_client,
         case_id=case.id_,
-        expected_actor_ids={FINDER_ACTOR_ID, VENDOR_ACTOR_ID},
+        expected_actor_ids={finder.id_, vendor.id_},
     )
 
     # Vendor1 invites Coordinator with COORDINATOR role only (not CASE_MANAGER).
@@ -265,9 +265,9 @@ def _phase_report_submission(
         vendor_client=vendor_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            VENDOR_ACTOR_ID,
-            COORDINATOR_ACTOR_ID,
+            finder.id_,
+            vendor.id_,
+            coordinator_in_coordinator.id_,
         },
     )
 
@@ -414,10 +414,10 @@ def _phase_coordinator_suggests_vendor2(
         vendor_client=vendor_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            VENDOR_ACTOR_ID,
-            COORDINATOR_ACTOR_ID,
-            VENDOR2_ACTOR_ID,
+            finder.id_,
+            vendor.id_,
+            coordinator_in_coordinator.id_,
+            vendor2.id_,
         },
         timeout_seconds=LATE_JOINER_TIMEOUT,
     )
@@ -500,10 +500,10 @@ def _phase_sync_verification(
             vendor_client=replica_client,
             case_id=case.id_,
             expected_actor_ids={
-                FINDER_ACTOR_ID,
-                VENDOR_ACTOR_ID,
-                COORDINATOR_ACTOR_ID,
-                VENDOR2_ACTOR_ID,
+                finder.id_,
+                vendor.id_,
+                coordinator.id_,
+                vendor2.id_,
             },
             timeout_seconds=p_timeout,
         )

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -196,7 +196,7 @@ def _phase_report_submission(
     wait_for_case_participants(
         vendor_client=vendor_client,
         case_id=case.id_,
-        expected_actor_ids={FINDER_ACTOR_ID, VENDOR_ACTOR_ID},
+        expected_actor_ids={finder.id_, vendor.id_},
     )
 
     with demo_check(
@@ -252,9 +252,9 @@ def _phase_report_submission(
         vendor_client=vendor_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            VENDOR_ACTOR_ID,
-            VENDOR2_ACTOR_ID,
+            finder.id_,
+            vendor.id_,
+            vendor2.id_,
         },
     )
 
@@ -343,18 +343,18 @@ def _phase_sync_verification(
         vendor_client=finder_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            VENDOR_ACTOR_ID,
-            VENDOR2_ACTOR_ID,
+            finder.id_,
+            vendor.id_,
+            vendor2.id_,
         },
     )
     wait_for_case_participants(
         vendor_client=vendor2_client,
         case_id=case.id_,
         expected_actor_ids={
-            FINDER_ACTOR_ID,
-            VENDOR_ACTOR_ID,
-            VENDOR2_ACTOR_ID,
+            finder.id_,
+            vendor.id_,
+            vendor2.id_,
         },
     )
 


### PR DESCRIPTION
- Closes #2628

## Summary

Fixes a 15-second timeout in Demo Integration CI: PR #2625 changed
`wait_for_case_participants` from count-based to identity-based, but left six
demo scenario files still passing hardcoded `*_ACTOR_ID` string constants as
`expected_actor_ids`. When `actor_id=None` is passed to `seed_actor`, the server
derives a UUID-based URI that differs from those constants, so the identity check
never satisfies and the scenario times out.

**Root cause:** `wait_for_case_participants` checks
`expected_actor_ids.issubset(case.actor_participant_index.keys())`. The index keys
are the actual URIs assigned at seeding time. When `actor_id=None` is passed, the
server derives a UUID slug (e.g. `http://finder:7999/api/v2/actors/<uuid>`), not
the expected constant. The passing scenarios either used `actor.id_` (already
fixed in #2625) or forced the hardcoded IDs at the seeding call site (`fcvcv_demo`).

## Changes

- **`vultron/demo/scenario/fccv_extension_demo.py`**: Replace hardcoded `*_ACTOR_ID` constants with `actor_obj.id_` attributes; thread `c2_in_c2` and `vendor` into `_phase_sync_verification`
- **`vultron/demo/scenario/fccv_handoff_demo.py`**: Replace hardcoded `*_ACTOR_ID` constants with `actor_obj.id_` attributes; thread `finder` into `_phase_ownership_handoff`, `c1` into `_phase_c2_invites_vendor`
- **`vultron/demo/scenario/fcv_demo.py`**: Replace hardcoded constants; thread `vendor` into `_phase_sync_verification`
- **`vultron/demo/scenario/fcvcv_demo.py`**: Replace hardcoded constants; thread `v1` into `_phase_c2_suggests_v2`, `v1/c2_in_c2/v2` into `_phase_sync_verification`
- **`vultron/demo/scenario/fvcv_extension_demo.py`**: Replace hardcoded constants with dynamic `actor_obj.id_` attributes
- **`vultron/demo/scenario/fvv_demo.py`**: Replace hardcoded constants with dynamic `actor_obj.id_` attributes
- **`test/architecture/test_demo_wait_for_participants_uses_dynamic_ids.py`**: New architecture ratchet (TB-13) that scans all scenario files for the hardcoded-constant anti-pattern at import time
- **`test/demo/test_fccv_handoff_demo.py`**: Pass missing `c1` arg to `_phase_c2_invites_vendor` call
- **`test/demo/test_fcvcv_demo.py`**: Pass missing `v1` arg to `_phase_c2_suggests_v2` call
- **`test/demo/test_issue_2361_2337_replication_timeout.py`**: Pass missing `v1`, `c2_in_c2`, `v2` args to both `_phase_sync_verification` calls

## Verification

- All unit tests pass
- black ✅ flake8 ✅ mypy ✅ pyright ✅
- Architecture ratchet: `pytest test/architecture/test_demo_wait_for_participants_uses_dynamic_ids.py`
- Demo Integration CI — five previously failing scenarios no longer time out: `fvcv-extension`, `fvv`, `fcv`, `fccv-extension`, `fccv-handoff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)