### PR TITLE
Add check-docs-sync skill and wire into build/bugfix/learn

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -209,6 +209,9 @@ Once the plan is confirmed:
    rules from `completeness-doctrine.md`.
 
 5. **Finalize**:
+   - Invoke `check-docs-sync` to identify any `docs/` updates required by
+     the fix (PD-03-007). Apply small updates inline; file a `type:Concern`
+     issue for large updates. Do not block the PR on large updates.
    - Invoke `archive-history`:
 
      ```text

--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -209,9 +209,6 @@ Once the plan is confirmed:
    rules from `completeness-doctrine.md`.
 
 5. **Finalize**:
-   - Invoke `check-docs-sync` to identify any `docs/` updates required by
-     the fix (PD-03-007). Apply small updates inline; file a `type:Concern`
-     issue for large updates. Do not block the PR on large updates.
    - Invoke `archive-history`:
 
      ```text
@@ -236,6 +233,10 @@ Once the plan is confirmed:
      issue_number: <N>
      ```
 
+   - Invoke `check-docs-sync` while CI runs in the cloud to identify any
+     `docs/` updates required by the fix (PD-03-007). Apply small updates
+     inline and commit them; file a `type:Concern` issue for large updates.
+     Do not block the PR on large updates.
    - Invoke `commit` if any learning files were created in
      `plan/incoming/learnings/` outside the PR branch.
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -273,7 +273,18 @@ that clearly belongs with it, apply the following:
    task (and therefore the same epic) where it was discovered — this keeps it
    visible in the epic tree and off the `no:parent-issue` orphan list.
 
-### Phase 7 — Pre-PR Code Review
+### Phase 7 — Docs Sync Check
+
+Invoke the `check-docs-sync` skill to identify any `docs/` updates required
+by this implementation (PD-03-008). This check runs when the diff is stable,
+before code review begins.
+
+- **Small updates** (single page edit, addition, or rewrite): apply inline
+  in this PR.
+- **Large updates** (simultaneous multi-page rewrite): file a `type:Concern`
+  issue; do not block the PR.
+
+### Phase 8 — Pre-PR Code Review
 
 Invoke the `code-review` agent against the current branch diff vs `main`.
 
@@ -296,7 +307,7 @@ be empty if changes are unstaged. Stage all changed files first (`git add`),
 then pass `git diff --cached` as the diff source for the review, or do a
 draft commit and use `git diff main...HEAD` normally.
 
-### Phase 8 — Open PR and Finalize
+### Phase 9 — Open PR and Finalize
 
 1. Compute diff size: ≤50 lines → `size:S`; 51–300 → `size:M`; 301+ → `size:L`.
    Update the `size:` label on the Issue.

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -269,22 +269,11 @@ that clearly belongs with it, apply the following:
    with evidence (failing command/output, clean-base proof, causality check,
    blocked/unblocked impact), wire structured blockers, add a handoff comment,
    and record the Bug link as a learning file in `plan/incoming/learnings/`.
-   Set `--parent "${CURRENT_TASK_NUMBER}"` so the bug is wired under the same
+   Set `--parent "${ISSUE_NUMBER}"` so the bug is wired under the same
    task (and therefore the same epic) where it was discovered — this keeps it
    visible in the epic tree and off the `no:parent-issue` orphan list.
 
-### Phase 7 — Docs Sync Check
-
-Invoke the `check-docs-sync` skill to identify any `docs/` updates required
-by this implementation (PD-03-008). This check runs when the diff is stable,
-before code review begins.
-
-- **Small updates** (single page edit, addition, or rewrite): apply inline
-  in this PR.
-- **Large updates** (simultaneous multi-page rewrite): file a `type:Concern`
-  issue; do not block the PR.
-
-### Phase 8 — Pre-PR Code Review
+### Phase 7 — Pre-PR Code Review
 
 Invoke the `code-review` agent against the current branch diff vs `main`.
 
@@ -307,7 +296,7 @@ be empty if changes are unstaged. Stage all changed files first (`git add`),
 then pass `git diff --cached` as the diff source for the review, or do a
 draft commit and use `git diff main...HEAD` normally.
 
-### Phase 9 — Open PR and Finalize
+### Phase 8 — Open PR and Finalize
 
 1. Compute diff size: ≤50 lines → `size:S`; 51–300 → `size:M`; 301+ → `size:L`.
    Update the `size:` label on the Issue.
@@ -326,9 +315,16 @@ draft commit and use `git diff main...HEAD` normally.
    returns the PR URL. Use the returned URL in the `archive-history` call
    below.
 
-3. Post `[ADVISORY]` findings as a PR comment (if any).
+3. Invoke `check-docs-sync` while CI runs in the cloud. Apply any small docs
+   updates inline and commit them before finalizing:
 
-4. Invoke `archive-history`:
+   ```text
+   Commit message: docs: sync docs/ for issue #<N>
+   ```
+
+4. Post `[ADVISORY]` findings as a PR comment (if any).
+
+5. Invoke `archive-history`:
 
    ```text
    TYPE    = implementation
