### PR TITLE
feat: flip StatusAuthorizationCallOutBundle defaults to RequireCaseOwnerApproval

### DIFF
--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -71,7 +71,7 @@ AddParticipantStatusBT (Sequence)
 ├─ AppendParticipantStatusNode          ← records the accepted portion
 ├─ StatusAdoptionGate (Fallback)         ← NEW
 │   ├─ CheckIsCaseOwnerNode             ← hard bypass: CASE_OWNER = gospel
-│   └─ CaseOwnerApprovesStatusUpdate    ← Evaluator call-out (AlwaysSucceed)
+│   └─ CaseOwnerApprovesStatusUpdate    ← Evaluator call-out (RequireCaseOwnerApproval)
 ├─ EmitAddCaseStatusToSelfNode          ← NEW: triggers canonicalization
 └─ EmitRMGapNoteNode                    ← NEW: Add(Note,Case) on RM anomaly (RSH-06-004, ADR-0067)
 ```
@@ -213,7 +213,7 @@ AddCaseStatusToCaseBT (Sequence)
 ├─ FinalizeCsFilterNode                 ← FAILURE on whole-refusal; publishes filter
 ├─ GuardedCommitOrSkip                  ← canonical ledger commit (CLP-10-006)
 ├─ AppendCaseStatusToCaseNode           ← records accepted portion
-├─ EmbargoTeardownAuthorizationGate     ← call-out (AlwaysSucceed default)
+├─ EmbargoTeardownAuthorizationGate     ← call-out (RequireCaseOwnerApproval)
 └─ ThreatTerminationBranchNode          ← fires teardown on CS.P, CS.X, CS.A
 ```
 
@@ -265,16 +265,17 @@ in `_RECOGNIZED_OVERRIDE_PRODUCERS` per RSH-05-014.
 ```text
 AddCaseStatusToCaseBT (Sequence) — effect nodes only
 ├─ AppendCaseStatusToCaseNode           ← canonical write
-├─ EmbargoTeardownAuthorizationGate     ← Evaluator call-out (AlwaysSucceed default)
+├─ EmbargoTeardownAuthorizationGate     ← Evaluator call-out (RequireCaseOwnerApproval)
 └─ ThreatTerminationBranchNode          ← fires teardown on CS.P, CS.X, CS.A
 ```
 
 ### EmbargoTeardownAuthorizationGate
 
 An Evaluator call-out that gates the entire side-effects block. Default:
-`AlwaysSucceed`. A production implementation can replace this with a policy
-check (e.g., require CASE_OWNER confirmation before executing teardown even
-when the canonical write was authorized).
+`RequireCaseOwnerApproval` (conservative: blocks until Case Owner approves,
+RSH-07-002, ADR-0076). An implementation MAY configure a permissive backend
+(e.g., `AlwaysSucceed` via `STATUS_AUTHORIZATION_PERMISSIVE`) for trusted or
+demo deployments (RSH-07-003).
 
 Note: the self-addressed `Add(CaseStatus)` path arrives with the CaseActor as
 sender (CASE_MANAGER role). This means even when `EmbargoTeardownAuthorizationGate` requires

--- a/plan/incoming/learnings/20260828-status-auth-adapter-injection-design.md
+++ b/plan/incoming/learnings/20260828-status-auth-adapter-injection-design.md
@@ -1,0 +1,15 @@
+---
+title: "STATUS_AUTHORIZATION_PERMISSIVE injected via port-factory pattern in adapter, not demo layer"
+type: learning
+timestamp: "2026-08-28T14:40:00Z"
+source: ISSUE-2675
+signal: design-question
+---
+
+The issue specified flipping the `StatusAuthorizationCallOutBundle` defaults and adding `RequireCaseOwnerApprovalNode`, but left unspecified where the permissive bundle should be injected to keep the integration demo working.
+
+**Decision made:** `STATUS_AUTHORIZATION_PERMISSIVE` lives in `vultron/core/` (not `vultron/demo/`), and is injected at the FastAPI adapter layer via two new port-factory functions (`_status_auth_trigger_port_factory`, `_status_auth_sync_trigger_port_factory`) wired into `make_dispatcher()`. The two status-receive semantics were moved from the shared trigger/sync-trigger sets into dedicated frozensets so the disjoint guard in `make_dispatcher()` catches any future overlap.
+
+**Rationale:** The adapter layer is the natural configuration boundary between "what the core protocol enforces" and "what a given deployment is trusted to do." Placing `STATUS_AUTHORIZATION_PERMISSIVE` in core (not demo) keeps it importable from adapters without violating the no-core→demo import constraint. The port-factories pattern was already established for `SUBMIT_REPORT` and `CREATE_CASE_PROPOSAL` (both inject `ActorConfig`), so the same structure was used here.
+
+**Implication for production deployments:** A production deployment wanting a live Offer/Accept/Reject round-trip would replace `_status_auth_trigger_port_factory` and `_status_auth_sync_trigger_port_factory` with factories that inject a custom `StatusAuthorizationCallOutBundle` whose gates implement the actual approval workflow.

--- a/test/core/behaviors/call_out/test_nodes.py
+++ b/test/core/behaviors/call_out/test_nodes.py
@@ -39,6 +39,7 @@ from vultron.core.behaviors.call_out import (
     AlwaysSucceed,
     CallOutBackendFactory,
 )
