### PR TITLE
fix: empty case_roles on invite-accept (race + ledger sibling + misrouted ownership Accept)

### DIFF
--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -15,6 +15,7 @@ relevant_packages:
   - vultron/core/behaviors/case/nodes/
   - vultron/core/use_cases/received/actor/
   - vultron/demo/scenario/fvcv_handoff_demo.py
+  - vultron/demo/scenario/fccv_handoff_demo.py
 ---
 
 # Ownership Transfer Protocol — Routing and Cascade Model
@@ -172,6 +173,13 @@ producing an unrecoverable hash-chain fork (ISSUE-2252).
 Remove the `post_to_inbox_and_wait` self-delivery block (lines ~427–434).
 The Accept now reaches the CaseActor automatically because
 `EmitAcceptCaseOwnershipTransferNode` addresses it there.
+
+### fccv_handoff_demo.py
+
+Same `post_to_inbox_and_wait` workaround pattern applied to
+`_phase_ownership_handoff`. Removed in PR #2735 (ISSUE-2719) — the Accept
+is addressed to the CaseActor per ADR-0042/ADR-0053 and delivered
+automatically, matching the `fvcv-handoff` pattern.
 
 After the Vendor1 offer-trigger returns, poll Coordinator's DataLayer with
 `find_ownership_transfer_offer_for_actor(coordinator_client, case_id, transferee_id=coordinator.id_)`

--- a/plan/incoming/learnings/datalayer-fallback-is-a-smell.md
+++ b/plan/incoming/learnings/datalayer-fallback-is-a-smell.md
@@ -1,0 +1,57 @@
+---
+date: 2026-08-27
+source: ISSUE-2719
+tags: [architecture, protocol, datalayer, anti-pattern]
+---
+
+# DataLayer fallback as a smell for masked protocol bugs
+
+When a BT node or use-case handler reads a protocol-significant field from the
+DataLayer *instead of* from the received activity message, treat it as a smell
+that the handler may be masking a protocol bug or a race condition.
+
+## The pattern
+
+```python
+# Smell: reading a field from the DataLayer that the message already carries
+invite_id = event.object_id
+invite = self.datalayer.read(invite_id)   # ← unnecessary DL round-trip
+raw_roles = getattr(invite, "roles", None)
+```
+
+The whole point of Vultron is to demonstrate that the *protocol* works — not
+that storage side-effects happen to arrive before a handler needs them.  If the
+handler can only function correctly when a prior delivery has already been
+processed and stored, that is a latent race condition, not a working protocol.
+
+## The fix
+
+Prefer reading from the received message directly:
+
+```python
+# Correct: roles come from the Accept's embedded Invite (always present)
+activity = getattr(event, "activity", None)
+invite_obj = getattr(activity, "object_", None)
+raw_roles = getattr(invite_obj, "roles", None)
+```
+
+If the field is not in the message, that is a *protocol violation* — log it as
+such and return an empty/default value.  Do not silently fall back to a
+DataLayer read, which would hide the violation and make the code appear to work
+only when a race is won.
+
+## When a DL read IS correct
+
+DataLayer reads are appropriate when the handler needs persisted state that
+*cannot* arrive in the message (e.g., reading the VulnerabilityCase to compute
+derived fields, or checking an idempotency guard).  The smell applies
+specifically to fields that the protocol message itself is supposed to carry.
+
+## Reference
+
+- ISSUE-2719: `_read_invite_roles()` in `accept_invite_tree.py` read the Invite
+  from the CaseActor's DataLayer instead of from `event.activity.object_.roles`.
+  Race condition: the cc self-delivery might not have been processed yet when the
+  Accept arrived.
+- Fixed 2026-08-27 by reading from `event.activity.object_` (the raw wire Invite
+  embedded in the Accept activity).

--- a/plan/incoming/learnings/datalayer-fallback-is-a-smell.md
+++ b/plan/incoming/learnings/datalayer-fallback-is-a-smell.md
@@ -1,7 +1,9 @@
 ---
-date: 2026-08-27
+title: DataLayer fallback is a smell for masked protocol bugs
+type: learning
+timestamp: 2026-08-27T00:00:00Z
 source: ISSUE-2719
-tags: [architecture, protocol, datalayer, anti-pattern]
+signal: concern
 ---
 
 # DataLayer fallback as a smell for masked protocol bugs