@@ -337,11 +333,11 @@ draft commit and use `git diff main...HEAD` normally.
    BODY    = "## Issue #<N> — <title>\n\n<completion summary, PR link>"
    ```
 
-5. Run the **upward-reflection checklist** per
+6. Run the **upward-reflection checklist** per
    `.agents/skills/shared/upward-reflection.md`. Record each triggered signal
    as a learning file. Do not write completion summaries here.
 
-6. Invoke `commit` if any learning files were created in `plan/incoming/learnings/`.
+7. Invoke `commit` if any learning files were created in `plan/incoming/learnings/`.
 
 ## Constraints
 

--- a/.agents/skills/check-docs-sync/SKILL.md
+++ b/.agents/skills/check-docs-sync/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Three-question docs-sync check: identifies docs/ pages that need updating
   after an implementation or bug-fix change, applies small updates inline
   (PD-03-007), and files a type:Concern issue for large multi-page rewrites.
-  Invoked by build (Phase 7), bugfix (Phase 4 finalize), and learn (Phase 8).
+  Invoked after the PR is pushed (while CI runs), by build (Phase 8), bugfix
+  (Phase 4 finalize), and learn (Phase 8).
 ---
 
 # Skill: Check Docs Sync
@@ -14,16 +15,17 @@ Normative requirement: `specs/project-documentation.yaml` **PD-03-007**.
 
 ## When to invoke
 
-After implementation is complete and validated (diff is stable), before the
-PR opens. Invoked by `build` (Phase 7), `bugfix` (Phase 4 finalize), and
-`learn` (Phase 8) for consistency.
+After the PR is pushed (CI starts in the cloud), while CI runs in parallel
+locally. Apply any small docs updates and commit them before the finalize steps
+(archive-history, learnings). Invoked by `build` (Phase 8), `bugfix` (Phase 4
+finalize), and `learn` (Phase 8) for consistency.
 
 ## Procedure
 
 ### Step 1 — Identify changed areas
 
 ```bash
-git diff main...HEAD --name-only
+git diff origin/main...HEAD --name-only
 ```
 
 Look at the changed files and identify the functional areas affected:
@@ -75,57 +77,43 @@ genuine multi-page rewrites that would bloat the PR beyond its original scope.
 For each small update:
 
 1. Write the change to the target `docs/` file.
-2. Invoke `build-docs` to validate the build passes:
+2. Invoke `format-markdown` to lint the updated file before building.
+3. Invoke `build-docs` to validate the build passes, tee-ing output to a temp
+   file so full context is available on failure:
 
    ```bash
