### PR TITLE
fix(demo): gate notify-fix-ready on vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} (CSB-18-001)

### DIFF
--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -107,8 +107,8 @@ No open entries.
 
 | Job name | Issue | Last blocked |
 |---|---|---|
-| `fvcv-extension` | — | 2026-07-31 |
-| `fccv-extension` | — | 2026-07-31 |
+| `fvcv-extension` | #2422 | 2026-08-26 |
+| `fccv-extension` | #2422 | 2026-08-26 |
 | `fv Demo Integration` | #2422 | 2026-08-20 |
 | `fv Invariant Harness` | #2422 | 2026-08-20 |
 | `fvcv-handoff Demo Integration` | #2257 | 2026-08-18 |
@@ -116,12 +116,15 @@ No open entries.
 | `fcv-reject Demo Integration` | #2390 | 2026-08-19 |
 | `fcv-reject Invariant Harness` | #2390 | 2026-08-19 |
 
-> `fv Demo Integration` / `fv Invariant Harness` now point to #2422 (vendor
-> RM.RECEIVED timeout at M3, cascading `notify-fix-ready` 422 from cross-machine
-> entailment guard, then vfd_state timeouts at M4/M5/M6).  Same async race-window
-> class as #2376 (fcvcv, coordinator/engage-case).  Invariant Harness fails as a
+> `fv Demo Integration` / `fv Invariant Harness` / `fvcv-extension` / `fccv-extension`
+> all point to #2422 (vendor RM.RECEIVED timeout at M3, cascading `notify-fix-ready`
+> 422 from cross-machine entailment guard, then vfd_state timeouts at M4/M5/M6).
+> Same async race-window class as #2376 (fcvcv, coordinator/engage-case).
+> Root fix: wrap `actor_notifies_fix_ready` in `demo_gate` polling
+> `wait_for_participant_rm_state(expected_states={RM.ACCEPTED,DEFERRED,CLOSED})`
+> across all 8 affected scenario files (ADR-0058).  Invariant Harness fails as a
 > downstream consequence of incomplete devlogs.  First confirmed 2026-08-20 on
-> PR #2419.
+> PR #2419.  Fix landed in PR resolving #2422 (2026-08-26).
 >
 >
 > `fvcv-handoff Demo Integration` / `fvcv-handoff Invariant Harness` now point to

--- a/test/demo/test_fccv_extension_demo.py
+++ b/test/demo/test_fccv_extension_demo.py
@@ -232,6 +232,53 @@ class TestFccvExtensionMilestoneAssertions:
         mock_wait_vfd.assert_called()
         mock_check_vfd.assert_called()
 
+    def test_phase_fix_lifecycle_gates_on_rm_accepted(self):
+        """_phase_fix_lifecycle polls vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (ADR-0058/CSB-18-001)."""
+        from vultron.core.states.rm import RM
+
+        c1_client = self._client()
+        vendor_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        case = self._case()
+
+        call_order = []
+        rm_calls = []
+
+        def _rm_wait(*a, **kw):
+            rm_calls.append(kw)
+            call_order.append("rm_wait")
+
+        with (
+            patch.object(demo, "wait_for_participant_rm_state", _rm_wait),
+            patch.object(
+                demo,
+                "actor_notifies_fix_ready",
+                side_effect=lambda *a, **kw: call_order.append("fix_ready"),
+            ),
+            patch.object(demo, "wait_for_participant_vfd_state"),
+            patch.object(demo, "_check_participant_vfd_state_in"),
+        ):
+            demo._phase_fix_lifecycle(
+                c1_client=c1_client,
+                vendor_client=vendor_client,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                case=case,
+            )
+
+        assert (
+            rm_calls
+        ), "wait_for_participant_rm_state must be called (ADR-0058/CSB-18-001)"
+        assert all(
+            c.get("expected_states") == {RM.ACCEPTED, RM.DEFERRED, RM.CLOSED}
+            for c in rm_calls
+        ), "expected_states must be {ACCEPTED, DEFERRED, CLOSED} (CSB-18-001)"
+        assert "rm_wait" in call_order and "fix_ready" in call_order
+        assert call_order.index("rm_wait") < call_order.index(
+            "fix_ready"
+        ), "wait_for_participant_rm_state must precede actor_notifies_fix_ready (ADR-0058)"
+
     def test_phase_publication_calls_verify_publicly_disclosed(self):
         """_phase_publication calls verify_publicly_disclosed at M7."""
         import contextlib

