### PR TITLE
docs: plan issue #2526 — identify notes/ content for public Explanation pages

### DIFF
--- a/plan/history/2608/idea/IDEA-2526.md
+++ b/plan/history/2608/idea/IDEA-2526.md
@@ -1,0 +1,42 @@
+---
+source: IDEA-2526
+timestamp: '2026-08-28T13:37:39.629918+00:00'
+title: Identify notes/ content to promote to public Explanation pages
+type: idea
+---
+
+## Summary
+
+Review the \`notes/\` directory for active documentation that explains design concepts, protocol semantics, or implementation patterns that belong in the public-facing Explanation quadrant of the docs site.
+
+## Motivation
+
+\`notes/\` contains rich, active internal documentation written for contributors — much of it explaining protocol design concepts that users and external implementers would benefit from. Examples:
+
+- \`notes/activitystreams-semantics.md\` — activities as state-change notifications, not commands; inbound/outbound semantics; Accept/Reject rules
+- \`notes/activity-factories.md\` — factory design rules and inventory for outbound activities
+- \`notes/actor-knowledge-model.md\` — how actors model their knowledge of other participants
+- \`notes/bt-integration.md\` — how behavior trees relate to protocol logic
+
+These concepts are either absent from the public docs or only touched on obliquely. The Explanation quadrant (diataxis: understanding-oriented) is the right home for this content.
+
+## Scope
+
+1. Review all \`status: active\` notes files in \`notes/\`
+2. For each, determine: (a) already covered in docs, (b) should be promoted as a new Explanation page, (c) contributor-only / too implementation-specific for public docs
+3. Create follow-on issues under this epic for each "should be promoted" decision
+
+This is a scoping and triage issue; the actual writing work goes in follow-on issues.
+
+## Acceptance Criteria
+
+- [ ] All \`status: active\` notes files reviewed
+- [ ] Triage decision documented (promote / skip / already covered) for each
+- [ ] Follow-on issues created for each approved promotion candidate
+
+## References
+
+- Epic: #607
+- Related: \`docs/topics/\` (Explanation quadrant); \`notes/documentation-strategy.md\`
+
+**Processed**: 2026-08-28 — implementation tracked in #2792, #2793, #2794, #2795, #2796, #2797, #2798, #2799.


### PR DESCRIPTION
- Closes #2526
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Triage of `notes/` for content promotable to the public Explanation quadrant (`docs/topics/`). Identifies 12 strong candidates + 4 borderlines, grouped into 8 topic clusters, each tracked as a follow-on Idea issue (#2792–#2799).

## Changes

- **`plan/history/2608/idea/IDEA-2526.md`**: History entry recording triage result and follow-on issues

## Implementation Issues

- #2792
- #2793
- #2794
- #2795
- #2796
- #2797
- #2798
- #2799