-   uv run mkdocs build --strict 2>&1 | tail -20
+   UV_NO_SYNC=1 uv run mkdocs build --strict 2>&1 | tee /tmp/mkdocs-build.log | tail -20
+   # On failure with insufficient tail output: grep /tmp/mkdocs-build.log
    ```
 
-3. Fix any linting or build errors before proceeding.
+4. Fix any linting or build errors before proceeding.
 
 ### Step 4 — File Concern for large updates
 
-For each large update (multi-page rewrite needed), file a `type:Concern`
-issue citing PD-03-007:
+For each large update (multi-page rewrite needed), invoke the `new-item` skill
+to file a `type:Concern` issue. Provide these details as context:
 
-```bash
-CONCERN_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Concern)
-ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
-  --title "docs: update <area> pages after <change>" \
-  --body "$(cat <<'EOF'
-## Context
+- **Type**: Concern
+- **Title**: `docs: update <area> pages after <change>`
+- **Context**: what implementation change requires the docs update
+- **Required docs updates**: each page that needs updating with what to change
+- **Source**: PD-03-007 — implementation PR must include docs updates or a
+  linked Concern; deferred only when multiple pages require simultaneous rewrite
+- **Deferred from PR**: `<PR_URL>` (fill in after the PR opens)
+- **Suggested label**: `size:M`
 
-<Describe what implementation change requires the docs update.>
-
-## Required docs updates
-
-<List each page that needs updating with a description of what to change.>
-
-## Source
-
-PD-03-007: When an implementation or bug-fix PR changes behavior, interfaces,
-or architecture described in `docs/`, the PR MUST include the corresponding
-`docs/` updates or a linked follow-up `type:Concern` issue. A deferred Concern
-is acceptable only when the required update would simultaneously rewrite
-multiple `docs/` pages.
-
-Deferred from PR: <PR_URL — fill in after PR opens>
-EOF
-)"
-  --issue-type-id "${CONCERN_TYPE_ID}" \
-  --label "size:M")
-bash .agents/skills/shared/add-to-project.sh "${ISSUE_NUMBER}"
-```
+`new-item` handles duplicate detection, parent epic selection, and creation.
 
 Record the Concern issue number for inclusion in the PR description:
-`Docs deferred: #<N>` (add to the PR body before it opens).
+`Docs deferred: #<N>` (add to the PR body after the PR opens).
 
 ### Step 5 — Report
 
 Return a summary of what was done:
 
-- List each `docs/` page updated inline (file path + short description)
-- List each Concern issue filed for large updates (issue number + title)
+- List each `docs/` page updated inline (file path + short description of what changed)
+- List each Concern issue filed for large updates: issue number, title, and 1–2
+  sentences describing what the concern entails and why the update was deferred
 - If no `docs/` updates were needed, state that explicitly
 
 ## Constraints

