### PR TITLE
fix(test): session-scoped real_registry fixture in test/metadata

### DIFF
--- a/plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2757.md
+++ b/plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2757.md
@@ -1,0 +1,35 @@
+---
+title: 3 pre-existing bugs surfaced by code review on PR #2775
+type: learning
+timestamp: 2026-08-27
+source: ISSUE-2757
+signal: concern
+---
+
+The automated code reviewer on PR #2775 identified 3 bugs in files outside the PR diff.
+None were introduced by the PR. Each should be tracked as a Bug or Concern issue.
+
+1. **`docs/adr/0076` + `vultron/core/behaviors/status/add_case_status_tree.py:86`**
+   ADR-0076's Validation section and the amended ADR-0046 both assert that
+   `RequireCaseOwnerApproval` is the out-of-the-box default for the StatusAdoptionGate
+   and EmbargoTeardownAuthorizationGate seams. The code still uses `AlwaysSucceed` for
+   both. The docstring on `add_case_status_tree.py:86` still reads "Default is
+   AlwaysSucceed". An operator reading the ADR believes the conservative posture is
+   active by default; the code provides zero protection without explicit configuration.
+
+2. **`vultron/demo/helpers/sync.py:241`** — `verify_replica_state` TOCTOU window:
+   `auth_entries` is fetched before `replica_entries`. In a fast-replicating environment,
+   the authoritative log can append entry index M+1 between the two fetches and the
+   replica can receive it before `replica_entries` is read. Then
+   `auth_entry_by_index.get(M+1)` returns `None` and the assertion fires with the
+   misleading message "replica is ahead of auth or coverage check is stale" when the
+   real cause is a stale auth fetch.
+
+3. **`.agents/skills/bugfix/SKILL.md:54`** — `calve-epics` Mode 1 is invoked at step 2,
+   before `orient-agent` at step 3. `calve-epics` must semantically match the bug issue
+   against open epics using domain terminology. The spec corpus, glossary, and schedule
+   loaded by `orient-agent` are the primary reference for that matching. Running
+   `calve-epics` before `orient-agent` means the matching runs without that context.
+
+Note: the actor.py `backend.update()` without `setup()` finding is already tracked in
+`plan/incoming/learnings/20260827-code-review-2109-deferred-preexisting.md` item 1.

--- a/test/metadata/conftest.py
+++ b/test/metadata/conftest.py
@@ -1,0 +1,17 @@
+"""Session-scoped fixtures shared across test/metadata/ sub-packages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vultron.metadata.specs.registry import load_registry
+
+_SPECS_DIR = Path(__file__).parents[2] / "specs"
+
+
+@pytest.fixture(scope="session")
+def real_registry():
+    """Load the actual specs/ directory once for the entire test session."""
+    return load_registry(_SPECS_DIR)

--- a/test/metadata/specs/test_coverage.py
+++ b/test/metadata/specs/test_coverage.py
@@ -227,13 +227,12 @@ def test_compute_uncovered_is_sorted(
 
 
 @pytest.mark.spec("SR-05-005")
-def test_compute_real_registry_has_nonzero_coverage():
+def test_compute_real_registry_has_nonzero_coverage(real_registry):
     """Smoke test: real registry + real test suite have at least one covered spec."""
     from vultron.metadata.specs.registry import find_repo_root
 
     repo_root = find_repo_root()
-    registry = load_registry(repo_root / "specs")
-    report = compute_protocol_coverage(registry, repo_root / "test")
+    report = compute_protocol_coverage(real_registry, repo_root / "test")
     assert report.covered_count > 0, (
         "No protocol-kind specs are covered — @pytest.mark.spec markers may "
         "have been stripped from the test suite."

--- a/test/metadata/specs/test_docs_render.py
+++ b/test/metadata/specs/test_docs_render.py
@@ -528,10 +528,11 @@ def test_render_for_kind_may_material_icon(general_registry):
 
 
 @pytest.mark.parametrize("kind", list(SpecKind))
-def test_render_for_kind_real_registry_produces_output(kind: SpecKind):
+def test_render_for_kind_real_registry_produces_output(
+    kind: SpecKind, real_registry
+):
     """Every SpecKind must render non-empty output from the real spec registry."""
-    registry = load_registry()
-    md = render_for_kind(kind.value, registry)
+    md = render_for_kind(kind.value, real_registry)
     assert len(md) > 0
     # At minimum one spec ID pattern should appear
     import re

--- a/test/metadata/specs/test_real_specs.py
+++ b/test/metadata/specs/test_real_specs.py
@@ -19,19 +19,10 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 from vultron.metadata.specs.lint import lint
-from vultron.metadata.specs.registry import load_registry
 from vultron.metadata.specs.render import main_llm_json
 
 _SPECS_DIR = Path(__file__).parents[3] / "specs"
-
-
-@pytest.fixture(scope="module")
-def real_registry():
-    """Load the actual specs/ directory once for all tests in this module."""
-    return load_registry(_SPECS_DIR)
 
 
 def test_real_specs_dir_exists():
@@ -53,9 +44,9 @@ def test_real_specs_cross_references(real_registry):
     )
 
 
-def test_real_specs_lint_no_hard_errors():
+def test_real_specs_lint_no_hard_errors(real_registry):
     """Full lint() returns exit code 0 (no hard errors) for specs/."""
-    exit_code = lint(_SPECS_DIR)
+    exit_code = lint(_SPECS_DIR, registry=real_registry)
     assert (
         exit_code == 0
     ), "spec-lint reported hard errors — run 'uv run spec-lint' to see details"

--- a/vultron/metadata/specs/lint.py
+++ b/vultron/metadata/specs/lint.py
@@ -700,7 +700,11 @@ def _check_phantom_spec_id_citations(
     return errors
 
 
-def lint(spec_dir: Path, adr_dir: Path | None = None) -> int:
+def lint(
+    spec_dir: Path,
+    adr_dir: Path | None = None,
+    registry: SpecRegistry | None = None,
+) -> int:
     """Validate the spec registry in ``spec_dir``.
 
     Hard errors cause exit code 1.  Advisory warnings are printed but do not