--- a/test/demo/test_fccv_extension_demo.py
+++ b/test/demo/test_fccv_extension_demo.py
@@ -207,6 +207,7 @@ class TestFccvExtensionMilestoneAssertions:
         case = self._case()
 
         with (
+            patch.object(demo, "wait_for_participant_rm_state"),
             patch.object(demo, "actor_notifies_fix_ready") as mock_fix_ready,
             patch.object(
                 demo, "wait_for_participant_vfd_state"

--- a/test/demo/test_fccv_handoff_demo.py
+++ b/test/demo/test_fccv_handoff_demo.py
@@ -645,6 +645,57 @@ class TestFccvHandoffMilestoneAssertions:
             )
         mock_m4.assert_called()
 
+    def test_phase_fix_lifecycle_gates_on_rm_accepted(self):
+        """_phase_fix_lifecycle polls vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (ADR-0058/CSB-18-001)."""
+        from vultron.core.states.rm import RM
+
+        finder_client = self._client()
+        c1_client = self._client()
+        vendor_client = self._client()
+        c1 = self._actor("urn:test:c1")
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        case = self._case()
+
+        call_order = []
+        rm_calls = []
+
+        def _rm_wait(*a, **kw):
+            rm_calls.append(kw)
+            call_order.append("rm_wait")
+
+        with (
+            patch.object(demo, "wait_for_participant_rm_state", _rm_wait),
+            patch.object(
+                demo,
+                "actor_notifies_fix_ready",
+                side_effect=lambda *a, **kw: call_order.append("fix_ready"),
+            ),
+            patch.object(demo, "wait_for_participant_vfd_state"),
+            patch.object(demo, "verify_fix_ready"),
+        ):
+            demo._phase_fix_lifecycle(
+                finder_client=finder_client,
+                c1_client=c1_client,
+                vendor_client=vendor_client,
+                c1=c1,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                case=case,
+            )
+
+        assert (
+            rm_calls
+        ), "wait_for_participant_rm_state must be called (ADR-0058/CSB-18-001)"
+        assert all(
+            c.get("expected_states") == {RM.ACCEPTED, RM.DEFERRED, RM.CLOSED}
+            for c in rm_calls
+        ), "expected_states must be {ACCEPTED, DEFERRED, CLOSED} (CSB-18-001)"
+        assert "rm_wait" in call_order and "fix_ready" in call_order
+        assert call_order.index("rm_wait") < call_order.index(
+            "fix_ready"
+        ), "wait_for_participant_rm_state must precede actor_notifies_fix_ready (ADR-0058)"
+
     def test_phase_publication_calls_verify_publicly_disclosed(self):
         """_phase_publication calls verify_publicly_disclosed at M6."""
         import contextlib

--- a/test/demo/test_fccv_handoff_demo.py
+++ b/test/demo/test_fccv_handoff_demo.py
@@ -622,6 +622,7 @@ class TestFccvHandoffMilestoneAssertions:
         case = self._case()
 
         with (
+            patch.object(demo, "wait_for_participant_rm_state"),
             patch.object(demo, "actor_notifies_fix_ready"),
             patch.object(demo, "wait_for_participant_vfd_state"),
             patch.object(demo, "verify_fix_ready") as mock_m4,

--- a/test/demo/test_fcv_demo.py
+++ b/test/demo/test_fcv_demo.py
@@ -421,6 +421,7 @@ class TestFcvMilestoneAssertions:
         case = self._case()
 
         with (
+            patch.object(demo, "wait_for_participant_rm_state"),
             patch.object(demo, "actor_notifies_fix_ready"),
             patch.object(demo, "wait_for_participant_vfd_state"),
             patch.object(demo, "verify_fix_ready") as mock_m5,

--- a/test/demo/test_fcv_demo.py
+++ b/test/demo/test_fcv_demo.py
@@ -443,6 +443,55 @@ class TestFcvMilestoneAssertions:
             )
         mock_m5.assert_called()
 
+    def test_phase_fix_lifecycle_gates_on_rm_accepted(self):
+        """_phase_fix_lifecycle polls vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (ADR-0058/CSB-18-001)."""
+        from vultron.core.states.rm import RM
+
+        coordinator_client = self._client()
+        vendor_client = self._client()
+        coordinator = self._actor("urn:test:coordinator")
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        case = self._case()
+
+        call_order = []
+        rm_calls = []
+
+        def _rm_wait(*a, **kw):
+            rm_calls.append(kw)
+            call_order.append("rm_wait")
+
+        with (
+            patch.object(demo, "wait_for_participant_rm_state", _rm_wait),
+            patch.object(
+                demo,
+                "actor_notifies_fix_ready",
+                side_effect=lambda *a, **kw: call_order.append("fix_ready"),
+            ),
+            patch.object(demo, "wait_for_participant_vfd_state"),
+            patch.object(demo, "verify_fix_ready"),
+        ):
+            demo._phase_fix_lifecycle(
+                coordinator_client=coordinator_client,
+                vendor_client=vendor_client,
+                coordinator=coordinator,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                case=case,
+            )
+
+        assert (
+            rm_calls
+        ), "wait_for_participant_rm_state must be called (ADR-0058/CSB-18-001)"
+        assert all(
+            c.get("expected_states") == {RM.ACCEPTED, RM.DEFERRED, RM.CLOSED}
+            for c in rm_calls
+        ), "expected_states must be {ACCEPTED, DEFERRED, CLOSED} (CSB-18-001)"
+        assert "rm_wait" in call_order and "fix_ready" in call_order
+        assert call_order.index("rm_wait") < call_order.index(
+            "fix_ready"
+        ), "wait_for_participant_rm_state must precede actor_notifies_fix_ready (ADR-0058)"
+
     def test_phase_publication_calls_verify_publicly_disclosed(self):
         """_phase_publication calls verify_publicly_disclosed at M6."""
         import contextlib

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -2132,6 +2132,7 @@ class TestFvMilestoneAssertions:
         case = self._case()
 
         with (
+            patch.object(demo, "wait_for_participant_rm_state"),
             patch.object(demo, "actor_notifies_fix_ready"),
             patch.object(demo, "wait_for_participant_vfd_state"),
             patch.object(demo, "verify_fix_ready") as mock_m4,
@@ -2151,6 +2152,58 @@ class TestFvMilestoneAssertions:
                 case=case,
             )
         mock_m4.assert_called()
+
+    def test_phase_fix_lifecycle_gates_on_rm_accepted(self):
+        """_phase_fix_lifecycle polls vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (ADR-0058/CSB-18-001)."""
+        import contextlib
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        case = self._case()
+
+        call_order = []
+
+        mock_rm_wait = MagicMock(
+            side_effect=lambda *a, **kw: call_order.append("rm_wait")
+        )
+        mock_fix_ready = MagicMock(
+            side_effect=lambda *a, **kw: call_order.append("fix_ready")
+        )
+
+        with (
+            patch.object(demo, "wait_for_participant_rm_state", mock_rm_wait),
+            patch.object(demo, "actor_notifies_fix_ready", mock_fix_ready),
+            patch.object(demo, "wait_for_participant_vfd_state"),
+            patch.object(demo, "verify_fix_ready"),
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            demo._phase_fix_lifecycle(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                case=case,
+            )
+
+        assert (
+            mock_rm_wait.called
+        ), "wait_for_participant_rm_state must be called before notify-fix-ready"
+        rm_call = mock_rm_wait.call_args_list[0]
+        assert rm_call.kwargs.get("expected_states") == {
+            RM.ACCEPTED,
+            RM.DEFERRED,
+            RM.CLOSED,
+        }, "expected_states must be {ACCEPTED, DEFERRED, CLOSED}"
+        assert "rm_wait" in call_order and "fix_ready" in call_order
+        assert call_order.index("rm_wait") < call_order.index(
+            "fix_ready"
+        ), "wait_for_participant_rm_state must be called before actor_notifies_fix_ready"
 
     def test_phase_publication_calls_verify_publicly_disclosed(self):
         """_phase_publication calls verify_publicly_disclosed at M6."""

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -2155,8 +2155,6 @@ class TestFvMilestoneAssertions:
 
     def test_phase_fix_lifecycle_gates_on_rm_accepted(self):
         """_phase_fix_lifecycle polls vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (ADR-0058/CSB-18-001)."""
-        import contextlib
-
         finder_client = self._client()
         vendor_client = self._client()
         vendor = self._actor("urn:test:vendor")
@@ -2177,11 +2175,6 @@ class TestFvMilestoneAssertions:
             patch.object(demo, "actor_notifies_fix_ready", mock_fix_ready),
             patch.object(demo, "wait_for_participant_vfd_state"),
             patch.object(demo, "verify_fix_ready"),
-            patch.object(
-                demo,
-                "demo_check",
-                side_effect=lambda _: contextlib.nullcontext(),
-            ),
         ):
             demo._phase_fix_lifecycle(
                 finder_client=finder_client,

--- a/test/demo/test_fvcv_extension_demo.py
+++ b/test/demo/test_fvcv_extension_demo.py
@@ -504,6 +504,7 @@ class TestFvcvExtensionMilestoneAssertions:
         case = self._case()
 
         with (
+            patch.object(demo, "wait_for_participant_rm_state"),
             patch.object(demo, "actor_notifies_fix_ready"),
             patch.object(demo, "wait_for_participant_vfd_state"),
             patch.object(demo, "verify_fix_ready") as mock_m4,

--- a/test/demo/test_fvcv_extension_demo.py
+++ b/test/demo/test_fvcv_extension_demo.py
@@ -528,6 +528,59 @@ class TestFvcvExtensionMilestoneAssertions:
             )
         mock_m4.assert_called()
 
+    def test_phase_fix_lifecycle_gates_on_rm_accepted(self):
+        """_phase_fix_lifecycle polls each vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (ADR-0058/CSB-18-001)."""
+        from vultron.core.states.rm import RM
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        vendor2_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        vendor2 = self._actor("urn:test:vendor2")
+        vendor2_in_vendor2 = self._actor("urn:test:vendor2")
+        case = self._case()
+
+        call_order = []
+        rm_calls = []
+
+        def _rm_wait(*a, **kw):
+            rm_calls.append(kw)
+            call_order.append("rm_wait")
+
+        with (
+            patch.object(demo, "wait_for_participant_rm_state", _rm_wait),
+            patch.object(
+                demo,
+                "actor_notifies_fix_ready",
+                side_effect=lambda *a, **kw: call_order.append("fix_ready"),
+            ),
+            patch.object(demo, "wait_for_participant_vfd_state"),
+            patch.object(demo, "verify_fix_ready"),
+        ):
+            demo._phase_fix_lifecycle(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                vendor2_client=vendor2_client,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                vendor2=vendor2,
+                vendor2_in_vendor2=vendor2_in_vendor2,
+                case=case,
+            )
+
+        assert (
+            len(rm_calls) == 2
+        ), f"wait_for_participant_rm_state must be called once per vendor (got {len(rm_calls)}) (ADR-0058/CSB-18-001)"
+        assert all(
+            c.get("expected_states") == {RM.ACCEPTED, RM.DEFERRED, RM.CLOSED}
+            for c in rm_calls
+        ), "expected_states must be {ACCEPTED, DEFERRED, CLOSED} for each vendor (CSB-18-001)"
+        assert "rm_wait" in call_order and "fix_ready" in call_order
+        assert call_order.index("rm_wait") < call_order.index(
+            "fix_ready"
+        ), "wait_for_participant_rm_state must precede actor_notifies_fix_ready (ADR-0058)"
+
     def test_phase_publication_calls_verify_publicly_disclosed(self):
         """_phase_publication calls verify_publicly_disclosed at M6."""
         import contextlib

--- a/test/demo/test_fvcv_handoff_demo.py
+++ b/test/demo/test_fvcv_handoff_demo.py
@@ -376,6 +376,7 @@ class TestFvcvHandoffMilestoneAssertions:
         case = self._case()
 
         with (
+            patch.object(demo, "wait_for_participant_rm_state"),
             patch.object(demo, "actor_notifies_fix_ready"),
             patch.object(demo, "wait_for_participant_vfd_state"),
             patch.object(demo, "verify_fix_ready") as mock_m4,

--- a/test/demo/test_fvcv_handoff_demo.py
+++ b/test/demo/test_fvcv_handoff_demo.py
@@ -400,6 +400,59 @@ class TestFvcvHandoffMilestoneAssertions:
             )
         mock_m4.assert_called()
 
+    def test_phase_fix_lifecycle_gates_on_rm_accepted(self):
+        """_phase_fix_lifecycle polls each vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (ADR-0058/CSB-18-001)."""
+        from vultron.core.states.rm import RM
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        vendor2_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        vendor2 = self._actor("urn:test:vendor2")
+        vendor2_in_vendor2 = self._actor("urn:test:vendor2")
+        case = self._case()
+
+        call_order = []
+        rm_calls = []
+
+        def _rm_wait(*a, **kw):
+            rm_calls.append(kw)
+            call_order.append("rm_wait")
+
+        with (
+            patch.object(demo, "wait_for_participant_rm_state", _rm_wait),
+            patch.object(
+                demo,
+                "actor_notifies_fix_ready",
+                side_effect=lambda *a, **kw: call_order.append("fix_ready"),
+            ),
+            patch.object(demo, "wait_for_participant_vfd_state"),
+            patch.object(demo, "verify_fix_ready"),
+        ):
+            demo._phase_fix_lifecycle(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                vendor2_client=vendor2_client,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                vendor2=vendor2,
+                vendor2_in_vendor2=vendor2_in_vendor2,
+                case=case,
+            )
+
+        assert (
+            len(rm_calls) == 2
+        ), f"wait_for_participant_rm_state must be called once per vendor (got {len(rm_calls)}) (ADR-0058/CSB-18-001)"
+        assert all(
+            c.get("expected_states") == {RM.ACCEPTED, RM.DEFERRED, RM.CLOSED}
+            for c in rm_calls
+        ), "expected_states must be {ACCEPTED, DEFERRED, CLOSED} for each vendor (CSB-18-001)"
+        assert "rm_wait" in call_order and "fix_ready" in call_order
+        assert call_order.index("rm_wait") < call_order.index(
+            "fix_ready"
+        ), "wait_for_participant_rm_state must precede actor_notifies_fix_ready (ADR-0058)"
+
     def test_phase_publication_calls_verify_publicly_disclosed(self):
         """_phase_publication calls verify_publicly_disclosed at M6."""
         import contextlib

--- a/test/demo/test_fvv_demo.py
+++ b/test/demo/test_fvv_demo.py
@@ -720,6 +720,59 @@ class TestFvvMilestoneAssertions:
             )
         mock_m4.assert_called()
 
+    def test_phase_fix_lifecycle_gates_on_rm_accepted(self):
+        """_phase_fix_lifecycle polls each vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (ADR-0058/CSB-18-001)."""
+        from vultron.core.states.rm import RM
+
+        finder_client = self._client()
+        vendor_client = self._client()
+        vendor2_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        vendor2 = self._actor("urn:test:vendor2")
+        vendor2_in_vendor2 = self._actor("urn:test:vendor2")
+        case = self._case()
+
+        call_order = []
+        rm_calls = []
+
+        def _rm_wait(*a, **kw):
+            rm_calls.append(kw)
+            call_order.append("rm_wait")
+
+        with (
+            patch.object(demo, "wait_for_participant_rm_state", _rm_wait),
+            patch.object(
+                demo,
+                "actor_notifies_fix_ready",
+                side_effect=lambda *a, **kw: call_order.append("fix_ready"),
+            ),
+            patch.object(demo, "wait_for_participant_vfd_state"),
+            patch.object(demo, "verify_fix_ready"),
+        ):
+            demo._phase_fix_lifecycle(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                vendor2_client=vendor2_client,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                vendor2=vendor2,
+                vendor2_in_vendor2=vendor2_in_vendor2,
+                case=case,
+            )
+
+        assert (
+            len(rm_calls) == 2
+        ), f"wait_for_participant_rm_state must be called once per vendor (got {len(rm_calls)}) (ADR-0058/CSB-18-001)"
+        assert all(
+            c.get("expected_states") == {RM.ACCEPTED, RM.DEFERRED, RM.CLOSED}
+            for c in rm_calls
+        ), "expected_states must be {ACCEPTED, DEFERRED, CLOSED} for each vendor (CSB-18-001)"
+        assert "rm_wait" in call_order and "fix_ready" in call_order
+        assert call_order.index("rm_wait") < call_order.index(
+            "fix_ready"
+        ), "wait_for_participant_rm_state must precede actor_notifies_fix_ready (ADR-0058)"
+
     def test_phase_publication_calls_verify_publicly_disclosed(self):
         """_phase_publication calls verify_publicly_disclosed at M6."""
         import contextlib

--- a/test/demo/test_fvv_demo.py
+++ b/test/demo/test_fvv_demo.py
@@ -698,6 +698,7 @@ class TestFvvMilestoneAssertions:
         case = self._case()
 
         with (
+            patch.object(demo, "wait_for_participant_rm_state"),
             patch.object(demo, "actor_notifies_fix_ready"),
             patch.object(demo, "wait_for_participant_vfd_state"),
             patch.object(demo, "verify_fix_ready") as mock_m4,

--- a/test/demo/test_issue_2361_2337_replication_timeout.py
+++ b/test/demo/test_issue_2361_2337_replication_timeout.py
@@ -80,6 +80,9 @@ def test_fv_finder_timeout_records_single_gate_failure_not_two_check_failures(
     monkeypatch.setattr(
         fv_demo_module, "verify_fix_ready", lambda *a, **kw: None
     )
+    monkeypatch.setattr(
+        fv_demo_module, "wait_for_participant_rm_state", lambda *a, **kw: None
+    )
 
     def _vfd_poll(client, case_id, actor_id, expected_states, **kw):
         if client is finder_client:
@@ -114,6 +117,65 @@ def test_fv_finder_timeout_records_single_gate_failure_not_two_check_failures(
         f"Use demo_gate (not demo_check) for the causal finder precondition "
         f"(#2361, ADR-0058)."
     )
+
+
+def test_fv_phase_fix_lifecycle_gates_on_rm_accepted(monkeypatch):
+    """_phase_fix_lifecycle polls vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (ADR-0058/CSB-18-001)."""
+    from vultron.core.states.rm import RM
+
+    reset_demo_failures()
+
+    vendor_client = MagicMock()
+    vendor_client.base_url = "http://vendor:7999/api/v2"
+    finder_client = MagicMock()
+    finder_client.base_url = "http://finder:7999/api/v2"
+    vendor = MagicMock()
+    vendor.id_ = _VENDOR_ID
+    vendor_in_vendor = MagicMock()
+    case = MagicMock()
+    case.id_ = _CASE_ID
+
+    call_order = []
+    rm_calls = []
+
+    def _rm_wait(*a, **kw):
+        rm_calls.append(kw)
+        call_order.append("rm_wait")
+
+    monkeypatch.setattr(
+        fv_demo_module, "wait_for_participant_rm_state", _rm_wait
+    )
+    monkeypatch.setattr(
+        fv_demo_module,
+        "actor_notifies_fix_ready",
+        lambda *a, **kw: call_order.append("fix_ready"),
+    )
+    monkeypatch.setattr(
+        fv_demo_module, "verify_fix_ready", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        fv_demo_module, "wait_for_participant_vfd_state", lambda *a, **kw: None
+    )
+
+    _phase_fix_lifecycle(
+        finder_client=finder_client,
+        vendor_client=vendor_client,
+        vendor=vendor,
+        vendor_in_vendor=vendor_in_vendor,
+        case=case,
+    )
+
+    assert (
+        rm_calls
+    ), "wait_for_participant_rm_state must be called (ADR-0058/CSB-18-001)"
+    assert all(
+        c.get("expected_states") == {RM.ACCEPTED, RM.DEFERRED, RM.CLOSED}
+        for c in rm_calls
+    ), "expected_states must be {ACCEPTED, DEFERRED, CLOSED} (CSB-18-001)"
+    assert "rm_wait" in call_order and "fix_ready" in call_order
+    assert call_order.index("rm_wait") < call_order.index(
+        "fix_ready"
+    ), "wait_for_participant_rm_state must precede actor_notifies_fix_ready (ADR-0058)"
 
 
 # ===========================================================================

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -39,6 +39,7 @@ import os
 import sys
 
 from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
     as_TransitiveActivity,
@@ -57,6 +58,7 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     assert_demo_success,
     check_server_availability,
     demo_check,
+    demo_gate,
     demo_step,
     post_to_inbox_and_wait,
     post_to_trigger,
@@ -95,6 +97,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
     wait_for_event_type_in_ledger,
+    wait_for_participant_rm_state,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -610,65 +613,78 @@ def _phase_fix_lifecycle(
     )
     logger.info("─" * 80)
 
-    actor_notifies_fix_ready(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
+        )
+        actor_notifies_fix_ready(
+            client=vendor_client,
+            actor=vendor_in_vendor,
+            case_id=case.id_,
         )
 
-    with demo_check("M5: C1 replica shows Vendor CS includes F (fix ready)"):
-        wait_for_participant_vfd_state(
-            client=c1_client,
-            case_id=case.id_,
-            actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
-        )
-        _check_participant_vfd_state_in(
-            c1_client,
-            case.id_,
-            vendor.id_,
-            {CS_vfd.VFd, CS_vfd.VFD},
-            "M5: C1 replica fix ready",
-        )
-        _check_participant_vfd_state_in(
-            vendor_client,
-            case.id_,
-            vendor.id_,
-            {CS_vfd.VFd, CS_vfd.VFD},
-            "M5: Vendor replica fix ready",
-        )
+        with demo_check(
+            "Vendor participant vfd_state transitions to VFd or VFD"
+        ):
+            wait_for_participant_vfd_state(
+                client=vendor_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
-    with demo_check(
-        "M6: C1 replica shows Vendor CS includes F (fix ready) — vendor stops at VFd"
-    ):
-        wait_for_participant_vfd_state(
-            client=c1_client,
-            case_id=case.id_,
-            actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd},
-        )
-        _check_participant_vfd_state_in(
-            c1_client,
-            case.id_,
-            vendor.id_,
-            {CS_vfd.VFd},
-            "M6: C1 replica fix ready",
-        )
-        _check_participant_vfd_state_in(
-            vendor_client,
-            case.id_,
-            vendor.id_,
-            {CS_vfd.VFd},
-            "M6: Vendor replica fix ready",
-        )
+        with demo_check(
+            "M5: C1 replica shows Vendor CS includes F (fix ready)"
+        ):
+            wait_for_participant_vfd_state(
+                client=c1_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
+            _check_participant_vfd_state_in(
+                c1_client,
+                case.id_,
+                vendor.id_,
+                {CS_vfd.VFd, CS_vfd.VFD},
+                "M5: C1 replica fix ready",
+            )
+            _check_participant_vfd_state_in(
+                vendor_client,
+                case.id_,
+                vendor.id_,
+                {CS_vfd.VFd, CS_vfd.VFD},
+                "M5: Vendor replica fix ready",
+            )
+
+        with demo_check(
+            "M6: C1 replica shows Vendor CS includes F (fix ready) — vendor stops at VFd"
+        ):
+            wait_for_participant_vfd_state(
+                client=c1_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd},
+            )
+            _check_participant_vfd_state_in(
+                c1_client,
+                case.id_,
+                vendor.id_,
+                {CS_vfd.VFd},
+                "M6: C1 replica fix ready",
+            )
+            _check_participant_vfd_state_in(
+                vendor_client,
+                case.id_,
+                vendor.id_,
+                {CS_vfd.VFd},
+                "M6: Vendor replica fix ready",
+            )
 
 
 def _phase_publication(

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -33,6 +33,7 @@ import os
 import sys
 
 from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
     as_TransitiveActivity,
@@ -52,6 +53,7 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     case_actor_id_on,
     check_server_availability,
     demo_check,
+    demo_gate,
     demo_step,
     post_to_inbox_and_wait,
     post_to_trigger,
@@ -94,6 +96,7 @@ from vultron.demo.helpers.polling import (
     wait_for_contiguous_ledger_coverage,
     wait_for_event_type_in_ledger,
     wait_for_object_stored,
+    wait_for_participant_rm_state,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -700,61 +703,74 @@ def _phase_fix_lifecycle(
     )
     logger.info("─" * 80)
 
-    actor_notifies_fix_ready(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
+        )
+        actor_notifies_fix_ready(
+            client=vendor_client,
+            actor=vendor_in_vendor,
+            case_id=case.id_,
         )
 
-    with demo_check("Finder replica shows Vendor CS includes F (fix ready)"):
-        wait_for_participant_vfd_state(
-            client=c1_client,
-            case_id=case.id_,
-            actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
-        )
-        wait_for_participant_vfd_state(
-            client=finder_client,
-            case_id=case.id_,
-            actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
-        )
-        verify_fix_ready(
-            receiver_client=c1_client,
-            reporter_client=finder_client,
-            case_id=case.id_,
-            receiver_actor_id=vendor.id_,
-        )
+        with demo_check(
+            "Vendor participant vfd_state transitions to VFd or VFD"
+        ):
+            wait_for_participant_vfd_state(
+                client=vendor_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
-    with demo_check(
-        "Finder replica shows Vendor CS includes F (fix ready) — vendor stops at VFd"
-    ):
-        wait_for_participant_vfd_state(
-            client=c1_client,
-            case_id=case.id_,
-            actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd},
-        )
-        wait_for_participant_vfd_state(
-            client=finder_client,
-            case_id=case.id_,
-            actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd},
-        )
-        verify_fix_ready(
-            receiver_client=c1_client,
-            reporter_client=finder_client,
-            case_id=case.id_,
-            receiver_actor_id=vendor.id_,
-        )
+        with demo_check(
+            "Finder replica shows Vendor CS includes F (fix ready)"
+        ):
+            wait_for_participant_vfd_state(
+                client=c1_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
+            wait_for_participant_vfd_state(
+                client=finder_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
+            verify_fix_ready(
+                receiver_client=c1_client,
+                reporter_client=finder_client,
+                case_id=case.id_,
+                receiver_actor_id=vendor.id_,
+            )
+
+        with demo_check(
+            "Finder replica shows Vendor CS includes F (fix ready) — vendor stops at VFd"
+        ):
+            wait_for_participant_vfd_state(
+                client=c1_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd},
+            )
+            wait_for_participant_vfd_state(
+                client=finder_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd},
+            )
+            verify_fix_ready(
+                receiver_client=c1_client,
+                reporter_client=finder_client,
+                case_id=case.id_,
+                receiver_actor_id=vendor.id_,
+            )
 
 
 def _phase_publication(

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -33,6 +33,7 @@ import os
 import sys
 
 from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
     as_TransitiveActivity,
@@ -51,6 +52,7 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     case_actor_id_on,
     check_server_availability,
     demo_check,
+    demo_gate,
     demo_step,
     post_to_trigger,
     reset_datalayer,
@@ -86,6 +88,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
     wait_for_event_type_in_ledger,
+    wait_for_participant_rm_state,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -498,51 +501,62 @@ def _phase_fix_lifecycle(
     )
     logger.info("─" * 80)
 
-    actor_notifies_fix_ready(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
+        )
+        actor_notifies_fix_ready(
+            client=vendor_client,
+            actor=vendor_in_vendor,
+            case_id=case.id_,
         )
 
-    with demo_check(
-        "M4: Coordinator replica shows Vendor CS includes F (fix ready)"
-    ):
-        wait_for_participant_vfd_state(
-            client=coordinator_client,
-            case_id=case.id_,
-            actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
-        )
-        verify_fix_ready(
-            receiver_client=coordinator_client,
-            reporter_client=vendor_client,
-            case_id=case.id_,
-            receiver_actor_id=vendor.id_,
-        )
+        with demo_check(
+            "Vendor participant vfd_state transitions to VFd or VFD"
+        ):
+            wait_for_participant_vfd_state(
+                client=vendor_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
-    with demo_check(
-        "M5: Coordinator replica shows Vendor CS includes F (fix ready) — vendor stops at VFd"
-    ):
-        wait_for_participant_vfd_state(
-            client=coordinator_client,
-            case_id=case.id_,
-            actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd},
-        )
-        verify_fix_ready(
-            receiver_client=coordinator_client,
-            reporter_client=vendor_client,
-            case_id=case.id_,
-            receiver_actor_id=vendor.id_,
-        )
+        with demo_check(
+            "M4: Coordinator replica shows Vendor CS includes F (fix ready)"
+        ):
+            wait_for_participant_vfd_state(
+                client=coordinator_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
+            verify_fix_ready(
+                receiver_client=coordinator_client,
+                reporter_client=vendor_client,
+                case_id=case.id_,
+                receiver_actor_id=vendor.id_,
+            )
+
+        with demo_check(
+            "M5: Coordinator replica shows Vendor CS includes F (fix ready) — vendor stops at VFd"
+        ):
+            wait_for_participant_vfd_state(
+                client=coordinator_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd},
+            )
+            verify_fix_ready(
+                receiver_client=coordinator_client,
+                reporter_client=vendor_client,
+                case_id=case.id_,
+                receiver_actor_id=vendor.id_,
+            )
 
 
 def _phase_publication(

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -41,6 +41,7 @@ import os
 import sys
 
 from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
     as_TransitiveActivity,
@@ -100,6 +101,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
     wait_for_event_type_in_ledger,
+    wait_for_participant_rm_state,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -710,34 +712,50 @@ def _phase_fix_lifecycle(
     logger.info("─" * 80)
 
     # V1 advances to fix-ready (VFd).
-    actor_notifies_fix_ready(
-        client=v1_client,
-        actor=v1_in_v1,
-        case_id=case.id_,
-    )
-
-    with demo_check("V1 participant vfd_state transitions to VFd"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "v1 RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=v1_client,
             case_id=case.id_,
             actor_id=v1.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
         )
+        actor_notifies_fix_ready(
+            client=v1_client,
+            actor=v1_in_v1,
+            case_id=case.id_,
+        )
+        with demo_check("V1 participant vfd_state transitions to VFd"):
+            wait_for_participant_vfd_state(
+                client=v1_client,
+                case_id=case.id_,
+                actor_id=v1.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
     # V2 advances to fix-ready (VFd).
-    actor_notifies_fix_ready(
-        client=v2_client,
-        actor=v2_in_v2,
-        case_id=case.id_,
-    )
-
-    with demo_check("V2 participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "v2 RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=v2_client,
             case_id=case.id_,
             actor_id=v2.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
         )
+        actor_notifies_fix_ready(
+            client=v2_client,
+            actor=v2_in_v2,
+            case_id=case.id_,
+        )
+        with demo_check("V2 participant vfd_state transitions to VFd or VFD"):
+            wait_for_participant_vfd_state(
+                client=v2_client,
+                case_id=case.id_,
+                actor_id=v2.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
     with demo_check("M5: C1 replica shows V1 and V2 CS include F (fix ready)"):
         wait_for_participant_vfd_state(

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -28,6 +28,7 @@ from typing import Optional, Tuple
 
 from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
@@ -632,61 +633,74 @@ def _phase_fix_lifecycle(
     )
     logger.info("─" * 80)
 
-    actor_notifies_fix_ready(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
+        )
+        actor_notifies_fix_ready(
+            client=vendor_client,
+            actor=vendor_in_vendor,
+            case_id=case.id_,
         )
 
-    with demo_gate("M4/M5: finder replica reflects fix-ready vfd_state"):
-        wait_for_participant_vfd_state(
-            client=finder_client,
-            case_id=case.id_,
-            actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
-        )
-        with demo_check("M4: both replicas show CS includes F (fix ready)"):
+        with demo_check(
+            "Vendor participant vfd_state transitions to VFd or VFD"
+        ):
             wait_for_participant_vfd_state(
                 client=vendor_client,
                 case_id=case.id_,
                 actor_id=vendor.id_,
                 expected_states={CS_vfd.VFd, CS_vfd.VFD},
             )
-            verify_fix_ready(
-                receiver_client=vendor_client,
-                reporter_client=finder_client,
-                case_id=case.id_,
-                receiver_actor_id=vendor.id_,
-            )
-        with demo_check(
-            "M5: both replicas show CS includes F (fix ready) — vendor stops at VFd"
-        ):
-            wait_for_participant_vfd_state(
-                client=vendor_client,
-                case_id=case.id_,
-                actor_id=vendor.id_,
-                expected_states={CS_vfd.VFd},
-            )
+
+        with demo_gate("M4/M5: finder replica reflects fix-ready vfd_state"):
             wait_for_participant_vfd_state(
                 client=finder_client,
                 case_id=case.id_,
                 actor_id=vendor.id_,
-                expected_states={CS_vfd.VFd},
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
             )
-            verify_fix_ready(
-                receiver_client=vendor_client,
-                reporter_client=finder_client,
-                case_id=case.id_,
-                receiver_actor_id=vendor.id_,
-            )
+            with demo_check(
+                "M4: both replicas show CS includes F (fix ready)"
+            ):
+                wait_for_participant_vfd_state(
+                    client=vendor_client,
+                    case_id=case.id_,
+                    actor_id=vendor.id_,
+                    expected_states={CS_vfd.VFd, CS_vfd.VFD},
+                )
+                verify_fix_ready(
+                    receiver_client=vendor_client,
+                    reporter_client=finder_client,
+                    case_id=case.id_,
+                    receiver_actor_id=vendor.id_,
+                )
+            with demo_check(
+                "M5: both replicas show CS includes F (fix ready) — vendor stops at VFd"
+            ):
+                wait_for_participant_vfd_state(
+                    client=vendor_client,
+                    case_id=case.id_,
+                    actor_id=vendor.id_,
+                    expected_states={CS_vfd.VFd},
+                )
+                wait_for_participant_vfd_state(
+                    client=finder_client,
+                    case_id=case.id_,
+                    actor_id=vendor.id_,
+                    expected_states={CS_vfd.VFd},
+                )
+                verify_fix_ready(
+                    receiver_client=vendor_client,
+                    reporter_client=finder_client,
+                    case_id=case.id_,
+                    receiver_actor_id=vendor.id_,
+                )
 
 
 def _phase_publication(

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -28,6 +28,7 @@ import os
 import sys
 
 from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
     as_TransitiveActivity,
@@ -47,6 +48,7 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     assert_demo_success,
     check_server_availability,
     demo_check,
+    demo_gate,
     demo_step,
     post_to_trigger,
     reset_datalayer,
@@ -84,6 +86,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
     wait_for_event_type_in_ledger,
+    wait_for_participant_rm_state,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -617,33 +620,53 @@ def _phase_fix_lifecycle(
     )
     logger.info("─" * 80)
 
-    actor_notifies_fix_ready(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor1 participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
         )
+        actor_notifies_fix_ready(
+            client=vendor_client,
+            actor=vendor_in_vendor,
+            case_id=case.id_,
+        )
+        with demo_check(
+            "Vendor1 participant vfd_state transitions to VFd or VFD"
+        ):
+            wait_for_participant_vfd_state(
+                client=vendor_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
-    actor_notifies_fix_ready(
-        client=vendor2_client,
-        actor=vendor2_in_vendor2,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor2 participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor2 RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor2_client,
             case_id=case.id_,
             actor_id=vendor2.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
         )
+        actor_notifies_fix_ready(
+            client=vendor2_client,
+            actor=vendor2_in_vendor2,
+            case_id=case.id_,
+        )
+        with demo_check(
+            "Vendor2 participant vfd_state transitions to VFd or VFD"
+        ):
+            wait_for_participant_vfd_state(
+                client=vendor2_client,
+                case_id=case.id_,
+                actor_id=vendor2.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
     with demo_check(
         "M5: Finder replica shows both vendors CS include F (fix ready)"

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -28,6 +28,7 @@ import os
 import sys
 
 from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_TransitiveActivity,
 )
@@ -87,6 +88,7 @@ from vultron.demo.helpers.polling import (
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
     wait_for_event_type_in_ledger,
+    wait_for_participant_rm_state,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -716,33 +718,53 @@ def _phase_fix_lifecycle(
     )
     logger.info("─" * 80)
 
-    actor_notifies_fix_ready(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor1 participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
         )
+        actor_notifies_fix_ready(
+            client=vendor_client,
+            actor=vendor_in_vendor,
+            case_id=case.id_,
+        )
+        with demo_check(
+            "Vendor1 participant vfd_state transitions to VFd or VFD"
+        ):
+            wait_for_participant_vfd_state(
+                client=vendor_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
-    actor_notifies_fix_ready(
-        client=vendor2_client,
-        actor=vendor2_in_vendor2,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor2 participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor2 RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor2_client,
             case_id=case.id_,
             actor_id=vendor2.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
         )
+        actor_notifies_fix_ready(
+            client=vendor2_client,
+            actor=vendor2_in_vendor2,
+            case_id=case.id_,
+        )
+        with demo_check(
+            "Vendor2 participant vfd_state transitions to VFd or VFD"
+        ):
+            wait_for_participant_vfd_state(
+                client=vendor2_client,
+                case_id=case.id_,
+                actor_id=vendor2.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
     with demo_check(
         "Finder replica shows both vendors CS include F (fix ready)"

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -29,6 +29,7 @@ import os
 import sys
 
 from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
     as_TransitiveActivity,
@@ -48,6 +49,7 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     assert_demo_success,
     check_server_availability,
     demo_check,
+    demo_gate,
     demo_step,
     post_to_trigger,
     reset_datalayer,
@@ -82,6 +84,7 @@ from vultron.demo.helpers.polling import (
     wait_for_contiguous_ledger_coverage,
     wait_for_event_type_in_ledger,
     wait_for_finder_case,
+    wait_for_participant_rm_state,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -460,33 +463,53 @@ def _phase_fix_lifecycle(
     )
     logger.info("─" * 80)
 
-    actor_notifies_fix_ready(
-        client=vendor_client,
-        actor=vendor_in_vendor,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor1 participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor_client,
             case_id=case.id_,
             actor_id=vendor.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
         )
+        actor_notifies_fix_ready(
+            client=vendor_client,
+            actor=vendor_in_vendor,
+            case_id=case.id_,
+        )
+        with demo_check(
+            "Vendor1 participant vfd_state transitions to VFd or VFD"
+        ):
+            wait_for_participant_vfd_state(
+                client=vendor_client,
+                case_id=case.id_,
+                actor_id=vendor.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
-    actor_notifies_fix_ready(
-        client=vendor2_client,
-        actor=vendor2_in_vendor2,
-        case_id=case.id_,
-    )
-
-    with demo_check("Vendor2 participant vfd_state transitions to VFd or VFD"):
-        wait_for_participant_vfd_state(
+    with demo_gate(
+        "vendor2 RM ∈ {ACCEPTED,DEFERRED,CLOSED} before notify-fix-ready (CSB-18-001)"
+    ):
+        wait_for_participant_rm_state(
             client=vendor2_client,
             case_id=case.id_,
             actor_id=vendor2.id_,
-            expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED},
         )
+        actor_notifies_fix_ready(
+            client=vendor2_client,
+            actor=vendor2_in_vendor2,
+            case_id=case.id_,
+        )
+        with demo_check(
+            "Vendor2 participant vfd_state transitions to VFd or VFD"
+        ):
+            wait_for_participant_vfd_state(
+                client=vendor2_client,
+                case_id=case.id_,
+                actor_id=vendor2.id_,
+                expected_states={CS_vfd.VFd, CS_vfd.VFD},
+            )
 
     with demo_check(
         "M4: Finder replica shows both vendors CS include F (fix ready)"


### PR DESCRIPTION
- Closes #2422
<!-- ⚠️ MUST BE FIRST — before any ## header -->

## Summary

`_phase_fix_lifecycle` in all 8 demo scenario files called `actor_notifies_fix_ready` without first confirming the vendor's RM state had advanced past `RECEIVED`. When `run_direct_path_rm_triage`'s inner RM.VALID gate timed out (slow async `validate-report` processing), the vendor stayed at `RM.RECEIVED`. `ValidateTriggerTransitionsNode` then rejected the `notify-fix-ready` trigger with HTTP 422 due to cross-machine entailment violation (CSB-18-001): VFD with F-bit requires RM ∈ {ACCEPTED, DEFERRED, CLOSED}.

Fix: Wrap `actor_notifies_fix_ready` (and its downstream VFD-state checks) in a `demo_gate` that first polls `wait_for_participant_rm_state(expected_states={RM.ACCEPTED, RM.DEFERRED, RM.CLOSED})` — the same causal gating pattern established by ADR-0058 and implemented in PR #2508 for `run_invite_path_rm_triage`.

## Changes

All 8 affected `_phase_fix_lifecycle` implementations:
- `vultron/demo/scenario/fv_demo.py` — single vendor; full body wrapped in outer gate (includes nested M4/M5 gate)
- `vultron/demo/scenario/fvv_demo.py`, `fvcv_extension_demo.py`, `fvcv_handoff_demo.py`, `fcvcv_demo.py` — two vendors; per-vendor gates before each `actor_notifies_fix_ready`
- `vultron/demo/scenario/fccv_extension_demo.py`, `fccv_handoff_demo.py`, `fcv_demo.py` — single vendor

Also: `from vultron.core.states.rm import RM` and `wait_for_participant_rm_state` added to imports where missing; `demo_gate` added to imports in 5 files that only had `demo_check`.

## Verification

- Added `test_phase_fix_lifecycle_gates_on_rm_accepted` in `test/demo/test_fv_demo.py` and all 6 sibling scenario test files — verifies `wait_for_participant_rm_state` is called with `{RM.ACCEPTED, RM.DEFERRED, RM.CLOSED}` before `actor_notifies_fix_ready` (ADR-0058/CSB-18-001)
- Updated `test_fv_finder_timeout_records_single_gate_failure_not_two_check_failures` to mock `wait_for_participant_rm_state` so it correctly tests the finder-VFD failure path (regression guard for #2361)
- All unit tests pass (`uv run pytest --tb=short`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)