--- a/.agents/skills/check-docs-sync/SKILL.md
+++ b/.agents/skills/check-docs-sync/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: check-docs-sync
+description: >
+  Three-question docs-sync check: identifies docs/ pages that need updating
+  after an implementation or bug-fix change, applies small updates inline
+  (PD-03-007), and files a type:Concern issue for large multi-page rewrites.
+  Invoked by build (Phase 7), bugfix (Phase 4 finalize), and learn (Phase 8).
+---
+
+# Skill: Check Docs Sync
+
+Verify that `docs/` is in sync with the current implementation changes.
+Normative requirement: `specs/project-documentation.yaml` **PD-03-007**.
+
+## When to invoke
+
+After implementation is complete and validated (diff is stable), before the
+PR opens. Invoked by `build` (Phase 7), `bugfix` (Phase 4 finalize), and
+`learn` (Phase 8) for consistency.
+
+## Procedure
+
+### Step 1 — Identify changed areas
+
+```bash
+git diff main...HEAD --name-only
+```
+
+Look at the changed files and identify the functional areas affected:
+
+- `vultron/` changes → protocol behavior, wire layer, adapters, BT nodes
+- `specs/` changes → specification requirements (PD, CM, ARCH, etc.)
+- `notes/` changes → design notes and durable insights
+- `.agents/skills/` changes → agent skill pipelines
+
+### Step 2 — Three-question docs-sync check
+
+For each changed area, answer three questions:
+
+**Q1 — Does this change introduce or modify behavior, interfaces, or
+architecture described in `docs/`?**
+
+Scan `docs/` for pages covering the changed area:
+
+- `docs/topics/` — protocol behavior descriptions
+- `docs/reference/` — API and data model reference
+- `docs/developer/` — developer guides and architecture
+- `docs/explanation/` — conceptual explanations
+- `docs/how-to/` — procedural how-to guides
+
+If no relevant `docs/` page exists and none is needed, answer "no" and
+move to the next area.
+
+**Q2 — What specific `docs/` pages need to be created or updated?**
+
+List each page with a short description of what needs to change (add a
+section, update a code example, new page covering X, etc.).
+
+**Q3 — Small or large update?**
+
+Apply the heuristic:
+
+| Required update | Disposition |
+|---|---|
+| Edit to one or more existing pages | **Small** — do now |
+| Add a single new page | **Small** — do now |
+| Rewrite a single existing page | **Small** — do now |
+| Simultaneously rewrite multiple pages completely | **Large** — file Concern |
+
+When in doubt, lean toward **Small** and do it now. The Concern path is for
+genuine multi-page rewrites that would bloat the PR beyond its original scope.
+
+### Step 3 — Apply small updates
+
+For each small update:
+
+1. Write the change to the target `docs/` file.
+2. Invoke `build-docs` to validate the build passes:
+
+   ```bash
+   uv run mkdocs build --strict 2>&1 | tail -20
+   ```
+
+3. Fix any linting or build errors before proceeding.
+
+### Step 4 — File Concern for large updates
+
+For each large update (multi-page rewrite needed), file a `type:Concern`
+issue citing PD-03-007:
+
+```bash
+CONCERN_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Concern)
+ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
+  --title "docs: update <area> pages after <change>" \
+  --body "$(cat <<'EOF'
+## Context
+
+<Describe what implementation change requires the docs update.>
+
+## Required docs updates
+
+<List each page that needs updating with a description of what to change.>
+
+## Source
+
+PD-03-007: When an implementation or bug-fix PR changes behavior, interfaces,
+or architecture described in `docs/`, the PR MUST include the corresponding
+`docs/` updates or a linked follow-up `type:Concern` issue. A deferred Concern
+is acceptable only when the required update would simultaneously rewrite
+multiple `docs/` pages.
+
+Deferred from PR: <PR_URL — fill in after PR opens>
+EOF
+)"
+  --issue-type-id "${CONCERN_TYPE_ID}" \
+  --label "size:M")
+bash .agents/skills/shared/add-to-project.sh "${ISSUE_NUMBER}"
+```
+
+Record the Concern issue number for inclusion in the PR description:
+`Docs deferred: #<N>` (add to the PR body before it opens).
+
+### Step 5 — Report
+
+Return a summary of what was done:
+
+- List each `docs/` page updated inline (file path + short description)
+- List each Concern issue filed for large updates (issue number + title)
+- If no `docs/` updates were needed, state that explicitly
+
+## Constraints
+
+- Only update `docs/` — do not modify code, tests, or `specs/`.
+- Always invoke `build-docs` after each inline `docs/` update; do not skip.
+- Small updates MUST be applied in the same PR, not deferred (PD-03-007).
+- File a Concern issue for every large update; never silently skip.
+- Cite PD-03-007 in every Concern issue body.

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -353,11 +353,7 @@ Do **not** reference `plan/incoming/learnings/` from durable docs.
    Fix all errors.
 2. If a requirement conflict cannot be resolved, create a learning file in
    `plan/incoming/learnings/` and **stop before committing**.