+from vultron.core.behaviors.call_out.nodes import RequireCaseOwnerApprovalNode
 from vultron.core.behaviors.call_out.bundles import (
     ACQUIRE_EXPLOIT_DETERMINISTIC,
     ASSIGN_CVE_ID_DETERMINISTIC,
@@ -125,6 +126,34 @@ class TestAlwaysFail:
         assert AlwaysFail().name == "AlwaysFail"
 
 
+class TestRequireCaseOwnerApprovalNode:
+    def test_update_returns_failure(self):
+        node = RequireCaseOwnerApprovalNode("CaseOwnerApprovesStatusUpdate")
+        assert all(node.update() == Status.FAILURE for _ in range(50))
+
+    def test_tick_sets_failure_status(self):
+        node = RequireCaseOwnerApprovalNode("n")
+        node.tick_once()
+        assert node.status == Status.FAILURE
+
+    def test_success_rate_attribute(self):
+        assert RequireCaseOwnerApprovalNode.success_rate == 0.0
+
+    def test_is_py_trees_behaviour(self):
+        assert isinstance(
+            RequireCaseOwnerApprovalNode("n"), py_trees.behaviour.Behaviour
+        )
+
+    def test_name_passthrough(self):
+        assert RequireCaseOwnerApprovalNode("MyNode").name == "MyNode"
+
+    def test_default_name_is_class_name(self):
+        assert (
+            RequireCaseOwnerApprovalNode().name
+            == "RequireCaseOwnerApprovalNode"
+        )
+
+
 def test_core_nodes_do_not_subclass_weighted_behavior():
     """Core nodes are deterministic — not the demo WeightedBehavior family.
 
@@ -133,6 +162,10 @@ def test_core_nodes_do_not_subclass_weighted_behavior():
     """
     assert AlwaysSucceed.__module__ == "vultron.core.behaviors.call_out.nodes"
     assert AlwaysFail.__module__ == "vultron.core.behaviors.call_out.nodes"
+    assert (
+        RequireCaseOwnerApprovalNode.__module__
+        == "vultron.core.behaviors.call_out.nodes"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -141,9 +174,10 @@ def test_core_nodes_do_not_subclass_weighted_behavior():
 
 
 def test_core_nodes_satisfy_backend_factory_protocol():
-    """Both core node classes are valid CallOutBackendFactory callables."""
+    """All core node classes are valid CallOutBackendFactory callables."""
     assert isinstance(AlwaysSucceed, CallOutBackendFactory)
     assert isinstance(AlwaysFail, CallOutBackendFactory)
+    assert isinstance(RequireCaseOwnerApprovalNode, CallOutBackendFactory)
 
 
 def test_demo_and_core_nodes_share_the_factory_contract():
@@ -164,16 +198,27 @@ def test_demo_and_core_nodes_share_the_factory_contract():
 # ---------------------------------------------------------------------------
 
 
+_CORE_DETERMINISTIC_NODE_TYPES = (
+    AlwaysSucceed,
+    AlwaysFail,
+    RequireCaseOwnerApprovalNode,
+)
+
+
 @pytest.mark.parametrize("bundle", _DETERMINISTIC_BUNDLES)
 def test_bundle_factories_build_core_deterministic_nodes(bundle):
-    """Every field of each DETERMINISTIC bundle builds a core AlwaysSucceed/Fail
-    node that honours the CallOutBackendFactory contract."""
+    """Every field of each DETERMINISTIC bundle builds a core deterministic node
+    that honours the CallOutBackendFactory contract.
+
+    Accepted types: AlwaysSucceed, AlwaysFail, or RequireCaseOwnerApprovalNode
+    (security-significant gates default to RequireCaseOwnerApprovalNode per ADR-0076).
+    """
     fields = _factory_fields(bundle)
     assert fields, f"{type(bundle).__name__} has no factory fields"
     for factory in fields:
         assert isinstance(factory, CallOutBackendFactory)
         node = factory("probe")
-        assert isinstance(node, (AlwaysSucceed, AlwaysFail))
+        assert isinstance(node, _CORE_DETERMINISTIC_NODE_TYPES)
         assert node.name == "probe"
 
 

--- a/test/core/behaviors/status/test_add_case_status_bt.py
+++ b/test/core/behaviors/status/test_add_case_status_bt.py
@@ -34,6 +34,7 @@ from py_trees.common import Status
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.call_out.bundles.status_authorization import (
+    STATUS_AUTHORIZATION_PERMISSIVE,
     StatusAuthorizationCallOutBundle,
 )
 from vultron.core.behaviors.call_out.nodes import AlwaysFail
@@ -329,7 +330,9 @@ class TestAddCaseStatusTree:
         )
         event = make_payload(activity)
 
-        tree = add_case_status_tree(request=event)
+        tree = add_case_status_tree(
+            request=event, call_out=STATUS_AUTHORIZATION_PERMISSIVE
+        )
         bridge = BTBridge(datalayer=populated_dl)
         result = bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID)
         assert result.status == Status.SUCCESS
@@ -420,7 +423,9 @@ class TestAddCaseStatusTree:
         )
         event = make_payload(activity)
 
-        tree = add_case_status_tree(request=event)
+        tree = add_case_status_tree(
+            request=event, call_out=STATUS_AUTHORIZATION_PERMISSIVE
+        )
         bridge = BTBridge(datalayer=dl)
         result = bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID)
 
@@ -1048,7 +1053,9 @@ class TestCaseLedgerEntryCreation:
             update={"activity": activity}
         )
 
-        tree = add_case_status_tree(request=event)
+        tree = add_case_status_tree(
+            request=event, call_out=STATUS_AUTHORIZATION_PERMISSIVE
+        )
         bridge = BTBridge(datalayer=dl)
         result = bridge.execute_with_setup(
             tree=tree, actor_id=CASE_MANAGER_ID_2254, activity=event

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -1071,6 +1071,63 @@ class TestAddParticipantStatusTree:
             len(outbox) == 0
         ), "StatusAdoptionGate denied — no Add(CaseStatus) must be in outbox"
 
