### PR TITLE
fix: SUBMIT_REPORT phrase produces trailing em-dash in event_phrase()

### DIFF
--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -585,13 +585,6 @@ class TestEventPhraseBehavioural:
             result
         ), f"Un-substituted slot in event_phrase('offer_actor_to_case'): {result!r}"
 
-    @pytest.mark.xfail(
-        reason=(
-            "SE-07-006: submit_report {target} slot not yet populated by runtime"
-            " — tracked in #2150"
-        ),
-        strict=True,
-    )
     def test_actor_target_phrase_no_dangling_dash(self):
         """Actor+target phrase: both slots filled; no dangling em-dash."""
         result = event_phrase("submit_report")

--- a/test/test_semantic_registry.py
+++ b/test/test_semantic_registry.py
@@ -323,13 +323,7 @@ def test_no_phrase_uses_unknown_slots(entry):
 # ---------------------------------------------------------------------------
 
 
-_TRAILING_DASH_XFAIL_REASONS = {
-    MessageSemantics.SUBMIT_REPORT: (
-        "SE-07-006: SUBMIT_REPORT phrase ends with {target}; "
-        "event_phrase() fills it with '—', producing trailing dash. "
-        "Tracked in #2745."
-    ),
-}
+_TRAILING_DASH_XFAIL_REASONS: dict[MessageSemantics, str] = {}
 
 
 @pytest.mark.spec("SE-07-006")

--- a/vultron/semantic_registry/report.py
+++ b/vultron/semantic_registry/report.py
@@ -63,7 +63,7 @@ ENTRIES: list[SemanticEntry] = [
         pattern=ReportSubmissionPattern,
         event_class=SubmitReportReceivedEvent,
         use_case_class=SubmitReportReceivedUseCase,
-        phrase="{actor} submitted the report to {target}",
+        phrase="{actor} submitted the report",
         wire_activity_class=_RmSubmitReportActivity,
         include_activity=True,
     ),


### PR DESCRIPTION
- Closes #2745

## Summary

Removes the trailing `{target}` slot from the `SUBMIT_REPORT` semantic-registry
phrase so `event_phrase()` no longer produces a dangling em-dash when `target`
is absent.

## Changes

- **`vultron/semantic_registry/report.py`**: reword `SUBMIT_REPORT` phrase from
  `"{actor} submitted the report to {target}"` to `"{actor} submitted the
  report"`; matches the pattern of all other report-domain entries (none carry
  `{target}`)
- **`test/test_semantic_registry.py`**: remove `SUBMIT_REPORT` entry from
  `_TRAILING_DASH_XFAIL_REASONS`; SE-07-006 parametrised test now passes
- **`test/demo/test_report.py`**: remove `strict xfail` marker from
  `TestEventPhraseBehavioural::test_actor_target_phrase_no_dangling_dash`; the
  phrase fix resolves the trailing-dash condition the xfail was tracking

## Verification

- 7823 unit tests pass, 15 xfailed, 0 failures
- Integration suite: 1238 passed, 2 xfailed, 0 failures (previously 1 failure on
  the XPASS strict-xfail; resolved by removing the marker)
- Black, flake8, mypy, pyright clean