-3. Invoke `check-docs-sync` to confirm all `docs/` updates have been applied
-   (PD-03-008). Because `learn` already handles `docs/` inline in Phase 5,
-   this is a consistency check — if the skill identifies additional pages,
-   apply them before committing.
-4. Stage and commit (branch was created at the end of Phase 3):
+3. Stage and commit (branch was created at the end of Phase 3):
 
    ```bash
    git add specs/<changed-files> notes/<changed-files> AGENTS.md \
@@ -382,6 +378,12 @@ Do **not** reference `plan/incoming/learnings/` from durable docs.
    `create-pr` performs the rebase on `origin/main`, runs linters, pushes, and
    returns the PR URL. Use the returned URL when filling in the `Docs PR:`
    field in the archive bodies (Phase 9).
+
+4. Invoke `check-docs-sync` while CI runs in the cloud to confirm all `docs/`
+   updates have been applied (PD-03-008). Because `learn` already handles
+   `docs/` inline in Phase 5, this is a consistency check — if the skill
+   identifies additional pages, apply them and push an additional commit before
+   Phase 9.
 
 ### Phase 9 — Archive Entries and Close Issues
 

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -353,7 +353,11 @@ Do **not** reference `plan/incoming/learnings/` from durable docs.
    Fix all errors.
 2. If a requirement conflict cannot be resolved, create a learning file in
    `plan/incoming/learnings/` and **stop before committing**.
-3. Stage and commit (branch was created at the end of Phase 3):
+3. Invoke `check-docs-sync` to confirm all `docs/` updates have been applied
+   (PD-03-008). Because `learn` already handles `docs/` inline in Phase 5,
+   this is a consistency check — if the skill identifies additional pages,
+   apply them before committing.
+4. Stage and commit (branch was created at the end of Phase 3):
 
    ```bash
    git add specs/<changed-files> notes/<changed-files> AGENTS.md \

--- a/plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2780.md
+++ b/plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2780.md
@@ -1,0 +1,33 @@
+---
+title: 2 pre-existing bugs surfaced by code review on PR for #2780
+type: learning
+timestamp: 2026-08-27
+source: ISSUE-2780
+signal: concern
+---
+
+Code review of the docs/skill-only PR for #2780 surfaced 2 bugs in files
+outside the PR diff. Neither was introduced by this PR. Tracking for filing.
+
+1. **`vultron/core/behaviors/sync/nodes/invite_accept_effect.py:105`** —
+   `except (ValueError, KeyError)` does not catch `TypeError`. If `raw_roles`
+   (derived from wire JSON) is a non-iterable (e.g., an integer in a malformed
+   message), `validate_roles(raw_roles)` raises `TypeError`, which propagates
+   uncaught out of `update()`, aborting the entire `AnnounceLogEntryReceivedBT`
+   sequence. The log entry is permanently skipped.
+
+2. **`vultron/core/behaviors/case/accept_invite_tree.py:387`** —
+   `_read_invite_roles` returns `[]` silently when `object_` is `None` or the
+   Invite's `roles` field is absent. Per the `datalayer-fallback-is-a-smell.md`
+   learning, a missing roles field is a protocol violation and SHOULD be logged
+   as such. No `WARNING` is emitted, so operators cannot distinguish
+   "roles gracefully absent" from "roles extraction quietly failed."
+
+Already tracked (not re-filed):
+
+- `sync.py:234` auth_entries empty guard → `20260827-pre-existing-bugs-from-code-review-2757.md`
+- `test/ci/invariants/common.py:941` partial ordering gap → Bug #2764
+- `vultron/core/behaviors/case/nodes/participant/common.py:357` misleading warning → Bug #2763
+- `vultron/core/behaviors/status/nodes/cs_dimension_filter.py:211` in-place mutation → Bug #2706
+- `vultron/core/use_cases/received/case_proposal.py:255` new VultronValidationError path → tracked
+- `vultron/core/use_cases/triggers/actor.py:224` backend.update() without setup() → tracked

--- a/specs/project-documentation.yaml
+++ b/specs/project-documentation.yaml
@@ -88,11 +88,13 @@ groups:
     priority: SHOULD
     kind: project
     statement: >-
-      Agents SHOULD invoke the `check-docs-sync` skill after implementation is complete and validated
-      but before the PR opens, to identify and apply any required `docs/` updates in the same PR.
+      Agents SHOULD invoke the `check-docs-sync` skill after the PR is pushed (while CI runs in the
+      cloud), before the finalize steps (archive-history, learnings), to identify and apply any
+      required `docs/` updates in the same PR.
     rationale: >-
