### PR TITLE
fix: fcv-reject async race window — causal gate, ledger sync phase, Optional note return

### DIFF
--- a/notes/codebase-structure.md
+++ b/notes/codebase-structure.md
@@ -245,22 +245,31 @@ bidirectional-equality pattern.
 
 ---
 
-## Demo Script Lifecycle Logging: `demo_step` / `demo_check`
+## Demo Script Lifecycle Logging: `demo_step` / `demo_check` / `demo_gate`
 
-All demo scripts use two context managers defined in `vultron/demo/utils.py`
-for structured lifecycle logging:
+All demo scripts use three context managers defined in `vultron/demo/utils.py`
+for structured lifecycle logging and failure accumulation. All three suppress
+exceptions into the `_demo_failures` accumulator (no re-raise); call
+`assert_demo_success()` at the end of each scenario to surface failures
+(DEMOCI-01-003, DEMOCI-01-004).
 
 - **`demo_step(description)`**: Wraps a workflow step. Logs `🚥 description`
   at INFO on entry, `🟢 description` on clean exit, `🔴 description` at ERROR
-  on exception (and re-raises).
-- **`demo_check(description)`**: Wraps a side-effect verification block. Logs
-  `📋 description` at INFO on entry, `✅ description` on success,
-  `❌ description` at ERROR on exception (and re-raises).
+  on exception. On exception, accumulates the failure and continues after the
+  block.
+- **`demo_check(description)`**: Wraps a standalone side-effect verification.
+  Logs `📋 description` at INFO on entry, `✅ description` on success,
+  `❌ description` at ERROR on exception. On exception, accumulates and
+  continues — subsequent steps outside the block always run. Use when a
+  verification failure should not skip dependent work.
+- **`demo_gate(description)`**: Causal precondition gate. Logs `🚧 description`
+  on entry, `🔓` on success, `🔒` on failure. On exception, Python immediately
+  exits the `with` body — steps inside the gate that follow the failing assertion
+  are skipped. Execution continues after the gate block. Use when continuing
+  after a precondition failure would produce meaningless secondary failures.
+  See ADR-0058.
 
-Import these from `vultron.demo.utils` in every demo script. Use them
-consistently to wrap numbered workflow steps and verification blocks so that
-log output clearly shows progress and failure location during test runs and
-live demos.
+Import these from `vultron.demo.utils` in every demo script.
 
 **Pattern**:
 
@@ -270,9 +279,15 @@ with demo_step("1. Create vulnerability report"):
 
 with demo_check("1a. Verify report persisted"):
     assert dl.get(report.as_id) is not None
