### PR TITLE
fix(demo): gate accept-actor-recommendation on Offer(CaseParticipant) arrival (ADR-0058)

### DIFF
--- a/test/core/use_cases/received/case/test_helpers.py
+++ b/test/core/use_cases/received/case/test_helpers.py
@@ -694,7 +694,7 @@ class TestStoreEmbeddedParticipantsProjectsWireIngress:
     reason=(
         "CBT-05-008: receiver MUST raise a protocol error for a bare-URI "
         "participant — NOT fall back to domain-knowledge inference. "
-        "Tracked by #2736."
+        "Tracked by #2808."
     ),
 )
 @pytest.mark.spec("CBT-05-008")

--- a/test/demo/test_fccv_extension_demo.py
+++ b/test/demo/test_fccv_extension_demo.py
@@ -572,3 +572,66 @@ class TestFccvExtensionCausalGates:
             )
 
         coverage_wait_called.assert_not_called()
+
+    def test_accept_not_called_when_cp_offer_gate_fails(self):
+        """demo_gate skips accept-actor-recommendation when find_cp_offer_for_case times out."""
+        finder_client = self._client()
+        c1_client = self._client()
+        c2_client = self._client()
+        vendor_client = self._client()
+        c1_in_c1 = self._actor("urn:test:c1-in-c1")
+        c2_in_c2 = self._actor("urn:test:c2-in-c2")
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor-in-vendor")
+        finder = self._actor("urn:test:finder")
+        case = self._case()
+
+        mock_post_to_trigger = MagicMock()
+
+        with (
+            patch.object(
+                demo,
+                "find_cp_offer_for_case",
+                side_effect=AssertionError(
+                    "timed out polling for Offer(CaseParticipant)"
+                ),
+            ),
+            patch.object(
+                demo,
+                "find_case_actor_participant_id",
+                return_value="urn:test:case-actor",
+            ),
+            patch.object(demo, "post_to_trigger", mock_post_to_trigger),
+            patch.object(
+                demo,
+                "find_case_invite_for_actor",
+                return_value="urn:test:invite",
+            ),
+            patch.object(demo, "wait_for_case_on_container"),
+            patch.object(demo, "wait_for_case_participants"),
+            patch.object(demo, "run_invite_path_rm_triage"),
+        ):
+            demo._phase_c2_suggests_vendor(
+                finder_client=finder_client,
+                c1_client=c1_client,
+                c2_client=c2_client,
+                vendor_client=vendor_client,
+                c1_in_c1=c1_in_c1,
+                c2_in_c2=c2_in_c2,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                case=case,
+                offer=MagicMock(),
+                report=MagicMock(),
+                finder=finder,
+            )
+
+        accept_calls = [
+            c
+            for c in mock_post_to_trigger.call_args_list
+            if c.kwargs.get("behavior") == "accept-actor-recommendation"
+        ]
+        assert not accept_calls, (
+            "accept-actor-recommendation must not be called when "
+            f"cp_offer gate fails: {accept_calls}"
+        )

--- a/test/demo/test_fcvcv_demo.py
+++ b/test/demo/test_fcvcv_demo.py
@@ -505,3 +505,67 @@ class TestFcvcvCausalGates(_Helpers):
             )
 
         coverage_wait_called.assert_not_called()
+
+    def test_accept_not_called_when_cp_offer_gate_fails(self):
+        """demo_gate skips accept-actor-recommendation when find_cp_offer_for_case times out."""
+        finder_client = self._client()
+        c1_client = self._client()
+        c2_client = self._client()
+        v2_client = self._client()
+        c1_in_c1 = self._actor("urn:test:c1-in-c1")
+        c2_in_c2 = self._actor("urn:test:c2-in-c2")
+        v1 = self._actor("urn:test:v1")
+        v2 = self._actor("urn:test:v2")
+        finder = self._actor("urn:test:finder")
+        case = self._case()
+
+        mock_post_to_trigger = MagicMock()
+
+        with (
+            patch.object(
+                demo,
+                "find_cp_offer_for_case",
+                side_effect=AssertionError(
+                    "timed out polling for Offer(CaseParticipant)"
+                ),
+            ),
+            patch.object(
+                demo,
+                "find_case_actor_participant_id",
+                return_value="urn:test:case-actor",
+            ),
+            patch.object(demo, "post_to_trigger", mock_post_to_trigger),
+            patch.object(demo, "get_actor_by_id", return_value=MagicMock()),
+            patch.object(
+                demo,
+                "find_case_invite_for_actor",
+                return_value="urn:test:invite",
+            ),
+            patch.object(demo, "wait_for_case_on_container"),
+            patch.object(demo, "wait_for_case_participants"),
+            patch.object(demo, "run_invite_path_rm_triage"),
+        ):
+            demo._phase_c2_suggests_v2(
+                finder_client=finder_client,
+                c1_client=c1_client,
+                c2_client=c2_client,
+                v2_client=v2_client,
+                c1_in_c1=c1_in_c1,
+                c2_in_c2=c2_in_c2,
+                v2=v2,
+                case=case,
+                offer=MagicMock(),
+                report=MagicMock(),
+                finder=finder,
+                v1=v1,
+            )
+
+        accept_calls = [
+            c
+            for c in mock_post_to_trigger.call_args_list
+            if c.kwargs.get("behavior") == "accept-actor-recommendation"
+        ]
+        assert not accept_calls, (
+            "accept-actor-recommendation must not be called when "
+            f"cp_offer gate fails: {accept_calls}"
+        )

