### PR TITLE
docs(bt): split bt-pitfalls.md into per-directory AGENTS.md files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,9 +487,11 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   `if bridge.execute_with_setup(...) == Status.FAILURE: raise VultronBTError(...)`.
   See [notes/bt-pitfalls.md](notes/bt-pitfalls.md).
 - **Ledger Commit Must Precede Outbox Write** —
-  see [notes/bt-pitfalls.md](notes/bt-pitfalls.md).
+  see [`vultron/core/behaviors/case/AGENTS.md`](vultron/core/behaviors/case/AGENTS.md)
+  § "Ledger Commit Must Precede Outbox Write".
 - **`disposition="rejected"` for Local-Only Correlation Markers** —
-  see [notes/bt-pitfalls.md](notes/bt-pitfalls.md).
+  see [`vultron/core/behaviors/case/AGENTS.md`](vultron/core/behaviors/case/AGENTS.md)
+  § "Use `disposition=\"rejected\"` for Local-Only Ledger Correlation Markers".
 - **Semantic Registry Pattern Must Match Inbound Wire Format** —
   see [notes/activitystreams-state-update.md](notes/activitystreams-state-update.md).
 - **`ActivityPattern.target_` Is Always Permissive Unless `strict=True`** —
@@ -524,8 +526,7 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   and record a Sentinel stub. See
   [notes/bt-fuzzer-nodes-report-management.md](notes/bt-fuzzer-nodes-report-management.md).
 - **BT Integration Tests Must Use Deterministic Factories When the Default Is
-  Probabilistic** — see `test/AGENTS.md` § "BT Factory Determinism" and
-  [notes/bt-pitfalls.md](notes/bt-pitfalls.md).
+  Probabilistic** — see `test/AGENTS.md` § "BT Factory Determinism".
 - **Emit Nodes in Case-Scoped Trigger BTs Must Fail Fast on Missing CaseActor** —
   FAILURE/exception when no routable CaseActor. See PCR-08-011.
 - **Module Split: Re-Import Moved Names for `monkeypatch` Compatibility** —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,8 +367,8 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   pass `TriggerActivityAdapter(dl)` to every use case in chained integration tests.
 - **Routing Prerequisites Must Be Resolved Before State Mutation** — resolve Case
   Manager ID in a read-only guard node BEFORE state-mutation node. See BT-19-001,
-  BT-19-002. [notes/bt-pitfalls.md](notes/bt-pitfalls.md) § "Routing-Gated
-  State Mutation".
+  BT-19-002. See
+  `vultron/core/behaviors/embargo/AGENTS.md` § "Routing-Gated State Mutation".
 - **Superseded Notes Sections Are Archived via `append-history note`** — stale
   sections (or whole files) go to `plan/history/YYMM/note/` with source ID
   `NOTES-<file-stem>--<section-slug>`; the `learn` skill Phase 5 drives this.
@@ -509,8 +509,7 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **Pre-Build Dedup Sets Before Fallback Loops** — `seen = set(d.values())`
   before the loop; O(n×m) → O(n+m).
 - **Consolidated Helper Needs One Test Per Distinct Lookup Path** —
-  see [notes/bt-pitfalls.md](notes/bt-pitfalls.md) § "Dual-Path
-  Consolidation Test Gap".
+  see `test/AGENTS.md` § "Dual-Path Consolidation Test Gap".
 - **Domain Sweep Audit: Catalog → Code, Then Factory Injection, Then
   `register_key`** — see
   [notes/bt-fuzzer-nodes-report-management.md](notes/bt-fuzzer-nodes-report-management.md).

--- a/notes/README.md
+++ b/notes/README.md
@@ -312,16 +312,16 @@ whether a new behavior must be a subtree, diagnosing layer-boundary violations
 (BT node calling use cases, importing from use_cases/), or auditing god nodes.
 
 **`bt-pitfalls.md`**
-Per-pitfall BT debugging notes: failure reason propagation, blackboard lookup
-semantics (`get()` vs attribute access, strict/lenient), idempotency patterns,
-role guards (`CheckIsCaseManagerNode`), `memory=False` partial-write semantics,
-blackboard key namespacing for concurrent executions (BTND-03-004), no-op path
-key clearing, `BTBridge.execute_with_setup` return value handling, ledger
-commit ordering, routing-gated state mutation, fan-out context handoff,
-and dual-path consolidation test gap patterns.
+Cross-cutting BT mechanics: failure reason propagation, blackboard lookup
+semantics (`get()` raises on unwritten READ keys), `memory=False` partial-write
+semantics, no-op path key clearing, blackboard key namespacing for concurrent
+executions (BTND-03-004), `BTBridge.execute_with_setup` return value handling,
+sentinel blackboard writes, and guard name / state-machine precondition
+alignment. Domain-specific pitfalls live in per-directory `AGENTS.md` files
+under `vultron/core/behaviors/`.
 **Load when**: debugging a BT that returns unexpected FAILURE/SUCCESS, auditing
-blackboard key race conditions, investigating idempotency failures, or
-reviewing BT subtree ordering for state-mutation safety.
+blackboard key race conditions, implementing a new BT node pattern, or
+investigating cross-cutting mechanics that span multiple BT domains.
 
 **`peer-broadcast-failure-semantics.md`**
 Fail-fast requirements for protocol-visible peer fan-out in BT paths:

--- a/notes/bt-pitfalls.md
+++ b/notes/bt-pitfalls.md
@@ -1,29 +1,29 @@
 ---
-title: BT Pitfalls and Debugging Notes
+title: BT Cross-Cutting Mechanics
 status: active
 description: >
-  Per-pitfall debugging notes for py_trees BT integration: failure reason
-  propagation, blackboard lookup semantics, idempotency patterns, role guards,
-  memory=False sequence semantics, blackboard key namespacing, and other
-  commonly encountered BT implementation pitfalls.
+  Cross-cutting mechanics for py_trees BT integration: failure reason
+  propagation, blackboard key semantics, idempotency patterns,
+  memory=False partial-write behavior, key namespacing, and other
+  mechanics that apply to any BT node or domain.
 related_specs:
   - specs/behavior-tree-integration.yaml
   - specs/behavior-tree-node-design.yaml
-  - specs/case-ledger-processing.yaml
 related_notes:
   - notes/bt-integration.md
   - notes/bt-canonical-reference.md
   - notes/bt-design-patterns.md
 relevant_packages:
   - py_trees
-  - vultron/bt
   - vultron/core/behaviors
 ---
 
-# BT Pitfalls and Debugging Notes
+# BT Cross-Cutting Mechanics
 
 > See also: [bt-integration.md](bt-integration.md) for design decisions and
-> [bt-canonical-reference.md](bt-canonical-reference.md) for the canonical BT structure.
+> [bt-canonical-reference.md](bt-canonical-reference.md) for the canonical BT
+> structure. Domain-specific pitfalls live in per-directory `AGENTS.md` files
+> under `vultron/core/behaviors/`.
 
 ## BT Failure Reason Propagation
 
@@ -59,64 +59,13 @@ source of diagnostic information.
 
 **Critical pitfall — `result.feedback_message` on the root is always empty**:
 When a `py_trees` Sequence fails because a child node fails, the root
-Sequence node's own `feedback_message` is always `""`. Logging
-`result.feedback_message` or `bt.root.feedback_message` after a BT failure
-therefore produces an empty string, not the diagnostic message set by the
-failing child. Always use `BTBridge.get_failure_reason(tree)` (depth-first walk
-to the first failing leaf) to get a meaningful message. Apply this pattern
-**everywhere** `feedback_message` is logged after a BT failure — not just for
-a single BT class.
+Sequence node's own `feedback_message` is always `""`. Always use
+`BTBridge.get_failure_reason(tree)` (depth-first walk to the first failing
+leaf) to get a meaningful message. Apply this pattern **everywhere**
+`feedback_message` is logged after a BT failure — not just for a single BT
+class.
 
 ---
-
-## AttachNoteToCase Idempotency: Check Attachment, Not Existence
-
-(DR-08, 2026-04-20)
-
-`AttachNoteToCaseNode.update()` MUST check whether the note is already
-**attached to the case** for idempotency — NOT whether the note object exists
-in the DataLayer.
-
-```python
-# WRONG — note may exist in DataLayer without being attached to the case
-if dl.read(note.id_) is not None:
-    return Status.SUCCESS  # false idempotency
-
-# CORRECT — check the case's note reference list
-case = dl.read(case_id)
-if note.id_ in case.notes:
-    return Status.SUCCESS  # truly idempotent
-case.notes.append(note.id_)
-dl.save(case)
-return Status.SUCCESS
-```
-
-**Why this matters**: The DataLayer stores notes as top-level objects
-independently of their attachment to a case. A note can be created and
-persisted without ever being added to `case.notes`. Checking `dl.read(note_id)
-is not None` would falsely skip re-attachment if the note was stored by another
-path but never linked.
-
----
-
-## Closing Bugs with Concrete Evidence
-
-(BUG-26041701 closure, 2026-04-22)
-
-When a backlog bug may already be fixed by unrelated work, close it with
-**concrete evidence** rather than forcing a redundant follow-up patch:
-
-1. **Code search**: confirm that the triggering condition is no longer possible
-   (e.g., search for the pattern that caused the original bug and verify it's
-   gone).
-2. **Regression test**: add or verify a test that would fail if the bug
-   recurred.
-3. **Document the fix points**: note which commits/layers addressed each aspect
-   of the root cause.
-
-**Anti-pattern**: Treating "I can't reproduce it" as sufficient closure — the
-fix may be coincidental and fragile. Concrete evidence ensures it won't
-silently regress.
 
 ## py_trees `blackboard.get()` Raises KeyError for Unwritten READ Keys
 
@@ -133,15 +82,11 @@ silently regress.
    that swallows it silently, status can be wrong.
 
 2. **Silent node shadowing** — a more insidious variant occurred during