+
+with demo_gate("2. Case seeded before notes phase"):
+    wait_for_case_on_container(client, case_id)
+    with demo_step("2a. Add note"):   # skipped if gate fails
+        add_note(...)
 ```
 
-**Cross-reference**: `test/demo/test_demo_context_managers.py` (18 tests).
+**Cross-reference**: `test/demo/test_demo_context_managers.py` (18 tests);
+ADR-0058 for the causal-gate design rationale.
 
 ---
 

--- a/plan/incoming/learnings/20260826-optional-note-propagates-demo-step-contract.md
+++ b/plan/incoming/learnings/20260826-optional-note-propagates-demo-step-contract.md
@@ -1,0 +1,19 @@
+---
+title: "Optional[as_Note] return propagates demo_step suppression contract to all callers"
+type: learning
+timestamp: "2026-08-26"
+source: ISSUE-2390
+signal: design-question
+---
+
+Changing `participant_adds_note_to_case` from `-> as_Note` to `-> Optional[as_Note]`
+was the correct fix, but it propagates `demo_step`'s exception-suppression contract
+to every caller: each must now guard `.id_` accesses on the returned value.
+
+The alternative — raising outside `demo_step` — would crash the scenario even when the
+failure is non-fatal, defeating the purpose of the context manager.
+
+**Pattern**: any demo helper that calls `post_to_trigger` inside a `demo_step` and
+extracts a result ID must return `Optional[T]` rather than `T`. Callers should treat
+`None` as "step failed, demo_step already recorded it" and skip dependent steps via
+conditional `in_reply_to`.

--- a/plan/incoming/learnings/20260826-sibling-demo-async-race-not-fixed.md
+++ b/plan/incoming/learnings/20260826-sibling-demo-async-race-not-fixed.md
@@ -1,0 +1,24 @@
+---
+title: "6 sibling demo scenarios have same async race window as fcv-reject (#2390)"
+type: learning
+timestamp: "2026-08-26"
+source: ISSUE-2390
+signal: concern
+---
+
+The `_phase_sync_verification` fix (wait_for_case_on_container +
+wait_for_contiguous_ledger_coverage before the notes phase) was added only to
+`fcv_reject_demo.py`. The following 6 sibling scenarios call
+`participant_adds_note_to_case` in chained note-reply sequences and are subject to
+the same race window when Finder/Coordinator has not yet replicated all ledger entries:
+
+- `fv_demo.py`
+- `fcv_demo.py`
+- `fvv_demo.py`
+- `fvcv_extension_demo.py`
+- `fvcv_handoff_demo.py`
+- `fcvcv_demo.py`
+
+These received `Optional[as_Note]` type-safety fixes in this PR but not behavioral
+async-race mitigations. Each should have a Bug issue filed and a
+`_phase_sync_verification` (or equivalent) added before its notes phase.

--- a/test/demo/test_fcv_reject_demo.py
+++ b/test/demo/test_fcv_reject_demo.py
@@ -1,0 +1,91 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Regression tests for ISSUE-2390: async race-window in fcv-reject demo.
+
+Root cause: ``participant_adds_note_to_case`` in ``notes.py`` raises an
+``AssertionError`` *outside* any ``demo_step``/``demo_gate`` context manager
+when the ``add-note-to-case`` trigger returns no note ID (e.g. because
+``post_to_trigger`` was suppressed by ``demo_step`` after an HTTP error).
+That bare ``raise`` escapes ``scenario_harness`` and crashes the scenario
+before Phase 4–5 run, leaving ``close_case`` and ``add_note_to_case`` absent
+from the case-actor ledger and the Finder log empty.
+
+The fix: move the ``note_id is None`` check inside ``demo_step`` so
+``demo_step`` accumulates the failure; add an early ``return None`` guard
+after the block so no downstream code runs against a ``None`` note ID.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx2 as httpx
+
+from vultron.demo.helpers.notes import participant_adds_note_to_case
+from vultron.demo.utils import reset_demo_failures
+
+
+def _make_note_fixtures():
+    mock_client = MagicMock()
+    mock_actor = MagicMock()
+    mock_actor.id_ = "http://example.test/actors/finder"
+    mock_case = MagicMock()
+    mock_case.id_ = "http://example.test/cases/case-1"
+    return mock_client, mock_actor, mock_case
+
+
+class TestParticipantAddsNoteNoNoteId:
+    """ISSUE-2390: AssertionError must not escape when trigger returns no note ID."""
+
+    def setup_method(self):
+        reset_demo_failures()
+
+    def test_empty_trigger_response_returns_none(self):
+        """Trigger returns {} — no note ID — function must return None, not raise."""
+        mock_client, mock_actor, mock_case = _make_note_fixtures()
+        with patch(
+            "vultron.demo.helpers.notes.post_to_trigger",
+            return_value={},
+        ):
+            result = participant_adds_note_to_case(
+                posting_client=mock_client,
+                watching_client=mock_client,
+                poster=mock_actor,
+                case=mock_case,
+                note_name="test-note",
+                note_content="test content",
+            )
+        assert result is None
+
+    def test_trigger_http_error_returns_none(self):
+        """Trigger raises HTTPStatusError — demo_step swallows it — function must return None, not raise."""
+        mock_client, mock_actor, mock_case = _make_note_fixtures()
+        mock_request = MagicMock()
+        mock_response = MagicMock()
+        http_error = httpx.HTTPStatusError(
+            "422 Unprocessable Entity",
+            request=mock_request,
+            response=mock_response,
+        )
+        with patch(
+            "vultron.demo.helpers.notes.post_to_trigger",
+            side_effect=http_error,
+        ):
+            result = participant_adds_note_to_case(
+                posting_client=mock_client,
+                watching_client=mock_client,
+                poster=mock_actor,
+                case=mock_case,
+                note_name="test-note",
+                note_content="test content",
+            )
+        assert result is None

--- a/test/demo/test_fcv_reject_demo.py
+++ b/test/demo/test_fcv_reject_demo.py
@@ -89,3 +89,30 @@ class TestParticipantAddsNoteNoNoteId:
                 note_content="test content",
             )
         assert result is None
+
+    def test_delivery_timeout_returns_none(self):
+        """demo_gate swallows wait_for_note_in_case timeout — function must return None, not raise."""
+        mock_client, mock_actor, mock_case = _make_note_fixtures()
+        with (
+            patch(
+                "vultron.demo.helpers.notes.post_to_trigger",
+                return_value={
+                    "note": {"id": "http://example.test/notes/note-1"}
+                },
+            ),
+            patch(
+                "vultron.demo.helpers.notes.wait_for_note_in_case",
+                side_effect=AssertionError(
+                    "note not found in case after timeout"
+                ),
+            ),
+        ):
+            result = participant_adds_note_to_case(
+                posting_client=mock_client,
+                watching_client=mock_client,
+                poster=mock_actor,
+                case=mock_case,
+                note_name="test-note",
+                note_content="test content",
+            )
+        assert result is None

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -553,6 +553,7 @@ class TestFinderAsksQuestion:
             case=case,
         )
 
+        assert question_note is not None
         assert question_note.id_ is not None
         demo.verify_object_stored(vendor_client, question_note.id_)
 
@@ -581,6 +582,7 @@ class TestFinderAsksQuestion:
             question_note=question_note,
         )
 
+        assert reply_note is not None
         assert reply_note.id_ is not None
         demo.verify_object_stored(vendor_client, reply_note.id_)
 

--- a/vultron/demo/helpers/notes.py
+++ b/vultron/demo/helpers/notes.py
@@ -24,7 +24,7 @@ from typing import Optional
 from vultron.demo.helpers.polling import wait_for_note_in_case
 from vultron.demo.utils import (
     DataLayerClient,
-    demo_check,
+    demo_gate,
     demo_step,
     post_to_trigger,
     verify_object_stored,
@@ -66,8 +66,9 @@ def participant_adds_note_to_case(
 
     Returns:
         The ``as_Note`` fetched from the *watching_client* DataLayer after
-        confirmed delivery, or ``None`` when the trigger fails (the failure is
-        recorded in the demo accumulator via ``demo_step``).
+        confirmed delivery, or ``None`` when the trigger or delivery check
+        fails (failures are recorded in the demo accumulator via
+        ``demo_step``/``demo_gate``).
     """
     body: dict[str, object] = {
         "case_id": case.id_,
@@ -96,11 +97,12 @@ def participant_adds_note_to_case(
     if note_id is None:
         return None
 
-    with demo_check("Note delivered to watching container"):
+    note: Optional[as_Note] = None
+    with demo_gate("Note delivered to watching container"):
         wait_for_note_in_case(watching_client, case.id_, note_id)
         verify_object_stored(watching_client, note_id)
+        logger.info("Note added to case: %s", note_id)
+        note_data = watching_client.get(watching_client.dl_path(note_id))
+        note = as_Note(**note_data)
 
-    logger.info("Note added to case: %s", note_id)
-
-    note_data = watching_client.get(watching_client.dl_path(note_id))
-    return as_Note(**note_data)
+    return note

--- a/vultron/demo/helpers/notes.py
+++ b/vultron/demo/helpers/notes.py
@@ -46,7 +46,7 @@ def participant_adds_note_to_case(
     note_name: str,
     note_content: str,
     in_reply_to: Optional[str] = None,
-) -> as_Note:
+) -> Optional[as_Note]:
     """Participant adds a note to a case via the ``add-note-to-case`` trigger.
 
     Models the AS2 ``Add(Note)`` action: the posting actor uses their own
@@ -66,11 +66,8 @@ def participant_adds_note_to_case(
 
     Returns:
         The ``as_Note`` fetched from the *watching_client* DataLayer after
-        confirmed delivery.
-
-    Raises:
-        AssertionError: If the trigger does not return a note ID, or if the
-            note does not appear in the case within the polling timeout.
+        confirmed delivery, or ``None`` when the trigger fails (the failure is
+        recorded in the demo accumulator via ``demo_step``).
     """
     body: dict[str, object] = {
         "case_id": case.id_,
@@ -81,6 +78,7 @@ def participant_adds_note_to_case(
         body["in_reply_to"] = in_reply_to
 
     result: dict = {}
+    note_id: str | None = None
     with demo_step(f"Participant adds note '{note_name}' to case"):
         result = post_to_trigger(
             client=posting_client,
@@ -89,12 +87,14 @@ def participant_adds_note_to_case(
             body=body,
             path_prefix="demo",
         )
+        note_id = result.get("note", {}).get("id")
+        if note_id is None:
+            raise AssertionError(
+                "add-note-to-case trigger did not return a note ID"
+            )
 
-    note_id = result.get("note", {}).get("id")
     if note_id is None:
-        raise AssertionError(
-            "add-note-to-case trigger did not return a note ID"
-        )
+        return None
 
     with demo_check("Note delivered to watching container"):
         wait_for_note_in_case(watching_client, case.id_, note_id)

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -546,7 +546,7 @@ def _phase_notes_exchange(
     c2_in_c2: as_Actor,
     vendor_in_vendor: as_Actor,
     case: as_VulnerabilityCase,
-) -> tuple[as_Note, as_Note, as_Note, as_Note]:
+) -> tuple[as_Note | None, as_Note | None, as_Note | None, as_Note | None]:
     """Run a four-way note exchange among all participants."""
     logger.info("─" * 80)
     logger.info("Phase 4: Notes exchange")
@@ -572,7 +572,7 @@ def _phase_notes_exchange(
         note_content=(
             "Yes, disabling the affected module is an effective interim workaround."
         ),
-        in_reply_to=question_note.id_,
+        in_reply_to=question_note.id_ if question_note is not None else None,
     )
 
     c2_note = participant_adds_note_to_case(
@@ -585,7 +585,7 @@ def _phase_notes_exchange(
             "We have confirmed that C2 and Vendor are engaged. "
             "Target disclosure in 30 days."
         ),
-        in_reply_to=c1_reply.id_,
+        in_reply_to=c1_reply.id_ if c1_reply is not None else None,
     )
 
     vendor_note = participant_adds_note_to_case(
@@ -598,7 +598,7 @@ def _phase_notes_exchange(
             "Vendor can confirm the issue affects our component. "
             "We will align our fix timeline with the 30-day target."
         ),
-        in_reply_to=c2_note.id_,
+        in_reply_to=c2_note.id_ if c2_note is not None else None,
     )
 
     logger.info(

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -632,7 +632,7 @@ def _phase_notes_exchange(
     c2_in_c2: as_Actor,
     vendor_in_vendor: as_Actor,
     case: as_VulnerabilityCase,
-) -> tuple[as_Note, as_Note, as_Note, as_Note]:
+) -> tuple[as_Note | None, as_Note | None, as_Note | None, as_Note | None]:
     """Run a four-way note exchange among all participants."""
     logger.info("─" * 80)
     logger.info("Phase 4b: Notes exchange")
@@ -658,7 +658,7 @@ def _phase_notes_exchange(
         note_content=(
             "Yes, disabling the affected module is an effective interim workaround."
         ),
-        in_reply_to=question_note.id_,
+        in_reply_to=question_note.id_ if question_note is not None else None,
     )
 
     c2_note = participant_adds_note_to_case(
@@ -671,7 +671,7 @@ def _phase_notes_exchange(
             "As the new case owner, I confirm Vendor is engaged. "
             "Target disclosure in 30 days."
         ),
-        in_reply_to=c1_reply.id_,
+        in_reply_to=c1_reply.id_ if c1_reply is not None else None,
     )
 
     vendor_note = participant_adds_note_to_case(
@@ -684,7 +684,7 @@ def _phase_notes_exchange(
             "Vendor confirms the issue and will align fix timeline with the "
             "coordinated disclosure window."
         ),
-        in_reply_to=c2_note.id_,
+        in_reply_to=c2_note.id_ if c2_note is not None else None,
     )
 
     logger.info(

--- a/vultron/demo/scenario/fcv_demo.py
+++ b/vultron/demo/scenario/fcv_demo.py
@@ -463,7 +463,7 @@ def _phase_notes_exchange(
             "We have confirmed the issue and are developing a fix. "
             "Estimated patch availability: 14 days."
         ),
-        in_reply_to=question_note.id_,
+        in_reply_to=question_note.id_ if question_note is not None else None,
     )
 
     participant_adds_note_to_case(
@@ -476,7 +476,7 @@ def _phase_notes_exchange(
             "All three parties engaged. Vendor fix expected in 14 days. "
             "Embargo holds until patch is deployed."
         ),
-        in_reply_to=vendor_reply.id_,
+        in_reply_to=vendor_reply.id_ if vendor_reply is not None else None,
     )
 
     logger.info(

--- a/vultron/demo/scenario/fcv_reject_demo.py
+++ b/vultron/demo/scenario/fcv_reject_demo.py
@@ -51,6 +51,7 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     case_actor_id_on,
     check_server_availability,
     demo_check,
+    demo_gate,
     demo_step,
     post_to_trigger,
     reset_datalayer,
@@ -80,6 +81,7 @@ from vultron.demo.helpers.polling import (
     resolve_case_actor_store_id,
     wait_for_all_participants_rm_closed,
     wait_for_case_em_terminated,
+    wait_for_case_on_container,
     wait_for_case_participants,
     wait_for_contiguous_ledger_coverage,
     wait_for_event_type_in_ledger,
@@ -288,17 +290,16 @@ def _phase_invite_vendor_reject(
 
     # Participant count remains 3: Coordinator + Finder + CaseActor.
     # Vendor must NOT appear as a 4th participant.
-    with demo_check(
-        "Participant count stays at 3 (Vendor not added after rejection)"
+    #
+    # Gate on the rejection being committed before checking participant count.
+    # The rejection is self-contained on the CaseActor (CLP-10-006) — no
+    # participant-effect Announce is sent, so the entry is only visible in the
+    # CaseActor's own store.  Using demo_gate here ensures that the participant
+    # count check is skipped (rather than run against stale state) if the
+    # CaseActor has not yet committed the rejection entry.
+    with demo_gate(
+        "reject_invite_actor_to_case committed (causal gate before participant count check)"
     ):
-        # Give the CaseActor time to process the Reject then confirm stability.
-        #
-        # Read the CaseActor's own store: the rejection is self-contained on the
-        # CaseActor — it records that the invitee declined and has no participant
-        # effect to announce (CLP-10-006) — so no replica ever receives this
-        # entry.  Before ADR-0073 the coordinator and the CaseActor it self-hosts
-        # shared one store, which is why reading the coordinator's own replica
-        # used to find it.
         wait_for_event_type_in_ledger(
             client=coordinator_client,
             case_id=case.id_,
@@ -307,12 +308,56 @@ def _phase_invite_vendor_reject(
                 coordinator_client, str(case.id_)
             ),
         )
-        wait_for_case_participants(
-            vendor_client=coordinator_client,
-            case_id=case.id_,
-            expected_actor_ids={finder.id_, coordinator.id_},
-        )
+        with demo_check(
+            "Participant count stays at 3 (Vendor not added after rejection)"
+        ):
+            wait_for_case_participants(
+                vendor_client=coordinator_client,
+                case_id=case.id_,
+                expected_actor_ids={finder.id_, coordinator.id_},
+            )
     logger.info("✓ M2: Vendor rejected invite — participant count stable at 3")
+
+
+def _phase_sync_verification(
+    finder_client: DataLayerClient,
+    coordinator_client: DataLayerClient,
+    case: as_VulnerabilityCase,
+) -> None:
+    """Wait for Finder to replicate all Phase 2 ledger entries before Phase 3.
+
+    Mirrors the sync-verification phase in ``fv_demo.py`` (SYNC-15-001).  The
+    Finder must hold the case and all coordinator-committed ledger entries
+    before the notes exchange begins; without this gate the
+    ``add-note-to-case`` trigger on the Finder container may fail because the
+    Finder's DataLayer has not yet received the case replica or the
+    post-rejection ledger tail from the CaseActor fan-out.
+    """
+    logger.info("─" * 80)
+    logger.info("Phase 2.5: Finder ledger sync verification")
+    logger.info("─" * 80)
+
+    with demo_gate("Finder case seeded before ledger coverage wait (SYNC-15)"):
+        wait_for_case_on_container(
+            client=finder_client,
+            case_id=case.id_,
+        )
+        coordinator_entries = _get_log_entries_for_case(
+            coordinator_client, case.id_
+        )
+        if coordinator_entries:
+            coord_tail = max(coordinator_entries, key=lambda e: e["log_index"])
+            coord_tail_index: int = coord_tail["log_index"]
+            logger.info(
+                "Waiting for Finder to replicate coordinator entries (0…%d)",
+                coord_tail_index,
+            )
+            with demo_gate("Finder ledger coverage (pre-notes sync)"):
+                wait_for_contiguous_ledger_coverage(
+                    client=finder_client,
+                    case_id=case.id_,
+                    expected_tail_index=coord_tail_index,
+                )
 
 
 def _phase_notes_exchange(
@@ -350,7 +395,7 @@ def _phase_notes_exchange(
             "We will proceed with Finder-only disclosure. "
             "Embargo will be terminated and we will publish."
         ),
-        in_reply_to=question_note.id_,
+        in_reply_to=question_note.id_ if question_note is not None else None,
     )
 
     logger.info(
@@ -570,6 +615,12 @@ def run_fcv_reject_demo(
             coordinator_in_coordinator=coordinator_in_coordinator,
             coordinator=_coordinator,
             vendor=vendor_obj,
+            case=case,
+        )
+
+        _phase_sync_verification(
+            finder_client=finder_client,
+            coordinator_client=coordinator_client,
             case=case,
         )
 

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -630,7 +630,13 @@ def _phase_notes_exchange(
     c2_in_c2: as_Actor,
     v2_in_v2: as_Actor,
     case: as_VulnerabilityCase,
-) -> tuple[as_Note, as_Note, as_Note, as_Note, as_Note]:
+) -> tuple[
+    as_Note | None,
+    as_Note | None,
+    as_Note | None,
+    as_Note | None,
+    as_Note | None,
+]:
     """Run a five-way note exchange among all participants."""
     logger.info("─" * 80)
     logger.info("Phase 4: Notes exchange")
@@ -656,7 +662,7 @@ def _phase_notes_exchange(
         note_content=(
             "Yes, disabling the affected module is an effective interim workaround."
         ),
-        in_reply_to=question_note.id_,
+        in_reply_to=question_note.id_ if question_note is not None else None,
     )
 
     v1_note = participant_adds_note_to_case(
@@ -668,7 +674,7 @@ def _phase_notes_exchange(
         note_content=(
             "V1 has reproduced the issue. We will have a fix ready within 14 days."
         ),
-        in_reply_to=c1_reply.id_,
+        in_reply_to=c1_reply.id_ if c1_reply is not None else None,
     )
 
     c2_note = participant_adds_note_to_case(
@@ -680,7 +686,7 @@ def _phase_notes_exchange(
         note_content=(
             "C2 confirms V2 is engaged. Target disclosure in 30 days."
         ),
-        in_reply_to=v1_note.id_,
+        in_reply_to=v1_note.id_ if v1_note is not None else None,
     )
 
     v2_note = participant_adds_note_to_case(
@@ -693,7 +699,7 @@ def _phase_notes_exchange(
             "V2 confirms the issue affects our component. "
             "We will align our fix and deployment timeline with the 30-day target."
         ),
-        in_reply_to=c2_note.id_,
+        in_reply_to=c2_note.id_ if c2_note is not None else None,
     )
 
     logger.info(

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -238,7 +238,7 @@ def finder_asks_question(
     vendor: as_Actor,
     finder: as_Actor,
     case: as_VulnerabilityCase,
-) -> as_Note:
+) -> as_Note | None:
     """Scenario alias: finder adds a question note to the case.
 
     Maintained for backward compatibility; prefer
@@ -264,8 +264,8 @@ def vendor_replies_to_question(
     vendor: as_Actor,
     finder: as_Actor,
     case: as_VulnerabilityCase,
-    question_note: as_Note,
-) -> as_Note:
+    question_note: as_Note | None,
+) -> as_Note | None:
     """Scenario alias: vendor adds a reply note to the case.
 
     Maintained for backward compatibility; prefer
@@ -283,7 +283,7 @@ def vendor_replies_to_question(
             "workaround. A patched version is expected within 30 days. "
             "We will notify all case participants when it is available."
         ),
-        in_reply_to=question_note.id_,
+        in_reply_to=question_note.id_ if question_note is not None else None,
     )
 
 

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -496,7 +496,7 @@ def _phase_notes_exchange(
     vendor_in_vendor: as_Actor,
     case: as_VulnerabilityCase,
     report: as_VulnerabilityReport,
-) -> tuple[as_Note, as_Note, as_VulnerabilityCase, as_Actor]:
+) -> tuple[as_Note | None, as_Note | None, as_VulnerabilityCase, as_Actor]:
     """Run the question-and-reply note exchange and verify M3 state."""
     logger.info("─" * 80)
     logger.info("Phase 3: Notes exchange")
@@ -529,8 +529,10 @@ def _phase_notes_exchange(
             report_id=report.id_,
             receiver_actor_id=vendor.id_,
             reporter_actor_id=finder.id_,
-            question_note_id=question_note.id_,
-            reply_note_id=reply_note.id_,
+            question_note_id=(
+                question_note.id_ if question_note is not None else None
+            ),
+            reply_note_id=reply_note.id_ if reply_note is not None else None,
         )
         logger.info("Final case state (Vendor): %s", logfmt(final_case))
 

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -539,7 +539,7 @@ def _phase_notes_exchange(
     coordinator_in_coordinator: as_Actor,
     vendor2_in_vendor2: as_Actor,
     case: as_VulnerabilityCase,
-) -> tuple[as_Note, as_Note, as_Note, as_Note]:
+) -> tuple[as_Note | None, as_Note | None, as_Note | None, as_Note | None]:
     """Run a four-way note exchange among all participants."""
     logger.info("─" * 80)
     logger.info("Phase 4: Notes exchange")
@@ -565,7 +565,7 @@ def _phase_notes_exchange(
         note_content=(
             "Yes, disabling the affected module is an effective interim workaround."
         ),
-        in_reply_to=question_note.id_,
+        in_reply_to=question_note.id_ if question_note is not None else None,
     )
 
     coordinator_note = participant_adds_note_to_case(
@@ -578,7 +578,7 @@ def _phase_notes_exchange(
             "We have confirmed that both Vendor1 and Vendor2 are engaged. "
             "Target disclosure in 30 days."
         ),
-        in_reply_to=vendor_reply.id_,
+        in_reply_to=vendor_reply.id_ if vendor_reply is not None else None,
     )
 
     vendor2_note = participant_adds_note_to_case(
@@ -591,7 +591,9 @@ def _phase_notes_exchange(
             "Vendor2 can confirm the issue affects our component as well. "
             "We will align our fix timeline with Vendor1."
         ),
-        in_reply_to=coordinator_note.id_,
+        in_reply_to=(
+            coordinator_note.id_ if coordinator_note is not None else None
+        ),
     )
 
     logger.info(

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -633,7 +633,7 @@ def _phase_notes_exchange(
     coordinator_in_coordinator: as_Actor,
     vendor2_in_vendor2: as_Actor,
     case: as_VulnerabilityCase,
-) -> tuple[as_Note, as_Note, as_Note, as_Note]:
+) -> tuple[as_Note | None, as_Note | None, as_Note | None, as_Note | None]:
     """Run a four-way note exchange among all participants.
 
     Emits ``add_note_to_case`` events into the canonical case ledger,
@@ -664,7 +664,7 @@ def _phase_notes_exchange(
         note_content=(
             "Yes, disabling the affected module is an effective interim workaround."
         ),
-        in_reply_to=question_note.id_,
+        in_reply_to=question_note.id_ if question_note is not None else None,
     )
 
     coordinator_note = participant_adds_note_to_case(
@@ -677,7 +677,7 @@ def _phase_notes_exchange(
             "As the new case owner, I confirm both Vendor1 and Vendor2 are "
             "engaged. Target disclosure in 30 days."
         ),
-        in_reply_to=vendor_reply.id_,
+        in_reply_to=vendor_reply.id_ if vendor_reply is not None else None,
     )
 
     vendor2_note = participant_adds_note_to_case(
@@ -690,7 +690,9 @@ def _phase_notes_exchange(
             "Vendor2 confirms the issue affects our component as well. "
             "We will align our fix timeline with Vendor1."
         ),
-        in_reply_to=coordinator_note.id_,
+        in_reply_to=(
+            coordinator_note.id_ if coordinator_note is not None else None
+        ),
     )
 
     logger.info(

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -393,7 +393,7 @@ def _phase_notes_exchange(
     vendor_in_vendor: as_Actor,
     vendor2_in_vendor2: as_Actor,
     case: as_VulnerabilityCase,
-) -> tuple[as_Note, as_Note, as_Note]:
+) -> tuple[as_Note | None, as_Note | None, as_Note | None]:
     """Run a three-way note exchange among Finder, Vendor1, and Vendor2."""
     logger.info("─" * 80)
     logger.info("Phase 3: Notes exchange")
@@ -421,7 +421,7 @@ def _phase_notes_exchange(
             "Yes, disabling the affected component is an effective workaround. "
             "A patched version is expected within 30 days."
         ),
-        in_reply_to=question_note.id_,
+        in_reply_to=question_note.id_ if question_note is not None else None,
     )
 
     vendor2_note = participant_adds_note_to_case(
@@ -434,7 +434,7 @@ def _phase_notes_exchange(
             "Vendor2 can confirm the issue affects our component. "
             "We will coordinate our fix timeline with Vendor1."
         ),
-        in_reply_to=reply_note.id_,
+        in_reply_to=reply_note.id_ if reply_note is not None else None,
     )
 
     logger.info(


### PR DESCRIPTION
- Closes #2390
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Fixes three compounding async race conditions in the `fcv-reject` demo scenario that caused intermittent CI failures in both the Demo Integration and Invariant Harness test jobs.

## Changes

- **`vultron/demo/helpers/notes.py`**: Changed `participant_adds_note_to_case` return type from `as_Note` to `Optional[as_Note]`; moved `note_id` extraction and `AssertionError` guard inside the `demo_step` block so failures are accumulated rather than crashing the scenario; added early-return `None` guard after the block.
- **`vultron/demo/scenario/fcv_reject_demo.py`**: Upgraded Phase 2 `demo_check` to `demo_gate` so causal timeout propagates correctly; added new `_phase_sync_verification` phase using `wait_for_case_on_container` + `wait_for_contiguous_ledger_coverage` to ensure Finder has replicated all coordinator ledger entries before the notes phase.
- **`vultron/demo/scenario/fv_demo.py`**, **`fcv_demo.py`**, **`fvv_demo.py`**, **`fvcv_extension_demo.py`**, **`fvcv_handoff_demo.py`**, **`fcvcv_demo.py`**, **`fccv_extension_demo.py`**, **`fccv_handoff_demo.py`**: Guarded all `in_reply_to=note.id_` accesses to match new `Optional[as_Note]` return contract; updated tuple return type annotations.
- **`test/demo/test_fcv_reject_demo.py`**: New unit tests covering the `None`-return paths when `post_to_trigger` returns an empty dict or raises `HTTPStatusError`.
- **`test/demo/test_fv_demo.py`**: Added `assert note is not None` guards before `.id_` attribute access.

## Also filed (sibling async races, type-safety only in this PR)

Sibling scenarios received `Optional[as_Note]` type fixes but not behavioral `_phase_sync_verification` mitigations — tracked in learning file `plan/incoming/learnings/20260826-sibling-demo-async-race-not-fixed.md` for follow-up Bug issues.

## Verification

- 7841 unit tests pass
- 3 new integration tests (test/demo/test_fcv_reject_demo.py): trigger-fail, HTTP error, delivery-timeout paths
- Black, flake8, mypy, pyright all clean (0 errors)