-      The `check-docs-sync` skill embeds the docs-sync check in `build`, `bugfix`, and `learn` as a
-      reusable shared phase. Source: CONCERN-2513.
+      Running docs-sync after pushing lets CI and docs work proceed in parallel, reducing total
+      wall-clock time. The `check-docs-sync` skill is embedded in `build`, `bugfix`, and `learn`.
+      Source: CONCERN-2513.
 - id: PD-04
   title: Documentation Build Validation
   specs:


### PR DESCRIPTION
- Closes #2780

## Summary

Creates the `check-docs-sync` reusable skill and wires it into the `build`,
`bugfix`, and `learn` skill pipelines so that docs/ drift is caught at
implementation time rather than deferred indefinitely (PD-03-007, PD-03-008).

### New skill: `check-docs-sync`

`.agents/skills/check-docs-sync/SKILL.md` implements a three-question
docs-sync check:

1. Does this change touch behavior/interfaces/architecture described in `docs/`?
2. What specific `docs/` pages need creating or updating?
3. Small (single page edit/add/rewrite) or large (multi-page rewrite)?

The small/large heuristic mirrors learn Phase 5's Promote disposition:

| Update type | Disposition |
|---|---|
| Edit one or more existing pages | Small — do now |
| Add a single new page | Small — do now |
| Rewrite a single existing page | Small — do now |
| Simultaneously rewrite multiple pages | Large — file Concern |

Small updates are applied inline; large updates produce a `type:Concern`
issue citing PD-03-007. `build-docs` is invoked after every inline update.

### Pipeline wiring

- **`build/SKILL.md`**: check-docs-sync moved to Phase 8 (after PR push,
  while CI runs); phases renumbered: Phase 7 = Pre-PR Code Review,
  Phase 8 = Open PR and Finalize (with check-docs-sync after create-pr).
- **`bugfix/SKILL.md`**: `check-docs-sync` added after `create-pr` in Phase 4
  "Finalize" (while CI runs in the cloud).
- **`learn/SKILL.md`**: `check-docs-sync` added as step 4 of Phase 8 after
  `create-pr`, as a consistency check on top of Phase 5's inline docs translation.

## Changes

- **`.agents/skills/check-docs-sync/SKILL.md`**: new skill implementing
  the three-question docs-sync check with the small/large heuristic,
  markdownlint + `build-docs` validation for inline updates, and Concern-issue
  filing via `new-item` for large multi-page rewrites. References PD-03-007 as
  normative requirement. Timing updated to after PR push (while CI runs).
- **`.agents/skills/build/SKILL.md`**: Phase 7 "Docs Sync Check" removed;
  Phase 7 = Pre-PR Code Review; Phase 8 "Open PR and Finalize" gains
  check-docs-sync step after create-pr. Fix `${CURRENT_TASK_NUMBER}` →
  `${ISSUE_NUMBER}` in Phase 6 pre-existing-failure guidance.
- **`.agents/skills/bugfix/SKILL.md`**: `check-docs-sync` moved to after
  `create-pr` in Phase 4 "Finalize". Adds calve-epics routing in Phase 1
  for sub-issue creation. Updates PARENT_ARG in REFERENCE.md.
- **`.agents/skills/learn/SKILL.md`**: `check-docs-sync` moved to step 4
  of Phase 8 after `create-pr`.
- **`.agents/skills/bugfix/REFERENCE.md`**: adds `PARENT_ARG="--parent
  ${ISSUE_NUMBER}"` for the Escalation pattern.
- **`.agents/skills/calve-epics/SKILL.md`**: Mode 1 zero-match behavior
  updated — when invoked by a skill requiring a parent, report no match back
  to caller instead of leaving issue at root.
- **`.agents/skills/deepen-context/SKILL.md`**: restructures
  compose-before-create section to be general (not BT-specific).
- **`specs/project-documentation.yaml`**: PD-03-008 updated to reflect
  after-push timing.
- **`plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2780.md`**:
  records 2 pre-existing bugs found during code review (now filed as #2801, #2802).

## Verification

- markdownlint-cli2 passes on all modified skill files
- No Python files changed; linters (black, flake8, mypy, pyright) clean