### PR TITLE
fix: document CasePersistence.actor_id must not raise NotImplementedError

### DIFF
--- a/notes/domain-validation.md
+++ b/notes/domain-validation.md
@@ -358,3 +358,27 @@ object that may be only partially initialised (e.g., freshly constructed
 from a DataLayer read before all derived fields are available).
 
 Source: ISSUE-1455 — three call sites fixed across BT nodes and use cases.
+
+### Contrast: `NotImplementedError` from a Property Is a Programming Error
+
+`ValueError` and `NotImplementedError` look similar but have opposite
+implications at a port boundary:
+
+| Exception | Meaning | Correct response |
+|---|---|---|
+| `ValueError` | Property is implemented; current data state is invalid | Catch at the calling boundary; treat as absence |
+| `NotImplementedError` | Property has no implementation | **Do not catch** — let it propagate as an unambiguous adapter-incomplete signal |
+
+`getattr(obj, "actor_id", None)` suppresses only `AttributeError`. If
+`actor_id` is a property that raises `NotImplementedError`, the default
+is never returned and the exception propagates — by design. Catching it and
+converting it to `VultronValidationError("no receiving actor")` would produce
+a misleading diagnosis: callers see a data-problem error when the real issue
+is an unimplemented adapter.
+
+**Port contract rule** (from `CasePersistence.actor_id`, CM-01-001): a port
+property that callers rely on for routing MUST NOT raise `NotImplementedError`.
+Implementations that do are broken adapters, and the propagation of the
+exception is the correct signal for catching that during development and testing.
+
+Source: ISSUE-2668 — port contract clarified and regression test added.

--- a/plan/incoming/learnings/20260827-not-implemented-from-property-is-programming-error.md
+++ b/plan/incoming/learnings/20260827-not-implemented-from-property-is-programming-error.md
@@ -1,0 +1,32 @@
+---
+title: "NotImplementedError from a port property is a programming error, not a data condition"
+type: learning
+timestamp: 2026-08-27
+source: ISSUE-2668
+signal: design-question
+---
+
+When a `CasePersistence` (or similar port) stub raises `NotImplementedError`
+from its `actor_id` property, callers like `resolve_receiving_actor_id` see the
+exception propagate past the `getattr(dl, "actor_id", None)` default.
+
+**Decision**: do NOT wrap the `getattr` in `try/except NotImplementedError`.
+
+**Why**: A property that raises `NotImplementedError` is a broken adapter — a
+programming error, not an "actor not available" data condition.  Catching it and
+converting it to `VultronValidationError("cannot resolve receiving actor")` would
+produce a misleading diagnosis: callers would see a data-problem error when the
+real issue is an unimplemented adapter.  The unambiguous signal of `NotImplementedError`
+propagating is MORE useful than the masked `VultronValidationError`.
+
+**Contrast with the `ValueError` pattern** documented in `notes/domain-validation.md`:
+`ValueError` can be raised from a *correctly-implemented* property when data
+preconditions are not met (e.g., `VulnerabilityCase.current_status` with no
+materialised entries) — so catching it is correct there.  `NotImplementedError` is
+categorically different: it signals an **absent implementation**, not a valid
+runtime data state.
+
+**How to apply**: when a port method/property MAY raise `NotImplementedError`,
+update the port contract docstring to say "MUST NOT raise `NotImplementedError`"
+and add a test that documents propagation as the programming-error signal.  Do NOT
+add a try/except guard that masks it.

--- a/test/core/use_cases/test_helpers.py
+++ b/test/core/use_cases/test_helpers.py
@@ -656,3 +656,27 @@ class TestResolveReceivingActorId:
         """``getattr`` default path: a stub port with no ``actor_id``."""
         with pytest.raises(VultronValidationError):
             resolve_receiving_actor_id(cast(SqliteDataLayer, object()), None)
+
+    def test_propagates_not_implemented_from_actor_id_property(
+        self,
+    ) -> None:
+        """A stub whose ``actor_id`` raises ``NotImplementedError`` propagates it.
+
+        ``NotImplementedError`` from a property getter is a programming error
+        (the adapter is incomplete), not a data-availability problem.  It must
+        not be silently converted to ``VultronValidationError`` — callers need
+        the unambiguous signal that the adapter is broken, not a misleading
+        "no receiving actor" diagnosis (CM-01-001 port contract).
+        """
+
+        class _StubWithRaisingActorId:
+            @property
+            def actor_id(self) -> str:
+                raise NotImplementedError(
+                    "actor_id not implemented on this stub"
+                )
+
+        with pytest.raises(NotImplementedError):
+            resolve_receiving_actor_id(
+                cast(SqliteDataLayer, _StubWithRaisingActorId()), None
+            )

--- a/vultron/core/ports/case_persistence.py
+++ b/vultron/core/ports/case_persistence.py
@@ -55,7 +55,15 @@ class CasePersistence(Protocol):
 
     @property
     def actor_id(self) -> str:
-        """The canonical URI of the actor whose store this is (ADR-0073)."""
+        """The canonical URI of the actor whose store this is (ADR-0073).
+
+        Implementations MUST return a non-empty string URI and MUST NOT raise
+        ``NotImplementedError``.  Callers such as ``resolve_receiving_actor_id``
+        treat a missing or non-string value as "no actor available" and raise
+        ``VultronValidationError`` — but they do not catch ``NotImplementedError``,
+        which is reserved as an unambiguous signal that the adapter is incomplete
+        (CM-01-001).
+        """
         ...
 
     def clone_for_actor(self, actor_id: str) -> "CasePersistence":


### PR DESCRIPTION
- Closes #2668
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Tightens the `CasePersistence.actor_id` port contract to explicitly forbid `NotImplementedError`, and adds a test documenting that a stub raising it propagates as a programming-error signal rather than being masked as `VultronValidationError`.

## Changes

- **`vultron/core/ports/case_persistence.py`**: Updated `actor_id` docstring — implementations MUST return a non-empty string URI and MUST NOT raise `NotImplementedError`; callers do not catch it (CM-01-001).
- **`test/core/use_cases/test_helpers.py`**: Added `test_propagates_not_implemented_from_actor_id_property` to `TestResolveReceivingActorId` — documents that `NotImplementedError` from a property getter propagates unhandled (programming error, not a data condition).

## Verification

- All 1238 integration tests pass, 3 xfailed (pre-existing)
- Unit tests pass
- Black, mypy, pyright clean
- [x] AC-1: No existing DataLayer implementations raise `NotImplementedError` from `actor_id`
  (grep of `vultron/core/ports/` and `vultron/adapters/` confirms only the new docstring mentions it)
- [x] AC-2: Port contract updated — `actor_id` MUST NOT raise `NotImplementedError`; decision
  documented in learning file `plan/incoming/learnings/20260827-not-implemented-from-property-is-programming-error.md`
- [x] AC-3: `test_propagates_not_implemented_from_actor_id_property` added to `TestResolveReceivingActorId`