### PR TITLE
refactor: convert bt_node.py fixname() prefix table to class attribute

### DIFF
--- a/plan/incoming/learnings/20260827-code-review-2109-deferred-preexisting.md
+++ b/plan/incoming/learnings/20260827-code-review-2109-deferred-preexisting.md
@@ -1,0 +1,32 @@
+---
+title: Code review of PR for #2109 surfaced 5 pre-existing bugs in unrelated files
+type: learning
+timestamp: 2026-08-27
+source: ISSUE-2109
+signal: deferred-bug
+---
+
+During the code review for PR implementing #2109 (fixname() prefix-map refactor),
+5 pre-existing bugs were found in unrelated files. None are in the files changed
+by the PR. These are DEFER items requiring follow-up issues.
+
+1. **vultron/core/use_cases/triggers/actor.py:224** — ActorDiscovery backend.update()
+   called without setup(), breaking directory-service backends that init resources in setup().
+
+2. **vultron/core/behaviors/embargo/nodes/lifecycle.py:373** — SetEmbargoActiveNode
+   TOCTOU: idempotency check and activate_embargo() read VulnerabilityCase independently;
+   concurrent requests can double-emit ledger entries.
+
+3. **vultron/core/behaviors/status/nodes/case_status.py:293** — AppendCaseStatusToCaseNode
+   persists filtered CaseStatus to DataLayer before linking it to the case; if
+   case.add_case_status() raises, the record is orphaned and original EM/PXA values are lost.
+
+4. **vultron/core/behaviors/status/nodes/cs_dimension_filter.py:211** — FilterCsPxaDimensionNode
+   mutates accumulator dict in-place relying on blackboard returning an object reference;
+   fragile if blackboard ever returns deep-copies.
+
+5. **vultron/core/behaviors/embargo/nodes/teardown.py:136** — ClearActiveEmbargoNode only
+   catches VultronNotFoundError; if instantiated with default STRICT mode and EM.NONE,
+   VultronInvalidStateTransitionError propagates uncaught and crashes the tree.
+
+**Action:** Create Bug/Concern issues for each. Not in scope of #2109 PR.

--- a/plan/incoming/learnings/20260827-mermaid-prefix-map-rendering-scope.md
+++ b/plan/incoming/learnings/20260827-mermaid-prefix-map-rendering-scope.md
@@ -1,0 +1,24 @@
+---
+title: BtNode._mermaid_prefix_map is scoped to the rendering node, not the named node
+type: learning
+timestamp: 2026-08-27
+source: ISSUE-2109
+signal: design-question
+---
+
+`BtNode.to_mermaid()` defines `fixname()` as a closure that reads
+`self._mermaid_prefix_map` — the map on the node that called `to_mermaid()`,
+not on the node whose name is being rendered. This means:
+
+- If `ParentSeq` overrides `_mermaid_prefix_map["c"] = "CHECK: "`, all
+  `ConditionCheck` children rendered *by ParentSeq* use `"CHECK: "`.
+- If a leaf `ConditionCheck` overrides its own map, the override has no effect
+  when its name is rendered by a parent — the parent's map is used.
+
+**Why:** `fixname(child.name)` is called from within the parent's method
+context, so `self` is the parent. This is consistent with how `to_mermaid()`
+composes recursively: each node controls the rendering of its direct children.
+
+**How to apply:** When adding a `_mermaid_prefix_map` override to customise
+display, place it on the *composite* (non-leaf) node that owns the subtree, not
+on the leaf nodes whose names should change.

--- a/test/bt/test_base/test_bt.py
+++ b/test/bt/test_base/test_bt.py
@@ -16,7 +16,15 @@ import unittest
 
 import vultron.bt.base.fuzzer as btz
 from vultron.bt.base import bt
-from vultron.bt.base.bt_node import BtNode, ConditionCheck, CountTicks
+from vultron.bt.base.bt_node import (
+    ActionNode,
+    BtNode,
+    ConditionCheck,
+    CountTicks,
+)
+from vultron.bt.base.composites import FallbackNode, SequenceNode
+from vultron.bt.base.decorators import Invert
+from vultron.bt.base.fuzzer import WeightedSuccess
 from vultron.bt.base.node_status import NodeStatus
 
 
@@ -242,6 +250,148 @@ class MyTestCase(unittest.TestCase):
             v = nodes[edge[1]]
 
             self.assertIn((u, v), graph.edges)
