### PR TITLE
fix: idempotency guard in _upgrade_participant_to_accepted (#2763)

### DIFF
--- a/test/core/use_cases/received/case/test_helpers.py
+++ b/test/core/use_cases/received/case/test_helpers.py
@@ -362,6 +362,96 @@ class TestBootstrapReporterUpgradesFromStart:
 
 
 # ---------------------------------------------------------------------------
+# _upgrade_participant_to_accepted must be a silent no-op on RM.ACCEPTED
+# (issue #2763)
+# ---------------------------------------------------------------------------
+
+
+class TestUpgradeParticipantIdempotencyWhenAlreadyAccepted:
+    """``_upgrade_participant_to_accepted`` must be a silent no-op when already at RM.ACCEPTED.
+
+    Regression for #2763: when ``latest_rm == RM.ACCEPTED``,
+    ``is_valid_rm_transition(RM.ACCEPTED, RM.ACCEPTED)`` is ``False`` (no
+    self-loop).  Before the fix, the SM-04-001 guard fired a misleading
+    ``WARNING``, filling logs on every ledger replay and masking genuine
+    SM-04-001 violations.
+
+    The function must:
+    - log nothing at WARNING or above,
+    - write no new DataLayer record,
+
+    when called with ``latest_rm == RM.ACCEPTED``.
+    """
+
+    _ACTOR_ID = "https://finder.example.org/actors/finder-2763"
+    _CASE_ID = "https://example.org/cases/case-2763"
+    _PARTICIPANT_ID = f"{_CASE_ID}/participants/finder-2763"
+
+    @pytest.fixture()
+    def dl(self):
+        return SqliteDataLayer("sqlite:///:memory:", actor_id=self._ACTOR_ID)
+
+    @pytest.fixture()
+    def participant_at_accepted(self, dl):
+        """Participant already at RM.ACCEPTED stored in the DataLayer."""
+        status = ParticipantStatus(
+            rm=RmDimension(state=RM.ACCEPTED),
+            context=self._CASE_ID,
+            attributed_to=self._ACTOR_ID,
+        )
+        participant = VultronParticipant(
+            id_=self._PARTICIPANT_ID,
+            attributed_to=self._ACTOR_ID,
+            context=self._CASE_ID,
+            participant_statuses=[status],
+        )
+        dl.create(participant)
+        return participant
+
+    def test_no_warning_and_no_extra_status_when_already_accepted(
+        self, dl, participant_at_accepted, caplog
+    ):
+        """No WARNING logged and no extra status written on idempotent replay (#2763).
+
+        SM-04-001 guard must not fire when ``latest_rm == RM.ACCEPTED`` —
+        the participant is already at the target state, so there is no
+        illegal transition.
+        """
+        import logging
+
+        from vultron.core.behaviors.case.nodes.participant.common import (
+            _upgrade_participant_to_accepted,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            _upgrade_participant_to_accepted(
+                dl=dl,
+                existing=participant_at_accepted,
+                participant_id=self._PARTICIPANT_ID,
+                case_id=self._CASE_ID,
+                reporter_actor_id=self._ACTOR_ID,
+                latest_rm=RM.ACCEPTED,
+            )
+
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert not warning_messages, (
+            "No WARNING must be logged when participant is already at "
+            f"RM.ACCEPTED; got: {warning_messages!r} (#2763)"
+        )
+
+        stored = dl.read(self._PARTICIPANT_ID)
+        assert stored is not None
+        statuses = getattr(stored, "participant_statuses", [])
+        assert len(statuses) == 1, (
+            "No extra status must be written when participant is already "
+            f"at RM.ACCEPTED; got {len(statuses)} status(es) (#2763)"
+        )
+        assert statuses[0].rm.state == RM.ACCEPTED
+
+
+# ---------------------------------------------------------------------------
 # RM-regression guard must not go inert on a shape mismatch (issue #2232)
 # ---------------------------------------------------------------------------
 

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -403,6 +403,9 @@ def _upgrade_participant_to_accepted(
     dl.read() returns core-typed objects for ParticipantStatus).
     """
     logger = logging.getLogger(__name__)
+    # Idempotency guard: already at target state, nothing to do (#2763).
+    if latest_rm == RM.ACCEPTED:
+        return
     # SM-04-001: guard before writing — RM.INVALID cannot advance to ACCEPTED
     # without first re-validating (INVALID → VALID → ACCEPTED).  START and
     # RECEIVED are bootstrap-forward jumps that remain valid because the


### PR DESCRIPTION
- Closes #2763

## Summary

Add an idempotency short-circuit before the SM-04-001 guard in `_upgrade_participant_to_accepted` so that calling the function when the participant is already at `RM.ACCEPTED` is a silent no-op rather than a misleading WARNING.

## Changes

- **`vultron/core/behaviors/case/nodes/participant/common.py`**: Add `if latest_rm == RM.ACCEPTED: return` before the SM-04-001 guard — `is_valid_rm_transition(RM.ACCEPTED, RM.ACCEPTED)` returns `False` (no self-loop), so without this guard the warning fires on every idempotent ledger replay
- **`test/core/use_cases/received/case/test_helpers.py`**: Add `TestUpgradeParticipantIdempotencyWhenAlreadyAccepted` regression test — asserts no WARNING is logged and no extra status record is written when the participant is already at `RM.ACCEPTED`

## Verification

- All 7824 unit tests pass (1 new)
- All 1239 integration tests pass
- Black, flake8, mypy, pyright clean