### PR TITLE
refactor(status): remove superseded all-or-nothing CS/RM validator nodes

### DIFF
--- a/docs/adr/0061-per-dimension-partial-accept.md
+++ b/docs/adr/0061-per-dimension-partial-accept.md
@@ -115,9 +115,10 @@ Actor re-adjudicating, not a regression, and are applied unchanged.
   is process-global and not cleared between executions. Both keys are therefore
   written on every tick (with `None` when inapplicable) and matched by object ID
   on read. This is a real hazard, not a hypothetical one.
-- Neutral, because `CheckParticipantRMNotClosedNode` remains in the codebase,
-  marked deprecated with a pointer to its replacement, rather than being
-  removed.
+- Neutral, because `CheckParticipantRMNotClosedNode` was removed (along with
+  `ValidateCaseStatusTransitionNode`, its CaseStatus counterpart) per the
+  project's no-backwards-compat-shims policy. Both nodes are superseded by
+  their respective per-dimension filter replacements.
 
 ## Validation
 

--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -180,7 +180,7 @@ Some ECA rules are not just "do A when B" but "do A *before* B." These use
   when the CS PXA state is pXa or pXA (exploit public without public awareness),
   the next CS event MUST be P. This is normatively specified but **not yet
   enforced in BT paths** — `cs_invariants.required_next_cs_events()` is not
-  called from `ValidateCaseStatusTransitionNode`. See #2524.
+  wired into any receive path. See #2524.
 - **CS history validity** (CSB-17-004, CSB-17-005): complete CS histories must
   be one of 70 valid histories; incomplete histories must be valid prefixes.
   Normatively specified but **not yet enforced** — `cs_invariants.is_valid_cs_history()`

--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -79,7 +79,7 @@ AddParticipantStatusBT (Sequence)
 ### Per-dimension partial accept (RSH-05, ADR-0061)
 
 `FilterParticipantStatusDimensionsNode` replaced the former
-`CheckParticipantRMNotClosedNode` guard. The old guard — and
+`CheckParticipantRMNotClosedNode` guard (now removed). The old guard — and
 `ValidateRMTransitionNode` inside the append subtree — refused a whole
 `ParticipantStatus` snapshot when its `rm` dimension was unacceptable, which
 discarded the accepted `vfd`/`pxa` values *and* aborted this Sequence before
