### PR TITLE
fix(status): remove vestigial save+read-back in participant-status write path

### DIFF
--- a/test/core/behaviors/status/nodes/append/test_actions.py
+++ b/test/core/behaviors/status/nodes/append/test_actions.py
@@ -71,12 +71,10 @@ class TestResolveAndPersistStatusObjectNode:
 
     def test_uses_fallback_when_missing_from_dl(self, bridge):
         """Fallback object is persisted and resolved when ID absent from DL."""
-        from vultron.wire.as2.vocab.objects.case_status import (
-            as_ParticipantStatus,
-        )
+        from vultron.core.models.participant_status import ParticipantStatus
         from .conftest import CASE_ID
 
-        fallback = as_ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
+        fallback = ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
         node = ResolveAndPersistStatusObjectNode(
             status_id=STATUS_ID, status_obj_fallback=fallback
         )

--- a/test/core/behaviors/status/nodes/append/test_actions.py
+++ b/test/core/behaviors/status/nodes/append/test_actions.py
@@ -81,6 +81,43 @@ class TestResolveAndPersistStatusObjectNode:
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
         assert result.status == Status.SUCCESS
 
+    def test_resolves_from_filtered_status(self, bridge):
+        """Filtered status from dimension filter is persisted and used directly without DL read-back."""
+        import py_trees
+        from vultron.core.models.participant_status import ParticipantStatus
+        from vultron.core.behaviors.status.nodes.dimension_filter import (
+            BB_DIMENSION_FILTER,
+        )
+        from .conftest import CASE_ID, PARTICIPANT_ID
+
+        filtered = ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
+        writer = py_trees.blackboard.Client(name="test-setup-filter")
+        writer.register_key(
+            key=BB_DIMENSION_FILTER, access=py_trees.common.Access.WRITE
+        )
+        writer.set(
+            BB_DIMENSION_FILTER,
+            {
+                "status_id": STATUS_ID,
+                "participant_id": PARTICIPANT_ID,
+                "refused": ("vfd",),
+                "filtered_status": filtered,
+            },
+            overwrite=True,
+        )
+
+        node = ResolveAndPersistStatusObjectNode(
+            status_id=STATUS_ID, status_obj_fallback=None
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+        reader = py_trees.blackboard.Client(name="test-verify-filter")
+        reader.register_key(
+            key="append_status_status_obj", access=py_trees.common.Access.READ
+        )
+        assert reader.get("append_status_status_obj") is filtered
+
 
 # ---------------------------------------------------------------------------
 # AppendStatusAndSaveParticipantNode

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -335,11 +335,14 @@ class TestResolveAndPersistStatusObjectNode:
         assert status_obj is not None
         assert status_obj.id_ == STATUS_ID
 
-    def test_persists_fallback_when_not_found(self, dl, bridge, status_obj):
+    def test_persists_fallback_when_not_found(self, dl, bridge):
         """Persists fallback object when status not in DataLayer."""
+        from vultron.core.models.participant_status import ParticipantStatus
+
+        fallback = ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
         node = ResolveAndPersistStatusObjectNode(
             status_id=STATUS_ID,
-            status_obj_fallback=status_obj,
+            status_obj_fallback=fallback,
         )
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
         assert result.status == Status.SUCCESS

--- a/test/core/behaviors/sync/nodes/test_participant_status_effect.py
+++ b/test/core/behaviors/sync/nodes/test_participant_status_effect.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 """Regression tests for ApplyParticipantStatusFromLedgerNode.
 
-Covers the critical round-trip serialization bug: a CORE ParticipantStatus
-appended directly to as_CaseParticipant.participant_statuses was serialized with
-default field values by Pydantic because the declared list element type
-(WireParticipantStatus) governed serialization rather than the actual runtime
-type.  The fix reads the saved status back from the DataLayer (which
-reconstructs it as the vocabulary-typed wire-format class) before appending.
+Covers the participant-status round-trip: a ratcheted ParticipantStatus is saved
+to the DataLayer and then appended directly to the participant record.  The node
+uses the in-memory ``status_obj`` rather than re-reading from the DataLayer,
+since ParticipantStatus has no reference fields that rehydrate_fields would
+expand (ADR-0034 makes the read-back vestigial).
 
 See: specs/multi-actor-demo.yaml DEMOMA-07-003 step 3.
 """

--- a/vultron/core/behaviors/status/nodes/append/actions.py
+++ b/vultron/core/behaviors/status/nodes/append/actions.py
@@ -101,7 +101,7 @@ class ResolveAndPersistStatusObjectNode(DataLayerActionWithPorts):
     portion (RSH-05).
 
     Otherwise tries the DataLayer first; if not found, uses
-    ``status_obj_fallback``, saves it, then re-reads the canonical record.
+    ``status_obj_fallback`` and saves it.
 
     Validates that the resolved object is a ParticipantStatus (has rm and
     vfd attributes).
@@ -164,14 +164,12 @@ class ResolveAndPersistStatusObjectNode(DataLayerActionWithPorts):
                 self.status_id,
                 ", ".join(filtered["refused"]),
             )