--- a/test/demo/test_fvcv_extension_demo.py
+++ b/test/demo/test_fvcv_extension_demo.py
@@ -953,3 +953,68 @@ class TestFvcvExtensionCausalGates:
             )
 
         coverage_wait_called.assert_not_called()
+
+    def test_accept_not_called_when_cp_offer_gate_fails(self):
+        """demo_gate skips accept-actor-recommendation when find_cp_offer_for_case times out."""
+        finder_client = self._client()
+        vendor_client = self._client()
+        coordinator_client = self._client()
+        vendor2_client = self._client()
+        vendor = self._actor("urn:test:vendor")
+        vendor_in_vendor = self._actor("urn:test:vendor-in-vendor")
+        coordinator_in_coordinator = self._actor("urn:test:coordinator")
+        vendor2 = self._actor("urn:test:vendor2")
+        vendor2_in_vendor2 = self._actor("urn:test:vendor2-in-vendor2")
+        finder = self._actor("urn:test:finder")
+        case = self._case()
+
+        mock_post_to_trigger = MagicMock()
+
+        with (
+            patch.object(
+                demo,
+                "find_cp_offer_for_case",
+                side_effect=AssertionError(
+                    "timed out polling for Offer(CaseParticipant)"
+                ),
+            ),
+            patch.object(
+                demo,
+                "find_case_actor_participant_id",
+                return_value="urn:test:case-actor",
+            ),
+            patch.object(demo, "post_to_trigger", mock_post_to_trigger),
+            patch.object(
+                demo,
+                "find_case_invite_for_actor",
+                return_value="urn:test:invite",
+            ),
+            patch.object(demo, "wait_for_case_on_container"),
+            patch.object(demo, "wait_for_case_participants"),
+            patch.object(demo, "run_invite_path_rm_triage"),
+        ):
+            demo._phase_coordinator_suggests_vendor2(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                coordinator_client=coordinator_client,
+                vendor2_client=vendor2_client,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                coordinator_in_coordinator=coordinator_in_coordinator,
+                vendor2=vendor2,
+                vendor2_in_vendor2=vendor2_in_vendor2,
+                case=case,
+                offer=MagicMock(),
+                report=MagicMock(),
+                finder=finder,
+            )
+
+        accept_calls = [
+            c
+            for c in mock_post_to_trigger.call_args_list
+            if c.kwargs.get("behavior") == "accept-actor-recommendation"
+        ]
+        assert not accept_calls, (
+            "accept-actor-recommendation must not be called when "
+            f"cp_offer gate fails: {accept_calls}"
+        )

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -352,37 +352,38 @@ def _phase_c2_suggests_vendor(
 
     # CaseActor processes Offer(Actor, Case) and forwards Offer(CaseParticipant)
     # to C1 (CASE_OWNER).  Poll C1's DataLayer for the offer.
-    cp_offer_id = None
-    with demo_check(
+    # All dependent steps (case_actor lookup and approve) are nested inside
+    # demo_gate so they are skipped if the offer never arrives (ADR-0058).
+    with demo_gate(
         "Offer(CaseParticipant) for Vendor arrived in C1's DataLayer"
     ):
         cp_offer_id = find_cp_offer_for_case(
             client=c1_client,
             case_id=case.id_,
         )
-    logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
+        logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
 
-    # Find the CaseActor's participant ID so we can route the Accept back.
-    case_actor_id = find_case_actor_participant_id(c1_client, case.id_)
-    if case_actor_id is None:
-        raise AssertionError(
-            "CaseActor participant not found in case — cannot route Accept"
-        )
-    logger.info("CaseActor participant ID: %s", case_actor_id)
+        # Find the CaseActor's participant ID so we can route the Accept back.
+        case_actor_id = find_case_actor_participant_id(c1_client, case.id_)
+        if case_actor_id is None:
+            raise AssertionError(
+                "CaseActor participant not found in case — cannot route Accept"
+            )
+        logger.info("CaseActor participant ID: %s", case_actor_id)
 
-    # Step M4 (ADR-0026 CM-16-006): C1 approves the recommendation.
-    with demo_step(
-        "C1 approves actor recommendation (accept-actor-recommendation)"
-    ):
-        post_to_trigger(
-            client=c1_client,
-            actor_id=c1_in_c1.id_,
-            behavior="accept-actor-recommendation",
-            body={
-                "cp_offer_id": cp_offer_id,
-                "case_actor_id": case_actor_id,
-            },
-        )
+        # Step M4 (ADR-0026 CM-16-006): C1 approves the recommendation.
+        with demo_step(
+            "C1 approves actor recommendation (accept-actor-recommendation)"
+        ):
+            post_to_trigger(
+                client=c1_client,
+                actor_id=c1_in_c1.id_,
+                behavior="accept-actor-recommendation",
+                body={
+                    "cp_offer_id": cp_offer_id,
+                    "case_actor_id": case_actor_id,
+                },
+            )
     logger.info("C1 sent Accept(Offer(CaseParticipant)) to CaseActor")
 
     # CaseActor receives Accept → emits Invite(Actor, Case) to Vendor.  Poll

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -437,33 +437,34 @@ def _phase_c2_suggests_v2(
 
     # CaseActor processes Offer(Actor, Case) and forwards
     # Offer(CaseParticipant) to C1.  Poll C1's DataLayer for the offer.
-    cp_offer_id = None
-    with demo_check("Offer(CaseParticipant) for V2 arrived in C1's DataLayer"):
+    # All dependent steps (case_actor lookup and approve) are nested inside
+    # demo_gate so they are skipped if the offer never arrives (ADR-0058).
+    with demo_gate("Offer(CaseParticipant) for V2 arrived in C1's DataLayer"):
         cp_offer_id = find_cp_offer_for_case(
             client=c1_client,
             case_id=case.id_,
         )
         logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
 
-    # Find the CaseActor's participant ID so we can route the Accept back.
-    case_actor_id = find_case_actor_participant_id(c1_client, case.id_)
-    if case_actor_id is None:
-        raise AssertionError(
-            "CaseActor participant not found in case — cannot route Accept"
-        )
-    logger.info("CaseActor participant ID: %s", case_actor_id)
+        # Find the CaseActor's participant ID so we can route the Accept back.
+        case_actor_id = find_case_actor_participant_id(c1_client, case.id_)
+        if case_actor_id is None:
+            raise AssertionError(
+                "CaseActor participant not found in case — cannot route Accept"
+            )
+        logger.info("CaseActor participant ID: %s", case_actor_id)
 
-    # C1 approves the recommendation (CM-16-006).
-    with demo_step("C1 approves actor recommendation"):
-        post_to_trigger(
-            client=c1_client,
-            actor_id=c1_in_c1.id_,
-            behavior="accept-actor-recommendation",
-            body={
-                "cp_offer_id": cp_offer_id,
-                "case_actor_id": case_actor_id,
-            },
-        )
+        # C1 approves the recommendation (CM-16-006).
+        with demo_step("C1 approves actor recommendation"):
+            post_to_trigger(
+                client=c1_client,
+                actor_id=c1_in_c1.id_,
+                behavior="accept-actor-recommendation",
+                body={
+                    "cp_offer_id": cp_offer_id,
+                    "case_actor_id": case_actor_id,
+                },
+            )
     logger.info("C1 sent Accept(Offer(CaseParticipant)) to CaseActor")
 
     # CaseActor sends Invite to V2.  Poll V2's DataLayer for the arriving

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -340,37 +340,38 @@ def _phase_coordinator_suggests_vendor2(
 
     # CaseActor processes Offer(Actor, Case) and forwards Offer(CaseParticipant)
     # to Vendor1 (CASE_OWNER).  Poll Vendor1's DataLayer for the offer.
-    cp_offer_id = None
-    with demo_check(
+    # All dependent steps (case_actor lookup and approve) are nested inside
+    # demo_gate so they are skipped if the offer never arrives (ADR-0058).
+    with demo_gate(
         "Offer(CaseParticipant) for Vendor2 arrived in Vendor1's DataLayer"
     ):
         cp_offer_id = find_cp_offer_for_case(
             client=vendor_client,
             case_id=case.id_,
         )
-    logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
+        logger.info("Offer(CaseParticipant) ID: %s", cp_offer_id)
 
-    # Find the CaseActor's participant ID so we can route the Accept back.
-    case_actor_id = find_case_actor_participant_id(vendor_client, case.id_)
-    if case_actor_id is None:
-        raise AssertionError(
-            "CaseActor participant not found in case — cannot route Accept"
-        )
-    logger.info("CaseActor participant ID: %s", case_actor_id)
+        # Find the CaseActor's participant ID so we can route the Accept back.
+        case_actor_id = find_case_actor_participant_id(vendor_client, case.id_)
+        if case_actor_id is None:
+            raise AssertionError(
+                "CaseActor participant not found in case — cannot route Accept"
+            )
+        logger.info("CaseActor participant ID: %s", case_actor_id)
 
-    # Step M4 (ADR-0026 CM-16-006): Vendor1 approves the recommendation.
-    with demo_step(
-        "Vendor1 approves actor recommendation (accept-actor-recommendation)"
-    ):
-        post_to_trigger(
-            client=vendor_client,
-            actor_id=vendor_in_vendor.id_,
-            behavior="accept-actor-recommendation",
-            body={
-                "cp_offer_id": cp_offer_id,
-                "case_actor_id": case_actor_id,
-            },
-        )
+        # Step M4 (ADR-0026 CM-16-006): Vendor1 approves the recommendation.
+        with demo_step(
+            "Vendor1 approves actor recommendation (accept-actor-recommendation)"
+        ):
+            post_to_trigger(
+                client=vendor_client,
+                actor_id=vendor_in_vendor.id_,
+                behavior="accept-actor-recommendation",
+                body={
+                    "cp_offer_id": cp_offer_id,
+                    "case_actor_id": case_actor_id,
+                },
+            )
     logger.info("Vendor1 sent Accept(Offer(CaseParticipant)) to CaseActor")
 
     # CaseActor receives Accept → emits Invite(Actor, Case) to Vendor2.  Per


### PR DESCRIPTION
- Closes #2806
<!-- ⚠️ MUST BE FIRST — before any ## header -->

## Summary

Three demo scenarios (`fcvcv`, `fvcv-extension`, `fccv-extension`) used
`demo_check` (advisory) to poll for the `Offer(CaseParticipant)` offer before
calling `accept-actor-recommendation`. When the offer hadn't propagated within
the 15 s window, `demo_check` swallowed the `AssertionError`, `cp_offer_id`
stayed `None`, and the API returned 422. Fix: replace `demo_check` with
`demo_gate` and nest the dependent steps inside the block per ADR-0058.

## Changes

- **`vultron/demo/scenario/fcvcv_demo.py`**: `_phase_c2_suggests_v2` — `demo_check` → `demo_gate`; nest `find_case_actor_participant_id`, `AssertionError` guard, and `post_to_trigger(behavior="accept-actor-recommendation")` inside gate block
- **`vultron/demo/scenario/fvcv_extension_demo.py`**: `_phase_coordinator_suggests_vendor2` — same pattern (Vendor1 approves for Vendor2)
- **`vultron/demo/scenario/fccv_extension_demo.py`**: `_phase_c2_suggests_vendor` — same pattern (C1 approves for Vendor)
- **`test/demo/test_fcvcv_demo.py`**: add `test_accept_not_called_when_cp_offer_gate_fails` to `TestFcvcvCausalGates`
- **`test/demo/test_fvcv_extension_demo.py`**: add same test to `TestFvcvExtensionCausalGates`
- **`test/demo/test_fccv_extension_demo.py`**: add same test to `TestFccvExtensionCausalGates`

Tests exercise the real `demo_gate` (not patched) per ADR-0058 test requirement;
patch `find_cp_offer_for_case` to raise `AssertionError` and assert
`post_to_trigger` is never called with `behavior="accept-actor-recommendation"`.

## Verification

- 9055 tests pass (3 new regression tests)
- Black, flake8, mypy, pyright clean