--- a/test/core/behaviors/case/test_accept_invite_tree.py
+++ b/test/core/behaviors/case/test_accept_invite_tree.py
@@ -13,20 +13,31 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Regression tests for _SignEmbargoConsentLeafNode (ADR-0048, CM-10-001).
+"""Regression tests for accept-invite BT nodes (ADR-0048, CM-10-001, CM-17-003).
 
 AC-4: The invitee MUST reach PEC.SIGNATORY after signing embargo consent.
-This test MUST fail on main before the fix and pass after.
+CM-17-003: Roles MUST be read from the Accept's embedded Invite, not DataLayer.
 """
 
+import types
+
+import py_trees
 import pytest
 from py_trees.common import Status
 
 from vultron.core.behaviors.case.accept_invite_tree import (
+    CreateInviteeParticipantAtReceivedNode,
     _SignEmbargoConsentLeafNode,
 )
+from vultron.core.models.activity import VultronActivity
+from vultron.core.models.base import VultronObject
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.events.actor import (
+    AcceptInviteActorToCaseReceivedEvent,
+)
 from vultron.core.states.participant_embargo_consent import PEC
+from vultron.enums.roles import CVDRole
 from test.core.behaviors.bt_harness import BTTestScenario
 
 _ACTOR_ID = "https://example.org/actors/invitee"
@@ -172,3 +183,65 @@ class TestSignEmbargoConsentLeafNode:
             new_invite_participant=participant,
         )
         assert result.status == Status.FAILURE
+
+
+_CM17_CASE_ID = "https://example.org/cases/case-cm17"
+_CM17_INVITEE_ID = "https://example.org/actors/vendor-invitee"
+_CM17_CASE_ACTOR_ID = "https://example.org/actors/case-actor"
+_CM17_INVITE_ID = "https://example.org/activities/invite-cm17"
+
+
+@pytest.mark.spec("CM-17-003")
+def test_create_invitee_participant_reads_roles_from_accept_activity_when_invite_absent_from_datalayer(
+    bt_scenario: BTTestScenario,
+) -> None:
+    """CM-17-003: roles come from event.activity.object_.roles, not DataLayer.
+
+    Reproduces the race condition where the Invite has not yet been stored in
+    the CaseActor's DataLayer when the Accept arrives (ISSUE-2719 Bug 1).
+    Before fix: _read_invite_roles() returned [] because datalayer.read()
+    returned None; the participant was persisted with case_roles=[].
+    After fix: roles are read from event.activity.object_.roles (the Invite
+    embedded in the Accept message), so DataLayer absence does not matter.
+    """
+    case = VulnerabilityCase(
+        id_=_CM17_CASE_ID, attributed_to=_CM17_CASE_ACTOR_ID
+    )
+    bt_scenario.seed(case)
+
+    # Build an Accept event whose activity.object_ carries roles.
+    # The Invite is intentionally NOT stored in the DataLayer to simulate
+    # the race condition (cc self-delivery not yet processed).
+    invite_wire = types.SimpleNamespace(roles=["vendor"])
+    accept_activity = VultronActivity(
+        id_="https://example.org/activities/accept-cm17",
+        type_="Accept",
+        actor=_CM17_INVITEE_ID,
+        object_=invite_wire,
+    )
+    event = AcceptInviteActorToCaseReceivedEvent(
+        activity_id="https://example.org/activities/accept-cm17",
+        actor_id=_CM17_INVITEE_ID,
+        object_=VultronObject(id_=_CM17_INVITE_ID, type_="Invite"),
+        activity=accept_activity,
+    )
+
+    node = CreateInviteeParticipantAtReceivedNode(
+        case_id=_CM17_CASE_ID,
+        invitee_id=_CM17_INVITEE_ID,
+    )
+
+    result = bt_scenario.run(
+        node,
+        actor_id=_CM17_CASE_ACTOR_ID,
+        activity=event,
+        invitee_case=case,
+        invitee_already_participant=False,
+    )
+
+    assert result.status == Status.SUCCESS
+    participant = py_trees.blackboard.Blackboard.storage.get(
+        "/new_invite_participant"
+    )
+    assert participant is not None
+    assert CVDRole.VENDOR in participant.case_roles