-   development of `SendOfferCaseManagerRoleNode` (historical; deleted in
-   issue #2429): the class body of `EmitCreateCaseActivity` was accidentally
-   embedded *inside* `SendOfferCaseManagerRoleNode` (as a duplicate `__init__`,
-   `setup`, and `update()` defined later in the same class body). Python
-   resolves to the *last* definition, so the correct `update()` was silently
-   replaced by the embedded one. The embedded `setup()` only registered
-   `case_id`, so `get("case_actor_id")` never raised — it was never even
-   called. The node returned `SUCCESS` whenever `case_id` was present, masking
-   the real logic entirely.
+   development: the class body of one node was accidentally embedded *inside*
+   another. Python resolves to the *last* definition, so the correct `update()`
+   was silently replaced. The embedded `setup()` only registered one key, so
+   `get()` for the missing key was never called, and the node returned `SUCCESS`
+   for the wrong reason.
 
 **Rules**:
 
@@ -150,11 +95,9 @@ silently regress.
   production node code.
 - In production `update()`, use `self.blackboard.get(key)` knowing it will
   raise if the key is unset. Guard with an explicit `try/except KeyError` or
-  ensure the key is always written before being read (i.e., the writing node
-  precedes the reading node in the sequence).
+  ensure the key is always written before being read.
 - When a new node class is added to a file, **always verify class boundaries
-  with `grep -n "^class " <file>`** before committing. Python silently accepts
-  duplicate method definitions within a class; the last definition wins.
+  with `grep -n "^class " <file>`** before committing.
 
 ---
 
@@ -189,44 +132,6 @@ if result.status == Status.FAILURE:
 
 This avoids collapsing domain errors into generic BT failure messages and
 lets tests assert on the original exception type.
-
----
-
-## Lenient vs. Strict Participant Lookup Node Variants
-
-(ISSUE-710, 2026-06-09)
-
-Two distinct lookup patterns exist for resolving a participant from an
-actor ID:
-
-- **Strict** (`LookupParticipantNode`, fail-on-missing): Required for
-  operations that must have a participant record (e.g., recording acceptance).
-  Returns `FAILURE` when the participant is not found.
-- **Lenient** (`OptionalLookupParticipantNode`, succeed-on-missing): Correct
-  for operations where the participant may not exist on this peer yet (e.g.,
-  processing an invite or reject). Returns `SUCCESS` even when the participant
-  is absent, so the broadcast log entry can proceed.
-
-**Why "Always SUCCESS" is intentional for the lenient variant**: When a
-peer receives a log entry for a participant it has not yet seen, succeeding
-allows the case ledger cascade to proceed. The state gap resolves when the
-participant is later introduced via the normal invite/accept flow.
-
-**Documentation rule**: The docstring for any lenient node MUST explicitly
-state that it always returns `SUCCESS` and explain *why* this is correct for
-its use case — so future reviewers understand it is a deliberate design
-choice, not a missing failure check.
-
-**Constructor parameter audit**: When migrating procedural logic to BT
-nodes, verify that all constructor parameters are actually used inside the
-node. An unused parameter (e.g., `actor_id_source`) creates confusion about
-whether the parameter controls behavior — it suggests a future branching
-path that may never be implemented.
-
-**Actor ID handoff in invite trees**: When the invitee actor ID differs
-from the sender actor ID, pass the *invitee* ID (not the sender) to
-`bridge.execute_with_setup()` so participant-lookup nodes resolve the
-correct participant record.
 
 ---
 
@@ -293,29 +198,11 @@ def update(self, ...) -> Status:
 ```
 
 This eliminates the class of bug where a helper returns `None` silently with
-no `self.feedback_message` set (see
-`core/behaviors/case/nodes/communication.py` `_read_case_obj()` for the
-canonical pre-ADR-0032 anti-pattern). Helpers are clean typed functions;
+no `self.feedback_message` set. Helpers are clean typed functions;
 `update()` owns the failure-to-`Status` translation. See ADR-0032.
 
----
-
-## Embargo Subtree Idempotency with Blackboard Flag
-
-(ISSUE-750, 2026-06-08)
-
-When a god node is decomposed into a sequence of leaf nodes, the original
-single-pass semantics may break if duplicate-run behavior depended on the
-god node's internal guard. Preserve idempotency explicitly:
-
-- Add a blackboard flag (e.g., `embargo_initialized: bool`) that is set
-  to `True` only when the current execution actually created a new embargo.
-- Side-effect leaves that should only fire on first initialization (e.g.,
-  seeding participants, creating events) MUST check this flag before
-  acting.
-- When moving EM transition logic to `EmbargoLifecycle.propose_embargo`,
-  keep event creation and participant-seeding behavior aligned with
-  existing duplicate-report tests to avoid introducing regressions.
+For the note-specific partial-write worked example, see
+`vultron/core/behaviors/note/AGENTS.md` § "`memory=False` Note Sequence".
 
 ---
 
@@ -340,134 +227,8 @@ Selector(
 ```
 
 **Blackboard handoff keys**: Each leaf node reads from and writes to named
-blackboard keys (`new_case_participant`, `participant_case`,
-`new_participant_id`). This makes each leaf independently testable and the
-overall flow readable from the tree structure alone.
-
----
-
-## Guarded Commit: Role-Gated Canonical Writes
-
-(ISSUE-1021, 2026-06-17; see `specs/case-ledger-processing.yaml` CLP-09 and
-`notes/case-ledger-authority.md` § "Commit Authorization and Coverage")
-
-Any canonical-write node (e.g., `CommitCaseLedgerEntryNode`) that may be
-reached from more than one actor context MUST be wrapped in a role-gated
-`Selector`, never invoked bare:
-
-```python
-Selector(
-    name="GuardedCommitCaseLedgerEntry",
-    memory=False,
-    children=[
-        Sequence(
-            children=[
-                CheckIsCaseManagerNode(case_id=case_id),
-                CommitCaseLedgerEntryNode(case_id=case_id),
-            ]
-        ),
-        py_trees.behaviours.Success(
-            name="CommitCaseLedgerEntrySkippedNotCaseManager"
-        ),
-    ],
-)
-```
-
-This is the same Selector/Sequence/Success idiom as the section above; the
-difference is what the condition checks. `CheckIsCaseManagerNode` resolves
-the case's `CVDRole.CASE_MANAGER` participant and compares it against the
-*actor active for this invocation* — never against the use-case class's
-identity, and never assumed from a previous invocation having passed.
-
-This matters specifically for use cases that can be invoked more than once
-for the same logical activity with different receiving actors (e.g.,
-`ack_report`'s case-actor invocation vs. its finder-relay invocation in the
-demo). Gating per invocation, inside the tree, is what makes it safe to wire
-the same shared subtree into both the trigger-side and received-side paths
-of such a use case — see CLP-09-004. Do not introduce `py_trees.decorators`
-for this; this codebase uses the Selector/Sequence/Success composite idiom
-exclusively (see also "Conditional BT Branches as Selector Composites"
-above).
-
-Wrap the pattern once as a reusable factory (e.g.
-`create_guarded_commit_case_ledger_entry_tree(case_id=None)`) rather than
-re-inlining the Selector at each call site, and migrate all existing bare
-`CommitCaseLedgerEntryNode` call sites to the factory — CLP-09-002 requires
-a test asserting no bare usage remains outside it.
-
-**`execute()` MUST do nothing but build one tree, run it once, and handle
-the result** (ADR-0022, CLP-10-005, issues #1036/#1047): a received-side
-use case's `execute()` method MUST (a) build exactly one BT via a
-tree-factory function in `vultron/core/behaviors/`, (b) call
-`BTBridge.execute_with_setup()` exactly once, with
-`actor_id=resolve_receiving_actor_id(self._dl, request.receiving_actor_id)`,
-and (c) handle the result (log, extract
-output — see "Procedural Glue Exception" above). The guarded-commit
-factory above MUST be composed as a child of that one tree, not invoked
-separately, and the use case's main operation MUST itself be a BT node —
-not procedural code sitting alongside the one `execute_with_setup()` call.
-
-An audit (issue #1036, broadened to also resolve #1047) found this rule
-violated in 9 use cases across 6 modules, in three different shapes:
-genuine actor-identity switching — a real second `execute_with_setup()`
-call under a different actor (`embargo.py` x3, `report.py` x2,
-`status.py`; this is the literal pattern #1036 and #1047 describe, and in
-`embargo.py`'s case the main tree already contains the identical
-guarded-commit branch as its last child, but it no-ops because that tree
-runs under the wrong actor); a single BT call preceded by non-BT
-procedural code for the main operation (`note.py`, `actor/case_manager_role.py`
-— a BT-06-001 gap, not actor-switching); and a single BT call under the
-correct actor but assembled inline in `execute()` instead of via a
-factory function (`case/lifecycle.py`). See ADR-0022 for the full
-per-site breakdown and
-`test/architecture/test_single_bt_execution_received_side.py` for the
-migration ratchet.
-
----
-
-## Fan-out / SYNC Decomposition: Context Handoff Pattern
-
-(ISSUE-755, 2026-06-10)
-
-For replay/fan-out flows, split nodes along blackboard context boundaries:
-
-1. **Collect context leaf** — reads domain state, writes derived context
-   (index, recipient list, current position) to named blackboard keys.
-2. **Side-effect leaves** — each reads the context written by step 1 and
-   performs a single side effect (emit activity, update record).
-
-**Condition+action hybrid nodes**: If a node checks a condition and then
-performs an action, decompose it further into a `Selector` composite:
-
-```python
-Selector(
-    name="EmitIfRecipientExists",
-    memory=False,
-    children=[
-        CheckRecipientPresent(),   # pure condition; returns FAILURE → fall through
-        AlwaysSuccess("skip"),     # no-op when condition already met
-    ],
-)
-```
-
-This preserves the original guard semantics without embedding conditional
-logic inside a single `update()`.
-
----
-
-## Inbox Test Seam Must Preserve Production Deferral Semantics
-
-(ISSUE-769, 2026-06-08)
-
-A test-only inbox pipeline that reimplements defer/replay logic can drift
-from production behavior unless it reuses the same expiry path. When
-writing case-deferral tests:
-
-- Set canonical `to` recipients matching the expected actor-scoped queue
-  so actor-scoped queues are exercised under the same addressing assumptions
-  as inbox processing.
-- Do not reimplement the defer/replay path inline in tests — call the
-  production code path directly so timing and queue semantics stay aligned.
+blackboard keys. This makes each leaf independently testable and the overall
+flow readable from the tree structure alone.
 
 ---
 
@@ -487,41 +248,6 @@ regressing call paths that provide context in one form but not the other.
 
 ---
 
-## Role Guard Required for All CASE_MANAGER-Only BT Subtrees
-
-(ISSUE-1030, 2026-06-18; see `specs/behavior-tree-integration.yaml` BT-17-001,
-BT-17-002)
-
-The `CheckIsCaseManagerNode` role guard is not only for `CommitCaseLedgerEntryNode`
-(see "Guarded Commit" above) — it MUST be applied to **any** BT subtree whose
-semantics are restricted to the `CVDRole.CASE_MANAGER` actor. The canonical
-composite is:
-
-```python
-Selector(
-    name="ActionIfCaseManager",
-    memory=False,
-    children=[
-        Sequence(
-            name="CaseManagerGuardedAction",
-            children=[
-                CheckIsCaseManagerNode(case_id=case_id),
-                ActionNode(case_id=case_id),   # your CASE_MANAGER-only node
-            ],
-        ),
-        py_trees.behaviours.Success(name="ActionSkippedNotCaseManager"),
-    ],
-)
-```
-
-**Why this is necessary**: Received-side use cases run the BT with the receiving
-actor's `actor_id`. Every participant that receives a broadcast may run the same
-BT. Without an in-tree role guard, a CASE_MANAGER-only node such as
-`EmitCloseCaseNode` fires for every receiving actor — including participants who
-should remain silent. Placing the guard outside the tree (e.g., in `execute()`) is
-insufficient because the same tree factory may be shared across trigger-side and
-received-side paths.
-
 ## Use DataLayer Outbox for Idempotency, Not Module-Level Sets
 
 (Resolved pattern — the former `AutoCloseBranchNode` used a module-level
@@ -530,16 +256,13 @@ received-side paths.
 
 A module-level `set[str]` used to prevent duplicate fires is **per-process**,
 not per-container. In a Docker deployment, vendor-1 and finder-1 each have
-separate Python processes with separate sets; a claim in finder-1 does not
-affect vendor-1. However, **within a single process**, two fires can race:
-if a phantom fire (wrong actor) runs first and claims the slot, the legitimate
-fire (correct actor) is silently skipped.
+separate Python processes with separate sets. Furthermore, within a single
+process, two fires can race: if a phantom fire (wrong actor) runs first and
+claims the slot, the legitimate fire (correct actor) is silently skipped.
 
 **Fix**: Use a `DataLayerCondition` node that queries the DataLayer outbox for
-an existing activity, not a module-level set. This survives process restarts and
-is visible to the BT audit trail. Issue #1030 observed the module-set race on
-the former `AutoCloseBranchNode`; `CloseNotYetEmittedConditionNode` (PR #1724)
-is the idiomatic replacement pattern.
+an existing activity, not a module-level set. This survives process restarts
+and is visible to the BT audit trail.
 
 ---
 
@@ -552,21 +275,14 @@ tick. If an early child succeeds but a later child fails, the early child's
 side effects **have already been committed**. The Sequence as a whole returns
 FAILURE, but local state written by the successful earlier children persists.
 
-Example: `add_note_to_case_trigger_bt` uses a `memory=False` Sequence with
-three children:
-
-1. `CreateNoteNode` — creates and writes the note to the DataLayer
-2. `AttachNoteFromResultNode` — attaches the note to the case
-3. `SenderSideBT` — enqueues the outbound activity
-
-If `SenderSideBT` fails (e.g., no CASE_MANAGER recipient resolved), steps 1
-and 2 have already committed. **The note IS attached to the case locally even
-though the overall BT returns FAILURE.** Tests MUST assert this partial-write
-behavior explicitly so future readers do not assume FAILURE → no writes occurred.
-
 **Design implication**: When using `memory=False` sequences for partially-
 reversible operations, document which steps are non-transactional and what
-state is committed if a later step fails.
+state is committed if a later step fails. Tests MUST assert partial-write
+behavior explicitly so future readers do not assume FAILURE → no writes
+occurred.
+
+For the note-domain worked example, see
+`vultron/core/behaviors/note/AGENTS.md` § "`memory=False` Note Sequence".
 
 ---
 
@@ -576,8 +292,8 @@ state is committed if a later step fails.
 BT-17-004)
 
 `py_trees.blackboard.Blackboard.storage` is process-global. `execute_with_setup`
-cleans only the `datalayer` and `trigger_activity_factory` keys on exit — it does
-NOT clean domain-specific output keys such as `broadcast_activity_id`.
+cleans only the `datalayer` and `trigger_activity_factory` keys on exit — it
+does NOT clean domain-specific output keys such as `broadcast_activity_id`.
 
 **Rule**: When a BT node takes a no-op path (empty recipient list, guard
 condition not met, etc.), it MUST explicitly write `None` to any output
@@ -596,9 +312,8 @@ if not recipients:
 ```
 
 **Consumer side**: Any node that reads an output key from a peer node MUST
-treat both `KeyError` (key never written, first-ever run) and `None` (key
-explicitly cleared by no-op path) as equivalent no-op sentinels. Only handle
-actual typed values.
+treat both `KeyError` (key never written) and `None` (key explicitly cleared
+by no-op path) as equivalent no-op sentinels.
 
 **Regression test pattern**: Add a test that runs two `execute_with_setup`
 calls back-to-back on the same blackboard instance without clearing between
@@ -607,131 +322,17 @@ the producer node takes a no-op path.
 
 ---
 
-## Routing-Gated State Mutation
-
-(BT-19, 2026-06-26; see `specs/behavior-tree-integration.yaml` BT-19-001,
-BT-19-002)
-
-A BT Sequence that performs a protocol state-machine transition (EM, RM, or CS)
-and then routes an outbound activity MUST resolve all routing prerequisites
-in a read-only guard node placed **before** the state-mutation node.
-
-**Why ordering matters**: Once the DataLayer accepts a state write (e.g.,
-`EM=EXITED`), the transition is committed. If the subsequent routing step
-then fails (missing Case Manager, missing factory), the outbound notification is
-never sent. Peers retain the prior state; local state has advanced — a
-divergence window that requires ledger-sync catch-up (SYNC-10) to repair.
-Moving the routing guard to the top of the Sequence eliminates the divergence:
-if routing prerequisites are absent, the tree returns `FAILURE` with zero
-DataLayer state change.
-
-**Shared factory requirement**: Duplicated monolithic BT nodes that inline both
-state mutation and dispatch in a single `update()` method drift independently.
-The canonical factory-composed path may correctly order the guard, while the
-automatic-cascade monolith retains the old unsafe ordering, reintroducing the
-divergence bug on that path only. All call sites for the same lifecycle
-transition MUST use a shared BT factory function (BT-19-002).
-
-**Canonical Sequence structure**:
-
-```text
-Sequence
-├── ResolveCaseManagerNode          ← read-only guard; FAILURE = bail, no write
-├── <StateTransitionNode>           ← mutation committed after guard passes
-└── <SendDispatchNode>              ← routing succeeds because guard already verified
-```
-
-**Anti-pattern** (Issue #1054 — `TerminateEmbargoNode`):
-
-```text
-Sequence
-├── TerminateEmbargoLifecycleNode   ← mutation committed first ← ❌
-└── SenderSideBT                    ← routing checked second; fail = divergence
-```
-
-**Fix**: Extract a shared factory (`terminate_embargo_bt`) that places
-`ResolveCaseManagerNode` before `TerminateEmbargoLifecycleNode`, and replace
-all standalone monolithic nodes with the factory output. Both trigger and
-cascade call sites use the shared factory directly (BT-19-002, PR #1263).
-
----
-
-## Demo Devlog Race: Wait for Replica Before Dumping
-
-(DEMO-DEVLOG-RACE, 2026-06-18)
-
-Demo phases that write JSONL devlogs will miss recently committed canonical
-ledger entries if they run before the async `Announce(CaseLedgerEntry)`
-fan-out has been processed and stored by the replica actor.
-
-**Pattern**: After any phase that commits a new canonical ledger entry, query
-the sender's current tail hash and poll until the replica acknowledges it before
-writing the devlog:
-
-```python
-vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
-if vendor_entries:
-    tail = max(vendor_entries, key=lambda e: e["log_index"])
-    wait_for_finder_log_entry(finder_client, case.id_, tail["entry_hash"])
-```
-
-Apply this poll-until-hash pattern after every phase that introduces a new
-ledger tail before a devlog dump. This is the same pattern used in
-`_phase_sync_verification` and ensures dump artifacts are always consistent
-with the replica's committed state.
-
----
-
-## Integration Tests Must Use Deterministic Factories When BT Default Is Probabilistic
-
-(BT-FACTORY-DETERMINISM, 2026-07-08; learning `ISSUE-1151`)
-
-When a tree builder's default `CallOutBackendFactory` wraps a probabilistic
-fuzzer node (e.g., `AlmostAlwaysSucceed` at 90% success), integration tests
-that assert `result.status == Status.SUCCESS` become flaky. Two such nodes in
-series give ~81% tree success — a failure probability that surfaces within a
-few test runs.
-
-**Pattern that caused this**: Adding factory injection to a tree builder (e.g.,
-`create_validate_report_tree`) where the fuzzer defaults (`EvaluateReportCredibility`,
-`EvaluateReportValidity`) are `AlmostAlwaysSucceed` nodes. Existing integration
-tests called the builder with no factory args and asserted `SUCCESS`.
-
-**Fix**: Add a module-level `_always_succeed_factory` helper to the test file
-and pass it explicitly to all integration tests that require `SUCCESS`:
-
-```python
-def _always_succeed_factory(name: str) -> py_trees.behaviour.Behaviour:
-    class _AlwaysSucceed(py_trees.behaviour.Behaviour):
-        def update(self):
-            return py_trees.common.Status.SUCCESS
-    return _AlwaysSucceed(name)
-```
-
-**Scope**: This applies only to integration tests (those that assert
-`Status.SUCCESS` on the full tree execution). Tree-structure tests (node names,
-child counts) and `FAILURE`-path tests (missing `DataLayer`, missing report)
-are not affected.
-
-**Rule**: Any time a tree builder's default factory wraps a probabilistic fuzzer
-node, update all integration tests that assert `SUCCESS` to pass an explicit
-deterministic factory. See `test/AGENTS.md` § "BT Factory Determinism".
-
----
-
 ## Namespaced Inter-Node Handoff Keys
 
 (CONCERN-1335, 2026-07-10; see `specs/behavior-tree-node-design.yaml` BTND-03-004)
 
 The py_trees blackboard is **process-global**. When a tree factory function is
-called for two concurrent incoming messages of the same type (e.g., two
-simultaneous `Offer(Actor, Case)` deliveries), both tree instances write to the
-same flat blackboard namespace. A node in instance A that writes `suggested_roles`
-will have that value overwritten by instance B before instance A's downstream
-consumer reads it — causing silent data corruption.
+called for two concurrent incoming messages of the same type, both tree
+instances write to the same flat blackboard namespace. A node in instance A that
+writes `suggested_roles` will have that value overwritten by instance B before
+instance A's downstream consumer reads it — causing silent data corruption.
 
-**Pattern**: Any BT node that writes an inter-node handoff key (a value written
-by one node and consumed by a downstream sibling in the same tree) MUST include
+**Pattern**: Any BT node that writes an inter-node handoff key MUST include
 the execution-scoped correlation ID in the key name:
 
 ```python
@@ -746,34 +347,15 @@ self.blackboard.register_key(self.blackboard_key, access=Access.WRITE)
 setattr(self.blackboard, self.blackboard_key, [CVDRole.VENDOR])
 ```
 
-The consumer node derives the same key from the same correlation ID:
-
-```python
-# In setup():
-id_segment = self.recommendation_id.split("/")[-1]
-self.blackboard_key = f"suggested_roles_{id_segment}"
-self.blackboard.register_key(self.blackboard_key, access=Access.READ)
-
-# In update():
-try:
-    roles = self.blackboard.get(self.blackboard_key)
-except KeyError:
-    roles = [CVDRole.VENDOR]  # safe default if key not set
-```
-
 **Key derivation convention**: `{noun}_{id_segment}` where `id_segment` is
-`correlation_id.split("/")[-1]` for HTTP URIs (same as `helpers.py` line 352),
-or the last colon-delimited segment for URN IDs. This matches the existing
-`object_{id_segment}` pattern used by `WriteObjectToBBNode` /
-`ReadObjectFromBBNode` in `helpers.py`.
+`correlation_id.split("/")[-1]` for HTTP URIs, or the last colon-delimited
+segment for URN IDs. This matches the existing `object_{id_segment}` pattern
+used by `WriteObjectToBBNode` / `ReadObjectFromBBNode` in `helpers.py`.
 
 **When this applies**: Any inter-node handoff key in a tree factory that may
 realistically be called with multiple concurrent executions — i.e., where the
 factory is called per-incoming-message for a message type that can arrive in
-bursts (offer/accept/reject workflows in particular). Keys that are always
-cleaned up and rewritten before being read (e.g., within a single Sequence with
-`memory=False`) are safe, but namespacing eliminates the risk entirely and
-is cheap to implement.
+bursts (offer/accept/reject workflows in particular).
 
 **Known instances** (catalogue for conformance audits):
 
@@ -782,15 +364,19 @@ is cheap to implement.
 | `suggested_roles` | `create_recommend_actor_to_case_received_tree` | `recommendation_id` | CONCERN-1335 |
 | `new_case_participant`, `participant_case`, `new_participant_id` | `create_receive_report_case_tree` | `report_id` | CONCERN-1349 |
 
-When auditing for compliance, grep for flat blackboard key registrations in
-tree factories called per-incoming-message and verify each inter-node handoff
-key includes the execution-scoped correlation ID segment.
+### BTND-03-004 Audit Scope: All Keys in the Subtree
 
-**Planned migration**: the imperative `register_key()` pattern is scheduled for
-replacement with py_trees typed Ports (`input_ports()` / `output_ports()`
-declarations), which enforce blackboard contracts at setup time rather than ad
-hoc. See `notes/py-trees-ports-adoption.md` for the planning analysis and the
-implementation issue sequence (#1808 → #1809).
+(ISSUE-1397, 2026-07-14)
+
+When namespacing blackboard keys per BTND-03-004, audit ALL
+`register_key` calls within the affected composite subtree — not just the
+keys named in the issue body.
+
+**How to audit**: grep for `register_key` across the affected module, list
+every key, then check whether each one crosses a concurrent-execution
+boundary. Keys that are always cleaned up and rewritten before being read
+within a single `Sequence(memory=False)` are low-risk, but namespacing
+eliminates the risk entirely and is cheap.
 
 ---
 
@@ -799,8 +385,8 @@ implementation issue sequence (#1808 → #1809).
 (ISSUE-1374, 2026-07-13)
 
 py_trees stores blackboard values by reference. Mutating a list retrieved from
-the blackboard (e.g., `list.pop(0)`, `list.append(x)`) updates the stored value
-in place — any subsequent reader sees the change without a write-back.
+the blackboard updates the stored value in place — any subsequent reader sees
+the change without a write-back.
 
 ```python
 # ❌ REDUNDANT — write-back is a no-op; same object is already updated
@@ -855,219 +441,7 @@ calling node returns `FAILURE` rather than `SUCCESS`.
 
 ---
 
-## Ledger Commit Must Precede Outbox Write
-
-(ISSUE-1325, 2026-07-13)
-
-When a BT subtree both commits a ledger correlation marker and records an
-outbox item, the ledger commit MUST happen first.
-
-If the outbox write happens first and the ledger commit subsequently fails,
-the outbox item is orphaned: an activity queued for delivery with no
-corresponding ledger entry. On the next invocation, the duplicate-detection
-guard finds no pending entry and takes the "fresh" path, triggering a
-duplicate offer or invite.
-
-Correct ordering in a tree or composite node:
-
-1. Build activity via factory (creates the object in the DataLayer)
-2. Commit ledger correlation marker (fail-fast if anything is wrong)
-3. Record outbox item (reached only if ledger commit succeeded)
-
-This invariant is enforced by CLP-10-006 in `specs/case-ledger-processing.yaml`.
-
----
-
-## Use `disposition="rejected"` for Local-Only Ledger Correlation Markers
-
-(ISSUE-1325, 2026-07-13)
-
-When a BT node needs a local ledger entry that does NOT correspond to a
-canonical AS2 activity (e.g., tracking an outbound
-`offer_case_participant` for duplicate detection), use
-`disposition="rejected"` in `create_commit_log_entry_tree`.
-
-`_validate_canonical_entry` returns early for non-`"recorded"` dispositions,
-bypassing the `_CANONICAL_PAYLOAD_SIGNATURES` allowlist check.  The entry is
-still persisted and `find_protocol_pair` does not filter on disposition, so
-the correlation marker remains visible to duplicate-detection nodes.
-
-The `_find_equivalent_recorded_entry` idempotency check also filters on
-`disposition == "recorded"`, so repeated calls each create a new marker —
-which is fine when the BT guarantees at-most-once execution per receipt (e.g.,
-via `GuardedCommit` in `create_receive_activity_tree`).
-
----
-
-## Idempotency Guards Must Be Silent — No Ledger Write on Duplicate
-
-(CONCERN-1754, 2026-08-05)
-
-`disposition="rejected"` is valid for **emit-side correlation markers** (see
-above).  It is **not** valid for **idempotency guard no-ops**.
-
-An idempotency guard is a `DataLayerCondition` node that detects "this event
-was already processed" and returns `Status.FAILURE` to abort the tree.
-Examples: `CheckInviteeNotAlreadyParticipantNode` (actor already a
-participant), `CheckCaseStatusIdempotencyNode` (status already appended).
-
-When a guard fires, **no ledger entry of any disposition must be written**
-(CLP-13-001).  Use only `logger.info` / `logger.debug`:
-
-```python
-self.logger.info(
-    "%s: actor '%s' already participant in case '%s' — skipping (idempotent)",
-    self.name, self.invitee_id, self.case_id,
-)
-return Status.FAILURE
-```
-
-**Why it matters**: A spurious `disposition="rejected"` entry for
-`invite_actor_to_case` appeared in the `fvcv_handoff_demo` ledger as
-"Invited an actor to the case [rejected]" with no actor name and no state
-transition.  Because the canonical ledger is replicated and contributes to
-the hash chain, any non-protocol content pollutes participants' replicas and
-misleads human readers and tooling alike (ADR-0019).
-
-**Distinction table**:
-
-| Pattern | Ledger entry? | Disposition | Use case |
-|---|---|---|---|
-| Emit-side correlation marker | ✅ yes | `"rejected"` | Dedup guard for outbound activities |
-| Received-side canonical entry | ✅ yes | `"recorded"` | CaseActor accepts a protocol assertion |
-| Idempotency guard no-op | ❌ **no** | — | Already-processed duplicate detected |
-
-**Resolved** (issue #2010, PR #2024, 2026-08-06): `SilentIdempotencyGuardMixin`
-(`vultron/core/behaviors/idempotency.py`) now exists and satisfies CLP-13-002.
-Both `CheckInviteeNotAlreadyParticipantNode` and `CheckCaseStatusIdempotencyNode`
-inherit it.  Implement all idempotency guards using this mixin — the
-`_idempotent_failure()` method returns `FAILURE` immediately after logging,
-making the "no ledger write" guarantee structural.
-
----
-
-## suggest-actor Accept Path Does Not Thread Roles Into Invite
-
-(ISSUE-1406, 2026-07-14)
-
-`create_accept_actor_recommendation_received_tree` (CaseActor receives
-`Accept(Offer(CaseParticipant))` from Case Owner) never writes the
-`suggested_roles` blackboard key. `EmitInviteActorToCaseNode` reads this key
-via `_read_suggested_roles()`, gets a `KeyError`, and passes `roles=None` to
-`factory.invite_actor_to_case()`. The resulting `Invite` carries `roles=None`,
-so after `Accept(Invite)` the new `VultronParticipant.case_roles` is `[]`.
-
-This is documented behavior (ADR-0032, BT-HELPER-01: no silent default
-substitution), not a bug.
-
-**Test implication**: Only the `invite_actor_to_case_trigger_bt` path (or a
-tree with `EvaluateDefaultRolesNode`) produces a non-empty `case_roles`. The
-`AcceptOfferCaseParticipant` received-side use case always produces
-`roles=None` in the Invite. Tests that verify roles end up on a participant
-MUST exercise the trigger path, not the received path.
-
-**Blackboard key contrast**:
-
-| Tree factory | Key written | Namespaced? |
-|---|---|---|
-| `create_recommend_actor_to_case_received_tree` | `suggested_roles_{id_segment}` | ✅ |
-| `create_accept_actor_recommendation_received_tree` | *(never written)* | N/A |
-
----
-
-## BTND-03-004 Audit Scope: All Keys in the Subtree
-
-(ISSUE-1397, 2026-07-14)
-
-When namespacing blackboard keys per BTND-03-004, audit ALL
-`register_key` calls within the affected composite subtree — not just the
-keys named in the issue body. Code review on ISSUE-1397 caught two more
-flat keys (`participant_accepted_status`, `owner_initial_status`) that were
-intra-Sequence only (currently low-risk) but still violate BTND-03-004.
-
-**How to audit**: grep for `register_key` across the affected module, list
-every key, then check whether each one crosses a concurrent-execution
-boundary. Keys that are always cleaned up and rewritten before being read
-within a single `Sequence(memory=False)` are low-risk, but namespacing
-eliminates the risk entirely and is cheap.
-
----
-
-## Production Collapse (FUZZ-08x): Use the Prior Collapse as a Concrete Template
-
-(ISSUE-1310, 2026-07-22; see also `notes/bt-fuzzer-nodes-report-management.md`)
-
-When implementing a FUZZ-08x Production Collapse, read the most recently merged
-sibling collapse first and mirror its file layout, import structure, test-file
-shape, and doc-update checklist. The pattern is stable across collapses:
-
-**What survives:**
-
-- Outer loop structure (evaluators/retrievers/effort gates)
-- All factory call-out points (ADR-0025)
-- Typed sub-loops where relevant
-
-**What is replaced:**
-
-- Granular simulator Actuator nodes → a single `EvaluatorCallOutPoint` (or
-  `suggest-actor-to-case` trigger for notification loop collapses)
-- The eliminated `InjectX` / `BypassX` fuzzer classes remain in the demo
-  module as catalogued simulator stand-ins; they stop being wired into the
-  production tree
-
-**Import structure:**
-
-- Decision model lives in the core tree module
-  (`vultron/core/behaviors/*/…_tree.py`)
-- Demo fuzzer Evaluator imports the model at module level
-- Core tree module uses **deferred (function-local) imports** of the fuzzer to
-  avoid the circular dependency
-
-**Default field encoding:** the `EvaluatorCallOutPoint` mixin writes
-`typ()` (a default-constructed instance) on SUCCESS, so a decision model's
-field defaults MUST encode the sensible default outcome (e.g.,
-`PublicationIntentDecision` defaults to publish fix + report, withhold
-exploit).
-
-**Arm gating:** use the positively-named gate idiom (BTND-08-001):
-`Selector(Sequence(ShouldPublishX, Prepare, Publish), Inverter(ShouldPublishX))`
-— a not-intended arm is a graceful SUCCESS no-op while a genuine
-Prepare/Publish FAILURE still propagates.
-
-**Doc-update checklist per collapse:**
-
-1. ADR: `proposed` → `accepted`, remove `PROVISIONAL` marker
-2. `specs/behavior-tree-integration.yaml` BT-20-xxx: remove `PROVISIONAL` from
-   rationale, update `tracking_issue` to the implementing PR/issue
-3. `notes/bt-fuzzer-nodes-report-management.md`: rewrite the matching
-   "Production Collapse N" section and each affected node's "Factory-fn
-   placement" line
-
-<!-- Source: ISSUE-1310 -->
-
----
-
-## Dual-Path Consolidation Test Gap
-
-(ISSUE-1378, 2026-07-14)
-
-When consolidating two helpers with different lookup paths into one unified
-function, the new test suite MUST exercise each distinct path in isolation.
-
-In ISSUE-1378, `_resolve_case_manager_id` was consolidated from two helpers:
-a primary `actor_participant_index` path and a fallback `case_participants`
-path. All 6 initial tests only populated `case_participants`, leaving the
-primary index path entirely untested. Code review caught the gap; a 7th test
-(`test_primary_index_path_returns_actor_id`) was added before the PR merged.
-
-**Pattern**: For a helper with N distinct lookup paths, write at least one
-test per path where that path is the *sole* source of truth — all other paths
-are left empty or unpopulated. "One test exercises both paths" means neither
-path is verified independently.
-
----
-
-## Guard Name Must Match the State-Machine Transition Precondition, Not Just the Absent Target
+## Guard Name Must Match the State-Machine Transition Precondition
 
 (ISSUE-1825, 2026-07-30)
 
@@ -1104,9 +478,8 @@ in `vultron/core/behaviors/` cannot import from `vultron/core/use_cases/`
 
 **Do not unify or move these helpers until #1428 is addressed.** Adding a
 shared helper module under `vultron/core/behaviors/` is a design decision
-requiring an ADR or spec entry (see the BTND-04 hierarchy rules). Until then,
-keep the inlined copy in `develop_fix.py` — it is not tech debt to fix in the
-same PR.
+requiring an ADR or spec entry. Until then, keep the inlined copy — it is not
+tech debt to fix in the same PR.
 
 <!-- Source: ISSUE-1812 -->
 
@@ -1119,21 +492,16 @@ same PR.
 `py_trees.behaviour.BehaviourWithPorts` raises `NoDataAvailable` when
 `get_input()` is called for a port whose blackboard key has no value. This
 happens in `initialise()` at the **start of the first tick** — not in
-`setup_ports()` or `setup()`. `setup_ports()` only registers key access;
-the read and the potential raise occur at the first actual `get_input()` call.
+`setup_ports()` or `setup()`.
 
 **ADR-0044 and BTND-03-011 use "early error detection" to mean "at
 `initialise()`, before the main `update()` logic"** — not "before any tick."
-The practical improvement over direct attribute access (`self.blackboard.key`)
-is that a missing key raises a typed `NoDataAvailable` (not `AttributeError` or
-`KeyError`) at the tree's first tick entry point.
 
 **Test pattern for missing-required-port coverage**:
 
 ```python
 # ❌ Wrong — setup_ports() does not raise; test passes vacuously
 node.setup_ports()
-# no assertion needed here; setup_ports() never raises
 
 # ✅ Correct — the raise happens in initialise()
 node.setup_ports()  # register keys; blackboard is still empty
@@ -1145,83 +513,11 @@ with pytest.raises(py_trees.blackboard.timebomb.NoDataAvailable):
 
 ---
 
-## Reverted "Symptom-Only" Fix May Be Correct After Root Cause Is Removed
-
-(ISSUE-1777, 2026-07-30)
-
-When git history shows a change was **reverted as a "symptom-only fix"**, that
-label means the change was *premature* — not that the change itself was wrong.
-After the root cause is removed, the reverted change may be exactly what
-MUST-level spec requirements demand.
-
-**Pattern from ADR-0041**: `("Add", "CaseStatus")` was added to
-`_CASE_AUTHORED_SIGNATURES`, then reverted as a "symptom fix." After the
-vendor-authored back-fill was removed and the CaseActor began authoring those
-entries natively (CM-22-003), adding the signature back was required by
-CLP-12-001.
-
-**Rule**: Before inheriting a revert's conclusion, check:
-
-1. Was the revert motivated by the change being *wrong* or merely *premature*?
-2. Does a MUST-level spec require the change once the root cause is resolved?
-
-A "symptom fix" label in a commit message does not mean "do not apply ever."
-Read the revert's commit message for its actual reasoning, then check the
-governing spec.
-
-<!-- Source: ISSUE-1777 -->
-
----
-
-## VFD/PXA Write-Boundary Validation in `CreateParticipantStatusNode`
-
-(ISSUE-1825, 2026-07-30; ISSUE-2478, 2026-08-22; see also `notes/case-state-model.md`)
-
-**Current state (PR #2503 / ISSUE-2478, 2026-08-22)**: `CreateParticipantStatusNode`
-now validates VFD and PXA transitions inline at the write boundary before any
-`dl.create()` / `dl.save()` call:
-
-- `_check_vfd_preconditions()` calls `is_valid_vfd_transition(current, target)` and
-  enforces role preconditions (CVDRole.VENDOR for `VFd`, CVDRole.DEPLOYER for `VFD`).
-  Same-state writes pass through. Invalid jumps return `Status.FAILURE` (CSB-16-001,
-  CSB-15-001/002).
-- `_check_pxa_precondition()` calls `is_valid_pxa_transition(current, target)`.
-  Invalid backward moves return `Status.FAILURE` (CSB-16-002).
-
-This closes the fragility identified in concern #1896: guard bypass or a missing
-upstream guard can no longer silently persist an illegal VFD/PXA snapshot.
-
-**Defence layers as of PR #2503:**
-
-- **Write node** (`CreateParticipantStatusNode`): fail-closed inline validation for
-  VFD adjacency, VFD role preconditions, and PXA monotonicity (primary boundary).
-- **Trigger path** (`add_participant_status_trigger_bt`): upstream
-  `ValidateTriggerTransitionsNode` raises `VultronValidationError` before the BT
-  write node is reached (added in PR #2307 / issues #2081, #1903).
-- **Received wire path** (`add_participant_status_tree`): `FilterParticipantStatusDimensionsNode`
-  - `ValidateRMTransitionNode` guard upstream (in place since `a17d7649`). Uses the weaker
-  `is_monotonic_vfd_forward` check intentionally — remote peers may advance through
-  multiple VFD steps between status messages; strict adjacency applies only to local
-  write nodes (CSB-16-001, AC-3).
-- **Architecture ratchet** (`test/architecture/test_vfd_rm_pxa_write_sites.py`): AST-audits
-  every `VfdDimension`/`RmDimension`/`PxaDimension` constructor call in `vultron/core/behaviors/`
-  and fails on any new unclassified site (added in PR #2307).
-
-**When writing or reviewing guard nodes that precede `CreateParticipantStatusNode`**:
-the write node is now a second line of defence, but upstream guards still matter —
-they surface invalid requests with richer error context (`VultronValidationError`) before
-the BT write node is reached, and they protect RM dimension writes (not validated by
-`CreateParticipantStatusNode` inline).
-
-<!-- Source: ISSUE-1825; GitHub concern #1896; PR #2307; ISSUE-2478; PR #2503 -->
-
----
-
 ## Sentinel Blackboard Writes Enable Structured Failure Context for Selector Fallbacks
 
 When a py_trees Sequence needs a fallback action on node failure, the standard
-Selector pattern only works cleanly if the failing node leaves the blackboard in
-a usable state for its sibling.
+Selector pattern only works cleanly if the failing node leaves the blackboard
+in a usable state for its sibling.
 
 **Pattern**: write sentinel values to the blackboard **before** returning
 `Status.FAILURE`. The sibling fallback node in the enclosing Selector can then
@@ -1238,14 +534,12 @@ return Status.FAILURE
 
 **Safety rule**: sentinel values MUST be semantically distinct from all valid
 data so that downstream consumers can distinguish "node failed" from "node
-succeeded with this value". Empty string vs. a 64-character hex hash and `-1`
-vs. a non-negative index are safe sentinels; `0` or `""` are not safe for fields
-where those are valid values.
+succeeded with this value".
 
 **When not to use this pattern**: if the failing node is not inside a Selector
 that has a fallback sibling, writing sentinel values is unnecessary overhead.
-Only add sentinels when you are composing a Selector with a specific fallback
-consumer in mind. *Source: ISSUE-1873*
+
+<!-- Source: ISSUE-1873 -->
 
 ---
 
@@ -1253,30 +547,26 @@ consumer in mind. *Source: ISSUE-1873*
 
 (ISSUE-2258, 2026-08-20)
 
-When a guard node detects an anomaly and needs to communicate structured context
-to a downstream effect node — but returns `Status.FAILURE` so the Sequence
-aborts before the effect node runs — use the blackboard as an explicit channel:
+When a guard node detects an anomaly and needs to communicate structured
+context to a downstream effect node — but returns `Status.FAILURE` so the
+Sequence aborts before the effect node runs — use the blackboard as an
+explicit channel:
 
 1. Define a module-level constant for the key (e.g.
    `BB_RM_ANOMALY = "rm_transition_anomaly"`).
-2. The guard node writes to this key on **every** tick: `None` on normal paths,
-   a typed dict on anomaly paths, **including the FAILURE path**.
+2. The guard node writes to this key on **every** tick: `None` on normal
+   paths, a typed dict on anomaly paths, **including the FAILURE path**.
 3. The effect node reads the key. It runs only on the SUCCESS path of the
-   Sequence (normal or partial-accept); on FAILURE it never runs.
-
-**Why write on the FAILURE path?** The Sequence aborts after FAILURE, so the
-effect node never runs. The anomaly write on the guard's FAILURE path is the
-only durable record for that tick. Any node that runs before the next tick
-can read it.
+   Sequence; on FAILURE it never runs.
 
 **Base class**: use `DataLayerAction` (not `DataLayerActionWithPorts`) for
 emission nodes that need both `self.blackboard` (standard py_trees blackboard)
-and DataLayer access. `DataLayerActionWithPorts` exposes the typed ports
-interface and does not provide `self.blackboard`; calling
-`self.blackboard.get(...)` on it raises `AttributeError`.
+and DataLayer access. `DataLayerActionWithPorts` does not provide
+`self.blackboard`; calling `self.blackboard.get(...)` on it raises
+`AttributeError`.
 
-See `vultron/core/behaviors/status/nodes/dimension_filter.py` for the reference
-implementation. *Source: ISSUE-2258*
+See `vultron/core/behaviors/status/nodes/dimension_filter.py` for the
+reference implementation. *Source: ISSUE-2258*
 
 ---
 

--- a/notes/flaky-tests.md
+++ b/notes/flaky-tests.md
@@ -107,6 +107,8 @@ No open entries.
 
 | Job name | Issue | Last blocked |
 |---|---|---|
+| `fcvcv Demo Integration` | #2733 | 2026-08-27 |
+| `fcvcv Invariant Harness` | #2733 | 2026-08-27 |
 | `fvcv-extension` | #2422 | 2026-08-26 |
 | `fccv-extension` | #2422 | 2026-08-26 |
 | `fv Demo Integration` | #2422 | 2026-08-20 |

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -324,8 +324,7 @@ def _always_succeed_factory(name: str) -> py_trees.behaviour.Behaviour:
 ```
 
 Structure tests and FAILURE-path tests are unaffected.
-See `notes/bt-pitfalls.md` § "Integration Tests Must Use Deterministic
-Factories When BT Default Is Probabilistic".
+See "BT Factory Determinism" above.
 
 ---
 
@@ -444,3 +443,22 @@ spec entry. Run `spec-coverage` to discover which protocol IDs have no markers
 yet.
 
 See SR-05-004, SR-05-005.
+
+---
+
+## Dual-Path Consolidation Test Gap
+
+(ISSUE-1378, 2026-07-14)
+
+When consolidating two helpers with different lookup paths into one unified
+function, the new test suite MUST exercise each distinct path in isolation.
+
+In ISSUE-1378, `_resolve_case_manager_id` was consolidated from two helpers:
+a primary `actor_participant_index` path and a fallback `case_participants`
+path. All 6 initial tests only populated `case_participants`, leaving the
+primary index path entirely untested.
+
+**Pattern**: For a helper with N distinct lookup paths, write at least one
+test per path where that path is the *sole* source of truth — all other paths
+are left empty or unpopulated. "One test exercises both paths" means neither
+path is verified independently.

--- a/vultron/core/behaviors/case/AGENTS.md
+++ b/vultron/core/behaviors/case/AGENTS.md
@@ -1,0 +1,199 @@
+# AGENTS.md — `vultron/core/behaviors/case/`
+
+Agent guidance for case-management BT nodes and subtrees in this package.
+
+> For project-wide BT conventions see
+> [`vultron/core/behaviors/AGENTS.md`](../AGENTS.md).
+
+---
+
+## Guarded Commit: Role-Gated Canonical Writes
+
+(ISSUE-1021, 2026-06-17; see `specs/case-ledger-processing.yaml` CLP-09 and
+`notes/case-ledger-authority.md` § "Commit Authorization and Coverage")
+
+Any canonical-write node (e.g., `CommitCaseLedgerEntryNode`) that may be
+reached from more than one actor context MUST be wrapped in a role-gated
+`Selector`, never invoked bare:
+
+```python
+Selector(
+    name="GuardedCommitCaseLedgerEntry",
+    memory=False,
+    children=[
+        Sequence(
+            children=[
+                CheckIsCaseManagerNode(case_id=case_id),
+                CommitCaseLedgerEntryNode(case_id=case_id),
+            ]
+        ),
+        py_trees.behaviours.Success(
+            name="CommitCaseLedgerEntrySkippedNotCaseManager"
+        ),
+    ],
+)
+```
+
+`CheckIsCaseManagerNode` resolves the case's `CVDRole.CASE_MANAGER`
+participant and compares it against the *actor active for this invocation* —
+never against the use-case class's identity, and never assumed from a previous
+invocation having passed.
+
+Wrap the pattern once as a reusable factory (e.g.
+`create_guarded_commit_case_ledger_entry_tree(case_id=None)`) rather than
+re-inlining the Selector at each call site; CLP-09-002 requires a test
+asserting no bare usage remains outside it.
+
+**`execute()` MUST do nothing but build one tree, run it once, and handle
+the result** (ADR-0022, CLP-10-005): a received-side use case's `execute()`
+method MUST (a) build exactly one BT via a tree-factory function in
+`vultron/core/behaviors/`, (b) call `BTBridge.execute_with_setup()` exactly
+once, and (c) handle the result. The guarded-commit factory MUST be composed
+as a child of that one tree, not invoked separately. See CLP-09-004.
+
+---
+
+## Role Guard Required for All CASE_MANAGER-Only BT Subtrees
+
+(ISSUE-1030, 2026-06-18; see `specs/behavior-tree-integration.yaml` BT-17-001,
+BT-17-002)
+
+`CheckIsCaseManagerNode` MUST be applied to **any** BT subtree whose
+semantics are restricted to the `CVDRole.CASE_MANAGER` actor, not only
+`CommitCaseLedgerEntryNode`. The canonical composite:
+
+```python
+Selector(
+    name="ActionIfCaseManager",
+    memory=False,
+    children=[
+        Sequence(
+            name="CaseManagerGuardedAction",
+            children=[
+                CheckIsCaseManagerNode(case_id=case_id),
+                ActionNode(case_id=case_id),
+            ],
+        ),
+        py_trees.behaviours.Success(name="ActionSkippedNotCaseManager"),
+    ],
+)
+```
+
+**Why this is necessary**: Received-side use cases run the BT with the
+receiving actor's `actor_id`. Without an in-tree role guard, a
+CASE_MANAGER-only node fires for every receiving actor. Placing the guard
+outside the tree (e.g., in `execute()`) is insufficient because the same tree
+factory may be shared across trigger-side and received-side paths.
+
+---
+
+## Ledger Commit Must Precede Outbox Write
+
+(ISSUE-1325, 2026-07-13)
+
+When a BT subtree both commits a ledger correlation marker and records an
+outbox item, the ledger commit MUST happen first.
+
+If the outbox write happens first and the ledger commit subsequently fails,
+the outbox item is orphaned: an activity queued for delivery with no
+corresponding ledger entry. On the next invocation, the duplicate-detection
+guard finds no pending entry and takes the "fresh" path, triggering a
+duplicate offer or invite.
+
+Correct ordering:
+
+1. Build activity via factory (creates the object in the DataLayer)
+2. Commit ledger correlation marker (fail-fast if anything is wrong)
+3. Record outbox item (reached only if ledger commit succeeded)
+
+This invariant is enforced by CLP-10-006 in `specs/case-ledger-processing.yaml`.
+
+---
+
+## Use `disposition="rejected"` for Local-Only Ledger Correlation Markers
+
+(ISSUE-1325, 2026-07-13)
+
+When a BT node needs a local ledger entry that does NOT correspond to a
+canonical AS2 activity (e.g., tracking an outbound `offer_case_participant`
+for duplicate detection), use `disposition="rejected"` in
+`create_commit_log_entry_tree`.
+
+`_validate_canonical_entry` returns early for non-`"recorded"` dispositions,
+bypassing the `_CANONICAL_PAYLOAD_SIGNATURES` allowlist check. The entry is
+still persisted and `find_protocol_pair` does not filter on disposition, so
+the correlation marker remains visible to duplicate-detection nodes.
+
+---
+
+## Idempotency Guards Must Be Silent — No Ledger Write on Duplicate
+
+(CONCERN-1754, 2026-08-05)
+
+`disposition="rejected"` is valid for **emit-side correlation markers** (see
+above). It is **not** valid for **idempotency guard no-ops**.
+
+An idempotency guard is a `DataLayerCondition` node that detects "this event
+was already processed" and returns `Status.FAILURE` to abort the tree. When
+a guard fires, **no ledger entry of any disposition must be written**
+(CLP-13-001). Use only `logger.info` / `logger.debug`:
+
+```python
+self.logger.info(
+    "%s: actor '%s' already participant in case '%s' — skipping (idempotent)",
+    self.name, self.invitee_id, self.case_id,
+)
+return Status.FAILURE
+```
+
+**Distinction table**:
+
+| Pattern | Ledger entry? | Disposition | Use case |
+|---|---|---|---|
+| Emit-side correlation marker | ✅ yes | `"rejected"` | Dedup guard for outbound activities |
+| Received-side canonical entry | ✅ yes | `"recorded"` | CaseActor accepts a protocol assertion |
+| Idempotency guard no-op | ❌ **no** | — | Already-processed duplicate detected |
+
+**Resolved** (issue #2010, PR #2024): `SilentIdempotencyGuardMixin`
+(`vultron/core/behaviors/idempotency.py`) now exists and satisfies CLP-13-002.
+Implement all idempotency guards using this mixin.
+
+---
+
+## VFD/PXA Write-Boundary Validation in `CreateParticipantStatusNode`
+
+(ISSUE-1825, 2026-07-30; ISSUE-2478, 2026-08-22; see also
+`notes/case-state-model.md`)
+
+`CreateParticipantStatusNode` validates VFD and PXA transitions inline at the
+write boundary before any `dl.create()` / `dl.save()` call:
+
+- `_check_vfd_preconditions()` calls `is_valid_vfd_transition(current, target)`
+  and enforces role preconditions (CVDRole.VENDOR for `VFd`, CVDRole.DEPLOYER
+  for `VFD`). Invalid jumps return `Status.FAILURE` (CSB-16-001,
+  CSB-15-001/002).
+- `_check_pxa_precondition()` calls `is_valid_pxa_transition(current, target)`.
+  Invalid backward moves return `Status.FAILURE` (CSB-16-002).
+
+**Defence layers as of PR #2503:**
+
+- **Write node** (`CreateParticipantStatusNode`): fail-closed inline validation
+  for VFD adjacency, VFD role preconditions, and PXA monotonicity (primary
+  boundary).
+- **Trigger path** (`add_participant_status_trigger_bt`): upstream
+  `ValidateTriggerTransitionsNode` raises `VultronValidationError` before the
+  BT write node is reached.
+- **Received wire path** (`add_participant_status_tree`): uses the weaker
+  `is_monotonic_vfd_forward` check intentionally — remote peers may advance
+  through multiple VFD steps between status messages; strict adjacency applies
+  only to local write nodes (CSB-16-001, AC-3).
+- **Architecture ratchet** (`test/architecture/test_vfd_rm_pxa_write_sites.py`):
+  AST-audits every `VfdDimension`/`RmDimension`/`PxaDimension` constructor
+  call in `vultron/core/behaviors/`.
+
+When writing or reviewing guard nodes that precede `CreateParticipantStatusNode`:
+the write node is a second line of defence, but upstream guards still matter —
+they surface invalid requests with richer error context before the BT write node
+is reached.
+
+<!-- Source: ISSUE-1825; GitHub concern #1896; PR #2307; ISSUE-2478; PR #2503 -->

--- a/vultron/core/behaviors/case/nodes/participant/AGENTS.md
+++ b/vultron/core/behaviors/case/nodes/participant/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md — `vultron/core/behaviors/case/nodes/participant/`
+
+Agent guidance for participant-lookup BT nodes in this package.
+
+> For project-wide BT conventions see
+> [`vultron/core/behaviors/AGENTS.md`](../../../AGENTS.md).
+
+---
+
+## Lenient vs. Strict Participant Lookup Node Variants
+
+(ISSUE-710, 2026-06-09)
+
+Two distinct lookup patterns exist for resolving a participant from an
+actor ID:
+
+- **Strict** (`LookupParticipantNode`, fail-on-missing): Required for
+  operations that must have a participant record (e.g., recording acceptance).
+  Returns `FAILURE` when the participant is not found.
+- **Lenient** (`OptionalLookupParticipantNode`, succeed-on-missing): Correct
+  for operations where the participant may not exist on this peer yet (e.g.,
+  processing an invite or reject). Returns `SUCCESS` even when the participant
+  is absent, so the broadcast log entry can proceed.
+
+**Why "Always SUCCESS" is intentional for the lenient variant**: When a
+peer receives a log entry for a participant it has not yet seen, succeeding
+allows the case ledger cascade to proceed. The state gap resolves when the
+participant is later introduced via the normal invite/accept flow.
+
+**Documentation rule**: The docstring for any lenient node MUST explicitly
+state that it always returns `SUCCESS` and explain *why* this is correct for
+its use case — so future reviewers understand it is a deliberate design
+choice, not a missing failure check.
+
+**Constructor parameter audit**: When migrating procedural logic to BT
+nodes, verify that all constructor parameters are actually used inside the
+node. An unused parameter creates confusion about whether it controls behavior.
+
+**Actor ID handoff in invite trees**: When the invitee actor ID differs
+from the sender actor ID, pass the *invitee* ID (not the sender) to
+`bridge.execute_with_setup()` so participant-lookup nodes resolve the
+correct participant record.

--- a/vultron/core/behaviors/case/nodes/suggest_actor/AGENTS.md
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md — `vultron/core/behaviors/case/nodes/suggest_actor/`
+
+Agent guidance for suggest-actor BT nodes in this package.
+
+> For project-wide BT conventions see
+> [`vultron/core/behaviors/AGENTS.md`](../../../AGENTS.md).
+
+---
+
+## suggest-actor Accept Path Does Not Thread Roles Into Invite
+
+(ISSUE-1406, 2026-07-14)
+
+`create_accept_actor_recommendation_received_tree` (CaseActor receives
+`Accept(Offer(CaseParticipant))` from Case Owner) never writes the
+`suggested_roles` blackboard key. `EmitInviteActorToCaseNode` reads this key
+via `_read_suggested_roles()`, gets a `KeyError`, and passes `roles=None` to
+`factory.invite_actor_to_case()`. The resulting `Invite` carries `roles=None`,
+so after `Accept(Invite)` the new `VultronParticipant.case_roles` is `[]`.
+
+This is documented behavior (ADR-0032, BT-HELPER-01: no silent default
+substitution), not a bug.
+
+**Test implication**: Only the `invite_actor_to_case_trigger_bt` path (or a
+tree with `EvaluateDefaultRolesNode`) produces a non-empty `case_roles`. The
+`AcceptOfferCaseParticipant` received-side use case always produces
+`roles=None` in the Invite. Tests that verify roles end up on a participant
+MUST exercise the trigger path, not the received path.
+
+**Blackboard key contrast**:
+
+| Tree factory | Key written | Namespaced? |
+|---|---|---|
+| `create_recommend_actor_to_case_received_tree` | `suggested_roles_{id_segment}` | ✅ |
+| `create_accept_actor_recommendation_received_tree` | *(never written)* | N/A |

--- a/vultron/core/behaviors/embargo/AGENTS.md
+++ b/vultron/core/behaviors/embargo/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — `vultron/core/behaviors/embargo/`
+
+Agent guidance for embargo-related BT nodes and subtrees in this package.
+
+> For project-wide BT conventions see
+> [`vultron/core/behaviors/AGENTS.md`](../AGENTS.md).
+
+---
+
+## Embargo Subtree Idempotency with Blackboard Flag
+
+(ISSUE-750, 2026-06-08)
+
+When a god node is decomposed into a sequence of leaf nodes, the original
+single-pass semantics may break if duplicate-run behavior depended on the
+god node's internal guard. Preserve idempotency explicitly:
+
+- Add a blackboard flag (e.g., `embargo_initialized: bool`) that is set
+  to `True` only when the current execution actually created a new embargo.
+- Side-effect leaves that should only fire on first initialization (e.g.,
+  seeding participants, creating events) MUST check this flag before
+  acting.
+- When moving EM transition logic to `EmbargoLifecycle.propose_embargo`,
+  keep event creation and participant-seeding behavior aligned with
+  existing duplicate-report tests to avoid introducing regressions.
+
+---
+
+## Routing-Gated State Mutation
+
+(BT-19, 2026-06-26; see `specs/behavior-tree-integration.yaml` BT-19-001,
+BT-19-002)
+
+A BT Sequence that performs a protocol state-machine transition (EM, RM, or CS)
+and then routes an outbound activity MUST resolve all routing prerequisites
+in a read-only guard node placed **before** the state-mutation node.
+
+**Why ordering matters**: Once the DataLayer accepts a state write (e.g.,
+`EM=EXITED`), the transition is committed. If the subsequent routing step
+then fails (missing Case Manager, missing factory), the outbound notification is
+never sent. Peers retain the prior state; local state has advanced — a
+divergence window that requires ledger-sync catch-up (SYNC-10) to repair.
+Moving the routing guard to the top of the Sequence eliminates the divergence:
+if routing prerequisites are absent, the tree returns `FAILURE` with zero
+DataLayer state change.
+
+**Shared factory requirement**: Duplicated monolithic BT nodes that inline both
+state mutation and dispatch in a single `update()` method drift independently.
+The canonical factory-composed path may correctly order the guard, while the
+automatic-cascade monolith retains the old unsafe ordering, reintroducing the
+divergence bug on that path only. All call sites for the same lifecycle
+transition MUST use a shared BT factory function (BT-19-002).
+
+**Canonical Sequence structure**:
+
+```text
+Sequence
+├── ResolveCaseManagerNode          ← read-only guard; FAILURE = bail, no write
+├── <StateTransitionNode>           ← mutation committed after guard passes
+└── <SendDispatchNode>              ← routing succeeds because guard already verified
+```
+
+**Anti-pattern** (Issue #1054 — `TerminateEmbargoNode`):
+
+```text
+Sequence
+├── TerminateEmbargoLifecycleNode   ← mutation committed first ← ❌
+└── SenderSideBT                    ← routing checked second; fail = divergence
+```
+
+**Fix**: Extract a shared factory (`terminate_embargo_bt`) that places
+`ResolveCaseManagerNode` before `TerminateEmbargoLifecycleNode`, and replace
+all standalone monolithic nodes with the factory output. Both trigger and
+cascade call sites use the shared factory directly (BT-19-002, PR #1263).

--- a/vultron/core/behaviors/inbox/AGENTS.md
+++ b/vultron/core/behaviors/inbox/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md — `vultron/core/behaviors/inbox/`
+
+Agent guidance for inbox-related BT nodes in this package.
+
+> For project-wide BT conventions see
+> [`vultron/core/behaviors/AGENTS.md`](../AGENTS.md).
+
+---
+
+## Inbox Test Seam Must Preserve Production Deferral Semantics
+
+(ISSUE-769, 2026-06-08)
+
+A test-only inbox pipeline that reimplements defer/replay logic can drift
+from production behavior unless it reuses the same expiry path. When
+writing case-deferral tests:
+
+- Set canonical `to` recipients matching the expected actor-scoped queue
+  so actor-scoped queues are exercised under the same addressing assumptions
+  as inbox processing.
+- Do not reimplement the defer/replay path inline in tests — call the
+  production code path directly so timing and queue semantics stay aligned.

--- a/vultron/core/behaviors/note/AGENTS.md
+++ b/vultron/core/behaviors/note/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md — `vultron/core/behaviors/note/`
+
+Agent guidance for note-related BT nodes in this package.
+
+> For project-wide BT conventions see
+> [`vultron/core/behaviors/AGENTS.md`](../AGENTS.md).
+
+---
+
+## AttachNoteToCase Idempotency: Check Attachment, Not Existence
+
+(DR-08, 2026-04-20)
+
+`AttachNoteToCaseNode.update()` MUST check whether the note is already
+**attached to the case** for idempotency — NOT whether the note object exists
+in the DataLayer.
+
+```python
+# WRONG — note may exist in DataLayer without being attached to the case
+if dl.read(note.id_) is not None:
+    return Status.SUCCESS  # false idempotency
+
+# CORRECT — check the case's note reference list
+case = dl.read(case_id)
+if note.id_ in case.notes:
+    return Status.SUCCESS  # truly idempotent
+case.notes.append(note.id_)
+dl.save(case)
+return Status.SUCCESS
+```
+
+**Why this matters**: The DataLayer stores notes as top-level objects
+independently of their attachment to a case. A note can be created and
+persisted without ever being added to `case.notes`. Checking
+`dl.read(note_id) is not None` would falsely skip re-attachment if the note
+was stored by another path but never linked.
+
+---
+
+## `memory=False` Note Sequence: Partial-Write on FAILURE
+
+(BTND07-913, 2026-06-15; see `specs/behavior-tree-node-design.yaml` BTND-07-001)
+
+`add_note_to_case_trigger_bt` uses a `Sequence(memory=False)` with three
+children:
+
+1. `CreateNoteNode` — creates and writes the note to the DataLayer
+2. `AttachNoteFromResultNode` — attaches the note to the case
+3. `SenderSideBT` — enqueues the outbound activity
+
+If `SenderSideBT` fails (e.g., no CASE_MANAGER recipient resolved), steps 1
+and 2 have already committed. **The note IS attached to the case locally even
+though the overall BT returns FAILURE.** Tests MUST assert this partial-write
+behavior explicitly so future readers do not assume FAILURE → no writes occurred.
+
+**Design implication**: When using `memory=False` sequences for partially-
+reversible operations, document which steps are non-transactional and what
+state is committed if a later step fails.
+
+For the generic `memory=False` partial-write rule, see
+`notes/bt-pitfalls.md` § "`memory=False` Sequence: Partial-Write Behavior on
+FAILURE".

--- a/vultron/core/behaviors/sync/AGENTS.md
+++ b/vultron/core/behaviors/sync/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md — `vultron/core/behaviors/sync/`
+
+Agent guidance for sync/replication-related BT nodes in this package.
+
+> For project-wide BT conventions see
+> [`vultron/core/behaviors/AGENTS.md`](../AGENTS.md).
+
+---
+
+## Fan-out / SYNC Decomposition: Context Handoff Pattern
+
+(ISSUE-755, 2026-06-10)
+
+For replay/fan-out flows, split nodes along blackboard context boundaries:
+
+1. **Collect context leaf** — reads domain state, writes derived context
+   (index, recipient list, current position) to named blackboard keys.
+2. **Side-effect leaves** — each reads the context written by step 1 and
+   performs a single side effect (emit activity, update record).
+
+**Condition+action hybrid nodes**: If a node checks a condition and then
+performs an action, decompose it further into a `Selector` composite:
+
+```python
+Selector(
+    name="EmitIfRecipientExists",
+    memory=False,
+    children=[
+        CheckRecipientPresent(),   # pure condition; returns FAILURE → fall through
+        AlwaysSuccess("skip"),     # no-op when condition already met
+    ],
+)
+```
+
+This preserves the original guard semantics without embedding conditional
+logic inside a single `update()`.

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -458,3 +458,31 @@ See `specs/demo-ci.yaml` DEMOCI-10, `specs/multi-actor-demo.yaml` DEMOMA-23,
 and [notes/demo-ci-invariants.md](../../notes/demo-ci-invariants.md).
 
 <!-- Source: ISSUE-2239 -->
+
+---
+
+### Demo Devlog Race: Wait for Replica Before Dumping
+
+(DEMO-DEVLOG-RACE, 2026-06-18)
+
+Demo phases that write JSONL devlogs will miss recently committed canonical
+ledger entries if they run before the async `Announce(CaseLedgerEntry)`
+fan-out has been processed and stored by the replica actor.
+
+**Pattern**: After any phase that commits a new canonical ledger entry, query
+the sender's current tail hash and poll until the replica acknowledges it
+before writing the devlog:
+
+```python
+vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
+if vendor_entries:
+    tail = max(vendor_entries, key=lambda e: e["log_index"])
+    wait_for_finder_log_entry(finder_client, case.id_, tail["entry_hash"])
+```
+
+Apply this poll-until-hash pattern after every phase that introduces a new
+ledger tail before a devlog dump. This is the same pattern used in
+`_phase_sync_verification` and ensures dump artifacts are always consistent
+with the replica's committed state.
+
+<!-- Source: DEMO-DEVLOG-RACE -->


### PR DESCRIPTION
- Closes #1899

## Summary

- **Trims `notes/bt-pitfalls.md`** from 1308 lines to ~598 lines, retitling it "BT Cross-Cutting Mechanics" — keeps only sections that apply across all BT domains (failure reason propagation, blackboard key semantics, `memory=False` partial-write, key namespacing, no-op path clearing, etc.)
- **Creates 7 new per-directory `AGENTS.md` files** under `vultron/core/behaviors/`: `note/`, `embargo/`, `sync/`, `inbox/`, `case/`, `case/nodes/participant/`, `case/nodes/suggest_actor/` — each containing only pitfalls scoped to that package (proximity-based auto-loading)
- **Adds domain-specific sections** to `test/AGENTS.md` (Dual-Path Consolidation Test Gap) and `vultron/demo/AGENTS.md` (Demo Devlog Race)
- **Updates deep links** in root `AGENTS.md` (2 references: Routing-Gated State Mutation → `embargo/AGENTS.md`; Dual-Path Consolidation → `test/AGENTS.md`) and stale cross-reference in `test/AGENTS.md`
- **Updates `notes/README.md`** description for `bt-pitfalls.md` to reflect narrower scope

## Acceptance criteria satisfied

- AC-1: bt-pitfalls.md reduced to ~598 lines (Bucket A only), retitled "BT Cross-Cutting Mechanics", frontmatter updated ✅
- AC-2: All Bucket B sections moved to per-directory AGENTS.md files ✅
- AC-3: Bucket C sections relocated (test/AGENTS.md, demo/AGENTS.md) or dropped ✅
- AC-4: Deep links updated in root AGENTS.md ✅
- AC-5: notes/README.md description updated ✅

## Test plan

- [x] `uv run black vultron/ test/` — clean (docs-only, no Python changes)
- [x] `uv run flake8 vultron/ test/ && uv run mypy && uv run pyright` — clean
- [x] `uv run pytest --tb=short` — 7841 passed, 0 failures
- [x] `uv run pytest -m integration --tb=short` — passed
- [x] `markdownlint-cli2` pre-commit hook — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)