-            status_obj = self.datalayer.read(self.status_id) or status_obj
         else:
             status_obj = self.datalayer.read(self.status_id)
         if not hasattr(status_obj, "id_"):
             status_obj = self.status_obj_fallback
             if status_obj is not None:
                 self.datalayer.save(status_obj)
-                status_obj = self.datalayer.read(self.status_id) or status_obj
 
         if status_obj is None or not hasattr(status_obj, "id_"):
             self.feedback_message = f"Status '{self.status_id}' not found"

--- a/vultron/core/behaviors/sync/nodes/participant_status_effect.py
+++ b/vultron/core/behaviors/sync/nodes/participant_status_effect.py
@@ -27,7 +27,6 @@ specs/sync-ledger-replication.yaml SYNC-02-002.
 from __future__ import annotations
 
 import logging
-from typing import cast
 
 from py_trees.common import Status
 
@@ -250,29 +249,12 @@ class ApplyParticipantStatusFromLedgerNode(DataLayerActionWithPorts):
             return Status.FAILURE
         status_obj = ratcheted
 
-        # Saved unconditionally: the read-back below is what actually reaches
-        # ``participant_statuses``, so skipping the save when the object already
-        # exists locally would silently discard the RM ratchet applied above and
-        # append the un-ratcheted status instead — regressing the replica's RM
-        # while the ratchet's own log line claims the opposite (RSH-05-007,
-        # SYNC-02-002).
+        # Saved unconditionally: ``status_obj`` carries the RM ratchet applied
+        # above; skipping the save would silently discard that ratchet,
+        # regressing the replica's RM visibility (RSH-05-007, SYNC-02-002).
         self.datalayer.save(status_obj)
 
-        # Read back from the DataLayer so the stored canonical record is used
-        # (ADR-0034: dl.read() returns core-typed objects).
-        status_from_dl = self.datalayer.read(status_id)
-        if status_from_dl is None:
-            self.logger.warning(
-                "%s: status '%s' not readable from DataLayer after"
-                " save — skipping participant update",
-                self.name,
-                status_id,
-            )
-            return Status.SUCCESS
-
-        participant.add_participant_status(
-            cast(ParticipantStatus, status_from_dl)
-        )
+        participant.add_participant_status(status_obj)
         self.datalayer.save(participant)
 
         self.logger.info(


### PR DESCRIPTION
- Closes #2720

## Summary

Two locations in the participant-status write path called `dl.read()` immediately
after `dl.save()` before appending the status to the participant record. These
read-backs were vestigial: `ParticipantStatus` has no reference fields that
`rehydrate_fields` would expand, so `dl.read()` returns a functionally
equivalent object to the one just saved. The `dl.save()` call already raises on
failure (`session.commit()`) so the read-back as an implicit save-failure check
was also redundant.

## Changes

- **`vultron/core/behaviors/sync/nodes/participant_status_effect.py`**
  (`ApplyParticipantStatusFromLedgerNode.update()`): removed `dl.read(status_id)`
  after `dl.save(status_obj)`; passes `status_obj` directly to
  `participant.add_participant_status()`; removed stale ADR-0034 comment and
  unnecessary null-check; removed unused `from typing import cast`.
- **`vultron/core/behaviors/status/nodes/append/actions.py`**
  (`ResolveAndPersistStatusObjectNode.update()`): removed both
  `self.datalayer.read(self.status_id) or status_obj` read-back calls
  (after filtered-save and after fallback-save); updated docstring.
- **Two tests corrected**: `test_uses_fallback_when_missing_from_dl` in
  `test_actions.py` and `test_add_participant_status_bt.py` were passing a
  wire-layer `as_ParticipantStatus` as `status_obj_fallback`. Production callers
  always provide a core `ParticipantStatus` (from `request.status`). Updated
  both to use the correct core type (ARCH-10-001).
- **Updated test docstring** in `test_participant_status_effect.py` to describe
  current behaviour rather than the now-removed read-back.
- **Added test** `test_resolves_from_filtered_status` in `test_actions.py`: covers
  the dimension-filter path in `ResolveAndPersistStatusObjectNode` (filtered status
  used directly without DL read-back).

## Verification

- `uv run pytest --tb=short`: 7820 passed, 390 skipped, 16 xfailed (0 new tests in original commit; 1 new test added in execute pass)
- `uv run pytest -m integration --tb=short`: 1231 passed, 3 xfailed
- black, flake8, mypy, pyright: clean
- [x] AC-1: `ApplyParticipantStatusFromLedgerNode.update()` — `dl.read(status_id)` removed after `dl.save(status_obj)`; `status_obj` passed directly to `participant.add_participant_status()`; stale ADR-0034 comment removed
- [x] AC-2: `ResolveAndPersistStatusObjectNode.update()` — both `datalayer.read(self.status_id) or status_obj` read-back calls removed
- [x] AC-3: Test suite passes: 7820 unit tests, 1231 integration tests (no failures)

Source: #2321