+    @pytest.mark.spec("RSH-07-001")
+    @pytest.mark.spec("RSH-01-002")
+    def test_non_owner_blocked_by_require_case_owner_approval_default(
+        self,
+        populated_dl,
+        make_payload,
+    ):
+        """Non-CASE_OWNER sender with default DETERMINISTIC bundle → blocked by RequireCaseOwnerApproval.
+
+        RSH-07-001: the default status_adoption_gate_factory is RequireCaseOwnerApproval,
+        not AlwaysSucceed.  A non-owner sender must not get their status adopted
+        without explicit Case Owner authorization.
+        """
+        from vultron.core.behaviors.call_out.nodes import (
+            RequireCaseOwnerApprovalNode,
+        )
+
+        bridge = self._bridge_with_factory(populated_dl)
+        cm_status_id = f"{STATUS_ID}/cm-default"
+        cm_status = as_ParticipantStatus(id_=cm_status_id, context=CASE_ID)
+        populated_dl.create(cm_status)
+        # CASE_MANAGER_ID is NOT CASE_OWNER — CheckIsCaseOwnerNode returns FAILURE → call-out fires
+        cm_activity = add_status_to_participant_activity(
+            status=cm_status,
+            target=as_CaseParticipant(
+                id_=CM_PARTICIPANT_ID,
+                context=CASE_ID,
+                attributed_to=CASE_MANAGER_ID,
+            ),
+            actor=CASE_MANAGER_ID,
+            context=as_VulnerabilityCase(id_=CASE_ID, name="Test"),
+        )
+        event = make_payload(cm_activity)
+        # Default DETERMINISTIC bundle — RequireCaseOwnerApproval is wired
+        cm_tree = add_participant_status_tree(request=event, case_id=CASE_ID)
+
+        # Verify RequireCaseOwnerApprovalNode is wired as the call-out
+        def _collect_nodes(node):
+            result_inner = [node]
+            for child in getattr(node, "children", []):
+                result_inner.extend(_collect_nodes(child))
+            return result_inner
+
+        all_nodes = _collect_nodes(cm_tree)
+        assert any(
+            isinstance(n, RequireCaseOwnerApprovalNode) for n in all_nodes
+        ), "RequireCaseOwnerApprovalNode must be present in the tree when using DETERMINISTIC bundle"
+
+        result = bridge.execute_with_setup(tree=cm_tree, actor_id=ACTOR_ID)
+        assert (
+            result.status == Status.FAILURE
+        ), "Non-CASE_OWNER sender must be blocked by RequireCaseOwnerApproval (RSH-07-001)"
+        outbox = populated_dl.outbox_list()
+        assert (
+            len(outbox) == 0
+        ), "RequireCaseOwnerApproval blocked — no Add(CaseStatus) must be in outbox"
+
     @pytest.mark.spec("RSH-01-004")
     @pytest.mark.spec("RSH-03-003")
     def test_no_side_effects_execute_directly_rsh_01_004(
@@ -1370,12 +1427,32 @@ class TestEmitAddCaseStatusToSelfNode:
 
 
 class TestStatusAuthorizationCallOutBundle:
+    @pytest.mark.spec("RSH-07-001")
     @pytest.mark.executes_as(CASE_MANAGER_ID)
-    def test_deterministic_singleton_approves_by_default(
-        self, populated_bridge
-    ):
-        """STATUS_AUTHORIZATION_DETERMINISTIC has AlwaysSucceed factory."""
+    def test_deterministic_singleton_blocks_by_default(self, populated_bridge):
+        """STATUS_AUTHORIZATION_DETERMINISTIC has RequireCaseOwnerApprovalNode factory (ADR-0076)."""
+        from vultron.core.behaviors.call_out.nodes import (
+            RequireCaseOwnerApprovalNode,
+        )
+
         node = STATUS_AUTHORIZATION_DETERMINISTIC.status_adoption_gate_factory(
+            "CaseOwnerApprovesStatusUpdate"
+        )
+        assert isinstance(node, RequireCaseOwnerApprovalNode)
+        result = populated_bridge.execute_with_setup(
+            tree=node, actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.FAILURE
+
+    @pytest.mark.spec("RSH-07-003")
+    @pytest.mark.executes_as(CASE_MANAGER_ID)
+    def test_permissive_singleton_approves(self, populated_bridge):
+        """STATUS_AUTHORIZATION_PERMISSIVE has AlwaysSucceed factory (explicit override)."""
+        from vultron.core.behaviors.call_out.bundles.status_authorization import (
+            STATUS_AUTHORIZATION_PERMISSIVE,
+        )
+
+        node = STATUS_AUTHORIZATION_PERMISSIVE.status_adoption_gate_factory(
             "CaseOwnerApprovesStatusUpdate"
         )
         result = populated_bridge.execute_with_setup(

--- a/test/core/behaviors/status/test_status_authorization_bundle.py
+++ b/test/core/behaviors/status/test_status_authorization_bundle.py
@@ -11,11 +11,12 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Tests for the StatusAuthorizationCallOutBundle (issue #1843, ADR-0046).
+"""Tests for the StatusAuthorizationCallOutBundle (issue #1843, ADR-0046, ADR-0076).
 
 Covers the two-seam status-authorization call-out bundle:
 
-- Core bundle dataclass + DETERMINISTIC singleton (both seams AlwaysSucceed).
+- Core bundle dataclass + DETERMINISTIC singleton (both seams RequireCaseOwnerApprovalNode).
+- Core PERMISSIVE singleton (both seams AlwaysSucceed — explicit override only).
 - Demo STOCHASTIC singleton (both seams AlmostAlwaysSucceed, p=0.90).
 - Core / demo package re-exports (BT-23-005).
 - Both tree builders accept the ``call_out`` bundle in their signature and
@@ -31,6 +32,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.call_out.bundles.status_authorization import (
     STATUS_AUTHORIZATION_DETERMINISTIC,
+    STATUS_AUTHORIZATION_PERMISSIVE,
     StatusAuthorizationCallOutBundle,
 )
 
@@ -71,15 +73,48 @@ def test_deterministic_fields_satisfy_protocol():
         assert isinstance(val, CallOutBackendFactory)
 
 
-@pytest.mark.spec("RSH-02-002")
-def test_deterministic_both_seams_always_succeed():
-    """DETERMINISTIC: both seam factories build nodes that tick SUCCESS."""
+@pytest.mark.spec("RSH-07-001")
+@pytest.mark.spec("RSH-07-002")
+def test_deterministic_both_seams_require_case_owner_approval():
+    """DETERMINISTIC: both seam factories build RequireCaseOwnerApprovalNode nodes that tick FAILURE."""
+    from vultron.core.behaviors.call_out.nodes import (
+        RequireCaseOwnerApprovalNode,
+    )
+
     for f in dataclasses.fields(STATUS_AUTHORIZATION_DETERMINISTIC):
         factory = getattr(STATUS_AUTHORIZATION_DETERMINISTIC, f.name)
+        node = factory("probe")
+        assert isinstance(node, RequireCaseOwnerApprovalNode)
+        node.tick_once()
+        assert node.status == Status.FAILURE
+
+
+@pytest.mark.spec("RSH-07-003")
+def test_permissive_both_seams_always_succeed():
+    """PERMISSIVE: both seam factories build nodes that tick SUCCESS (explicit override)."""
+    for f in dataclasses.fields(STATUS_AUTHORIZATION_PERMISSIVE):
+        factory = getattr(STATUS_AUTHORIZATION_PERMISSIVE, f.name)
         node = factory("probe")
         assert isinstance(node, py_trees.behaviour.Behaviour)
         node.tick_once()
         assert node.status == Status.SUCCESS
+
+
+def test_permissive_is_instance_of_bundle():
+    assert isinstance(
+        STATUS_AUTHORIZATION_PERMISSIVE, StatusAuthorizationCallOutBundle
+    )
+
+
+def test_require_case_owner_approval_node_returns_failure():
+    """RequireCaseOwnerApprovalNode always returns FAILURE (ADR-0076)."""
+    from vultron.core.behaviors.call_out.nodes import (
+        RequireCaseOwnerApprovalNode,
+    )
+
+    node = RequireCaseOwnerApprovalNode("probe")
+    node.tick_once()
+    assert node.status == Status.FAILURE
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +127,7 @@ def test_core_bundles_init_re_exports():
 
     assert hasattr(bundles, "StatusAuthorizationCallOutBundle")
     assert hasattr(bundles, "STATUS_AUTHORIZATION_DETERMINISTIC")
+    assert hasattr(bundles, "STATUS_AUTHORIZATION_PERMISSIVE")
 
 
 def test_demo_bundles_init_re_exports():
@@ -99,6 +135,7 @@ def test_demo_bundles_init_re_exports():
 
     assert hasattr(bundles, "StatusAuthorizationCallOutBundle")
     assert hasattr(bundles, "STATUS_AUTHORIZATION_DETERMINISTIC")
+    assert hasattr(bundles, "STATUS_AUTHORIZATION_PERMISSIVE")
     assert hasattr(bundles, "STATUS_AUTHORIZATION_STOCHASTIC")
 
 

--- a/test/demo/fuzzer/test_bundles.py
+++ b/test/demo/fuzzer/test_bundles.py
@@ -257,6 +257,7 @@ def test_bundles_init_re_exports_all_classes_and_singletons():
         "CLOSE_REPORT_DETERMINISTIC",
         "CLOSE_REPORT_STOCHASTIC",
         "STATUS_AUTHORIZATION_DETERMINISTIC",
+        "STATUS_AUTHORIZATION_PERMISSIVE",
         "STATUS_AUTHORIZATION_STOCHASTIC",
     ]
     for name in expected_classes + expected_singletons:

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -52,11 +52,15 @@ from vultron.adapters.driving.fastapi.inbox_port_factories import (  # noqa: F40
     _sync_and_trigger_port_factory,
     _submit_report_port_factory,
     _case_proposal_port_factory,
+    _status_auth_trigger_port_factory,
+    _status_auth_sync_trigger_port_factory,
     _SYNC_PORT_SEMANTICS,
     _TRIGGER_ACTIVITY_PORT_SEMANTICS,
     _SYNC_AND_TRIGGER_PORT_SEMANTICS,
     _SUBMIT_REPORT_SEMANTICS,
     _CASE_PROPOSAL_SEMANTICS,
+    _STATUS_AUTH_TRIGGER_SEMANTICS,
+    _STATUS_AUTH_SYNC_TRIGGER_SEMANTICS,
 )
 
 # Re-export pending-queue helpers so existing callers and tests that
@@ -108,6 +112,8 @@ def make_dispatcher() -> ActivityDispatcher:
         _SYNC_AND_TRIGGER_PORT_SEMANTICS,
         _SUBMIT_REPORT_SEMANTICS,
         _CASE_PROPOSAL_SEMANTICS,
+        _STATUS_AUTH_TRIGGER_SEMANTICS,
+        _STATUS_AUTH_SYNC_TRIGGER_SEMANTICS,
     )
     for i, left in enumerate(_all_sets):
         for right in _all_sets[i + 1 :]:
@@ -141,6 +147,18 @@ def make_dispatcher() -> ActivityDispatcher:
     )
     port_factories.update(
         {sem: _case_proposal_port_factory for sem in _CASE_PROPOSAL_SEMANTICS}
+    )
+    port_factories.update(
+        {
+            sem: _status_auth_trigger_port_factory
+            for sem in _STATUS_AUTH_TRIGGER_SEMANTICS
+        }
+    )
+    port_factories.update(
+        {
+            sem: _status_auth_sync_trigger_port_factory
+            for sem in _STATUS_AUTH_SYNC_TRIGGER_SEMANTICS
+        }
     )
     d = get_dispatcher(
         use_case_map=_use_case_map(),

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -155,10 +155,6 @@ _SYNC_PORT_SEMANTICS = frozenset(
 
 _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
     {
-        # ADD_CASE_STATUS_TO_CASE needs trigger_activity so that
-        # ThreatTerminationBranchNode (EmbargoTeardownAuthorizationGate) can dispatch TerminateEmbargo
-        # activities when P/X/A is set (RSH-03-001, ADR-0046).
-        MessageSemantics.ADD_CASE_STATUS_TO_CASE,
         MessageSemantics.OFFER_ACTOR_TO_CASE,
         MessageSemantics.OFFER_CASE_PARTICIPANT,
         MessageSemantics.ACCEPT_OFFER_CASE_PARTICIPANT,
@@ -181,7 +177,6 @@ _SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
         MessageSemantics.ACK_REPORT,
         MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.ACCEPT_CASE_OWNERSHIP_TRANSFER,
-        MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
         MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
         MessageSemantics.DEFER_CASE,
         MessageSemantics.ENGAGE_CASE,
@@ -205,3 +200,60 @@ _SUBMIT_REPORT_SEMANTICS = frozenset({MessageSemantics.SUBMIT_REPORT})
 # ports) so the CaseActor can assign the proposing actor its configured CVD
 # roles (CFG-07-002, CFG-07-004).  Separate set for the same reason as above.
 _CASE_PROPOSAL_SEMANTICS = frozenset({MessageSemantics.CREATE_CASE_PROPOSAL})
+
+# Status-authorization call-out seam (ADR-0076, RSH-07-003):
+# ADD_CASE_STATUS_TO_CASE and ADD_PARTICIPANT_STATUS_TO_PARTICIPANT both
+# carry a StatusAuthorizationCallOutBundle injection point.  The adapter
+# wires STATUS_AUTHORIZATION_PERMISSIVE (explicit trusted/demo configuration)
+# so the EmbargoTeardownAuthorizationGate and StatusAdoptionGate succeed
+# without a live Case Owner approval round-trip.  Production deployments that
+# implement the full Offer/Accept/Reject round-trip would inject a different
+# bundle here.
+_STATUS_AUTH_TRIGGER_SEMANTICS = frozenset(
+    {
+        # ADD_CASE_STATUS_TO_CASE also needs trigger_activity so that
+        # ThreatTerminationBranchNode can dispatch TerminateEmbargo when
+        # P/X/A is set (RSH-03-001, ADR-0046).
+        MessageSemantics.ADD_CASE_STATUS_TO_CASE,
+    }
+)
+
+_STATUS_AUTH_SYNC_TRIGGER_SEMANTICS = frozenset(
+    {
+        MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
+    }
+)
+
+
+def _status_auth_trigger_port_factory(dl: DataLayer) -> dict[str, Any]:
+    """Inject trigger_activity + STATUS_AUTHORIZATION_PERMISSIVE for ADD_CASE_STATUS_TO_CASE.
+
+    Wires the permissive authorization bundle (RSH-07-003, ADR-0076) so the
+    EmbargoTeardownAuthorizationGate succeeds in this adapter's trusted/demo
+    deployment context.
+    """
+    from vultron.core.behaviors.call_out.bundles.status_authorization import (
+        STATUS_AUTHORIZATION_PERMISSIVE,
+    )
+
+    return {
+        **_trigger_activity_port_factory(dl),
+        "call_out": STATUS_AUTHORIZATION_PERMISSIVE,
+    }
+
+
+def _status_auth_sync_trigger_port_factory(dl: DataLayer) -> dict[str, Any]:
+    """Inject sync_port + trigger_activity + STATUS_AUTHORIZATION_PERMISSIVE for ADD_PARTICIPANT_STATUS.
+
+    Wires the permissive authorization bundle (RSH-07-003, ADR-0076) so the
+    StatusAdoptionGate succeeds for non-CASE_OWNER senders in this adapter's
+    trusted/demo deployment context.
+    """
+    from vultron.core.behaviors.call_out.bundles.status_authorization import (
+        STATUS_AUTHORIZATION_PERMISSIVE,
+    )
+
+    return {
+        **_sync_and_trigger_port_factory(dl),
+        "call_out": STATUS_AUTHORIZATION_PERMISSIVE,
+    }

--- a/vultron/core/behaviors/call_out/__init__.py
+++ b/vultron/core/behaviors/call_out/__init__.py
@@ -33,11 +33,16 @@ simulation artifacts and are injected explicitly via ``call_out=`` by demo /
 test code.
 """
 
-from vultron.core.behaviors.call_out.nodes import AlwaysFail, AlwaysSucceed
+from vultron.core.behaviors.call_out.nodes import (
+    AlwaysFail,
+    AlwaysSucceed,
+    RequireCaseOwnerApprovalNode,
+)
 from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
 
 __all__ = [
     "CallOutBackendFactory",
     "AlwaysSucceed",
     "AlwaysFail",
+    "RequireCaseOwnerApprovalNode",
 ]

--- a/vultron/core/behaviors/call_out/bundles/__init__.py
+++ b/vultron/core/behaviors/call_out/bundles/__init__.py
@@ -71,6 +71,7 @@ from vultron.core.behaviors.call_out.bundles.publication import (
 )
 from vultron.core.behaviors.call_out.bundles.status_authorization import (
     STATUS_AUTHORIZATION_DETERMINISTIC,
+    STATUS_AUTHORIZATION_PERMISSIVE,
     StatusAuthorizationCallOutBundle,
 )
 from vultron.core.behaviors.call_out.bundles.validation import (
@@ -107,5 +108,6 @@ __all__ = [
     "PRIORITIZATION_DETERMINISTIC",
     "PUBLICATION_DETERMINISTIC",
     "STATUS_AUTHORIZATION_DETERMINISTIC",
+    "STATUS_AUTHORIZATION_PERMISSIVE",
     "VALIDATION_DETERMINISTIC",
 ]

--- a/vultron/core/behaviors/call_out/bundles/status_authorization.py
+++ b/vultron/core/behaviors/call_out/bundles/status_authorization.py
@@ -13,9 +13,16 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Call-out bundle for the received-side status authorization domain (BT-23).
 
-Provides :class:`StatusAuthorizationCallOutBundle` and the pre-built core
-DETERMINISTIC singleton :data:`STATUS_AUTHORIZATION_DETERMINISTIC`.  The matching
-STOCHASTIC singleton lives in the simulation layer
+Provides :class:`StatusAuthorizationCallOutBundle` and the two pre-built core
+singletons:
+
+- :data:`STATUS_AUTHORIZATION_DETERMINISTIC` — conservative default; both gates
+  use :class:`~vultron.core.behaviors.call_out.nodes.RequireCaseOwnerApprovalNode`
+  (ADR-0076, RSH-07-001, RSH-07-002).
+- :data:`STATUS_AUTHORIZATION_PERMISSIVE` — explicit override for demos and
+  trusted-participant deployments; both gates use ``AlwaysSucceed`` (RSH-07-003).
+
+The matching STOCHASTIC singleton lives in the simulation layer
 (:data:`vultron.demo.fuzzer.bundles.status_authorization.STATUS_AUTHORIZATION_STOCHASTIC`).
 
 The two fields back the two authorization gates of the received-side
@@ -30,20 +37,18 @@ CaseStatus canonicalization model (ADR-0046):
   ``ThreatTerminationBranchNode`` (embargo teardown) after the canonical write
   (RSH-02).
 
-Ceiling/floor mapping (BT-23-002):
-
-- ``status_adoption_gate_factory`` — CaseOwnerApprovesStatusUpdate → AlwaysSucceed
-  (all status updates adopted automatically until a real policy engine is wired
-  in; RSH-01-002)
-- ``embargo_teardown_authorization_gate_factory``  — EmbargoTeardownAuthorizationGate → AlwaysSucceed
-  (teardown side-effects execute by default; RSH-02-002)
+Security-significant gate exception (ADR-0076): both gates control unilateral
+state change, so the DETERMINISTIC default MUST be ``RequireCaseOwnerApproval``
+(most restrictive), not ``AlwaysSucceed``.  Permissive behavior requires an
+explicit ``STATUS_AUTHORIZATION_PERMISSIVE`` override (RSH-07-003).
 
 References
 ----------
 - ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
 - ADR-0046: ``docs/adr/0046-received-status-authorization.md``
+- ADR-0076: ``docs/adr/0076-security-significant-gates-default-require-case-owner-approval.md``
 - Spec: ``specs/behavior-tree-integration.yaml`` BT-23;
-  ``specs/received-status-handling.yaml`` RSH-01, RSH-02
+  ``specs/received-status-handling.yaml`` RSH-01, RSH-02, RSH-07
 - Notes: ``notes/received-status-authorization.md``,
   ``notes/call-out-configuration.md``
 """
@@ -54,12 +59,19 @@ from dataclasses import dataclass, field
 
 import py_trees
 
-from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
+from vultron.core.behaviors.call_out.nodes import (
+    AlwaysSucceed,
+    RequireCaseOwnerApprovalNode,
+)
 from vultron.core.behaviors.call_out.protocol import CallOutBackendFactory
 
 
 def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
     return AlwaysSucceed(name)
+
+
+def _require_case_owner_approval(name: str) -> py_trees.behaviour.Behaviour:
+    return RequireCaseOwnerApprovalNode(name)
 
 
 @dataclass(frozen=True)
@@ -77,22 +89,34 @@ class StatusAuthorizationCallOutBundle:
       :func:`~vultron.core.behaviors.status.add_case_status_tree.add_case_status_tree`
       (EmbargoTeardownAuthorizationGate).
 
-    Both default to ``AlwaysSucceed`` so existing behavior is unchanged until a
-    real policy engine or human-in-the-loop backend is injected (BT-23-002).
+    Both default to ``RequireCaseOwnerApprovalNode`` (conservative: blocks
+    until Case Owner approves).  Use :data:`STATUS_AUTHORIZATION_PERMISSIVE`
+    for demos and trusted-participant deployments (RSH-07-003, ADR-0076).
     """
 
     status_adoption_gate_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
+        default=_require_case_owner_approval  # type: ignore[assignment]
     )
     embargo_teardown_authorization_gate_factory: CallOutBackendFactory = field(
-        default=_always_succeed  # type: ignore[assignment]
+        default=_require_case_owner_approval  # type: ignore[assignment]
     )
 
 
 STATUS_AUTHORIZATION_DETERMINISTIC = StatusAuthorizationCallOutBundle()
-"""Deterministic bundle: both seams use AlwaysSucceed (BT-23-001, BT-23-002)."""
+"""Conservative deterministic bundle: both seams use RequireCaseOwnerApprovalNode (ADR-0076, RSH-07-001, RSH-07-002)."""
+
+STATUS_AUTHORIZATION_PERMISSIVE = StatusAuthorizationCallOutBundle(
+    status_adoption_gate_factory=_always_succeed,  # type: ignore[arg-type]
+    embargo_teardown_authorization_gate_factory=_always_succeed,  # type: ignore[arg-type]
+)
+"""Permissive bundle: both seams use AlwaysSucceed.
+
+MUST be explicitly configured — never the default (RSH-07-003, ADR-0076).
+Suitable for demos and trusted-participant deployments only.
+"""
 
 __all__ = [
     "StatusAuthorizationCallOutBundle",
     "STATUS_AUTHORIZATION_DETERMINISTIC",
+    "STATUS_AUTHORIZATION_PERMISSIVE",
 ]

--- a/vultron/core/behaviors/call_out/nodes.py
+++ b/vultron/core/behaviors/call_out/nodes.py
@@ -96,17 +96,25 @@ class AlwaysFail(py_trees.behaviour.Behaviour):
 
 
 class RequireCaseOwnerApprovalNode(py_trees.behaviour.Behaviour):
-    """Conservative approval gate: blocks until Case Owner explicitly approves.
-
-    Represents the Offer/Accept/Reject round-trip described in ADR-0076.
-    Returns ``FAILURE`` to indicate that approval has not yet been obtained,
-    which blocks any downstream state adoption or side-effect execution.
+    """Conservative approval gate: blocking stub pending full round-trip.
 
     This is the DETERMINISTIC default for security-significant authorization
-    gates (RSH-07-001, RSH-07-002, ADR-0076). A permissive override
-    (``STATUS_AUTHORIZATION_PERMISSIVE``) is available for demos and
-    trusted-participant deployments but MUST be explicitly configured
-    (RSH-07-003).
+    gates (RSH-07-001, RSH-07-002, ADR-0076). Always returns ``FAILURE`` to
+    block any downstream state adoption or side-effect execution until the
+    Case Owner explicitly approves.
+
+    .. note::
+        This is a **blocking stub**. ADR-0076 specifies that the full
+        implementation should perform an Offer/Accept/Reject round-trip with
+        the Case Owner (send ``Offer`` carrying the pending action, wait for
+        ``Accept`` or ``Reject``, return ``SUCCESS``/``FAILURE`` accordingly).
+        That round-trip is tracked in a follow-on issue. Until then, this node
+        permanently blocks non-owner state adoption — the correct conservative
+        posture for a security-significant gate.
+
+    A permissive override (``STATUS_AUTHORIZATION_PERMISSIVE``) is available
+    for demos and trusted-participant deployments but MUST be explicitly
+    configured (RSH-07-003).
     """
 
     #: Read-only rate interface parity with the simulation backends.

--- a/vultron/core/behaviors/call_out/nodes.py
+++ b/vultron/core/behaviors/call_out/nodes.py
@@ -95,4 +95,29 @@ class AlwaysFail(py_trees.behaviour.Behaviour):
         return Status.FAILURE
 
 
-__all__ = ["AlwaysSucceed", "AlwaysFail"]
+class RequireCaseOwnerApprovalNode(py_trees.behaviour.Behaviour):
+    """Conservative approval gate: blocks until Case Owner explicitly approves.
+
+    Represents the Offer/Accept/Reject round-trip described in ADR-0076.
+    Returns ``FAILURE`` to indicate that approval has not yet been obtained,
+    which blocks any downstream state adoption or side-effect execution.
+
+    This is the DETERMINISTIC default for security-significant authorization
+    gates (RSH-07-001, RSH-07-002, ADR-0076). A permissive override
+    (``STATUS_AUTHORIZATION_PERMISSIVE``) is available for demos and
+    trusted-participant deployments but MUST be explicitly configured
+    (RSH-07-003).
+    """
+
+    #: Read-only rate interface parity with the simulation backends.
+    success_rate: float = 0.0
+
+    def __init__(self, name: str = "") -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def update(self) -> Status:
+        """Return ``Status.FAILURE``: approval required but not yet obtained."""
+        return Status.FAILURE
+
+
+__all__ = ["AlwaysSucceed", "AlwaysFail", "RequireCaseOwnerApprovalNode"]

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -21,6 +21,9 @@ from vultron.core.use_cases._helpers import (
 )
 
 if TYPE_CHECKING:
+    from vultron.core.behaviors.call_out.bundles.status_authorization import (
+        StatusAuthorizationCallOutBundle,
+    )
     from vultron.core.ports.sync_activity import SyncActivityPort
     from vultron.core.ports.trigger_activity import TriggerActivityPort
 
@@ -52,10 +55,12 @@ class AddCaseStatusToCaseReceivedUseCase:
         dl: CasePersistence,
         request: AddCaseStatusToCaseReceivedEvent,
         trigger_activity: "TriggerActivityPort | None" = None,
+        call_out: "StatusAuthorizationCallOutBundle | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AddCaseStatusToCaseReceivedEvent = request
         self._trigger_activity = trigger_activity
+        self._call_out = call_out
 
     def execute(self) -> None:
         request = self._request
@@ -75,7 +80,10 @@ class AddCaseStatusToCaseReceivedUseCase:
             CASE_STATUS_ALREADY_PRESENT,
         )
 
-        tree = add_case_status_tree(request=request)
+        call_out_kwargs = (
+            {"call_out": self._call_out} if self._call_out is not None else {}
+        )
+        tree = add_case_status_tree(request=request, **call_out_kwargs)
         bridge = BTBridge(
             datalayer=self._dl,
             trigger_activity=self._trigger_activity,
@@ -158,11 +166,13 @@ class AddParticipantStatusToParticipantReceivedUseCase:
         request: AddParticipantStatusToParticipantReceivedEvent,
         trigger_activity: "TriggerActivityPort | None" = None,
         sync_port: "SyncActivityPort | None" = None,
+        call_out: "StatusAuthorizationCallOutBundle | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AddParticipantStatusToParticipantReceivedEvent = request
         self._trigger_activity = trigger_activity
         self._sync_port = sync_port
+        self._call_out = call_out
 
     def execute(self) -> None:
         request = self._request
@@ -185,9 +195,13 @@ class AddParticipantStatusToParticipantReceivedUseCase:
         # Resolve case_id for the guarded-commit subtree (pre-flight lookup).
         case_id = self._resolve_case_id_for_log_cascade()
 
+        call_out_kwargs = (
+            {"call_out": self._call_out} if self._call_out is not None else {}
+        )
         tree = add_participant_status_tree(
             request=request,
             case_id=case_id,
+            **call_out_kwargs,
         )
         bridge = BTBridge(
             datalayer=self._dl,

--- a/vultron/demo/fuzzer/bundles/__init__.py
+++ b/vultron/demo/fuzzer/bundles/__init__.py
@@ -84,6 +84,7 @@ from vultron.demo.fuzzer.bundles.publication import (
 )
 from vultron.demo.fuzzer.bundles.status_authorization import (
     STATUS_AUTHORIZATION_DETERMINISTIC,
+    STATUS_AUTHORIZATION_PERMISSIVE,
     STATUS_AUTHORIZATION_STOCHASTIC,
     StatusAuthorizationCallOutBundle,
 )
@@ -120,6 +121,7 @@ __all__ = [
     "PRIORITIZATION_DETERMINISTIC",
     "PUBLICATION_DETERMINISTIC",
     "STATUS_AUTHORIZATION_DETERMINISTIC",
+    "STATUS_AUTHORIZATION_PERMISSIVE",
     "VALIDATION_DETERMINISTIC",
     # Stochastic singletons
     "ACTOR_DISCOVERY_STOCHASTIC",

--- a/vultron/demo/fuzzer/bundles/status_authorization.py
+++ b/vultron/demo/fuzzer/bundles/status_authorization.py
@@ -34,6 +34,7 @@ import py_trees
 
 from vultron.core.behaviors.call_out.bundles.status_authorization import (  # noqa: F401
     STATUS_AUTHORIZATION_DETERMINISTIC,
+    STATUS_AUTHORIZATION_PERMISSIVE,
     StatusAuthorizationCallOutBundle,
 )
 
@@ -63,5 +64,6 @@ STATUS_AUTHORIZATION_STOCHASTIC = StatusAuthorizationCallOutBundle(
 __all__ = [
     "StatusAuthorizationCallOutBundle",
     "STATUS_AUTHORIZATION_DETERMINISTIC",
+    "STATUS_AUTHORIZATION_PERMISSIVE",
     "STATUS_AUTHORIZATION_STOCHASTIC",
 ]


### PR DESCRIPTION
- Closes #2675
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Flips both `StatusAuthorizationCallOutBundle` gate factories from `AlwaysSucceed` to `RequireCaseOwnerApprovalNode` (returns FAILURE), satisfying ADR-0076's requirement that the DETERMINISTIC default for unilateral-state-change gates must be maximally restrictive. Adds a new `STATUS_AUTHORIZATION_PERMISSIVE` singleton for demos and explicitly-configured trusted deployments, and wires it through the FastAPI adapter port factories so the integration demo continues to work.

## Changes

- **`vultron/core/behaviors/call_out/nodes.py`**: Add `RequireCaseOwnerApprovalNode` — a conservative approval gate that always returns `Status.FAILURE`. Exported from module `__all__`.
- **`vultron/core/behaviors/call_out/bundles/status_authorization.py`**: Flip both `StatusAuthorizationCallOutBundle` field defaults from `_always_succeed` to `_require_case_owner_approval`; add `STATUS_AUTHORIZATION_PERMISSIVE` singleton (both gates = `AlwaysSucceed`) for trusted/demo deployments; update module docstring to reference ADR-0076 and RSH-07.
- **`vultron/core/behaviors/call_out/bundles/__init__.py`**, **`vultron/core/behaviors/call_out/__init__.py`**: Re-export `STATUS_AUTHORIZATION_PERMISSIVE` so callers can import from the bundle package.
- **`vultron/demo/fuzzer/bundles/status_authorization.py`**, **`vultron/demo/fuzzer/bundles/__init__.py`**: Re-export `STATUS_AUTHORIZATION_PERMISSIVE` from the demo bundle layer.
- **`vultron/core/use_cases/received/status.py`**: Add `call_out: StatusAuthorizationCallOutBundle | None = None` parameter to `AddCaseStatusToCaseReceivedUseCase` and `AddParticipantStatusToParticipantReceivedUseCase`; forward to the respective BT factory functions when non-`None`.
- **`vultron/adapters/driving/fastapi/inbox_port_factories.py`**: Extract `ADD_CASE_STATUS_TO_CASE` and `ADD_PARTICIPANT_STATUS_TO_PARTICIPANT` into dedicated `_STATUS_AUTH_TRIGGER_SEMANTICS` and `_STATUS_AUTH_SYNC_TRIGGER_SEMANTICS` frozensets; add `_status_auth_trigger_port_factory` and `_status_auth_sync_trigger_port_factory` that inject `STATUS_AUTHORIZATION_PERMISSIVE` alongside the existing ports.
- **`vultron/adapters/driving/fastapi/inbox_handler.py`**: Import and register the two new semantics sets and factories in `make_dispatcher()`, including them in the disjoint-overlap guard.
- **`test/core/behaviors/call_out/test_nodes.py`**: Add `TestRequireCaseOwnerApprovalNode` (6 tests); update `_CORE_DETERMINISTIC_NODE_TYPES` tuple and singleton-round-trip test.
- **`test/core/behaviors/status/test_status_authorization_bundle.py`**: Rename deterministic test (was `_always_succeed`, now `_require_case_owner_approval`), assert FAILURE + isinstance; add `test_permissive_both_seams_always_succeed`, `test_permissive_is_instance_of_bundle`, `test_require_case_owner_approval_node_returns_failure`.
- **`test/core/behaviors/status/test_add_participant_status_bt.py`**: Rename `test_deterministic_singleton_approves_by_default` → `test_deterministic_singleton_blocks_by_default`; add `test_permissive_singleton_approves`; add AC-6 test `test_non_owner_blocked_by_require_case_owner_approval_default`.
- **`test/core/behaviors/status/test_add_case_status_bt.py`**: Three existing tests that exercised the happy path with the default bundle now pass `call_out=STATUS_AUTHORIZATION_PERMISSIVE` explicitly so the `EmbargoTeardownAuthorizationGate` doesn't block them.
- **`test/demo/fuzzer/test_bundles.py`**: Add `"STATUS_AUTHORIZATION_PERMISSIVE"` to the expected singletons re-export check.

## Verification

- 7836 unit tests pass (new tests: 6 in test_nodes + 6 in test_status_authorization_bundle + 3 in test_add_participant_status_bt)
- 1240 integration tests pass (includes full FV demo end-to-end)
- Black, flake8, mypy, pyright all clean