### PR TITLE
process: enforce epic parent on all new issue-creation paths

### DIFF
--- a/.agents/skills/bugfix/REFERENCE.md
+++ b/.agents/skills/bugfix/REFERENCE.md
@@ -48,6 +48,9 @@ file each as a new Bug-type GitHub issue. Do not pursue them in the current run.
 
 ```bash
 BUG_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Bug)
+# Inherit parent from the issue being fixed so the escalated bug is
+# visible in the epic tree (no:parent-issue orphans break prioritisation).
+PARENT_ARG="--parent ${ISSUE_NUMBER}"
 .agents/skills/manage-github-issue/manage_github_issue.sh \
   --title "<short bug title>" \
   --body "$(cat <<'EOF'
@@ -68,7 +71,8 @@ BUG_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Bug)
 Discovered during analysis of #N.
 EOF
 )" \
-  --issue-type-id "${BUG_TYPE_ID}"
+  --issue-type-id "${BUG_TYPE_ID}" \
+  ${PARENT_ARG}
 ```
 
 Reference newly filed issues in the PR description:

--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -51,6 +51,12 @@ If this fails, stop and investigate before proceeding.
      --issue-type-id "${BUG_TYPE_ID}")
    ```
 
+   Immediately after creation, route the new issue onto the epic forest:
+   invoke `calve-epics` Mode 1 on `${ISSUE_NUMBER}`. If `calve-epics` reports
+   no matching epic, present an `AskUserQuestion` with the top 5 closest open
+   epics plus "Specify other epic number". **A parent epic is required** —
+   do not proceed to Phase 2 until the issue is wired to a parent.
+
 3. Invoke `orient-agent` to load baseline context.
 4. Fetch the issue body and comments.
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -269,6 +269,9 @@ that clearly belongs with it, apply the following:
    with evidence (failing command/output, clean-base proof, causality check,
    blocked/unblocked impact), wire structured blockers, add a handoff comment,
    and record the Bug link as a learning file in `plan/incoming/learnings/`.
+   Set `--parent "${CURRENT_TASK_NUMBER}"` so the bug is wired under the same
+   task (and therefore the same epic) where it was discovered — this keeps it
+   visible in the epic tree and off the `no:parent-issue` orphan list.
 
 ### Phase 7 — Pre-PR Code Review
 

--- a/.agents/skills/calve-epics/SKILL.md
+++ b/.agents/skills/calve-epics/SKILL.md
@@ -96,9 +96,9 @@ parent is wrong). Goal: land each on the epic that matches it.
      failure. Do **not** invent an epic on your own. When Mode 1 is invoked
      **directly** (e.g. by `update-plan`): leave the issue at root and record
      it as a candidate for Mode 2. When Mode 1 is invoked by a skill that
-     **requires** a parent (e.g. `plan-issue`, `new-item`, `bugfix`): report
-     no match back to the caller — the caller is responsible for asking the
-     user to select an existing epic or triggering Mode 2.
+     **requires** a parent (e.g. `plan-issue`, `bugfix`): report no match back
+     to the caller — the caller is responsible for asking the user to select an
+     existing epic or triggering Mode 2.
    - **Two or more plausible epics** → ask the user with `AskUserQuestion`,
      presenting the candidates with a one-line rationale each. Route to their
      choice.

--- a/.agents/skills/calve-epics/SKILL.md
+++ b/.agents/skills/calve-epics/SKILL.md
@@ -93,8 +93,12 @@ parent is wrong). Goal: land each on the epic that matches it.
    - **Exactly one clearly-matching epic** → parent it there automatically via
      `manage-github-issue` (`--sub-issue`). No need to ask.
    - **Zero plausible epics** → this is a calving signal, not a routing
-     failure. Leave the issue at root and record it as a candidate for Mode 2.
-     Do **not** invent an epic on your own.
+     failure. Do **not** invent an epic on your own. When Mode 1 is invoked
+     **directly** (e.g. by `update-plan`): leave the issue at root and record
+     it as a candidate for Mode 2. When Mode 1 is invoked by a skill that
+     **requires** a parent (e.g. `plan-issue`, `new-item`, `bugfix`): report
+     no match back to the caller — the caller is responsible for asking the
+     user to select an existing epic or triggering Mode 2.
    - **Two or more plausible epics** → ask the user with `AskUserQuestion`,
      presenting the candidates with a one-line rationale each. Route to their
      choice.

--- a/.agents/skills/new-item/SKILL.md
+++ b/.agents/skills/new-item/SKILL.md
@@ -66,14 +66,16 @@ do not add a symptom/root frame to Ideas.
 ### Phase 4 — Epic Parent Selection
 
 **A parent epic is required for all new issues.** Query open Epic issues and
-rank likely matches. Present top ~5 suggestions plus "Specify other epic number".
-If the user provides another issue number, validate it is an open Epic;
-re-prompt until valid. Do **not** offer a "None / skip" option — an issue
-without a parent epic is invisible to sprint planning and prioritisation.
+rank likely matches. Present top ~5 suggestions, "Specify other epic number",
+and **"Create new epic (none of these fit)"** as explicit choices. If the user
+provides another issue number, validate it is an open Epic; re-prompt until
+valid. Do **not** offer a "None / skip" option — an issue without a parent epic
+is invisible to sprint planning and prioritisation.
 
-If no existing epic fits the new item, do not create the issue yet: invoke
-`calve-epics` Mode 2 to propose a new epic, confirm it with the user, and then
-proceed with that new epic as the parent. Allow at most one parent epic.
+If the user selects "Create new epic (none of these fit)", do not create the
+issue yet: invoke `calve-epics` Mode 2 to propose a new epic, confirm it with
+the user, and then proceed with that new epic as the parent. Allow at most one
+parent epic.
 
 ### Phase 5 — Build Title + Body
 

--- a/.agents/skills/new-item/SKILL.md
+++ b/.agents/skills/new-item/SKILL.md
@@ -2,7 +2,7 @@
 name: new-item
 description: >
   Create or update a single GitHub Idea or Concern issue from freeform input,
-  with type inference, duplicate checks, and optional Epic parent wiring. Use
+  with type inference, duplicate checks, and mandatory Epic parent wiring. Use
   when a developer wants to quickly capture a new planning item as type:Idea or
   type:Concern.
 ---
@@ -65,10 +65,15 @@ do not add a symptom/root frame to Ideas.
 
 ### Phase 4 — Epic Parent Selection
 
-Query open Epic issues and rank likely matches. Present top ~5 suggestions, plus
-"Specify other epic" and "None". If user provides another issue number, validate
-it is an open Epic; re-prompt until valid or none selected. Allow at most one
-parent epic.
+**A parent epic is required for all new issues.** Query open Epic issues and
+rank likely matches. Present top ~5 suggestions plus "Specify other epic number".
+If the user provides another issue number, validate it is an open Epic;
+re-prompt until valid. Do **not** offer a "None / skip" option — an issue
+without a parent epic is invisible to sprint planning and prioritisation.
+
+If no existing epic fits the new item, do not create the issue yet: invoke
+`calve-epics` Mode 2 to propose a new epic, confirm it with the user, and then
+proceed with that new epic as the parent. Allow at most one parent epic.
 
 ### Phase 5 — Build Title + Body
 

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -301,9 +301,15 @@ bash .agents/skills/shared/add-to-project.sh "${IMPL_NUMBER}"
 parent Epic (`EPIC_NUMBER` non-empty) is already on the right glacier — leave
 it at its inherited tier. But an impl issue with **no** parent epic should not
 be left flat at Someday: invoke the **`calve-epics`** skill (Mode 1) to route
-it onto the epic it matches, inheriting that epic's Schedule tier. If no epic
-fits, `calve-epics` leaves it at root as a calving candidate — do not mint a
-new epic inline here.
+it onto the epic it matches, inheriting that epic's Schedule tier.
+
+**A parent epic is mandatory.** If `calve-epics` Mode 1 finds no match, do
+**not** leave the issue at root. Instead use `AskUserQuestion` to present the
+full list of open epics and require the user to select the best fit. If the
+user determines a new epic is warranted, run `calve-epics` Mode 2 to propose
+and confirm it before closing this skill. An impl issue without a parent epic
+is invisible to prioritisation and blocks future sprint planning — never ship
+one orphaned.
 
 ### Phase 8b — Add Implementation Issue References to Docs PR (Ideas and Concerns only)
 


### PR DESCRIPTION
- Closes #2715

## Summary

- Five skill files had exit paths where a new GitHub issue could be created
  without a parent epic, making it invisible to sprint planning and
  prioritization (the `no:parent-issue` orphan problem).
- A bulk-parenting pass on 2026-08-26 routed all 54 existing orphaned issues
  to their appropriate epics.
- This PR patches the five skill files so future issue creation always wires
  a parent.

## Changes

| File | What was broken | Fix |
|---|---|---|
| `bugfix/REFERENCE.md` | Escalation creates sibling bugs with no `--parent` | Now sets `--parent "${ISSUE_NUMBER}"` — escalated bug is a sub-issue of the bug being fixed |
| `bugfix/SKILL.md` | Phase 1 new-bug creation had no epic routing step | After creation, requires `calve-epics` Mode 1; `AskUserQuestion` gate if no match found |
| `build/SKILL.md` | Phase 6 pre-existing-bug creation had no `--parent` | Now sets `--parent "${CURRENT_TASK_NUMBER}"` |
| `plan-issue/SKILL.md` | Phase 8 allowed impl issues to stay at root when `calve-epics` found no match | "Leave at root" exit removed; replaced with mandatory `AskUserQuestion` + `calve-epics` Mode 2 |
| `new-item/SKILL.md` | Phase 4 offered "None" as a valid epic parent | "None" removed; epic is mandatory; `calve-epics` Mode 2 for genuinely new-epic cases |
| `calve-epics/SKILL.md` | Mode 1 zero-match always left issue at root regardless of caller intent | Distinguishes direct invocation vs. caller-required invocation |

## Test plan

- [ ] Run `/bugfix` and intentionally escalate a sibling bug — verify the
  escalated issue appears as a sub-issue of the bug being fixed
- [ ] Run `/build` on a task and trigger the Phase 6 pre-existing-bug path —
  verify the created bug is a sub-issue of the current task
- [ ] Run `/new-item` and choose "no existing epic fits" — verify `calve-epics`
  Mode 2 is triggered rather than creating an orphan
- [ ] Run `/plan-issue` through Phase 8 with no matching epic — verify the
  skill asks for a parent rather than leaving the issue at root
- [ ] Confirm `is:issue state:open no:parent-issue -type:Epic` returns 0
  results after any of the above flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)