### PR TITLE
fix: raise VultronProtocolViolationError on bare-URI participant in bootstrap

### DIFF
--- a/plan/history/2608/learning/CONCERN-2736.md
+++ b/plan/history/2608/learning/CONCERN-2736.md
@@ -1,0 +1,51 @@
+---
+source: CONCERN-2736
+timestamp: '2026-08-28T15:27:10.147455+00:00'
+title: Audit fallback-to-datalayer and inference-from-absence patterns
+type: learning
+---
+
+## Concern
+
+Defensive coding patterns were masking protocol failures. Specifically, bootstrap
+`Create(VulnerabilityCase)` was silently synthesising a reporter participant record
+from domain knowledge ("they submitted a report, therefore RM.ACCEPTED") when the
+payload carried participants as bare URI strings rather than inline typed objects,
+violating CBT-01-007.
+
+## Audit Outcome
+
+Full codebase audit found exactly two confirmed masking patterns, both in the
+`_handle_bootstrap` path of `CreateCaseReceivedUseCase`:
+
+1. **`_store_embedded_participants`** — a bare-string `continue` guard that
+   silently skipped participants that arrived as URI strings (violating CBT-01-007)
+2. **`EnsureReporterParticipantAtAcceptedNode` / `_ensure_reporter_participant`** —
+   synthesised a reporter participant at `RM.ACCEPTED` using domain knowledge when
+   the wire payload omitted the inline object
+
+All other candidates reviewed (async replication partial views in
+`participant_status_effect.py`, CaseActor reading own state, wire→core type
+coercions) were confirmed false positives with documented intent.
+
+## Resolution
+
+Implemented CBT-05-008: receivers now raise `VultronProtocolViolationError` on
+any bare-URI participant **before** any DataLayer writes (validate-before-persist —
+"examine the shipment before shelving"). The two fallback artifacts were deleted.
+
+## Learning
+
+The "validate-before-persist" principle: bootstrap must validate the entire payload
+before committing any state. Persisting the case object before validating participants
+(the old order) created a window where partial state could be written. The spec
+analogy: don't put parts on the shelf until you've confirmed the shipment is correct.
+
+A new error type `VultronProtocolViolationError` — the inbound mirror of
+`VultronOutboxObjectIntegrityError` — surfaces these violations explicitly.
+
+## References
+
+- PR: <https://github.com/CERTCC/Vultron/pull/2813>
+- Impl issue: #2808
+- Spec: `specs/case-bootstrap-trust.yaml` (CBT-05-008)

--- a/specs/case-bootstrap-trust.yaml
+++ b/specs/case-bootstrap-trust.yaml
@@ -426,8 +426,10 @@ groups:
     verification: >-
       Tests confirm that when a bootstrap `Create(VulnerabilityCase)` arrives
       with a participant listed as a bare URI string rather than an inline
-      typed object, the receiver raises a protocol error and does not accept
-      the bootstrap.
+      typed object, the receiver raises `VultronProtocolViolationError` and
+      does not accept the bootstrap. The validation step runs before any
+      DataLayer writes so bootstrap is atomic: either the full payload is
+      valid and committed, or nothing is written.
     relationships:
     - rel_type: implements
       spec_id: CBT-01-007

