### PR TITLE
fix(polling): propagate construction errors from wait_for_initialized_case

### DIFF
--- a/test/demo/test_milestones_replica_polling.py
+++ b/test/demo/test_milestones_replica_polling.py
@@ -592,3 +592,33 @@ class TestWaitForInitializedCase:
                     timeout_seconds=0.1,
                     poll_interval=0.5,
                 )
+
+    def test_timeout_message_reveals_construction_error(self):
+        """Bug #2769: timeout message names the actual exception, not just a generic timeout.
+
+        When as_VulnerabilityCase(**case_raw) raises on every tick, the
+        AssertionError on timeout must include the exception type and message
+        so callers can diagnose schema breakage rather than chasing a slow poll.
+        """
+        client = _LateInitializedCaseClient(delay=0)
+        with (
+            patch(
+                "vultron.demo.utils.case_actor_id_for_report",
+                return_value=_IC_CASE_ACTOR_ID,
+            ),
+            patch(
+                "vultron.demo.helpers.polling.as_VulnerabilityCase",
+                side_effect=TypeError("simulated schema breakage"),
+            ),
+            pytest.raises(AssertionError) as exc_info,
+        ):
+            wait_for_initialized_case(
+                client=cast(DataLayerClient, client),
+                report_id=_IC_REPORT_ID,
+                timeout_seconds=0.1,
+                poll_interval=0.5,
+            )
+        assert "simulated schema breakage" in str(exc_info.value), (
+            "timeout message must include the actual TypeError, "
+            f"got: {exc_info.value}"
+        )

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -1349,26 +1349,20 @@ def wait_for_initialized_case(
     found: list[as_VulnerabilityCase] = []
 
     def _check() -> bool:
-        try:
-            cases_by_id: dict = client.get(
-                client.dl_path("VulnerabilityCases/", actor_id=case_actor_id)
-            )
-            for case_raw in cases_by_id.values():
-                try:
-                    case = as_VulnerabilityCase(**case_raw)
-                    if case.case_participants:
-                        found.append(case)
-                        logger.info(
-                            "Initialized VulnerabilityCase found in CaseActor"
-                            " store %s: %s",
-                            case_actor_id,
-                            case.id_,
-                        )
-                        return True
-                except Exception:  # noqa: BLE001
-                    continue
-        except Exception:  # noqa: BLE001
-            pass
+        cases_by_id: dict = client.get(
+            client.dl_path("VulnerabilityCases/", actor_id=case_actor_id)
+        )
+        for case_raw in cases_by_id.values():
+            case = as_VulnerabilityCase(**case_raw)
+            if case.case_participants:
+                found.append(case)
+                logger.info(
+                    "Initialized VulnerabilityCase found in CaseActor"
+                    " store %s: %s",
+                    case_actor_id,
+                    case.id_,
+                )
+                return True
         return False
 
     _poll_until(
@@ -1379,6 +1373,9 @@ def wait_for_initialized_case(
         f" store {case_actor_id!r} at {client.base_url}",
         swallow_exceptions=True,
     )
+    assert (
+        found
+    ), "invariant: _poll_until returns only when _check returned True"
     return found[0]
 
 


### PR DESCRIPTION
- Closes #2769

## Summary

`wait_for_initialized_case._check()` had two nested `except Exception` handlers
that silently swallowed `as_VulnerabilityCase(**case_raw)` construction failures,
causing `_poll_until` to time out with a bare message and no trace of the real
`ValidationError` or `TypeError`.

## Changes

- **`vultron/demo/helpers/polling.py`**: Remove both exception handlers from
  `_check()` so all failures propagate to `_poll_until` (which already handles
  them via `swallow_exceptions=True`). On timeout, the last captured exception
  is now named in the `AssertionError` message. Add `assert found` before
  `found[0]` to make the loop invariant explicit.
- **`test/demo/test_milestones_replica_polling.py`**: Add regression test
  `test_timeout_message_reveals_construction_error` — patches
  `as_VulnerabilityCase` to always raise `TypeError` and asserts the timeout
  message includes the exception detail.

## Verification

- 7824 unit tests pass (1 new); 15 xfails as expected
- Black, flake8, mypy, pyright all clean