@@ -217,8 +217,8 @@ AddCaseStatusToCaseBT (Sequence)
 └─ ThreatTerminationBranchNode          ← fires teardown on CS.P, CS.X, CS.A
 ```
 
-`ValidateCaseStatusTransitionNode` (the former all-or-nothing guard) is
-retained in the module and tested but is no longer wired into this tree.
+`ValidateCaseStatusTransitionNode` (the former all-or-nothing guard) has been
+removed; per-dimension filter nodes are its replacement.
 
 ### Three-node design
 

--- a/plan/history/2608/note/CONCERN-2700.md
+++ b/plan/history/2608/note/CONCERN-2700.md
@@ -1,0 +1,11 @@
+---
+source: CONCERN-2700
+timestamp: '2026-08-28T14:24:40.515224+00:00'
+title: case_status.py dl.save(case_status) called before add_dimension — dimension
+  may not be persisted
+type: note
+---
+
+Closed as stale. The `add_dimension`-before-save ordering concern described here was eliminated by the ISSUE-2256 per-dimension filter refactor. Current `AppendCaseStatusToCaseNode.update()` save ordering is correct: save filtered status → add to case → save case. No code fix needed.
+
+Resolved by PR #2805 (<https://github.com/CERTCC/Vultron/pull/2805>), which removed the superseded `ValidateCaseStatusTransitionNode` and `CheckParticipantRMNotClosedNode` nodes entirely.

--- a/plan/history/2608/note/CONCERN-2739.md
+++ b/plan/history/2608/note/CONCERN-2739.md
@@ -1,0 +1,10 @@
+---
+source: CONCERN-2739
+timestamp: '2026-08-28T14:23:51.266552+00:00'
+title: save ordering in case_status.py — dimension may not be persisted
+type: note
+---
+
+Closed as duplicate of CONCERN-2700. Both concerns described the same stale `add_dimension`-before-save ordering issue in `case_status.py`. The pattern they flagged was eliminated by the ISSUE-2256 per-dimension filter refactor; no separate code fix was needed.
+
+Resolved by PR #2805 (<https://github.com/CERTCC/Vultron/pull/2805>), which removed the superseded `ValidateCaseStatusTransitionNode` and `CheckParticipantRMNotClosedNode` nodes entirely.

--- a/plan/history/2608/note/CONCERN-2740.md
+++ b/plan/history/2608/note/CONCERN-2740.md
@@ -1,0 +1,10 @@
+---
+source: CONCERN-2740
+timestamp: '2026-08-28T14:25:28.256405+00:00'
+title: ValidateCaseStatusTransitionNode intentionally unwired but not removed
+type: note
+---
+
+`ValidateCaseStatusTransitionNode` was intentionally unwired from `add_case_status_tree` as part of ISSUE-2256's per-dimension filter refactor (RSH-05, ADR-0061). The per-dimension filter nodes (`FilterCsEmDimensionNode`, `FilterCsPxaDimensionNode`, `FinalizeCsFilterNode`) are the correct replacement. The node had been retained as a deprecated shim in the module but never re-wired.
+
+Resolved by PR #2805 (<https://github.com/CERTCC/Vultron/pull/2805>), which removed `ValidateCaseStatusTransitionNode` and its RM counterpart `CheckParticipantRMNotClosedNode` entirely per the project's no-backwards-compat-shims policy. ADR-0061 was revised in-place to replace the "Neutral, because CheckParticipantRMNotClosedNode remains deprecated..." bullet with a statement that both nodes were removed.

--- a/specs/received-status-handling.yaml
+++ b/specs/received-status-handling.yaml
@@ -304,9 +304,9 @@ groups:
     note: >
       Implemented by `FilterParticipantStatusDimensionsNode` in
       `vultron/core/behaviors/status/nodes/dimension_filter.py`, wired as a
-      precondition guard of `add_participant_status_tree`. It supersedes
-      `CheckParticipantRMNotClosedNode`, whose all-or-nothing RM refusal was
-      the defect reported in ISSUE-2235.
+      precondition guard of `add_participant_status_tree`. It supersedes and
+      replaced `CheckParticipantRMNotClosedNode` (now removed), whose
+      all-or-nothing RM refusal was the defect reported in ISSUE-2235.
     stories:
     - story_2022_045
     - story_2022_088

--- a/test/architecture/test_receive_side_bt_commit_ordering.py
+++ b/test/architecture/test_receive_side_bt_commit_ordering.py
@@ -100,9 +100,7 @@ def test_no_direct_calls_to_guarded_commit_outside_lifecycle() -> None:
 #: ``precondition_guards``, never in ``effect_nodes``.
 REJECTION_VALIDATORS = {
     "ValidateRMTransitionNode",
-    "ValidateCaseStatusTransitionNode",
     "CheckCaseStatusIdempotencyNode",
-    "CheckParticipantRMNotClosedNode",
     "FinalizeCsFilterNode",
 }
 

--- a/test/core/behaviors/status/nodes/append/test_conditions.py
+++ b/test/core/behaviors/status/nodes/append/test_conditions.py
@@ -31,7 +31,6 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.status.nodes.append import (
-    CheckParticipantRMNotClosedNode,
     CheckStatusNotAlreadyAppendedNode,
     LoadParticipantNode,
     ResolveAndPersistStatusObjectNode,
@@ -339,70 +338,3 @@ class TestValidateRMTransitionNode:
         assert (
             anomaly is None
         ), f"Expected no anomaly for adjacent transition, got {anomaly}"
-
-
-# ---------------------------------------------------------------------------
-# CheckParticipantRMNotClosedNode
-# ---------------------------------------------------------------------------
-
-
-class TestCheckParticipantRMNotClosedNode:
-    def test_open_participant_succeeds(self, populated_dl):
-        """Participant not in CLOSED state → SUCCESS."""
-        bridge = BTBridge(datalayer=populated_dl)
-        node = CheckParticipantRMNotClosedNode(participant_id=PARTICIPANT_ID)
-        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
-        assert result.status == Status.SUCCESS
-
-    def test_missing_participant_succeeds(self, bridge):
-        """Participant not found in DataLayer → SUCCESS (no terminal check)."""
-        node = CheckParticipantRMNotClosedNode(
-            participant_id="https://example.org/missing/participant"
-        )
-        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
-        assert result.status == Status.SUCCESS
-
-    @pytest.mark.spec("RSH-05-006")
-    def test_closed_participant_fails(self, populated_dl):
-        """Participant already in RM.CLOSED without prior status match → FAILURE."""
-        closed_status = as_ParticipantStatus(
-            id_="https://example.org/cases/case-01/statuses/c1",
-            context=CASE_ID,
-            rm_state=RM.CLOSED,
-        )
-        populated_dl.create(closed_status)
-        p = populated_dl.read(PARTICIPANT_ID)
-        p.participant_statuses.append(closed_status)
-        populated_dl.save(p)
-
-        bridge = BTBridge(datalayer=populated_dl)
-        node = CheckParticipantRMNotClosedNode(
-            participant_id=PARTICIPANT_ID, status_id=STATUS_ID
-        )
-        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
-        assert result.status == Status.FAILURE
-
-    def test_closed_participant_with_matching_status_succeeds(
-        self, populated_dl
-    ):
-        """Participant CLOSED but status already appended → SUCCESS (idempotent)."""
-        status = populated_dl.read(STATUS_ID)
-        closed_status = as_ParticipantStatus(
-            id_="https://example.org/cases/case-01/statuses/c1",
-            context=CASE_ID,
-            rm_state=RM.CLOSED,
-        )
-        populated_dl.create(closed_status)
-        p = populated_dl.read(PARTICIPANT_ID)
-        # STATUS_ID appended first, then CLOSED last — so participant_status
-        # (= participant_statuses[-1]) is CLOSED, but STATUS_ID is present.
-        p.participant_statuses.append(status)
-        p.participant_statuses.append(closed_status)
-        populated_dl.save(p)
-
-        bridge = BTBridge(datalayer=populated_dl)
-        node = CheckParticipantRMNotClosedNode(
-            participant_id=PARTICIPANT_ID, status_id=STATUS_ID
-        )
-        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
-        assert result.status == Status.SUCCESS

--- a/test/core/behaviors/status/nodes/test_case_status.py
+++ b/test/core/behaviors/status/nodes/test_case_status.py
@@ -16,10 +16,9 @@
 """Unit tests for case status workflow nodes (submodule path).
 
 Verifies CASE_STATUS_ALREADY_PRESENT, CheckCaseStatusIdempotencyNode,
-ValidateCaseStatusTransitionNode, and AppendCaseStatusToCaseNode imported
-directly from the submodule.
+and AppendCaseStatusToCaseNode imported directly from the submodule.
 
-Per issue #758 AC-1, AC-2, AC-3.
+Per issue #758 AC-1, AC-3.
 """
 
 import pytest
@@ -32,10 +31,7 @@ from vultron.core.behaviors.status.nodes.case_status import (
     CASE_STATUS_ALREADY_PRESENT,
     AppendCaseStatusToCaseNode,
     CheckCaseStatusIdempotencyNode,
-    ValidateCaseStatusTransitionNode,
 )
-from vultron.core.models.case import VulnerabilityCase
-from vultron.core.states.em import EM
 from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
@@ -131,106 +127,6 @@ class TestCheckCaseStatusIdempotencyNode:
         )
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
         assert result.status == Status.FAILURE
-
-
-# ---------------------------------------------------------------------------
-# ValidateCaseStatusTransitionNode
-# ---------------------------------------------------------------------------
-
-
-class TestValidateCaseStatusTransitionNode:
-    def test_first_status_always_passes(self, populated_bridge, status_obj):
-        node = ValidateCaseStatusTransitionNode(
-            case_id=CASE_ID,
-            status_id=STATUS_ID,
-            status_obj_fallback=status_obj,
-        )
-        result = populated_bridge.execute_with_setup(
-            tree=node, actor_id=ACTOR_ID
-        )
-        assert result.status == Status.SUCCESS
-
-    def test_valid_em_transition_passes(self, populated_bridge):
-        # Default case has a as_CaseStatus with em_state=EM.NONE;
-        # NONE → PROPOSED is a valid forward transition.
-        new_status = as_CaseStatus(
-            id_=STATUS2_ID, context=CASE_ID, em_state=EM.PROPOSED
-        )
-        populated_bridge.datalayer.save(new_status)
-
-        node = ValidateCaseStatusTransitionNode(
-            case_id=CASE_ID,
-            status_id=STATUS2_ID,
-            status_obj_fallback=new_status,
-        )
-        result = populated_bridge.execute_with_setup(
-            tree=node, actor_id=ACTOR_ID
-        )
-        assert result.status == Status.SUCCESS
-
-    def test_invalid_em_transition_fails(self, populated_bridge):
-        # Default case has a as_CaseStatus with em_state=EM.NONE;
-        # NONE → ACTIVE is invalid (skips PROPOSED).
-        new_status = as_CaseStatus(
-            id_=STATUS2_ID, context=CASE_ID, em_state=EM.ACTIVE
-        )
-        populated_bridge.datalayer.save(new_status)
-
-        node = ValidateCaseStatusTransitionNode(
-            case_id=CASE_ID,
-            status_id=STATUS2_ID,
-            status_obj_fallback=new_status,
-        )
-        result = populated_bridge.execute_with_setup(
-            tree=node, actor_id=ACTOR_ID
-        )
-        assert result.status == Status.FAILURE
-
-    def test_no_current_status_allows_any_transition(self):
-        """SUCCESS when case.current_status raises ValueError (no materialized status).
-
-        AC-2: first-status-ever escape hatch — when current_status raises
-        ValueError the node must return SUCCESS rather than crash or FAILURE.
-        This tests the try/except ValueError branch introduced to fix the
-        latent getattr(case, "current_status", None) bug (getattr does not
-        suppress ValueError from property getters).
-        """
-        from unittest.mock import MagicMock, PropertyMock
-
-        from vultron.core.behaviors.status.nodes.case_status import (
-            ValidateCaseStatusTransitionNode,
-        )
-
-        new_status = as_CaseStatus(
-            id_=STATUS2_ID,
-            context=CASE_ID,
-            em_state=EM.ACTIVE,
-        )
-
-        # Use spec=VulnerabilityCase so isinstance() passes, but override current_status to raise.
-        mock_case = MagicMock(spec=VulnerabilityCase)
-        mock_case.case_participants = []
-        mock_case.case_statuses = []
-        type(mock_case).current_status = PropertyMock(
-            side_effect=ValueError("no materialized CaseStatus")
-        )
-
-        mock_dl = MagicMock()
-        mock_dl.read.side_effect = lambda obj_id, **_: (
-            mock_case if obj_id == CASE_ID else new_status
-        )
-
-        node = ValidateCaseStatusTransitionNode(
-            case_id=CASE_ID,
-            status_id=STATUS2_ID,
-            status_obj_fallback=new_status,
-        )
-        # Inject mock datalayer directly on the instance.
-        node.datalayer = mock_dl
-
-        result = node.update()
-
-        assert result == Status.SUCCESS
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/status/test_add_case_status_bt.py
+++ b/test/core/behaviors/status/test_add_case_status_bt.py
@@ -15,14 +15,13 @@
 
 """Tests for AddCaseStatus BT nodes and tree factory.
 
-Covers all three steps of the AddCaseStatusToCaseBT sequence:
+Covers steps of the AddCaseStatusToCaseBT sequence:
   1. CheckCaseStatusIdempotencyNode  — duplicate skipped, new status passes
-  2. ValidateCaseStatusTransitionNode — invalid EM/PXA rejected, valid passes
-  3. AppendCaseStatusToCaseNode      — status appended and persisted
+  2. AppendCaseStatusToCaseNode      — status appended and persisted
 
 Also covers the full tree factory and use-case-level integration.
 
-Per issue #758 AC-1, AC-2, AC-3.
+Per issue #758 AC-1, AC-3.
 """
 
 from typing import cast
@@ -44,7 +43,6 @@ from vultron.core.behaviors.status.nodes import (
     CASE_STATUS_ALREADY_PRESENT,
     AppendCaseStatusToCaseNode,
     CheckCaseStatusIdempotencyNode,
-    ValidateCaseStatusTransitionNode,
 )
 from vultron.core.behaviors.status.nodes.lifecycle import (
     ThreatTerminationBranchNode,
@@ -161,106 +159,6 @@ class TestCheckCaseStatusIdempotencyNode:
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
         assert result.status == Status.FAILURE
         assert node.feedback_message != CASE_STATUS_ALREADY_PRESENT
-
-
-# ---------------------------------------------------------------------------
-# ValidateCaseStatusTransitionNode
-# ---------------------------------------------------------------------------
-
-
-class TestValidateCaseStatusTransitionNode:
-    def test_first_status_always_valid(self, populated_bridge):
-        """No current_status → transition always allowed (first status)."""
-        node = ValidateCaseStatusTransitionNode(
-            case_id=CASE_ID,
-            status_id=STATUS_ID,
-            status_obj_fallback=None,
-        )
-        result = populated_bridge.execute_with_setup(
-            tree=node, actor_id=ACTOR_ID
-        )
-        assert result.status == Status.SUCCESS
-
-    def test_valid_em_transition_succeeds(self, dl):
-        """NONE → PROPOSED is a valid EM transition → SUCCESS."""
-        case = as_VulnerabilityCase(id_=CASE_ID, name="EM Valid")
-        initial = as_CaseStatus(
-            id_=f"{CASE_ID}/statuses/init",
-            context=CASE_ID,
-            em_state=EM.NONE,
-        )
-        case.case_statuses.append(initial)
-        dl.create(case)
-
-        good_status = as_CaseStatus(
-            id_=STATUS_ID, context=CASE_ID, em_state=EM.PROPOSED
-        )
-        dl.create(good_status)
-
-        bridge = BTBridge(datalayer=dl)
-        node = ValidateCaseStatusTransitionNode(
-            case_id=CASE_ID,
-            status_id=STATUS_ID,
-            status_obj_fallback=good_status,
-        )
-        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
-        assert result.status == Status.SUCCESS
-
-    def test_invalid_em_transition_fails(self, dl):
-        """NONE → ACTIVE skips PROPOSED — invalid EM transition → FAILURE."""
-        case = as_VulnerabilityCase(id_=CASE_ID, name="EM Invalid")
-        initial = as_CaseStatus(
-            id_=f"{CASE_ID}/statuses/init",
-            context=CASE_ID,
-            em_state=EM.NONE,
-        )
-        case.case_statuses.append(initial)
-        dl.create(case)
-
-        bad_status = as_CaseStatus(
-            id_=STATUS_ID, context=CASE_ID, em_state=EM.ACTIVE
-        )
-        dl.create(bad_status)
-
-        bridge = BTBridge(datalayer=dl)
-        node = ValidateCaseStatusTransitionNode(
-            case_id=CASE_ID,
-            status_id=STATUS_ID,
-            status_obj_fallback=bad_status,
-        )
-        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
-        assert result.status == Status.FAILURE
-
-    def test_invalid_pxa_transition_fails(self, dl):
-        """pxa → PXA skips intermediate steps — invalid PXA transition → FAILURE."""
-        # The default seed as_CaseStatus already has pxa_state=CS_pxa.pxa.
-        # A direct jump from pxa to PXA (all bits set at once) is invalid.
-        case = as_VulnerabilityCase(id_=CASE_ID, name="PXA Invalid")
-        dl.create(case)
-
-        bad_status = as_CaseStatus(
-            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.PXA
-        )
-        dl.create(bad_status)
-
-        bridge = BTBridge(datalayer=dl)
-        node = ValidateCaseStatusTransitionNode(
-            case_id=CASE_ID,
-            status_id=STATUS_ID,
-            status_obj_fallback=bad_status,
-        )
-        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
-        assert result.status == Status.FAILURE
-
-    def test_case_not_found_fails(self, bridge):
-        """Case not in DataLayer → FAILURE."""
-        node = ValidateCaseStatusTransitionNode(
-            case_id="https://example.org/cases/nonexistent",
-            status_id=STATUS_ID,
-            status_obj_fallback=None,
-        )
-        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
-        assert result.status == Status.FAILURE
 
 
 # ---------------------------------------------------------------------------
@@ -395,10 +293,10 @@ class TestAddCaseStatusTree:
     ):
         """EM advances (NONE→PROPOSED) with stale PXA regression → BT SUCCEEDS.
 
-        Bug #2256: ValidateCaseStatusTransitionNode returned FAILURE when PXA
-        regressed, discarding the valid EM advance and aborting the Sequence
-        before ThreatTerminationBranchNode.  Per-dimension adjudication must
-        accept the EM advance and carry the current PXA forward.
+        Bug #2256: all-or-nothing CS validation discarded the valid EM advance
+        when PXA regressed and aborted the Sequence before
+        ThreatTerminationBranchNode.  Per-dimension adjudication must accept
+        the EM advance and carry the current PXA forward.
         """
         case = as_VulnerabilityCase(id_=CASE_ID, name="EM PXA Split")
         # The case auto-seeds an initial CaseStatus (pxa=pxa by default).
@@ -848,8 +746,7 @@ class TestRegressionCSPTeardownPath:
     committed before broadcast in both paths).
 
     The new pipeline uses ThreatTerminationBranchNode directly (EmbargoTeardownAuthorizationGate).
-    ValidateCaseStatusTransitionNode is tested separately; this regression
-    focuses on teardown outcome parity.
+    This regression focuses on teardown outcome parity.
 
     AC #8 from issue #1844.
     """

--- a/vultron/core/behaviors/status/add_participant_status_tree.py
+++ b/vultron/core/behaviors/status/add_participant_status_tree.py
@@ -45,10 +45,10 @@ EmbargoTeardownAuthorizationGate; ``add_participant_status_tree`` does not execu
 ``FilterParticipantStatusDimensionsNode`` adjudicates ``rm``, ``vfd`` and
 ``pxa`` independently before the commit, so an unacceptable value in one
 dimension no longer discards the accepted dimensions or aborts the Sequence
-before the StatusAdoptionGate emit (RSH-05, ISSUE-2235).  It replaces the former
-``CheckParticipantRMNotClosedNode`` guard, subsuming the terminal-``RM.CLOSED``
-check: a wholly refused assertion still returns FAILURE here, before any
-canonical ledger entry is committed.
+before the StatusAdoptionGate emit (RSH-05, ISSUE-2235).  It replaced the
+former ``CheckParticipantRMNotClosedNode`` guard (now removed), subsuming the
+terminal-``RM.CLOSED`` check: a wholly refused assertion still returns FAILURE
+here, before any canonical ledger entry is committed.
 
 Per specs/multi-actor-demo.yaml DEMOMA-07-003, DEMOMA-07-005.
 Per specs/received-status-handling.yaml RSH-01-001 to RSH-01-004, RSH-05.

--- a/vultron/core/behaviors/status/nodes/__init__.py
+++ b/vultron/core/behaviors/status/nodes/__init__.py
@@ -31,21 +31,20 @@ Submodules:
   (SkipIfIdempotentNode, LoadParticipantNode,
   CheckStatusNotAlreadyAppendedNode, ResolveAndPersistStatusObjectNode,
   AppendStatusAndSaveParticipantNode)
-- ``rm_validation``: All-or-nothing RM guards for the append sequence
-  (ValidateRMTransitionNode, CheckParticipantRMNotClosedNode)
+- ``rm_validation``: RM transition guard for the append sequence
+  (ValidateRMTransitionNode)
 - ``lifecycle``: Public disclosure and auto-close emit lifecycle nodes
   (_PublicDisclosureSkipConditionNode, PublicDisclosureBranchNode,
   ThreatTerminationBranchNode, EmitAddCaseStatusToSelfNode, EmitCloseCaseNode)
 - ``rm_anomaly``: RM transition anomaly notification (EmitRMGapNoteNode)
-- ``case_status``: Idempotency guard, EM/PXA transition validation, and
-  append nodes for the AddCaseStatusToCase workflow
+- ``case_status``: Idempotency guard and append nodes for the
+  AddCaseStatusToCase workflow
 """
 
 from vultron.core.behaviors.status.nodes.case_status import (
     CASE_STATUS_ALREADY_PRESENT,
     AppendCaseStatusToCaseNode,
     CheckCaseStatusIdempotencyNode,
-    ValidateCaseStatusTransitionNode,
 )
 from vultron.core.behaviors.status.nodes.cs_dimension_filter import (
     BB_CASE_STATUS_DIM_FILTER,
@@ -70,7 +69,6 @@ from vultron.core.behaviors.status.nodes.append import (
     SkipIfIdempotentNode,
 )
 from vultron.core.behaviors.status.nodes.rm_validation import (
-    CheckParticipantRMNotClosedNode,
     ValidateRMTransitionNode,
 )
 from vultron.core.behaviors.status.nodes.lifecycle import (
@@ -99,7 +97,6 @@ __all__ = [
     "AppendStatusAndSaveParticipantNode",
     "SkipIfIdempotentNode",
     # rm_validation
-    "CheckParticipantRMNotClosedNode",
     "ValidateRMTransitionNode",
     # lifecycle
     "_PublicDisclosureSkipConditionNode",
@@ -115,6 +112,5 @@ __all__ = [
     "FilterCsEmDimensionNode",
     "FilterCsPxaDimensionNode",
     "FinalizeCsFilterNode",
-    "ValidateCaseStatusTransitionNode",
     "AppendCaseStatusToCaseNode",
 ]

--- a/vultron/core/behaviors/status/nodes/append/__init__.py
+++ b/vultron/core/behaviors/status/nodes/append/__init__.py
@@ -30,7 +30,6 @@ from vultron.core.behaviors.status.nodes.append.actions import (
     ResolveAndPersistStatusObjectNode,
 )
 from vultron.core.behaviors.status.nodes.append.conditions import (
-    CheckParticipantRMNotClosedNode,
     CheckStatusNotAlreadyAppendedNode,
     SkipIfIdempotentNode,
     ValidateRMTransitionNode,
@@ -41,7 +40,6 @@ __all__ = [
     "SkipIfIdempotentNode",
     "CheckStatusNotAlreadyAppendedNode",
     "ValidateRMTransitionNode",
-    "CheckParticipantRMNotClosedNode",
     # actions
     "LoadParticipantNode",
     "ResolveAndPersistStatusObjectNode",

--- a/vultron/core/behaviors/status/nodes/append/conditions.py
+++ b/vultron/core/behaviors/status/nodes/append/conditions.py
@@ -24,7 +24,7 @@ Contains the two idempotency-guard nodes used directly in the append sequence:
 
 RM-transition guards live in
 :mod:`vultron.core.behaviors.status.nodes.rm_validation` (BTND-07-004) and are
-re-exported here for backward-compatibility.
+re-exported here for convenience.
 """
 
 import logging
@@ -36,7 +36,6 @@ from py_trees.ports import BehaviourWithPorts, NoDataAvailable, PortInformation
 from vultron.core.behaviors.helpers import DataLayerConditionWithPorts
 from vultron.core.models._helpers import _as_id
 from vultron.core.behaviors.status.nodes.rm_validation import (
-    CheckParticipantRMNotClosedNode,
     ValidateRMTransitionNode,
 )
 
@@ -46,7 +45,6 @@ __all__ = [
     "SkipIfIdempotentNode",
     "CheckStatusNotAlreadyAppendedNode",
     "ValidateRMTransitionNode",
-    "CheckParticipantRMNotClosedNode",
 ]
 
 

--- a/vultron/core/behaviors/status/nodes/case_status.py
+++ b/vultron/core/behaviors/status/nodes/case_status.py
@@ -15,15 +15,14 @@
 
 """Case status workflow nodes for AddCaseStatusToCase.
 
-Contains the idempotency guard, all-or-nothing transition validator, and
-append node implementing the AddCaseStatusToCase BT sequence (issue #758).
+Contains the idempotency guard and append node implementing the
+AddCaseStatusToCase BT sequence (issue #758).
 
 Per-dimension adjudication nodes (RSH-05, ADR-0061, ISSUE-2256) live in
 :mod:`cs_dimension_filter` to keep this module under the 500-line limit.
 """
 
 import logging
-from typing import Any
 
 from py_trees.common import Status
 
@@ -40,8 +39,6 @@ from vultron.core.models._helpers import _as_id
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.protocols import PersistableModel
-from vultron.core.states.cs import is_valid_pxa_transition
-from vultron.core.states.em import is_valid_em_transition
 
 logger = logging.getLogger(__name__)
 
@@ -101,107 +98,6 @@ class CheckCaseStatusIdempotencyNode(
                 self.status_id,
                 self.case_id,
             )
-
-        return Status.SUCCESS
-
-
-class ValidateCaseStatusTransitionNode(DataLayerConditionWithPorts):
-    """AC-2: Validate that the new CaseStatus represents a legal state transition.
-
-    Uses ``case.current_status`` as the reference point.  When the case has no
-    current status (first status ever), the transition is unconditionally
-    allowed.  Otherwise both the EM state and PXA state transitions are
-    validated independently.
-
-    Returns SUCCESS when the transition is valid (or there is no prior status).
-    Returns FAILURE when an invalid EM or PXA transition is detected.
-
-    Per issue #758 AC-2.
-    """
-
-    def __init__(
-        self,
-        case_id: str,
-        status_id: str,
-        status_obj_fallback: PersistableModel | None,
-        name: str | None = None,
-    ):
-        super().__init__(name=name or self.__class__.__name__)
-        self.case_id = case_id
-        self.status_id = status_id
-        self.status_obj_fallback = status_obj_fallback
-
-    def _resolve_status(self) -> object | None:
-        assert self.datalayer is not None
-        status_obj = self.datalayer.read(self.status_id)
-        if hasattr(status_obj, "id_"):
-            return status_obj
-        return self.status_obj_fallback
-
-    def _check_transition(
-        self,
-        label: str,
-        current: object,
-        new: object,
-        validator: Any,
-    ) -> bool:
-        if new is None or current == new:
-            return True
-        if validator(current, new):
-            return True
-        self.feedback_message = (
-            f"Invalid {label} transition {current} → {new}"
-            f" for case '{self.case_id}'"
-        )
-        self.logger.warning(
-            "ValidateCaseStatusTransition: %s — rejecting",
-            self.feedback_message,
-        )
-        return False
-
-    def update(self) -> Status:
-        if (f := self._require_datalayer()) is not None:
-            return f
-        assert self.datalayer is not None
-
-        case = self.datalayer.read(self.case_id)
-        if not isinstance(case, VulnerabilityCase):
-            self.feedback_message = f"Case '{self.case_id}' not found"
-            self.logger.warning(
-                "ValidateCaseStatusTransition: %s", self.feedback_message
-            )
-            return Status.FAILURE
-
-        try:
-            current_status = case.current_status
-        except ValueError:
-            return Status.SUCCESS
-
-        status_obj = self._resolve_status()
-        if status_obj is None:
-            self.feedback_message = f"Status '{self.status_id}' not found"
-            self.logger.warning(
-                "ValidateCaseStatusTransition: %s", self.feedback_message
-            )
-            return Status.FAILURE
-
-        em_dim = getattr(status_obj, "em", None)
-        pxa_dim = getattr(status_obj, "pxa", None)
-        if not self._check_transition(
-            "EM",
-            current_status.em.state,
-            em_dim.state if em_dim is not None else None,
-            is_valid_em_transition,
-        ):
-            return Status.FAILURE
-
-        if not self._check_transition(
-            "PXA",
-            current_status.pxa.state,
-            pxa_dim.state if pxa_dim is not None else None,
-            is_valid_pxa_transition,
-        ):
-            return Status.FAILURE
 
         return Status.SUCCESS
 

--- a/vultron/core/behaviors/status/nodes/rm_validation.py
+++ b/vultron/core/behaviors/status/nodes/rm_validation.py
@@ -33,8 +33,6 @@ from vultron.core.behaviors.helpers import (
     read_rm_states,
 )
 from vultron.core.behaviors.status.nodes.dimension_filter import BB_RM_ANOMALY
-from vultron.core.models._helpers import _as_id
-from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.states.rm import (
     RM,
     is_monotonic_rm_forward,
@@ -199,95 +197,5 @@ class ValidateRMTransitionNode(DataLayerConditionWithPorts):
                 "from_rm": current_rm,
                 "to_rm": new_rm_state,
             },
-        )
-        return Status.FAILURE
-
-
-class CheckParticipantRMNotClosedNode(DataLayerConditionWithPorts):
-    """Pre-flight guard: FAILURE when participant is in RM.CLOSED with no prior
-    status match.
-
-    .. deprecated:: RSH-05
-
-        Superseded by
-        :class:`~vultron.core.behaviors.status.nodes.dimension_filter.FilterParticipantStatusDimensionsNode`,
-        which subsumes this terminal-``RM.CLOSED`` check and no longer discards
-        the other dimensions of the snapshot along with ``rm``.  Do not wire
-        this node back into ``add_participant_status_tree`` — an all-or-nothing
-        RM guard there is exactly the defect in ISSUE-2235.  Retained for
-        callers that want the narrow check in isolation.
-
-    Rejects CLOSED→CLOSED rewrites before the commit runs (CLP-10-006).
-
-    When ``status_id`` is supplied and the participant is CLOSED, returns
-    SUCCESS if ``status_id`` is already in ``participant.participant_statuses``
-    (idempotent delivery of a VALID→CLOSED update whose trigger side already
-    appended the status).  Returns FAILURE only for genuine CLOSED→CLOSED
-    rewrite attempts (status not yet in participant's list).
-
-    Returns SUCCESS when the participant has no current status, the current
-    RM state is not CLOSED, or the incoming status was already appended.
-    """
-
-    def __init__(
-        self,
-        participant_id: str,
-        status_id: str = "",
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self.participant_id = participant_id
-        self.status_id = status_id
-
-    def update(self) -> Status:
-        if (f := self._require_datalayer()) is not None:
-            return f
-        assert self.datalayer is not None
-
-        participant = self.datalayer.read(self.participant_id)
-        if not isinstance(participant, CaseParticipant):
-            self.logger.debug(
-                "%s: participant '%s' not found — allowing (no terminal check)",
-                self.name,
-                self.participant_id,
-            )
-            return Status.SUCCESS
-
-        current_status = getattr(participant, "participant_status", None)
-        if current_status is None:
-            return Status.SUCCESS
-
-        states = read_rm_states(self, current_status)
-        if states is None:
-            return Status.FAILURE
-        (current_rm,) = states
-        if current_rm != RM.CLOSED:
-            return Status.SUCCESS
-
-        # Participant is CLOSED. Allow if the incoming status was already
-        # appended by the trigger side (idempotent re-delivery of VALID→CLOSED).
-        if self.status_id:
-            existing_ids = [
-                _as_id(s)
-                for s in getattr(participant, "participant_statuses", [])
-            ]
-            if self.status_id in existing_ids:
-                self.logger.debug(
-                    "%s: participant '%s' is CLOSED but status '%s' already"
-                    " in participant_statuses — allowing idempotent commit",
-                    self.name,
-                    self.participant_id,
-                    self.status_id,
-                )
-                return Status.SUCCESS
-
-        self.feedback_message = (
-            f"Participant '{self.participant_id}' is already in terminal"
-            " RM.CLOSED — rejecting status update (DEMOMA-07-003)"
-        )
-        self.logger.info(
-            "%s: %s",
-            self.name,
-            self.feedback_message,
         )
         return Status.FAILURE


### PR DESCRIPTION
- Closes #2740

## Summary

Removes `ValidateCaseStatusTransitionNode` and `CheckParticipantRMNotClosedNode` entirely. Both nodes were superseded by the per-dimension filter nodes introduced in ISSUE-2256 (RSH-05, ADR-0061), had no remaining callers in any tree, and were retained only as deprecated shims — which conflicts with the project's no-backwards-compat-shims policy.

## Changes

- **`vultron/core/behaviors/status/nodes/case_status.py`**: Deleted `ValidateCaseStatusTransitionNode` class and its unused `Any`, `is_valid_em_transition`, `is_valid_pxa_transition` imports; updated module docstring.
- **`vultron/core/behaviors/status/nodes/rm_validation.py`**: Deleted `CheckParticipantRMNotClosedNode` class and its unused `_as_id`, `CaseParticipant` imports.
- **`vultron/core/behaviors/status/nodes/__init__.py`**: Removed both nodes from imports and `__all__`; updated submodule docstring entries.
- **`vultron/core/behaviors/status/nodes/append/__init__.py`** and **`conditions.py`**: Removed `CheckParticipantRMNotClosedNode` from imports and `__all__`; removed "backward-compatibility" shim language from docstring.
- **`test/architecture/test_receive_side_bt_commit_ordering.py`**: Removed both node names from `REJECTION_VALIDATORS` — they no longer exist to be mis-placed.
- **`test/core/behaviors/status/nodes/test_case_status.py`**: Removed `ValidateCaseStatusTransitionNode` import and its `TestValidateCaseStatusTransitionNode` test class.
- **`test/core/behaviors/status/test_add_case_status_bt.py`**: Removed `ValidateCaseStatusTransitionNode` import and `TestValidateCaseStatusTransitionNode` class; updated two comments that named the deleted node.
- **`test/core/behaviors/status/nodes/append/test_conditions.py`**: Removed `CheckParticipantRMNotClosedNode` import and `TestCheckParticipantRMNotClosedNode` test class.
- **`vultron/core/behaviors/status/add_participant_status_tree.py`**: Updated docstring to past tense for the removed node.
- **`docs/adr/0061-per-dimension-partial-accept.md`**: Revised the "Neutral" consequence bullet to reflect that both nodes were removed per the project policy rather than deprecated-and-retained.
- **`notes/behavioral-conformance-specs.md`**, **`notes/received-status-authorization.md`**: Updated references from present tense to reflect removal.
- **`specs/received-status-handling.yaml`**: Updated RSH-05-001 note to say `CheckParticipantRMNotClosedNode` was superseded and removed.

Also resolves stale concerns #2700 and #2739: the `add_dimension`-before-save ordering they described was eliminated when ISSUE-2256 introduced per-dimension filter nodes; no code fix was needed for those.

## Verification

- 7812 unit tests pass (183 in the directly-affected status and architecture suites)
- 1240 integration tests pass
- black, flake8, mypy, pyright all clean