### PR TITLE
docs: add CM-16-018 trust invariant — roles from stored Offer, not received Accept

### DIFF
--- a/plan/incoming/learnings/20260827-issue-1760-adr-already-done.md
+++ b/plan/incoming/learnings/20260827-issue-1760-adr-already-done.md
@@ -1,0 +1,21 @@
+---
+title: Issue 1760 — ADR section already present; only spec entry was missing
+type: learning
+timestamp: 2026-08-27
+source: ISSUE-1760
+signal: process-issue
+---
+
+Issue #1760 stated that ADR-0026 "does not document" the trust invariant for
+roles coming from the stored Offer rather than the received Accept. In practice,
+the ADR already had the full "Trust Rule: Roles Come From the Offer, Not the
+Accept" section — it was added in commit f415f83a ("docs: promote learnings —
+spec gaps, pitfalls, notes, and bug fix") on 2026-07-28.
+
+The actual gap was the missing normative spec entry in specs/case-management.yaml,
+which this PR (2743) adds as CM-16-018.
+
+**Lesson**: when an issue references both a doc file and a spec file, verify each
+independently before branching. The pre-claim AC verification gate in build Phase
+2 skips when there are no formal `- [ ] AC-N:` items, so free-form issues with
+prose requirements need a manual check of each named artifact.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -1509,6 +1509,34 @@ groups:
       `Offer(CaseParticipant)` to the Case Owner.
     rationale: Sending a duplicate transformed Offer would create a second pending decision
       for the same actor, leading to conflicting state if the Case Owner responds to both.
+  - id: CM-16-018
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When the CaseActor processes `Accept(Offer(CaseParticipant))` from the Case
+      Owner, the roles assigned to the new participant MUST be read from the stored
+      outgoing `Offer(CaseParticipant)` that the CaseActor constructed and sent —
+      not from the embedded `CaseParticipant` object inside the received `Accept`.
+    rationale: >-
+      The received `Accept` is untrusted: the accepting actor may have modified or
+      omitted roles, or sent only a bare ID reference. Reading roles from the
+      received `Accept` would allow a malicious or minimally-conformant acceptor to
+      substitute unauthorized roles. The stored `Offer` is the CaseActor's own
+      record of the intended participant roles and is the authoritative source of
+      truth.
+    verification: >-
+      Inspection of
+      `vultron/core/use_cases/received/actor/offer_case_participant.py`
+      (`AcceptOfferCaseParticipantReceivedUseCase.execute()`) confirms that roles
+      are read from the DataLayer-stored Offer activity (`self._dl.read(offer_id)`),
+      not from the embedded `CaseParticipant` in the received `Accept`.
+    adr:
+    - ADR-0026
+    relationships:
+    - rel_type: refines
+      spec_id: CM-16-006
+    lint_suppress:
+    - missing_story_reference
 - id: CM-17
   title: Invitation Flow — Enrichment and Roles
   specs:

--- a/test/core/use_cases/received/actor/test_offer_case_participant.py
+++ b/test/core/use_cases/received/actor/test_offer_case_participant.py
@@ -486,6 +486,7 @@ class TestRolesFromStoredOffer:
         )
         return dl, event
 
+    @pytest.mark.spec("CM-16-018")
     def test_invite_carries_roles_from_stored_offer(self):
         """Roles from the stored Offer are threaded into the emitted Invite.
 
@@ -518,6 +519,7 @@ class TestRolesFromStoredOffer:
             f"expected ['{CVDRole.VENDOR.value}'], got {invite_roles!r}"
         )
 
+    @pytest.mark.spec("CM-16-018")
     def test_participant_case_roles_vendor_after_full_round_trip(self):
         """Full round-trip: Accept(Invite) creates participant with VENDOR role.
 


### PR DESCRIPTION
- Closes #1760

## Summary

Adds spec entry CM-16-018 to `specs/case-management.yaml` formalizing the
trust invariant that roles for an invited actor MUST come from the stored
`Offer(CaseParticipant)` the CaseActor sent — not from the embedded object
in the received `Accept`.

## Changes

- **`specs/case-management.yaml`**: Add CM-16-018 (`kind: protocol`,
  `priority: MUST`) under the CM-16 Actor Suggestion Routing group,
  refining CM-16-006. References ADR-0026, which already documents this
  invariant in its Consequences section (added in commit f415f83a).

## Notes

- ADR-0026 already has the "Trust Rule: Roles Come From the Offer, Not the
  Accept" section; this PR adds the corresponding normative spec entry.
- Implementation (`AcceptOfferCaseParticipantReceivedUseCase.execute()`)
  already conforms — see `vultron/core/use_cases/received/actor/offer_case_participant.py`.

## Pre-PR Review (DEFER)

Two pre-existing findings from the code review, not in this diff:

- `_record_named_peer` skips `dl.create()` on backend exception — tracked #2707
- `SetEmbargoActiveNode.update()` uncaught `ValueError` — filed #2742