### PR TITLE
fix: catch ValueError from activate_embargo in SetEmbargoActiveNode

### DIFF
--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -689,6 +689,38 @@ class TestSetEmbargoActiveNode:
         updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em.state == EM.NONE
 
+    def test_returns_failure_when_current_status_raises_value_error(self):
+        """FAILURE when case.current_status raises ValueError (no materialized status).
+
+        Regression test for issue #2742: activate_embargo() calls
+        case.current_status.em.state internally when em_before is not provided.
+        A ValueError from an empty case_statuses list must be caught and mapped
+        to Status.FAILURE, not propagate as an uncaught exception.
+        """
+        from unittest.mock import MagicMock, PropertyMock
+
+        from vultron.core.models.case import VulnerabilityCase
+
+        mock_case = MagicMock(spec=VulnerabilityCase)
+        mock_case.case_participants = []
+        mock_case.active_embargo = None
+        type(mock_case).current_status = PropertyMock(
+            side_effect=ValueError("no materialized CaseStatus")
+        )
+
+        mock_dl = MagicMock()
+        mock_dl.read.return_value = mock_case
+
+        node = SetEmbargoActiveNode(
+            case_id="https://example.org/cases/any",
+            embargo_id="https://example.org/cases/any/embargo_events/e1",
+        )
+        node.datalayer = mock_dl
+
+        result = node.update()
+
+        assert result == py_trees.common.Status.FAILURE
+
     @pytest.mark.spec("EMB-18-001")
     def test_em_write_goes_through_embargo_lifecycle(self):
         """EMB-18-001: EM write is delegated to EmbargoLifecycle.activate_embargo().

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -402,6 +402,10 @@ class SetEmbargoActiveNode(DataLayerActionWithPorts):
             self.feedback_message = str(exc)
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
+        except ValueError as exc:
+            self.feedback_message = str(exc)
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
 
         em_before = result.em_before
         em_after = result.em_after


### PR DESCRIPTION
- Closes #2742
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

`SetEmbargoActiveNode.update()` called `EmbargoLifecycle.activate_embargo()` without `em_before`; the service then read `case.current_status.em.state` internally, which raises `ValueError` when `case_statuses` contains no materialized `CaseStatus` objects. Add `except ValueError` to map this to `Status.FAILURE`.

## Changes

- **`vultron/core/behaviors/embargo/nodes/lifecycle.py`**: add `except ValueError` clause to `SetEmbargoActiveNode.update()` — logs WARNING and returns `Status.FAILURE`, consistent with the other error arms.
- **`test/core/behaviors/embargo/nodes/test_lifecycle.py`**: add regression test `test_returns_failure_when_current_status_raises_value_error` using the `PropertyMock(side_effect=ValueError(...))` pattern established in `TestValidateEmbargoRevisionStateNode`.

## Root cause

All other lifecycle nodes (`ProposeEmbargoLifecycleNode`, etc.) inherit from `_EmbargoLifecycleNode`, which pre-reads EM state via `ReadEmStateNode` (which already catches `ValueError`) and passes `em_before` to the service. `SetEmbargoActiveNode` does not follow that pattern — it calls `activate_embargo()` without `em_before`, leaving the internal `current_status` read unguarded.

## Verification

- 7823 unit tests pass (1 new)
- 1238 integration tests pass
- Black, flake8, mypy, pyright clean