+
+
+class TestMermaidPrefixMap(unittest.TestCase):
+    def setUp(self):
+        BtNode._objcount = 0
+
+    def test_prefix_map_exists_on_btnode(self):
+        self.assertTrue(hasattr(BtNode, "_mermaid_prefix_map"))
+        self.assertIsInstance(BtNode._mermaid_prefix_map, dict)
+
+    def test_prefix_map_covers_known_prefixes(self):
+        pfx_map = BtNode._mermaid_prefix_map
+        # Each known prefix used by base node types must be in the map
+        for prefix in (">", "^", "z", "a", "c", "?"):
+            self.assertIn(prefix, pfx_map)
+
+    def test_to_mermaid_sequence_with_action_and_condition(self):
+        class MyCondition(ConditionCheck):
+            def func(self):
+                return True
+
+        class MyAction(ActionNode):
+            def func(self):
+                return True
+
+        class MySeq(SequenceNode):
+            _children = [MyCondition, MyAction]
+
+        root = MySeq()
+        output = root.to_mermaid()
+
+        # Verify preamble and postamble
+        self.assertTrue(output.startswith("```mermaid\ngraph TD\n"))
+        self.assertTrue(output.endswith("\n```"))
+
+        # Verify prefix symbols are applied
+        self.assertIn("&rarr; MySeq", output)  # SequenceNode ">"
+        self.assertIn("#11052; MyCondition", output)  # ConditionCheck "c"
+        self.assertIn("#9648; MyAction", output)  # ActionNode "a"
+
+        # Verify no raw prefix strings remain in node labels
+        for line in output.splitlines():
+            if "[" in line and "]" in line:
+                label_start = line.index("[")
+                label_end = line.rindex("]")
+                label = line[label_start:label_end]
+                self.assertNotIn(">_", label)
+                self.assertNotIn("a_", label)
+                self.assertNotIn("c_", label)
+
+    def test_to_mermaid_fallback_and_invert(self):
+        class MyCondition(ConditionCheck):
+            def func(self):
+                return True
+
+        class MyInvert(Invert):
+            _children = [MyCondition]
+
+        class MyFallback(FallbackNode):
+            _children = [MyCondition, MyInvert]
+
+        root = MyFallback()
+        output = root.to_mermaid()
+
+        self.assertIn("? MyFallback", output)  # FallbackNode "?"
+        self.assertIn("#8645; MyInvert", output)  # Invert "^"
+        self.assertIn("#11052; MyCondition", output)  # ConditionCheck "c"
+
+    def test_to_mermaid_weighted_success(self):
+        class MyAction(ActionNode):
+            def func(self):
+                return True
+
+        class MyWeighted(WeightedSuccess):
+            pass
+
+        class MySeq(SequenceNode):
+            _children = [MyAction, MyWeighted]
+
+        root = MySeq()
+        output = root.to_mermaid()
+
+        self.assertIn("#127922; MyWeighted", output)  # WeightedSuccess "z"
+
+    def test_to_mermaid_snapshot(self):
+        class MyCondition(ConditionCheck):
+            def func(self):
+                return True
+
+        class MyAction(ActionNode):
+            def func(self):
+                return True
+
+        class MySeq(SequenceNode):
+            _children = [MyCondition, MyAction]
+
+        root = MySeq()
+        expected = (
+            "```mermaid\n"
+            "graph TD\n"
+            '  MySeq_1["&rarr; MySeq"]\n'
+            '  MyCondition_2["#11052; MyCondition"]\n'
+            "  MySeq_1 --> MyCondition_2\n"
+            '  MyAction_3["#9648; MyAction"]\n'
+            "  MySeq_1 --> MyAction_3\n"
+            "```"
+        )
+        self.assertEqual(expected, root.to_mermaid())
+
+    def test_to_mermaid_leftright_flag(self):
+        class MyCondition(ConditionCheck):
+            def func(self):
+                return True
+
+        class MySeq(SequenceNode):
+            _children = [MyCondition]
+
+        root = MySeq()
+        output = root.to_mermaid(topdown=False)
+        self.assertIn("graph LR", output)
+        self.assertNotIn("graph TD", output)
+
+    def test_subclass_can_override_prefix_map(self):
+        # fixname() uses the *containing node's* _mermaid_prefix_map,
+        # so overriding the map on a non-leaf node changes how it renders
+        # its own children's names.
+        class MyCondition(ConditionCheck):
+            def func(self):
+                return True
+
+        class CustomSeq(SequenceNode):
+            _mermaid_prefix_map = dict(BtNode._mermaid_prefix_map)
+            _mermaid_prefix_map["c"] = "CHECK: "
+            _children = [MyCondition]
+
+        root = CustomSeq()
+        output = root.to_mermaid()
+
+        # CustomSeq's overridden map is used when rendering child labels
+        self.assertIn("CHECK: MyCondition", output)
+        # Root's own ">" prefix still resolves correctly
+        self.assertIn("&rarr; CustomSeq", output)
 
 
 if __name__ == "__main__":