--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -66,8 +66,8 @@ AUDITED_SITES: list[tuple[str, str]] = sorted(
         ("case/case_proposal_received_tree.py", "RmDimension"),
         ("case/case_proposal_received_tree.py", "RmDimension"),
         # BOOTSTRAP — participant/common.py: initial accepted-status builder
-        ("case/nodes/participant/common.py", "RmDimension"),
-        ("case/nodes/participant/common.py", "RmDimension"),
+        # (two entries removed: _ensure_reporter_participant and
+        #  _upgrade_participant_to_accepted deleted in #2808)
         ("case/nodes/participant/common.py", "RmDimension"),
         ("case/nodes/participant/common.py", "RmDimension"),
         ("case/nodes/participant/common.py", "VfdDimension"),

--- a/test/core/use_cases/received/case/test_helpers.py
+++ b/test/core/use_cases/received/case/test_helpers.py
@@ -12,18 +12,13 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Tests for _ensure_reporter_participant helper and EnsureReporterParticipantAtAcceptedNode
-(CBT-05-006/007, #589, #624).
+"""Tests for bootstrap helpers and protocol-error enforcement.
 
 Covers:
-  CBT-05-006  Bootstrap Create seeds the reporter participant at RM.ACCEPTED
-              when the participant arrives as a bare string ID (fix for #589).
-  CBT-05-007  Bootstrap Create upgrades an existing RM.START participant to
-              RM.ACCEPTED (fix for #624).
-
-Both requirements are now exercised via ``EnsureReporterParticipantAtAcceptedNode``
-(a BT leaf node) called through BTBridge from ``CreateCaseReceivedUseCase._handle_bootstrap``
-(BT-06-001, BT-15-001, #943).
+  CBT-05-007  Bootstrap Create stores the reporter participant at RM.ACCEPTED
+              when a fully inline participant object is provided (CBT-01-008).
+  CBT-05-008  Bootstrap Create MUST raise VultronProtocolViolationError when
+              a participant arrives as a bare URI string (#2736, #2808).
 """
 
 from typing import Any, cast
@@ -31,6 +26,7 @@ from typing import Any, cast
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.errors import VultronProtocolViolationError
 from vultron.core.models.participant import VultronParticipant
 from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
@@ -48,407 +44,78 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (
 )
 
 # ---------------------------------------------------------------------------
-# CBT-05-006: Reporter participant seeded with RM.ACCEPTED on bootstrap (#589)
-# ---------------------------------------------------------------------------
-
-
-class TestBootstrapCreateReporterParticipant:
-    """Bootstrap Create must seed the reporter's participant at RM.ACCEPTED.
-
-    When Create(as_VulnerabilityCase) arrives with participant IDs as bare
-    strings, _store_embedded_participants skips them.  The reporter's own
-    participant record would then be absent from their DataLayer, causing
-    SvcAddParticipantStatusUseCase._resolve_current_participant_state to
-    fall back to RM.START — the root cause of #589.
-
-    The fix: _handle_bootstrap calls EnsureReporterParticipantAtAcceptedNode
-    via BTBridge, which infers from the reporter's submitted report that they
-    have already RM.ACCEPTED and creates the participant record with that state
-    if it is not already present (BT-06-001, BT-15-001, #943).
-    """
-
-    _VENDOR_ID = "https://vendor.example.org/actors/vendor-589"
-    _FINDER_ID = "https://finder.example.org/actors/finder-589"
-    _CASE_ID = "https://example.org/cases/case-589"
-    _REPORT_ID = "https://example.org/reports/report-589"
-    _FINDER_PARTICIPANT_ID = f"{_CASE_ID}/participants/finder-589"
-    _VENDOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor-589"
-
-    @pytest.fixture()
-    def dl(self):
-        return SqliteDataLayer(
-            "sqlite:///:memory:",
-            # The *receiving* actor's own store (ADR-0041 AC-5): a received
-            # Create(VulnerabilityCase) is applied to the receiver's replica.
-            actor_id=self._FINDER_ID,
-        )
-
-    @pytest.fixture()
-    def seeded_dl(self, dl):
-        """DataLayer with the Finder's pre-existing report and case link."""
-        report = VultronReport(
-            id_=self._REPORT_ID,
-            attributed_to=self._FINDER_ID,
-        )
-        dl.create(report)
-
-        link = VultronReportCaseLink(
-            report_id=self._REPORT_ID,
-            trusted_case_creator_id=self._VENDOR_ID,
-        )
-        dl.save(link)
-        return dl
-
-    @pytest.fixture()
-    def case_with_string_participants(self):
-        """as_VulnerabilityCase whose participants are bare string IDs.
-
-        This is the common wire representation when the sender serialises the
-        domain VultronCase (which stores participant IDs, not objects).
-        The fixture also includes a CASE_MANAGER participant inline so that
-        the bootstrap trust path extracts a trusted_case_actor_id.
-        """
-        case_actor_participant = as_CaseParticipant(
-            case_roles=[CVDRole.CASE_MANAGER],
-            id_=self._VENDOR_PARTICIPANT_ID,
-            attributed_to=self._VENDOR_ID,
-            context=self._CASE_ID,
-        )
-        case = as_VulnerabilityCase(
-            id_=self._CASE_ID,
-            name="Bug #589 regression case",
-            case_participants=[
-                case_actor_participant,  # inline so CBT-01-003 can extract it
-                self._FINDER_PARTICIPANT_ID,  # bare string — typical case
-            ],
-        )
-        case.actor_participant_index[self._VENDOR_ID] = (
-            self._VENDOR_PARTICIPANT_ID
-        )
-        case.actor_participant_index[self._FINDER_ID] = (
-            self._FINDER_PARTICIPANT_ID
-        )
-        return case
-
-    @pytest.fixture()
-    def create_event(self, make_payload, case_with_string_participants):
-        activity = create_case_activity(
-            case_with_string_participants, actor=self._VENDOR_ID
-        )
-        return make_payload(activity, receiving_actor_id=self._FINDER_ID)
-
-    def test_reporter_participant_created_after_bootstrap(
-        self, seeded_dl, create_event
-    ):
-        """Reporter participant must exist in DataLayer after bootstrap (#589).
-
-        When the bootstrap Create(as_VulnerabilityCase) carries the reporter's
-        participant as a bare string ID, the DataLayer must still produce a
-        standalone participant record for the reporter so that subsequent
-        SvcAddParticipantStatusUseCase calls can read it.
-        """
-        CreateCaseReceivedUseCase(seeded_dl, create_event).execute()
-
-        stored = seeded_dl.read(self._FINDER_PARTICIPANT_ID)
-        assert stored is not None, (
-            "Reporter participant must be created in the DataLayer after "
-            "bootstrap even when case_participants contains a bare string ID "
-            "(regression #589)"
-        )
-
-    def test_reporter_participant_has_rm_accepted_after_bootstrap(
-        self, seeded_dl, create_event
-    ):
-        """Reporter participant must start at RM.ACCEPTED after bootstrap.
-
-        The reporter submitted a report — by definition they have accepted the
-        vulnerability from their own RM perspective.  The seeded participant
-        must reflect this so that _resolve_current_participant_state returns
-        RM.ACCEPTED rather than RM.START (#589).
-        """
-        CreateCaseReceivedUseCase(seeded_dl, create_event).execute()
-
-        stored = seeded_dl.read(self._FINDER_PARTICIPANT_ID)
-        assert stored is not None
-        statuses = getattr(stored, "participant_statuses", [])
-        assert statuses, (
-            "Reporter participant must have at least one ParticipantStatus "
-            "after bootstrap (#589)"
-        )
-        latest = statuses[-1]
-        rm_state = latest.rm.state if hasattr(latest, "rm") else None
-        assert rm_state == RM.ACCEPTED, (
-            f"Reporter participant must have rm_state=RM.ACCEPTED after "
-            f"bootstrap; got {rm_state!r} (#589)"
-        )
-
-
-# ---------------------------------------------------------------------------
-# CBT-05-007: Reporter participant upgraded from RM.START to RM.ACCEPTED (#624)
+# CBT-05-007: Reporter participant stored at RM.ACCEPTED when inline (#589)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.spec("CBT-05-007")
-class TestBootstrapReporterUpgradesFromStart:
-    """Bootstrap Create upgrades an existing RM.START participant to RM.ACCEPTED.
+def test_reporter_participant_stored_at_accepted_when_inline(make_payload):
+    """Reporter participant at RM.ACCEPTED in inline payload is preserved (#589).
 
-    When ``_store_embedded_participants`` stores the wire-layer snapshot, it may
-    seed the reporter's participant with ``rm_state=RM.START`` (the wire default).
-    ``EnsureReporterParticipantAtAcceptedNode`` must detect this and upgrade the
-    participant to ``RM.ACCEPTED`` via BTBridge (#624, BT-06-001, BT-15-001,
-    #943).
+    CBT-01-008 requires the sender to include the reporter's participant inline
+    at RM.ACCEPTED.  CBT-05-008 requires the receiver to reject bare-string
+    participants.  This test confirms that when the sender complies (fully
+    inline participant at RM.ACCEPTED), the receiver stores it correctly via
+    _store_embedded_participants so subsequent Add(ParticipantStatus) calls can
+    read it at RM.ACCEPTED.
     """
+    from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
 
-    _VENDOR_ID = "https://vendor.example.org/actors/vendor-624"
-    _FINDER_ID = "https://finder.example.org/actors/finder-624"
-    _CASE_ID = "https://example.org/cases/case-624"
-    _REPORT_ID = "https://example.org/reports/report-624"
-    _FINDER_PARTICIPANT_ID = f"{_CASE_ID}/participants/finder-624"
-    _VENDOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor-624"
+    _VENDOR_ID = "https://vendor.example.org/actors/vendor-cbt05007"
+    _FINDER_ID = "https://finder.example.org/actors/finder-cbt05007"
+    _CASE_ID = "https://example.org/cases/case-cbt05007"
+    _REPORT_ID = "https://example.org/reports/report-cbt05007"
+    _FINDER_PARTICIPANT_ID = f"{_CASE_ID}/participants/finder-cbt05007"
+    _VENDOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor-cbt05007"
 
-    @pytest.fixture()
-    def dl(self):
-        return SqliteDataLayer(
-            "sqlite:///:memory:",
-            # The *receiving* actor's own store (ADR-0041 AC-5): a received
-            # Create(VulnerabilityCase) is applied to the receiver's replica.
-            actor_id=self._FINDER_ID,
-        )
-
-    @pytest.fixture()
-    def base_dl(self, dl):
-        """DataLayer with report and link pre-seeded."""
-        report = VultronReport(
-            id_=self._REPORT_ID,
-            attributed_to=self._FINDER_ID,
-        )
-        dl.create(report)
-
-        link = VultronReportCaseLink(
-            report_id=self._REPORT_ID,
-            trusted_case_creator_id=self._VENDOR_ID,
-        )
-        dl.save(link)
-        return dl
-
-    @pytest.fixture()
-    def case_with_string_participants(self):
-        case_actor_participant = as_CaseParticipant(
-            case_roles=[CVDRole.CASE_MANAGER],
-            id_=self._VENDOR_PARTICIPANT_ID,
-            attributed_to=self._VENDOR_ID,
-            context=self._CASE_ID,
-        )
-        case = as_VulnerabilityCase(
-            id_=self._CASE_ID,
-            name="Bug #624 regression case",
-            case_participants=[
-                case_actor_participant,
-                self._FINDER_PARTICIPANT_ID,  # bare string
-            ],
-        )
-        case.actor_participant_index[self._VENDOR_ID] = (
-            self._VENDOR_PARTICIPANT_ID
-        )
-        case.actor_participant_index[self._FINDER_ID] = (
-            self._FINDER_PARTICIPANT_ID
-        )
-        return case
-
-    def _create_event(self, make_payload, case):
-        activity = create_case_activity(case, actor=self._VENDOR_ID)
-        return make_payload(activity, receiving_actor_id=self._FINDER_ID)
-
-    def _pre_seed_participant(self, dl, rm_state: RM) -> VultronParticipant:
-        """Store a finder participant at the given rm_state before bootstrap."""
-        status = ParticipantStatus(
-            rm=RmDimension(state=rm_state),
-            context=self._CASE_ID,
-            attributed_to=self._FINDER_ID,
-        )
-        participant = VultronParticipant(
-            id_=self._FINDER_PARTICIPANT_ID,
-            attributed_to=self._FINDER_ID,
-            context=self._CASE_ID,
-            participant_statuses=[status],
-        )
-        dl.create(participant)
-        return participant
-
-    def test_reporter_participant_upgraded_from_start_to_accepted(
-        self, base_dl, make_payload, case_with_string_participants
-    ):
-        """Reporter participant at RM.START must be upgraded to RM.ACCEPTED (#624).
-
-        Pre-condition: reporter's participant is already in the DataLayer at
-        RM.START (seeded by _store_embedded_participants or a prior bootstrap).
-        Post-condition: after CreateCaseReceivedUseCase, the participant's latest
-        rm_state is RM.ACCEPTED.
-        """
-        self._pre_seed_participant(base_dl, RM.START)
-        event = self._create_event(make_payload, case_with_string_participants)
-
-        CreateCaseReceivedUseCase(base_dl, event).execute()
-
-        stored = base_dl.read(self._FINDER_PARTICIPANT_ID)
-        assert stored is not None
-        statuses = getattr(stored, "participant_statuses", [])
-        assert statuses, "Reporter participant must have at least one status"
-        latest_rm = statuses[-1].rm.state
-        assert latest_rm == RM.ACCEPTED, (
-            f"Reporter participant must be upgraded to RM.ACCEPTED from "
-            f"RM.START; got {latest_rm!r} (#624)"
-        )
-
-    def test_reporter_participant_noop_if_already_accepted(
-        self, base_dl, make_payload, case_with_string_participants
-    ):
-        """Reporter participant already at RM.ACCEPTED must not be modified (#624)."""
-        self._pre_seed_participant(base_dl, RM.ACCEPTED)
-        event = self._create_event(make_payload, case_with_string_participants)
-
-        CreateCaseReceivedUseCase(base_dl, event).execute()
-
-        stored = base_dl.read(self._FINDER_PARTICIPANT_ID)
-        assert stored is not None
-        statuses = getattr(stored, "participant_statuses", [])
-        assert len(statuses) == 1, (
-            "Reporter participant already at RM.ACCEPTED must not gain extra "
-            f"statuses; got {len(statuses)} (#624)"
-        )
-        assert statuses[0].rm.state == RM.ACCEPTED
-
-    def test_reporter_participant_noop_if_already_closed(
-        self, base_dl, make_payload, case_with_string_participants
-    ):
-        """Reporter participant already at RM.CLOSED must not be downgraded (#624)."""
-        self._pre_seed_participant(base_dl, RM.CLOSED)
-        event = self._create_event(make_payload, case_with_string_participants)
-
-        CreateCaseReceivedUseCase(base_dl, event).execute()
-
-        stored = base_dl.read(self._FINDER_PARTICIPANT_ID)
-        assert stored is not None
-        statuses = getattr(stored, "participant_statuses", [])
-        assert len(statuses) == 1, (
-            "Reporter participant at RM.CLOSED must not gain extra statuses "
-            f"(it is already beyond ACCEPTED); got {len(statuses)} (#624)"
-        )
-        assert statuses[0].rm.state == RM.CLOSED
-
-    def test_reporter_participant_noop_if_at_invalid(
-        self, base_dl, make_payload, case_with_string_participants
-    ):
-        """Reporter participant at RM.INVALID must not be upgraded to ACCEPTED.
-
-        RM.INVALID is a validation-failure branch: the report was determined
-        invalid.  Bypassing re-validation by jumping directly to RM.ACCEPTED
-        violates SM-04-001 (explicit precondition guard before state write).
-        The participant must remain at RM.INVALID (#2481).
-        """
-        self._pre_seed_participant(base_dl, RM.INVALID)
-        event = self._create_event(make_payload, case_with_string_participants)
-
-        CreateCaseReceivedUseCase(base_dl, event).execute()
-
-        stored = base_dl.read(self._FINDER_PARTICIPANT_ID)
-        assert stored is not None
-        statuses = getattr(stored, "participant_statuses", [])
-        assert len(statuses) == 1, (
-            "Reporter participant at RM.INVALID must not gain extra statuses "
-            f"(upgrade to ACCEPTED must be blocked); got {len(statuses)} (#2481)"
-        )
-        assert statuses[0].rm.state == RM.INVALID
-
-
-# ---------------------------------------------------------------------------
-# _upgrade_participant_to_accepted must be a silent no-op on RM.ACCEPTED
-# (issue #2763)
-# ---------------------------------------------------------------------------
-
-
-class TestUpgradeParticipantIdempotencyWhenAlreadyAccepted:
-    """``_upgrade_participant_to_accepted`` must be a silent no-op when already at RM.ACCEPTED.
-
-    Regression for #2763: when ``latest_rm == RM.ACCEPTED``,
-    ``is_valid_rm_transition(RM.ACCEPTED, RM.ACCEPTED)`` is ``False`` (no
-    self-loop).  Before the fix, the SM-04-001 guard fired a misleading
-    ``WARNING``, filling logs on every ledger replay and masking genuine
-    SM-04-001 violations.
-
-    The function must:
-    - log nothing at WARNING or above,
-    - write no new DataLayer record,
-
-    when called with ``latest_rm == RM.ACCEPTED``.
-    """
-
-    _ACTOR_ID = "https://finder.example.org/actors/finder-2763"
-    _CASE_ID = "https://example.org/cases/case-2763"
-    _PARTICIPANT_ID = f"{_CASE_ID}/participants/finder-2763"
-
-    @pytest.fixture()
-    def dl(self):
-        return SqliteDataLayer("sqlite:///:memory:", actor_id=self._ACTOR_ID)
-
-    @pytest.fixture()
-    def participant_at_accepted(self, dl):
-        """Participant already at RM.ACCEPTED stored in the DataLayer."""
-        status = ParticipantStatus(
-            rm=RmDimension(state=RM.ACCEPTED),
-            context=self._CASE_ID,
-            attributed_to=self._ACTOR_ID,
-        )
-        participant = VultronParticipant(
-            id_=self._PARTICIPANT_ID,
-            attributed_to=self._ACTOR_ID,
-            context=self._CASE_ID,
-            participant_statuses=[status],
-        )
-        dl.create(participant)
-        return participant
-
-    def test_no_warning_and_no_extra_status_when_already_accepted(
-        self, dl, participant_at_accepted, caplog
-    ):
-        """No WARNING logged and no extra status written on idempotent replay (#2763).
-
-        SM-04-001 guard must not fire when ``latest_rm == RM.ACCEPTED`` —
-        the participant is already at the target state, so there is no
-        illegal transition.
-        """
-        import logging
-
-        from vultron.core.behaviors.case.nodes.participant.common import (
-            _upgrade_participant_to_accepted,
-        )
-
-        with caplog.at_level(logging.WARNING):
-            _upgrade_participant_to_accepted(
-                dl=dl,
-                existing=participant_at_accepted,
-                participant_id=self._PARTICIPANT_ID,
-                case_id=self._CASE_ID,
-                reporter_actor_id=self._ACTOR_ID,
-                latest_rm=RM.ACCEPTED,
+    dl = SqliteDataLayer("sqlite:///:memory:", actor_id=_FINDER_ID)
+    report = VultronReport(id_=_REPORT_ID, attributed_to=_FINDER_ID)
+    dl.create(report)
+    link = VultronReportCaseLink(
+        report_id=_REPORT_ID,
+        trusted_case_creator_id=_VENDOR_ID,
+    )
+    dl.save(link)
+    vendor_participant = as_CaseParticipant(
+        case_roles=[CVDRole.CASE_MANAGER],
+        id_=_VENDOR_PARTICIPANT_ID,
+        attributed_to=_VENDOR_ID,
+        context=_CASE_ID,
+    )
+    finder_participant = as_CaseParticipant(
+        id_=_FINDER_PARTICIPANT_ID,
+        attributed_to=_FINDER_ID,
+        context=_CASE_ID,
+        participant_statuses=[
+            as_ParticipantStatus(
+                context=_CASE_ID,
+                attributed_to=_FINDER_ID,
+                rm_state=RM.ACCEPTED,
             )
+        ],
+    )
+    case = as_VulnerabilityCase(
+        id_=_CASE_ID,
+        name="CBT-05-007 inline participant test",
+        case_participants=[vendor_participant, finder_participant],
+    )
+    case.actor_participant_index[_VENDOR_ID] = _VENDOR_PARTICIPANT_ID
+    case.actor_participant_index[_FINDER_ID] = _FINDER_PARTICIPANT_ID
+    activity = create_case_activity(case, actor=_VENDOR_ID)
+    event = make_payload(activity, receiving_actor_id=_FINDER_ID)
 
-        warning_messages = [
-            r.message for r in caplog.records if r.levelno >= logging.WARNING
-        ]
-        assert not warning_messages, (
-            "No WARNING must be logged when participant is already at "
-            f"RM.ACCEPTED; got: {warning_messages!r} (#2763)"
-        )
+    CreateCaseReceivedUseCase(dl, event).execute()
 
-        stored = dl.read(self._PARTICIPANT_ID)
-        assert stored is not None
-        statuses = getattr(stored, "participant_statuses", [])
-        assert len(statuses) == 1, (
-            "No extra status must be written when participant is already "
-            f"at RM.ACCEPTED; got {len(statuses)} status(es) (#2763)"
-        )
-        assert statuses[0].rm.state == RM.ACCEPTED
+    stored = dl.read(_FINDER_PARTICIPANT_ID)
+    assert (
+        stored is not None
+    ), "Reporter participant must exist after bootstrap"
+    statuses = getattr(stored, "participant_statuses", [])
+    assert statuses, "Reporter participant must have at least one status"
+    assert statuses[-1].rm.state == RM.ACCEPTED, (
+        f"Reporter participant must be at RM.ACCEPTED after bootstrap;"
+        f" got {statuses[-1].rm.state!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -689,17 +356,9 @@ class TestStoreEmbeddedParticipantsProjectsWireIngress:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "CBT-05-008: receiver MUST raise a protocol error for a bare-URI "
-        "participant — NOT fall back to domain-knowledge inference. "
-        "Tracked by #2736."
-    ),
-)
 @pytest.mark.spec("CBT-05-008")
 def test_bootstrap_bare_uri_participant_raises_protocol_error(make_payload):
-    """Bootstrap with a bare-URI participant MUST raise a protocol error."""
+    """Bootstrap with a bare-URI participant MUST raise VultronProtocolViolationError."""
     _VENDOR_ID = "https://vendor.example.org/actors/vendor-cbt05008"
     _FINDER_ID = "https://finder.example.org/actors/finder-cbt05008"
     _CASE_ID = "https://example.org/cases/case-cbt05008"
@@ -733,5 +392,5 @@ def test_bootstrap_bare_uri_participant_raises_protocol_error(make_payload):
     case.actor_participant_index[_FINDER_ID] = _FINDER_PARTICIPANT_ID
     activity = create_case_activity(case, actor=_VENDOR_ID)
     event = make_payload(activity, receiving_actor_id=_FINDER_ID)
-    with pytest.raises(Exception):  # MUST raise a protocol error
+    with pytest.raises(VultronProtocolViolationError):
         CreateCaseReceivedUseCase(dl, event).execute()

--- a/vultron/core/behaviors/case/nodes/participant/__init__.py
+++ b/vultron/core/behaviors/case/nodes/participant/__init__.py
@@ -46,9 +46,6 @@ from vultron.core.behaviors.case.nodes.participant.owner import (
     ResolveOwnerInitialStatusNode,
     ShouldAdvanceOwnerToAcceptedNode,
 )
-from vultron.core.behaviors.case.nodes.participant._bootstrap import (
-    EnsureReporterParticipantAtAcceptedNode,
-)
 from vultron.core.behaviors.case.nodes.participant.participant_add import (
     AttachParticipantToCaseNode,
     CaseHasActiveEmbargoNode,
@@ -97,7 +94,6 @@ __all__ = [
     "CreateCaseParticipantNode",
     "CreateParticipantStatusNode",
     "ValidateTriggerTransitionsNode",
-    "EnsureReporterParticipantAtAcceptedNode",
 ]
 
 # TYPE_CHECKING stubs so mypy resolves composite names to their actual types.

--- a/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
+++ b/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
@@ -13,59 +13,10 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Bootstrap participant BT node.
+"""Bootstrap participant BT node module — intentionally empty.
 
-Separated from participant_add.py to keep that module under the BTND-07-004
-500-line limit.  This node is only used during Create(VulnerabilityCase)
-bootstrap flows, not during normal report-receive flows.
+``EnsureReporterParticipantAtAcceptedNode`` was removed when CBT-05-008 was
+implemented.  Receivers now raise ``VultronProtocolViolationError`` on
+bare-URI participants rather than synthesising state from domain knowledge
+(#2736, #2808).
 """
-
-from py_trees.common import Status
-
-from vultron.core.behaviors.case.nodes.participant.common import (
-    _ensure_reporter_participant,
-)
-from vultron.core.behaviors.helpers import DataLayerActionWithPorts
-from vultron.core.models.case import VulnerabilityCase
-from vultron.core.models.report_case_link import VultronReportCaseLink
-
-
-class EnsureReporterParticipantAtAcceptedNode(DataLayerActionWithPorts):
-    """BT leaf node that seeds or upgrades the reporter participant to RM.ACCEPTED.
-
-    Called from ``CreateCaseReceivedUseCase._handle_bootstrap`` via BTBridge
-    after a ``Create(VulnerabilityCase)`` bootstrap.  When participants arrive
-    as bare string IDs, ``_store_embedded_participants`` cannot create records
-    for them.  This node ensures the reporter's participant record exists at
-    ``RM.ACCEPTED`` — inferred from the fact that they submitted a report (#589,
-    #624).
-
-    Args:
-        link: The ``VultronReportCaseLink`` associating the report to the case.
-        case_obj: The bootstrapped ``VulnerabilityCase`` domain object.
-        case_id: ID of the case (for log context).
-    """
-
-    def __init__(
-        self,
-        link: VultronReportCaseLink,
-        case_obj: VulnerabilityCase,
-        case_id: str,
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self.link = link
-        self.case_obj = case_obj
-        self.case_id = case_id
-
-    def update(self) -> Status:
-        if (f := self._require_datalayer()) is not None:
-            return f
-        assert self.datalayer is not None
-        _ensure_reporter_participant(
-            self.datalayer,
-            self.link,
-            self.case_obj,
-            self.case_id,
-        )
-        return Status.SUCCESS

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -41,7 +41,6 @@ from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.core.models._helpers import (
-    _as_id,
     _report_phase_status_id,
     report_phase_context,
 )

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -16,7 +16,7 @@
 """Shared helpers for participant BT nodes."""
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from vultron.core.models.enums import VultronObjectType
 from vultron.core.models.dimensions import (
@@ -26,13 +26,10 @@ from vultron.core.models.dimensions import (
 )
 from vultron.core.models.participant_status import (
     ParticipantStatus,
-    coerce_cvd_roles,
-    coerce_em_consent_state,
     participant_status_rm_state,
     participant_status_vfd_state,
 )
 from vultron.core.models.case import VulnerabilityCase
-from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.ports.case_persistence import (
@@ -41,7 +38,7 @@ from vultron.core.ports.case_persistence import (
 )
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.cs import CS_vfd
-from vultron.core.states.rm import RM, is_rm_at_least, is_valid_rm_transition
+from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.core.models._helpers import (
     _as_id,
@@ -271,188 +268,3 @@ def _queue_participant_add_notification(
         sender_actor_id,
     )
     return True
-
-
-def _ensure_reporter_participant(
-    dl: CasePersistence,
-    link: VultronReportCaseLink,
-    case_obj: VulnerabilityCase,
-    case_id: str,
-) -> None:
-    """Ensure the reporter's participant record is at RM.ACCEPTED (#589, #624).
-
-    When ``Create(VulnerabilityCase)`` carries participant IDs as bare
-    strings, ``_store_embedded_participants`` skips them.  Without an
-    explicit participant record in the DataLayer,
-    ``SvcAddParticipantStatusUseCase._resolve_current_participant_state``
-    falls back to ``RM.START``, causing the Vendor's Case Actor to reject the
-    subsequent ``Add(ParticipantStatus)`` as a backwards transition.
-
-    The reporter submitted the original report, which implies they have
-    already ``RM.ACCEPTED`` from their own perspective.  The reporter is
-    identified as ``attributed_to`` of the ``Offer(Report)`` activity
-    (``report.attributed_to``).  Their ``START→RECEIVED→VALID→ACCEPTED`` arc
-    is hidden from the protocol — their first observable action already
-    implies ``RM.ACCEPTED`` (#624).
-
-    This function:
-
-    * Creates the participant record at ``RM.ACCEPTED`` if it is absent.
-    * Upgrades an existing participant from any state below ``RM.ACCEPTED``
-      (e.g. ``RM.START`` seeded by the wire-layer default) to ``RM.ACCEPTED``.
-    * No-ops if the participant is already at or beyond ``RM.ACCEPTED``.
-
-    This invariant applies **only** to the reporter/finder.  All other
-    participants enter through a visible protocol interaction and their RM
-    lifecycle proceeds normally from ``RM.RECEIVED``.
-
-    Args:
-        dl: The reporter's local DataLayer.
-        link: The ``VultronReportCaseLink`` associating the report to this
-            case bootstrap.
-        case_obj: The bootstrapped ``VulnerabilityCase`` snapshot.
-        case_id: ID of the case (for log context and status context).
-    """
-    logger = logging.getLogger(__name__)
-    report = dl.read(link.report_id)
-    if report is None:
-        logger.warning(
-            "ensure_reporter_participant: report '%s' not found "
-            "— cannot seed reporter participant (#589)",
-            link.report_id,
-        )
-        return
-
-    reporter_actor_id = _as_id(getattr(report, "attributed_to", None))
-    if not reporter_actor_id:
-        logger.warning(
-            "ensure_reporter_participant: report '%s' has no attributed_to "
-            "— cannot seed reporter participant (#589)",
-            link.report_id,
-        )
-        return
-
-    index = getattr(case_obj, "actor_participant_index", {}) or {}
-    participant_id = index.get(reporter_actor_id)
-    if not participant_id:
-        logger.warning(
-            "ensure_reporter_participant: reporter '%s' not in "
-            "actor_participant_index for case '%s' — skipping (#589)",
-            reporter_actor_id,
-            case_id,
-        )
-        return
-
-    existing = dl.read(participant_id)
-    if existing is not None:
-        statuses = getattr(existing, "participant_statuses", []) or []
-        latest_rm = statuses[-1].rm.state if statuses else RM.START
-        if is_rm_at_least(latest_rm, RM.ACCEPTED):
-            logger.debug(
-                "ensure_reporter_participant: participant '%s' already "
-                "≥ RM.ACCEPTED — skipping (#589, #624)",
-                participant_id,
-            )
-            return
-        _upgrade_participant_to_accepted(
-            dl, existing, participant_id, case_id, reporter_actor_id, latest_rm
-        )
-        return
-
-    status = ParticipantStatus(
-        rm=RmDimension(state=RM.ACCEPTED),
-        context=case_id,
-        attributed_to=reporter_actor_id,
-        consent=PecDimension(state=PEC.NO_EMBARGO),
-        cvd_role=[CVDRole.REPORTER],
-    )
-    participant = VultronParticipant(
-        id_=participant_id,
-        attributed_to=reporter_actor_id,
-        context=case_id,
-        participant_statuses=[status],
-    )
-    try:
-        dl.create(participant)
-        logger.info(
-            "ensure_reporter_participant: created participant '%s' for "
-            "reporter '%s' at RM.ACCEPTED (#589)",
-            participant_id,
-            reporter_actor_id,
-        )
-    except ValueError:
-        logger.debug(
-            "ensure_reporter_participant: participant '%s' was concurrently "
-            "created — idempotent (#589)",
-            participant_id,
-        )
-
-
-def _upgrade_participant_to_accepted(
-    dl: CasePersistence,
-    existing: Any,
-    participant_id: str,
-    case_id: str,
-    reporter_actor_id: str,
-    latest_rm: RM,
-) -> None:
-    """Upgrade an existing participant record from below RM.ACCEPTED to RM.ACCEPTED.
-
-    Saves the new status as an independent DataLayer record, then reads it back
-    via the DataLayer so the stored canonical record is used (ADR-0034:
-    dl.read() returns core-typed objects for ParticipantStatus).
-    """
-    logger = logging.getLogger(__name__)
-    # Idempotency guard: already at target state, nothing to do (#2763).
-    if latest_rm == RM.ACCEPTED:
-        return
-    # SM-04-001: guard before writing — RM.INVALID cannot advance to ACCEPTED
-    # without first re-validating (INVALID → VALID → ACCEPTED).  START and
-    # RECEIVED are bootstrap-forward jumps that remain valid because the
-    # reporter is known to have accepted by virtue of submitting the report.
-    if not is_valid_rm_transition(
-        latest_rm, RM.ACCEPTED
-    ) and latest_rm not in (
-        RM.START,
-        RM.RECEIVED,
-    ):
-        logger.warning(
-            "ensure_reporter_participant: participant '%s' is at %s — "
-            "upgrade to RM.ACCEPTED blocked; re-validation required "
-            "before accepting (SM-04-001)",
-            participant_id,
-            latest_rm,
-        )
-        return
-    _coerced_consent = coerce_em_consent_state(
-        getattr(existing, "embargo_consent_state", None)
-    )
-    upgrade_status = ParticipantStatus(
-        rm=RmDimension(state=RM.ACCEPTED),
-        context=case_id,
-        attributed_to=reporter_actor_id,
-        consent=(
-            PecDimension(state=_coerced_consent)
-            if _coerced_consent is not None
-            else None
-        ),
-        cvd_role=coerce_cvd_roles(getattr(existing, "roles", [])),
-    )
-    try:
-        dl.create(upgrade_status)
-    except ValueError:
-        dl.save(upgrade_status)
-    wire_status = dl.read(upgrade_status.id_)
-    if isinstance(existing, CaseParticipant):
-        existing.add_participant_status(
-            wire_status
-            if isinstance(wire_status, ParticipantStatus)
-            else upgrade_status
-        )
-    dl.save(existing)
-    logger.info(
-        "ensure_reporter_participant: upgraded participant '%s' from "
-        "%s to RM.ACCEPTED (#589, #624)",
-        participant_id,
-        latest_rm,
-    )

--- a/vultron/core/use_cases/received/case/__init__.py
+++ b/vultron/core/use_cases/received/case/__init__.py
@@ -1,7 +1,3 @@
-from vultron.core.behaviors.case.nodes.participant.common import (
-    _ensure_reporter_participant,
-    _upgrade_participant_to_accepted,
-)
 from vultron.core.use_cases.received.case._helpers import (
     _find_report_case_link,
     _check_participant_embargo_acceptance,
@@ -31,8 +27,6 @@ __all__ = [
     "_find_report_case_link",
     "_check_participant_embargo_acceptance",
     "_store_embedded_participants",
-    "_ensure_reporter_participant",
-    "_upgrade_participant_to_accepted",
     "CreateCaseReceivedUseCase",
     "UpdateCaseReceivedUseCase",
     "EngageCaseReceivedUseCase",

--- a/vultron/core/use_cases/received/case/_helpers.py
+++ b/vultron/core/use_cases/received/case/_helpers.py
@@ -5,10 +5,6 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from vultron.core.behaviors.case.nodes.participant.common import (  # noqa: F401
-    _ensure_reporter_participant,
-    _upgrade_participant_to_accepted,
-)
 from vultron.core.behaviors.case.update_support import (
     find_excluded_actor_ids,
 )
@@ -148,8 +144,6 @@ def _store_embedded_participants(
     """
     participants = getattr(case_obj, "case_participants", []) or []
     for participant_ref in participants:
-        if isinstance(participant_ref, str):
-            continue
         pid = getattr(participant_ref, "id_", None)
         if pid is None:
             continue

--- a/vultron/core/use_cases/received/case/create.py
+++ b/vultron/core/use_cases/received/case/create.py
@@ -2,18 +2,14 @@
 
 import logging
 
-from vultron.core.behaviors.bridge import BTBridge
-from vultron.core.behaviors.case.nodes.participant import (
-    EnsureReporterParticipantAtAcceptedNode,
-)
 from vultron.core.models.events.case import CreateCaseReceivedEvent
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CasePersistence
+from vultron.errors import VultronProtocolViolationError
 
 from vultron.core.use_cases._helpers import (
     _resolve_case_manager_id,
-    resolve_receiving_actor_id,
 )
 
 from ._helpers import (
@@ -162,6 +158,19 @@ class CreateCaseReceivedUseCase:
                 case_id,
             )
 
+        # CBT-05-008 / CBT-01-007: all participants MUST be inline typed objects.
+        # Raise before persisting anything so bootstrap is atomic: the full
+        # payload must be valid before any state is committed ("examine the
+        # shipment before shelving its contents").
+        participants = getattr(case_obj, "case_participants", []) or []
+        bare = [p for p in participants if isinstance(p, str)]
+        if bare:
+            raise VultronProtocolViolationError(
+                f"Bootstrap Create(VulnerabilityCase) for case '{case_id}'"
+                f" contains {len(bare)} bare-URI participant reference(s);"
+                f" inline typed objects required (CBT-01-007, CBT-05-008)"
+            )
+
         logger.info(
             "create_case_received: bootstrap accepted for case '%s' from "
             "'%s'; seeding replica (CBT-01-006)",
@@ -210,25 +219,3 @@ class CreateCaseReceivedUseCase:
         # the inbox router may have already seeded the case before dispatch.
         _store_embedded_participants(case_obj, self._dl, case_id)
         _store_embedded_embargo(case_obj, self._dl, case_id)
-
-        # #589: when participants arrive as bare string IDs (the common case),
-        # _store_embedded_participants cannot create records for them.  Ensure
-        # the reporter's own participant is seeded at RM.ACCEPTED — inferred
-        # from the fact that they submitted a report.  This is a protocol-
-        # significant RM state transition, so it runs via BTBridge (BT-15-001).
-        # The *receiving* actor, not the sender (BT-17-005). `actor_id` here is
-        # the case creator, deliberately so for `_find_report_case_link` above,
-        # but the node seeds the reporter's participant into the receiver's own
-        # replica — and under ADR-0073 the executing actor selects that store, so
-        # passing the sender would look for the report in the creator's store and
-        # find nothing.
-        BTBridge(datalayer=self._dl).execute_with_setup(
-            tree=EnsureReporterParticipantAtAcceptedNode(
-                link=link,
-                case_obj=case_obj,
-                case_id=case_id,
-            ),
-            actor_id=resolve_receiving_actor_id(
-                self._dl, self._request.receiving_actor_id
-            ),
-        )

--- a/vultron/errors.py
+++ b/vultron/errors.py
@@ -100,6 +100,21 @@ class VultronOutboxObjectIntegrityError(VultronError):
         super().__init__(message)
 
 
+class VultronProtocolViolationError(VultronError):
+    """Raised when an inbound protocol message violates a mandatory requirement.
+
+    The inbound mirror of :exc:`VultronOutboxObjectIntegrityError`.  While
+    that class catches outbound integrity failures (sending a bare URI when an
+    inline object is required), this class catches inbound structural
+    violations — messages received that break a MUST-level spec requirement.
+
+    First use: CBT-05-008 — bootstrap ``Create(VulnerabilityCase)`` carrying a
+    participant as a bare URI string rather than a fully inline typed object.
+    Receivers MUST raise this error and reject the bootstrap rather than
+    silently synthesising participant state from domain knowledge.
+    """
+
+
 class CvdStateModelError(VultronError):
     """Base class for errors in the CVD state model."""
 


### PR DESCRIPTION
- Closes #2736
- Closes #2808

## Summary

Implements CBT-05-008: bootstrap `Create(VulnerabilityCase)` now raises `VultronProtocolViolationError` when any participant arrives as a bare URI string rather than a fully inline typed object, and does so **before** any DataLayer writes (validate-before-persist / "examine the shipment before shelving").

Removes the fallback path (`EnsureReporterParticipantAtAcceptedNode`, `_ensure_reporter_participant`) that silently synthesised a reporter participant from domain knowledge, which masked the underlying protocol violation.

## Changes

- **`vultron/errors.py`**: Add `VultronProtocolViolationError(VultronError)` — inbound mirror of `VultronOutboxObjectIntegrityError`; first use is CBT-05-008
- **`vultron/core/use_cases/received/case/create.py`**: Validate participants before `dl.create()` in `_handle_bootstrap`; remove `BTBridge`/`EnsureReporterParticipantAtAcceptedNode` call
- **`vultron/core/behaviors/case/nodes/participant/_bootstrap.py`**: Empty module — `EnsureReporterParticipantAtAcceptedNode` removed
- **`vultron/core/behaviors/case/nodes/participant/common.py`**: Delete `_ensure_reporter_participant` and `_upgrade_participant_to_accepted` (domain-knowledge inference path)
- **`vultron/core/behaviors/case/nodes/participant/__init__.py`**: Remove `EnsureReporterParticipantAtAcceptedNode` export
- **`vultron/core/use_cases/received/case/_helpers.py`**: Remove bare-string `continue` guard from `_store_embedded_participants`; remove re-export of deleted functions
- **`vultron/core/use_cases/received/case/__init__.py`**: Remove exports of deleted functions
- **`test/core/use_cases/received/case/test_helpers.py`**: Remove xfail from CBT-05-008 test; tighten `pytest.raises(Exception)` → `pytest.raises(VultronProtocolViolationError)`; add CBT-05-007 happy-path test (inline participant at RM.ACCEPTED); remove obsolete tests for deleted functions
- **`specs/case-bootstrap-trust.yaml`**: Update CBT-05-008 `verification:` to name `VultronProtocolViolationError` and describe atomic validate-before-persist behaviour
- **`test/architecture/test_vfd_rm_pxa_write_sites.py`**: Remove 2 `RmDimension` audit entries for the deleted functions

## Verification

- 7807 tests pass (3 tests removed: 2 for `EnsureReporterParticipantAtAcceptedNode`/`_ensure_reporter_participant`, 1 for `_upgrade_participant_to_accepted` — all tested code that was deleted)
- Black clean
- Previously xfail CBT-05-008 test now passes as a regular test
- Architecture invariant tests (spec coverage ratchet, write-site audit) pass