@@ -713,6 +717,9 @@ def lint(spec_dir: Path, adr_dir: Path | None = None) -> int:
             so that ``uv run spec-lint`` from the repository root picks up
             ``docs/adr/`` automatically.  To skip the ADR-reference check,
             pass a path that does not exist on disk.
+        registry: Pre-loaded :class:`SpecRegistry` instance.  When provided,
+            the ``load_registry(spec_dir)`` call is skipped, avoiding
+            redundant I/O in callers that already hold a loaded registry.
 
     Returns:
         ``0`` if no hard errors, ``1`` if any hard errors found.
@@ -723,11 +730,12 @@ def lint(spec_dir: Path, adr_dir: Path | None = None) -> int:
     hard_errors: list[str] = []
     warnings: list[str] = []
 
-    try:
-        registry = load_registry(spec_dir)
-    except (ValidationError, ValueError) as exc:
-        print(f"[FATAL] Registry load failed:\n{exc}", file=sys.stderr)
-        return 1
+    if registry is None:
+        try:
+            registry = load_registry(spec_dir)
+        except (ValidationError, ValueError) as exc:
+            print(f"[FATAL] Registry load failed:\n{exc}", file=sys.stderr)
+            return 1
 
     hard_errors.extend(registry.validate_cross_references())
     hard_errors.extend(_check_prefix_consistency(registry))


### PR DESCRIPTION
- Closes #2757

## Summary

Eliminates redundant `load_registry()` calls across `test/metadata/specs/` by
introducing a session-scoped `real_registry` fixture in `test/metadata/conftest.py`.
The real spec corpus is now loaded exactly once per test session (down from 8 loads).

## Changes

- **`test/metadata/conftest.py`** (new) — `@pytest.fixture(scope="session")` named
  `real_registry` that calls `load_registry(specs/)` once per session (AC-1).
- **`test/metadata/specs/test_real_specs.py`** — removed the module-scoped
  `real_registry` fixture (superseded by the session fixture); wired `real_registry`
  into `test_real_specs_lint_no_hard_errors` and passes it to `lint()` (AC-2).
- **`test/metadata/specs/test_docs_render.py`** — `test_render_for_kind_real_registry_produces_output`
  now receives `real_registry` as a fixture parameter instead of calling
  `load_registry()` inline on each of its 4 parametrized invocations (AC-3).
- **`test/metadata/specs/test_coverage.py`** — `test_compute_real_registry_has_nonzero_coverage`
  now receives `real_registry` as a fixture parameter instead of calling
  `load_registry()` inline (AC-4).
- **`vultron/metadata/specs/lint.py`** — `lint()` gains an optional
  `registry: SpecRegistry | None = None` parameter; when provided, the
  `load_registry(spec_dir)` call is skipped (AC-5).
- **`plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2757.md`** (new) —
  records 3 pre-existing bugs surfaced by code review on this PR; queued for the
  `learn` skill to process into Bug issues.

## Verification

- `uv run pytest test/metadata/ --tb=short` — 489 passed
- `uv run pytest --tb=short` — 7820 passed (full unit suite)
- `uv run pytest -m integration --tb=short` — 1238 passed
- Black, flake8, mypy, pyright all clean
- [x] AC-1: `test/metadata/conftest.py` created with session-scoped `real_registry` fixture
- [x] AC-2: `test_real_specs.py` module fixture removed; `real_registry` wired into lint test
- [x] AC-3: `test_docs_render.py` inline `load_registry()` calls replaced with fixture
- [x] AC-4: `test_coverage.py` inline `load_registry()` call replaced with fixture
- [x] AC-5: `lint()` gains optional `registry` parameter; skips load when provided