### PR TITLE
Add "What Is Vultron?" explanation page for CVD practitioners and architects

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,12 @@ anyone seeking interoperability in the CVD ecosystem.
 
 ## So what *is* Vultron?
 
+!!! tip "Looking for the full answer?"
+
+    See [What Is Vultron?](topics/background/what-is-vultron.md) for an
+    in-depth explanation aimed at CVD practitioners and systems architects
+    evaluating whether to adopt the protocol.
+
 Vultron is:
 
 - A set of high-level processes representing the steps involved in coordinated

--- a/docs/topics/background/index.md
+++ b/docs/topics/background/index.md
@@ -12,6 +12,12 @@
     For technical reference, see [Reference](../../reference/index.md).
     If you're just trying to understand the CVD process, we recommend that you start with the [CERT Guide to Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD){:target="_blank"}.
 
+!!! tip "New to Vultron?"
+
+    If you want a concise overview of what Vultron is, why it exists, and
+    whether it is relevant to your organization, start with
+    [What Is Vultron?](what-is-vultron.md).
+
 The CVD process
 addresses a human coordination problem that spans individuals and
 organizations. As we wrote in [*The CERT* *Guide to Coordinated

--- a/docs/topics/background/what-is-vultron.md
+++ b/docs/topics/background/what-is-vultron.md
@@ -14,16 +14,18 @@
     [How-to Guides](../../howto/index.md).
 
 CVD is a multi-party coordination problem. When a vulnerability spans several
-vendors, a coordinator, and a national CERT, the parties typically coordinate
-via email threads, shared spreadsheets, and bespoke one-off integrations.
+vendors, a coordinator, and a national CSIRT, the parties typically rely on a
+patchwork of one-off tracking systems — bug trackers, bug bounty platforms,
+bespoke coordination services — that rarely integrate with each other, and
+when they do, only on a point-to-point basis.
 Every new coordination relationship requires custom effort, and there is no
 shared protocol: a system built for one organization's CVD workflow cannot
 interoperate with another's without explicit bilateral agreements.
 
 Vultron is a proposal for changing that. It is a federated, open-source
-protocol for CVD coordination — one that any tool, CERT, or vendor can
-implement to participate in ad-hoc coordination across organizational
-boundaries.
+protocol for CVD coordination — one that any tool, CSIRT, vendor, or service
+provider can implement to participate in ad-hoc coordination across
+organizational boundaries.
 
 ## Vultron as a Protocol in Four Senses
 
@@ -37,7 +39,7 @@ Vultron specifies a wire format based on
 [ActivityStreams 2.0](https://www.w3.org/TR/activitystreams-core/){:target="_blank"}
 for the messages that CVD participants exchange: report submissions, state
 change notifications, embargo proposals, and invitations. Any system can
-implement this wire format independently of the others.
+implement this wire format independently of other implementations.
 
 This is the *syntactic* layer: two systems speaking Vultron at this level can
 exchange structured data, even if they do not yet interpret it identically.
@@ -47,11 +49,15 @@ exchange structured data, even if they do not yet interpret it identically.
 Beyond the wire format, Vultron specifies *behavioral requirements*: given a
 current case state and a received message, what should a well-behaved
 participant do next? These requirements are captured as machine-readable specs
-in the RMB, EMB, and CSB families and illustrated as Behavior Trees in the
-[Behavior Logic](../behavior_logic/index.md) section.
+in the [RMB](../../reference/specs/protocol.md#rmb),
+[EMB](../../reference/specs/protocol.md#emb), and
+[CSB](../../reference/specs/protocol.md#csb) families and illustrated as
+Behavior Trees in the [Behavior Logic](../behavior_logic/index.md) section.
 
-**The protocol says what messages mean. The behavior logic says when to send
-them.**
+!!! note "Syntax describes meaning; behavior specifies timing"
+
+    The wire format says what messages *mean*. The behavioral requirements
+    say *when* to send them.
 
 For example: a participant whose report transitions to *Accepted* should emit
 a Report Accepted notification. Most of this is automatable; the reference
@@ -75,7 +81,9 @@ hands control back to a human, a policy engine, or an external service.
     Call-out points are *by design* — the protocol cannot decide for you
     whether to accept a report, how long an embargo should last, or whether
     an advisory is ready to publish. These are the judgment calls that
-    belong to your organization or your stakeholders.
+    belong to your organization or your stakeholders. Each can be fulfilled
+    by an automated policy with built-in defaults, left open to human
+    judgment, or handled by any hybrid of the two.
 
 ### 3. Diplomatic — Shared Vocabulary for Embargo and Trust
 
@@ -106,20 +114,21 @@ you gain interoperability with every other Vultron-compatible participant.
 
 A Vultron-compatible system operates at one or more conformance levels:
 
-| Level | Name | What it requires |
-|---|---|---|
-| **L1** | Syntax | Well-formed messages — correct wire format, valid AS2 structure |
-| **L2** | Semantic | Correct state transitions in response to received messages |
-| **L3** | Behavioral | The right observable outputs — right messages, right order, given state conditions |
+| Level | What it requires |
+|---|---|
+| **Syntax** | Well-formed messages — correct wire format, valid AS2 structure |
+| **Semantic** | Correct state transitions in response to received messages |
+| **Behavioral** | The right observable outputs — right messages, right order, given state conditions |
 
-The reference implementation (this repository) demonstrates L1–L3 compliance.
-You can run it as a test peer to verify your own implementation, or use it as
-a starting point and replace the components your organization already has.
+The reference implementation (this repository) demonstrates all three
+conformance levels. You can run it as a test peer to verify your own
+implementation, or use it as a starting point and replace the components
+your organization already has.
 
-An L1-only implementation can exchange structured data. An L2+ implementation
-participates correctly in shared case state. L3 is where the behavioral
-automation lives — where Vultron begins to reduce coordination overhead
-compared to email and bespoke tools.
+A Syntax-level implementation can exchange structured data. Semantic
+conformance means participating correctly in shared case state. Behavioral
+conformance is where the automation lives — where Vultron begins to reduce
+coordination overhead compared to ad-hoc tools.
 
 ## What Vultron Is Not
 

--- a/docs/topics/background/what-is-vultron.md
+++ b/docs/topics/background/what-is-vultron.md
@@ -1,0 +1,195 @@
+# What Is Vultron?
+
+!!! tip inline end "Is this page for me?"
+
+    This page is written for two readers:
+
+    - A **CVD practitioner** (security researcher, coordinator, CERT/CSIRT
+      analyst) who wants to know whether Vultron solves a problem they
+      actually have.
+    - A **systems architect** who wants to understand what "Vultron
+      conformance" would mean for their organization's tools and processes.
+
+    If you are already sold and want to implement, jump to
+    [How-to Guides](../../howto/index.md).
+
+CVD is a multi-party coordination problem. When a vulnerability spans several
+vendors, a coordinator, and a national CERT, the parties typically coordinate
+via email threads, shared spreadsheets, and bespoke one-off integrations.
+Every new coordination relationship requires custom effort, and there is no
+shared protocol: a system built for one organization's CVD workflow cannot
+interoperate with another's without explicit bilateral agreements.
+
+Vultron is a proposal for changing that. It is a federated, open-source
+protocol for CVD coordination — one that any tool, CERT, or vendor can
+implement to participate in ad-hoc coordination across organizational
+boundaries.
+
+## Vultron as a Protocol in Four Senses
+
+The word *protocol* is doing a lot of work here. Vultron is a protocol in
+four distinct senses, and understanding all four is the fastest way to see
+what it can and cannot do for you.
+
+### 1. Technical — Message Format and Syntax
+
+Vultron specifies a wire format based on
+[ActivityStreams 2.0](https://www.w3.org/TR/activitystreams-core/){:target="_blank"}
+for the messages that CVD participants exchange: report submissions, state
+change notifications, embargo proposals, and invitations. Any system can
+implement this wire format independently of the others.
+
+This is the *syntactic* layer: two systems speaking Vultron at this level can
+exchange structured data, even if they do not yet interpret it identically.
+
+### 2. Procedural — Behavior Logic
+
+Beyond the wire format, Vultron specifies *behavioral requirements*: given a
+current case state and a received message, what should a well-behaved
+participant do next? These requirements are captured as machine-readable specs
+in the RMB, EMB, and CSB families and illustrated as Behavior Trees in the
+[Behavior Logic](../behavior_logic/index.md) section.
+
+**The protocol says what messages mean. The behavior logic says when to send
+them.**
+
+For example: a participant whose report transitions to *Accepted* should emit
+a Report Accepted notification. Most of this is automatable; the reference
+implementation handles it. But some decisions cannot be automated — these are
+**call-out points**, explicit seams in the behavior trees where the protocol
+hands control back to a human, a policy engine, or an external service.
+
+!!! info "Call-out point shapes"
+
+    Each call-out point in the Vultron behavior trees has one of five
+    interaction shapes:
+
+    | Shape | What it does |
+    |---|---|
+    | **Sentinel** | Watches for a condition; fires a protocol trigger when met |
+    | **Evaluator** | Makes a structured decision and records a recommendation |
+    | **Retriever** | Fetches external data (e.g., assigns a CVE ID) |
+    | **Composer** | Generates content (e.g., drafts an advisory) |
+    | **Actuator** | Causes a side effect in an external system |
+
+    Call-out points are *by design* — the protocol cannot decide for you
+    whether to accept a report, how long an embargo should last, or whether
+    an advisory is ready to publish. These are the judgment calls that
+    belong to your organization or your stakeholders.
+
+### 3. Diplomatic — Shared Vocabulary for Embargo and Trust
+
+CVD coordination breaks down most often not because of technical failure
+but because parties have different unstated assumptions: when does the
+embargo start? Who can invite additional participants? What happens if
+someone drops out?
+
+Vultron provides a shared vocabulary for these negotiations: explicit
+Embargo state transitions (Proposed → Active → Revise → eXited), formal
+invite/accept/reject handshakes, and a trust bootstrap mechanism for
+establishing relationships between previously unknown parties. This
+*diplomatic* layer is what allows distrusting parties to coordinate
+without a central authority.
+
+### 4. Coordinative — Enabling Ad-Hoc Interoperability
+
+Taken together, the three preceding layers create a fourth property: any
+Vultron-compatible system can join a CVD case with any other
+Vultron-compatible system without bespoke setup. A new participant can
+receive a case invitation, seed its local replica from the canonical
+ledger, and participate in state coordination — all via the shared protocol.
+
+This is the value proposition for adopters: you implement Vultron once, and
+you gain interoperability with every other Vultron-compatible participant.
+
+## What Conformance Means for Your System
+
+A Vultron-compatible system operates at one or more conformance levels:
+
+| Level | Name | What it requires |
+|---|---|---|
+| **L1** | Syntax | Well-formed messages — correct wire format, valid AS2 structure |
+| **L2** | Semantic | Correct state transitions in response to received messages |
+| **L3** | Behavioral | The right observable outputs — right messages, right order, given state conditions |
+
+The reference implementation (this repository) demonstrates L1–L3 compliance.
+You can run it as a test peer to verify your own implementation, or use it as
+a starting point and replace the components your organization already has.
+
+An L1-only implementation can exchange structured data. An L2+ implementation
+participates correctly in shared case state. L3 is where the behavioral
+automation lives — where Vultron begins to reduce coordination overhead
+compared to email and bespoke tools.
+
+## What Vultron Is Not
+
+!!! note "Work in progress"
+
+    Vultron is **not yet ready for production use**. The protocol design and
+    reference implementation are under active development.
+
+Vultron is **not** a drop-in replacement for:
+
+- *Tracking systems* — Bugzilla, Jira, ServiceNow
+- *CVD and threat coordination tools* — VINCE, MISP
+- *Vulnerability disclosure platforms or programs* — HackerOne, Bugcrowd, DC3
+  VDP
+
+Instead, Vultron is designed to serve as a *lingua franca* for exchanging case
+coordination data *between* those systems. It is meant to be a feature set
+that existing products can adopt to gain interoperability — not a product in
+itself.
+
+Vultron is also **not** a vulnerability prioritization tool, though it is
+designed to be compatible with schemes like
+[SSVC](https://github.com/CERTCC/SSVC){:target="_blank"} and
+[CVSS](https://www.first.org/cvss/){:target="_blank"} at its call-out points.
+
+## Where to Go Next
+
+Your starting point depends on what you need:
+
+<div class="grid cards" markdown>
+
+- :material-shield-search:{ .lg .middle } **CVD Practitioner**
+
+    ---
+
+    You coordinate disclosures and want to understand how Vultron models the
+    process.
+
+    [:octicons-arrow-right-24: Background](index.md) →
+    [:octicons-arrow-right-24: Process Models](../process_models/index.md) →
+    [:octicons-arrow-right-24: Behavior Logic](../behavior_logic/index.md)
+
+- :fontawesome-solid-building:{ .lg .middle } **Systems Architect**
+
+    ---
+
+    You are evaluating whether to implement Vultron in your organization's
+    tools. Start with the formal protocol and implementation guidance.
+
+    [:octicons-arrow-right-24: Formal Protocol](../../reference/formal_protocol/index.md) →
+    [:octicons-arrow-right-24: How-to Guides](../../howto/index.md)
+
+- :fontawesome-solid-code:{ .lg .middle } **Tool Builder**
+
+    ---
+
+    You are implementing the wire format or integrating with an existing
+    Vultron node.
+
+    [:octicons-arrow-right-24: How-to Guides](../../howto/index.md) →
+    [:octicons-arrow-right-24: Reference](../../reference/index.md)
+
+- :material-source-pull:{ .lg .middle } **Vultron Contributor**
+
+    ---
+
+    You want to run the reference implementation, explore the codebase, or
+    contribute.
+
+    [:octicons-arrow-right-24: Tutorials](../../tutorials/index.md) →
+    [:octicons-arrow-right-24: Reference](../../reference/index.md)
+
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
     - 'topics/index.md'
     - Background:
       - 'topics/background/index.md'
+      - What Is Vultron?: 'topics/background/what-is-vultron.md'
       - Interoperability: 'topics/background/interoperability.md'
       - Defining CVD Success: 'topics/background/cvd_success.md'
     - Process Models:

--- a/plan/incoming/learnings/20260827-code-review-1314-deferred-preexisting.md
+++ b/plan/incoming/learnings/20260827-code-review-1314-deferred-preexisting.md
@@ -29,10 +29,11 @@ New findings → issues filed:
 Already-tracked findings (not re-filed):
 
 1. **vultron/core/behaviors/status/nodes/cs_dimension_filter.py:223** —
-   `FilterCsPxaDimensionNode` in-place mutation pattern. Already recorded in
-   `20260827-code-review-2109-deferred-preexisting.md` (item #4) and
-   `20260826-pre-existing-bugs-from-code-review-2204.md` (item #2).
+   `FilterCsPxaDimensionNode` in-place mutation pattern. Tracked as #2706.
 
 2. **vultron/core/behaviors/embargo/nodes/lifecycle.py:373** —
-   `SetEmbargoActiveNode` TOCTOU double-read. Already recorded in
-   `20260827-code-review-2109-deferred-preexisting.md` (item #2).
+   `SetEmbargoActiveNode` TOCTOU (concurrent double-emit of ledger entries
+   when idempotency check and `activate_embargo()` read `VulnerabilityCase`
+   independently). No dedicated issue yet; related to #2742 (ValueError escape
+   from `activate_embargo()`). Tracked in
+   `20260827-code-review-2109-deferred-preexisting.md` item #2.

--- a/plan/incoming/learnings/20260827-code-review-1314-deferred-preexisting.md
+++ b/plan/incoming/learnings/20260827-code-review-1314-deferred-preexisting.md
@@ -1,0 +1,38 @@
+---
+title: Code review of PR for #1314 surfaced 5 pre-existing bugs in unrelated files
+type: learning
+timestamp: 2026-08-27
+source: ISSUE-1314
+signal: deferred-bug
+---
+
+During the code review for the docs-only PR implementing #1314
+(what-is-vultron.md explanation page), 5 pre-existing bugs were found in
+unrelated implementation files. None are in the files changed by the PR.
+
+New findings → issues filed:
+
+1. **vultron/core/use_cases/received/embargo.py:266** — `InviteToEmbargoOnCaseReceivedUseCase`
+   falls back to `dl.actor_id` as `invitee_id` when `receiving_actor_id` is
+   `None`, silently signing the case actor into its own embargo invitation.
+   Filed as #2762.
+
+2. **vultron/core/behaviors/case/nodes/participant/common.py:410** —
+   `_upgrade_participant_to_accepted` logs a misleading SM-04-001 warning on
+   idempotent `RM.ACCEPTED` replay, filling logs with noise and masking real
+   violations. Filed as #2763.
+
+3. **test/ci/invariants/common.py:941** — `check_causal_edges` yields false
+   negatives when ledger entries are missing `log_index` (`log_index()` returns
+   `--1`), silently passing an invalid ordering check. Filed as #2764.
+
+Already-tracked findings (not re-filed):
+
+1. **vultron/core/behaviors/status/nodes/cs_dimension_filter.py:223** —
+   `FilterCsPxaDimensionNode` in-place mutation pattern. Already recorded in
+   `20260827-code-review-2109-deferred-preexisting.md` (item #4) and
+   `20260826-pre-existing-bugs-from-code-review-2204.md` (item #2).
+
+2. **vultron/core/behaviors/embargo/nodes/lifecycle.py:373** —
+   `SetEmbargoActiveNode` TOCTOU double-read. Already recorded in
+   `20260827-code-review-2109-deferred-preexisting.md` (item #2).


### PR DESCRIPTION
- Closes #1314

## Summary

Adds `docs/topics/background/what-is-vultron.md` — an evaluator-facing
explanation page answering "Does Vultron solve a problem I have, and is it
worth adopting?" for CVD practitioners and systems architects.

## Changes

- **`docs/topics/background/what-is-vultron.md`** (new): covers the
  coordination problem, Vultron as a protocol in four senses (technical /
  procedural / diplomatic / coordinative), behavior logic and call-out points
  in plain terms, the L1–L3 conformance story, what Vultron is not, and
  role-based navigation cards.
- **`mkdocs.yml`**: adds "What Is Vultron?" entry to the Background section.
- **`docs/index.md`**: adds a tip admonition linking to the new page from the
  "So what *is* Vultron?" section.
- **`docs/topics/background/index.md`**: adds a tip admonition at the top
  linking first-time readers to the new page.
- **`plan/incoming/learnings/20260827-code-review-1314-deferred-preexisting.md`**:
  records three pre-existing bugs found in code review (#2762, #2763, #2764)
  and two already-tracked ones.

### Deferred pre-existing bugs (code review, out of scope of this PR)

- #2762 — `InviteToEmbargoOnCaseReceivedUseCase` wrong `invitee_id` fallback
  when `receiving_actor_id` is None
- #2763 — `_upgrade_participant_to_accepted` misleading SM-04-001 warning on
  idempotent replay
- #2764 — `check_causal_edges` false negative when `log_index` is missing

## Test plan

- [x] `uv run mkdocs build --strict` — passes, no broken links
- [x] `uv run pytest --tb=short` — 7820 passed, 16 xfailed
- [x] `uv run pytest -m integration --tb=short` — 1231 passed, 3 xfailed
- [x] flake8, mypy, pyright — all clean