--- a/test/core/behaviors/sync/nodes/test_invite_accept_effect.py
+++ b/test/core/behaviors/sync/nodes/test_invite_accept_effect.py
@@ -105,3 +105,50 @@ def test_apply_invite_accept_skips_missing_case(bridge, case_actor):
     )
 
     assert result.status == Status.SUCCESS
+
+
+@pytest.mark.spec("CM-17-003")
+def test_apply_invite_accept_from_ledger_preserves_roles(
+    bridge, datalayer, case_actor, case_with_actor
+):
+    """CM-17-003: ledger path sets case_roles from payload_snapshot object.roles.
+
+    Before fix: stub CaseParticipant was created with no case_roles regardless
+    of what the payload_snapshot["object"]["roles"] contained (ISSUE-2719 Bug 1
+    sibling). After fix: roles are extracted and set on the participant.
+    """
+    entry = _to_persistable_entry(
+        HashChainLedgerRecord(
+            case_id=CASE_ID,
+            log_index=1,
+            object_id="https://example.org/activities/accept-invite-with-roles",
+            event_type="accept_invite_actor_to_case",
+            payload_snapshot={
+                "actor": {"id": INVITEE_ACTOR_ID},
+                "object": {
+                    "id": "https://example.org/activities/invite-001",
+                    "type": "Invite",
+                    "roles": ["vendor"],
+                },
+            },
+            prev_log_hash="0" * 64,
+        )
+    )
+    event = _make_event(entry, actor_id=case_actor.id_)
+
+    result = bridge.execute_with_setup(
+        tree=ApplyInviteAcceptFromLedgerNode(name="ApplyInviteAccept"),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=event,
+    )
+
+    assert result.status == Status.SUCCESS
+    updated = datalayer.read(CASE_ID)
+    assert INVITEE_ACTOR_ID in updated.actor_participant_index
+
+    from vultron.enums.roles import CVDRole
+
+    participant_id = updated.actor_participant_index[INVITEE_ACTOR_ID]
+    participant = datalayer.read(participant_id)
+    assert participant is not None
+    assert CVDRole.VENDOR in participant.case_roles

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -365,21 +365,24 @@ class CreateInviteeParticipantAtReceivedNode(DataLayerActionWithPorts):
             self._activity_bb = None
 
     def _read_invite_roles(self) -> list:
-        """Read roles from the Invite stored in DataLayer (CM-17-003).
+        """Read roles from the Invite embedded in the Accept activity (CM-17-003).
 