--- a/test/test_semantic_registry.py
+++ b/test/test_semantic_registry.py
@@ -327,7 +327,7 @@ _TRAILING_DASH_XFAIL_REASONS = {
     MessageSemantics.SUBMIT_REPORT: (
         "SE-07-006: SUBMIT_REPORT phrase ends with {target}; "
         "event_phrase() fills it with '—', producing trailing dash. "
-        "Tracked in #2150."
+        "Tracked in #2745."
     ),
     MessageSemantics.OFFER_CASE_PARTICIPANT: (
         "SE-07-006: OFFER_CASE_PARTICIPANT phrase ends with {object}; "

--- a/vultron/bt/base/bt_node.py
+++ b/vultron/bt/base/bt_node.py
@@ -18,6 +18,7 @@ It also provides a number of core node types that can be used to build a Behavio
 """
 
 import logging
+import re
 from copy import deepcopy
 from typing import Any, Iterable
 
@@ -46,6 +47,17 @@ class BtNode:
     _node_shape: str = "box"
     _children: Iterable | None = None
     _objcount: int = 0
+
+    # Maps name_pfx values to their Mermaid display symbols.
+    # Subclasses can override individual entries by redefining the dict.
+    _mermaid_prefix_map: dict[str, str] = {
+        ">": "&rarr; ",
+        "^": "#8645; ",
+        "z": "#127922; ",
+        "a": "#9648; ",
+        "c": "#11052; ",
+        "?": "? ",
+    }
 
     def __init__(self):
         BtNode._objcount += 1
@@ -248,8 +260,6 @@ class BtNode:
     def to_mermaid(self, depth=0, topdown=True) -> str:
         """Returns a string representation of the tree rooted at this node in mermaid format."""
 
-        import re
-
         if self._is_leaf_node:
             # this is a leaf node, we aren't doing anything with it
             return ""
@@ -264,15 +274,11 @@ class BtNode:
                 parts.append("graph LR")
 
         def fixname(nstr: str) -> str:
-            # see #2109 — prefix table should move to subclass attributes
-            nstr = re.sub(r"^>_", "&rarr; ", nstr)
-            nstr = re.sub(r"^\^_", "#8645; ", nstr)
-            nstr = re.sub(r"^z_", "#127922; ", nstr)
-            nstr = re.sub(r"^a_", "#9648; ", nstr)
-            nstr = re.sub(r"^c_", "#11052; ", nstr)
-            nstr = re.sub(r"^\?_", "? ", nstr)
+            for prefix, symbol in self._mermaid_prefix_map.items():
+                if nstr.startswith(f"{prefix}_"):
+                    nstr = symbol + nstr[len(prefix) + 1 :]
+                    break
             nstr = re.sub(r"_\d+$", "", nstr)
-
             return nstr
 
         name = fixname(self.name)


### PR DESCRIPTION
- Closes #2109

## Summary

Replaces the six hard-coded `re.sub` calls in the nested `fixname()` function
inside `BtNode.to_mermaid()` with a `_mermaid_prefix_map: dict[str, str]`
class attribute on `BtNode`. `fixname()` now iterates the map so subclasses
can override individual symbol entries without patching the method.

## Changes

- **`vultron/bt/base/bt_node.py`**: Add `_mermaid_prefix_map` class attribute;
  refactor `fixname()` to iterate it via `self`; move `import re` to module level
- **`test/bt/test_base/test_bt.py`**: New `TestMermaidPrefixMap` class with 7
  tests covering AC-1 (attribute + known prefixes), AC-2/AC-3 (snapshot output,
  no raw prefixes in labels), all six prefix symbols, `topdown=False`, and
  subclass override

## Verification

- 20 tests in `test/bt/test_base/test_bt.py` pass (7 new)
- Full unit suite: 7807 passed, 18 xfailed
- Integration suite: 1231 passed, 3 xfailed
- Black, flake8, mypy, pyright clean

## AC verification

- [x] AC-1: `fixname()` regex table replaced with `_mermaid_prefix_map` class attribute
- [x] AC-2: Snapshot test (`test_to_mermaid_snapshot`) pins full mermaid output
- [x] AC-3: No prefix broken — all six prefix→symbol pairs verified by tests

## Advisory (pre-existing, out of scope)

Code review surfaced five pre-existing findings in files not changed by this PR.
Follow-up issues to be created separately:

1. `triggers/actor.py:224` — ActorDiscovery backend called without `setup()`
2. `embargo/nodes/lifecycle.py:373` — SetEmbargoActiveNode TOCTOU double-read
3. `status/nodes/case_status.py:293` — filtered CaseStatus persisted before case links it
4. `status/nodes/cs_dimension_filter.py:211` — in-place dict mutation relies on reference semantics
5. `embargo/nodes/teardown.py:136` — unhandled `VultronInvalidStateTransitionError` in default STRICT mode