-        Resolves invite_id via the ``activity`` blackboard key, reads the
-        stored Invite, and coerces any ``roles`` strings to ``CVDRole``.
-        Returns an empty list when the invite carries no roles or cannot
-        be read.
+        Resolves roles from ``event.activity.object_`` — the raw wire Invite
+        carried inside the received ``Accept`` activity, as hydrated by the
+        wire extractor (``include_activity=True`` in the semantic registry).
+        This path is race-free: the roles arrive in the protocol message
+        itself, so no DataLayer lookup is needed or performed.
+
+        Returns an empty list when no roles are present.
         """
         event = self._activity_bb
         if event is None:
             return []
-        invite_id = getattr(event, "object_id", None)
-        if not invite_id or self.datalayer is None:
+        activity = getattr(event, "activity", None)
+        if activity is None:
             return []
-        invite = self.datalayer.read(invite_id)
-        raw_roles = getattr(invite, "roles", None)
+        invite_obj = getattr(activity, "object_", None)
+        raw_roles = getattr(invite_obj, "roles", None)
         if not raw_roles:
             return []
         try:

--- a/vultron/core/behaviors/sync/nodes/invite_accept_effect.py
+++ b/vultron/core/behaviors/sync/nodes/invite_accept_effect.py
@@ -31,6 +31,7 @@ from vultron.core.behaviors.sync.nodes._helpers import (
 )
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
+from vultron.enums.roles import validate_roles
 
 logger = logging.getLogger(__name__)
 
@@ -93,10 +94,22 @@ class ApplyInviteAcceptFromLedgerNode(_LedgerEffectNode):
             )
             return Status.SUCCESS
 
+        obj_snapshot = snapshot.get("object")
+        raw_roles = (
+            obj_snapshot.get("roles")
+            if isinstance(obj_snapshot, dict)
+            else None
+        )
+        try:
+            case_roles = validate_roles(raw_roles) if raw_roles else []
+        except (ValueError, KeyError):
+            case_roles = []
+
         participant = CaseParticipant(
             id_=f"{case_id}/participants/{invitee_id.rstrip('/').rsplit('/', 1)[-1]}",
             attributed_to=invitee_id,
             context=case_id,
+            case_roles=case_roles,
         )
         if self.datalayer.read(participant.id_) is None:
             self.datalayer.create(participant)

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -55,16 +55,12 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     demo_check,
     demo_gate,
     demo_step,
-    post_to_inbox_and_wait,
     post_to_trigger,
     ref_id,
     reset_datalayer,
     reset_demo_failures,
     setup_demo_logging,
-    verify_object_stored,
 )
-
-# post_to_inbox_and_wait is retained for self-delivery (CONCERN-1653 exception).
 from vultron.demo.helpers.actions import (
     actor_closes_case,
     actor_notifies_fix_ready,
@@ -376,15 +372,9 @@ def _phase_ownership_handoff(
             accept_ownership.id_,
         )
 
-    # Deliver the Accept to C2's own inbox so AcceptCaseOwnershipTransfer-
-    # ReceivedUseCase runs locally and sets case.attributed_to = C2 on C2's
-    # replica.  C1's copy updates when C2's outbox delivers the Accept to C1's
-    # inbox (same pattern as FVCV-handoff).
-    with demo_step("Delivering ownership Accept to C2's own inbox"):
-        post_to_inbox_and_wait(c2_client, c2_in_c2.id_, accept_ownership)
-    with demo_check("Ownership Accept stored in C2's DataLayer"):
-        verify_object_stored(c2_client, accept_ownership.id_)
-
+    # C2's outbox delivers the Accept to the CaseActor automatically (ADR-0042,
+    # ADR-0053).  The CaseActor processes it and propagates the change via ledger
+    # sync — same pattern as FVCV-handoff which has no manual delivery step here.
     # Verify C1's case now shows C2 as attributed_to.
     with demo_check(
         "Case attributed_to updated to C2 on C1's DataLayer (AC-1)"


### PR DESCRIPTION
- Closes #2719
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Fixes two deterministic CI failures in the `fcv` and `fccv-handoff` Demo Integration scenarios that were unmasked by PR #2705.

## Changes

- **`vultron/core/behaviors/case/accept_invite_tree.py`**: `_read_invite_roles()` now reads roles from `event.activity.object_.roles` (the raw wire `Invite` embedded in the received `Accept` message, hydrated by the wire extractor). Removes the DataLayer lookup that caused a race condition when the CaseActor's cc self-delivery had not yet been processed.

- **`vultron/core/behaviors/sync/nodes/invite_accept_effect.py`**: `ApplyInviteAcceptFromLedgerNode` now extracts roles from `payload_snapshot["object"]["roles"]` when creating the stub `CaseParticipant`, fixing the ledger-replication path sibling of Bug 1.

- **`vultron/demo/scenario/fccv_handoff_demo.py`**: Removes incorrect `post_to_inbox_and_wait(c2_client, c2_in_c2.id_, accept_ownership)` step. The ownership-transfer `Accept` is addressed to the CaseActor; ADR-0068 refused delivery to C2's coordinator inbox with 400. The outbox delivers to the CaseActor automatically per ADR-0042/ADR-0053 — matching the passing `fvcv-handoff` pattern.

- **`plan/incoming/learnings/datalayer-fallback-is-a-smell.md`**: Captures the anti-pattern: reading protocol-visible fields from the DataLayer instead of from the received message masks race conditions and protocol violations.

- **`test/core/behaviors/case/test_accept_invite_tree.py`**: Adds `test_create_invitee_participant_reads_roles_from_accept_activity_when_invite_absent_from_datalayer` (CM-17-003 regression).

- **`test/core/behaviors/sync/nodes/test_invite_accept_effect.py`**: Adds `test_apply_invite_accept_from_ledger_preserves_roles` (CM-17-003 sibling regression).

## Verification

- 7,801 unit tests pass (2 new regression tests)
- Black, flake8, mypy, pyright all clean
- Both new tests fail before the fix and pass after