### PR TITLE
retire WriteEmStateNode and add RSVP deadline to wire layer

### DIFF
--- a/docs/adr/0065-embargo-invite-rsvp-deadline.md
+++ b/docs/adr/0065-embargo-invite-rsvp-deadline.md
@@ -150,10 +150,14 @@ sender a way to get their own invite discarded.
 - A test that a late `Accept` with an incompatible embargo produces a fresh
   invite rather than a rejection, and that case participation survives.
 
-This ADR is `accepted-provisional`: the direction is ratified, but nothing
-implements it yet. Details — in particular the floor value and the exact
-compatibility predicate for a late `Accept` — are expected to converge once the
-implementation Tasks land. Revise this ADR in place if they do not hold.
+This ADR is `accepted-provisional`: the direction is ratified. The wire layer
+is now implemented (PR #2816, issues #2211/#2712): `em_propose_embargo_activity()`
+accepts `rsvp_deadline` on `Invite.end_time`; `InviteToEmbargoOnCaseReceivedEvent`
+exposes `rsvp_deadline` with UTC normalisation; sub-floor values are clamped
+on receipt; `ActorConfig` carries `min_rsvp_window` (72h) and
+`default_rsvp_window` (7d). Remaining: CaseActor lazy-evaluation enforcement
+(Part 3 of the decision) and the late-`Accept` compatibility predicate (Part 4).
+Revise this ADR to `accepted` once those land.
 
 ## Pros and Cons of the Options
 

--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -66,14 +66,18 @@ EM state transition logic is currently duplicated across several places:
 - `ClearActiveEmbargoNode` — migrated (PR #2691); routes through
   `EmbargoLifecycle.terminate_active_embargo()`
 - `SetEmbargoActiveNode` — migrated (PR #2691, issue #2696); routes through
-  new `EmbargoLifecycle.activate_embargo()` in STRICT mode; returns FAILURE
+  `EmbargoLifecycle.activate_embargo()` in STRICT mode; returns FAILURE
   for non-standard EM transitions (EMB-18-002)
 - `AdvanceEMStateToActiveNode` — migrated; uses `EmbargoLifecycle.propose_embargo()`
+- `WriteEmStateNode` — **retired** (PR #2816, issue #2712); the last BT node
+  that directly assigned `EmDimension` to `case.current_status.em`. All five
+  `EmbargoLifecycle` service methods now unconditionally own their own EM reads
+  and writes. The `caller_owns_em_io` pattern is fully removed.
 
-There is still **no single authoritative place** that owns what it means to
-"accept an embargo offer" or "terminate an embargo" across the trigger-side and
-BT-side implementations. Bugs fixed in one will not propagate to the other
-until the trigger-side and received-side use cases are migrated.
+BT-side direct EM assignment is **complete**. `EmbargoLifecycle` is the single
+authoritative owner for EM state writes on the BT side. Trigger-side and
+received-side use cases are still pending migration — bugs fixed in the service
+will not propagate to them until they are migrated.
 
 ---
 

--- a/test/core/behaviors/case/nodes/test_embargo.py
+++ b/test/core/behaviors/case/nodes/test_embargo.py
@@ -293,23 +293,21 @@ class TestAttachEmbargoToCaseNodeAC1:
     """AC-1 regression for AttachEmbargoToCaseNode (issue #2583)."""
 
     @pytest.mark.spec("EMB-18-001")
-    def test_em_write_delegates_to_write_em_state_node(
+    def test_em_write_routes_through_embargo_lifecycle(
         self,
         bt_scenario: BTTestScenario,
         actor_id: str,
         case_obj: VultronCase,
     ) -> None:
-        """AC-1 (issue #2583): EM write is delegated to WriteEmStateNode.
+        """AC-1 (issue #2712): EM write routes through EmbargoLifecycle.activate_embargo.
 
-        When WriteEmStateNode.update() is patched to return FAILURE the
-        node must propagate FAILURE — proving the inline write was replaced
-        by delegation.
+        When activate_embargo raises VultronError the node returns FAILURE —
+        proving the EM write is delegated to the service layer.
         """
         from unittest.mock import patch
 
-        from vultron.core.behaviors.embargo.nodes.em_state import (
-            WriteEmStateNode,
-        )
+        from vultron.core.services.embargo_lifecycle import EmbargoLifecycle
+        from vultron.errors import VultronInvalidStateTransitionError
 
         embargo = EmbargoEvent(
             end_time=datetime.now(tz=timezone.utc) + timedelta(days=1),
@@ -324,7 +322,9 @@ class TestAttachEmbargoToCaseNodeAC1:
         )
 
         with patch.object(
-            WriteEmStateNode, "update", return_value=Status.FAILURE
+            EmbargoLifecycle,
+            "activate_embargo",
+            side_effect=VultronInvalidStateTransitionError("forced failure"),
         ):
             result = bt_scenario.run(
                 AttachEmbargoToCaseNode(),

--- a/test/core/behaviors/embargo/nodes/test_em_state.py
+++ b/test/core/behaviors/embargo/nodes/test_em_state.py
@@ -13,28 +13,15 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Unit tests for ReadEmStateNode and WriteEmStateNode (em_state.py).
-
-Verifies AC-1, AC-2 of issue #1474: the em_state read/write BT nodes
-follow DataLayerCondition / DataLayerAction base class patterns and
-correctly replace the inline em_state accesses that previously lived in
-the EmbargoLifecycle service methods.
-"""
+"""Unit tests for ReadEmStateNode (em_state.py)."""
 
 from unittest.mock import MagicMock, PropertyMock
 
 import py_trees
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-from vultron.core.behaviors.embargo.nodes.em_state import (
-    ReadEmStateNode,
-    WriteEmStateNode,
-)
-from vultron.core.behaviors.helpers import (
-    DataLayerActionWithPorts,
-    DataLayerConditionWithPorts,
-)
-from vultron.core.models.case import VulnerabilityCase
+from vultron.core.behaviors.embargo.nodes.em_state import ReadEmStateNode
+from vultron.core.behaviors.helpers import DataLayerConditionWithPorts
 from vultron.core.states.em import EM
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
     as_VulnerabilityCase,
@@ -174,159 +161,3 @@ class TestReadEmStateNode:
 
         assert status == py_trees.common.Status.FAILURE
         assert "error" in result_out
-
-
-class TestWriteEmStateNodeInheritance:
-    """WriteEmStateNode follows the DataLayerAction base class pattern (AC-2)."""
-
-    def test_is_data_layer_action(self):
-        """WriteEmStateNode inherits from DataLayerActionWithPorts."""
-        node = WriteEmStateNode(
-            case_id="https://example.org/cases/test",
-            result_out={},
-        )
-        assert isinstance(node, DataLayerActionWithPorts)
-
-
-class TestWriteEmStateNode:
-    """WriteEmStateNode writes em_after from result_out to the case."""
-
-    def test_writes_em_after_and_persists(self):
-        """SUCCESS and em_state updated on case when result_out has em_after."""
-        dl = SqliteDataLayer(
-            "sqlite:///:memory:",
-            actor_id="https://test.example/api/v2/actors/test-actor",
-        )
-        case, _ = make_case_and_embargo("wsn1", em_state=EM.PROPOSED)
-        case.active_embargo = None
-        dl.create(case)
-        setup_blackboard(dl)
-
-        result_out: dict = {"em_after": EM.ACTIVE}
-        node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
-        bt = py_trees.trees.BehaviourTree(root=node)
-        bt.setup()
-        bt.tick()
-
-        assert node.status == py_trees.common.Status.SUCCESS
-
-        updated_case = dl.read(case.id_)
-        assert isinstance(updated_case, VulnerabilityCase)
-        assert updated_case.current_status.em.state == EM.ACTIVE
-
-    def test_idempotent_when_already_at_target(self):
-        """SUCCESS without saving when em_state already equals em_after."""
-        dl = SqliteDataLayer(
-            "sqlite:///:memory:",
-            actor_id="https://test.example/api/v2/actors/test-actor",
-        )
-        case, _ = make_case_and_embargo("wsn2", em_state=EM.ACTIVE)
-        dl.create(case)
-        setup_blackboard(dl)
-
-        result_out: dict = {"em_after": EM.ACTIVE}
-        node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
-        bt = py_trees.trees.BehaviourTree(root=node)
-        bt.setup()
-        bt.tick()
-
-        assert node.status == py_trees.common.Status.SUCCESS
-
-    def test_returns_failure_when_em_after_missing(self):
-        """FAILURE when result_out['em_after'] is absent."""
-        dl = SqliteDataLayer(
-            "sqlite:///:memory:",
-            actor_id="https://test.example/api/v2/actors/test-actor",
-        )
-        case, _ = make_case_and_embargo("wsn3", em_state=EM.ACTIVE)
-        dl.create(case)
-        setup_blackboard(dl)
-
-        result_out: dict = {}  # no em_after key
-        node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
-        bt = py_trees.trees.BehaviourTree(root=node)
-        bt.setup()
-        bt.tick()
-
-        assert node.status == py_trees.common.Status.FAILURE
-
-    def test_returns_failure_when_em_after_not_em_type(self):
-        """FAILURE when result_out['em_after'] is not an EM enum value."""
-        dl = SqliteDataLayer(
-            "sqlite:///:memory:",
-            actor_id="https://test.example/api/v2/actors/test-actor",
-        )
-        case, _ = make_case_and_embargo("wsn4", em_state=EM.ACTIVE)
-        dl.create(case)
-        setup_blackboard(dl)
-
-        result_out: dict = {"em_after": "ACTIVE"}  # string, not EM enum
-        node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
-        bt = py_trees.trees.BehaviourTree(root=node)
-        bt.setup()
-        bt.tick()
-
-        assert node.status == py_trees.common.Status.FAILURE
-
-    def test_returns_failure_when_case_missing(self):
-        """FAILURE when case_id not found in the DataLayer."""
-        dl = SqliteDataLayer(
-            "sqlite:///:memory:",
-            actor_id="https://test.example/api/v2/actors/test-actor",
-        )
-        setup_blackboard(dl)
-
-        result_out: dict = {"em_after": EM.EXITED}
-        node = WriteEmStateNode(
-            case_id="https://example.org/cases/nonexistent",
-            result_out=result_out,
-        )
-        bt = py_trees.trees.BehaviourTree(root=node)
-        bt.setup()
-        bt.tick()
-
-        assert node.status == py_trees.common.Status.FAILURE
-
-    def test_returns_failure_when_datalayer_not_set(self):
-        """FAILURE when datalayer is None (direct invocation without BTBridge)."""
-        result_out: dict = {"em_after": EM.EXITED}
-        node = WriteEmStateNode(
-            case_id="https://example.org/cases/any",
-            result_out=result_out,
-        )
-        node.datalayer = None
-
-        status = node.update()
-
-        assert status == py_trees.common.Status.FAILURE
-
-
-class TestReadWriteEmStateIntegration:
-    """Round-trip: ReadEmStateNode → WriteEmStateNode applies the state change."""
-
-    def test_read_then_write_transitions_em_state(self):
-        """Read PROPOSED, write ACTIVE: case persists EM.ACTIVE."""
-        dl = SqliteDataLayer(
-            "sqlite:///:memory:",
-            actor_id="https://test.example/api/v2/actors/test-actor",
-        )
-        case, _ = make_case_and_embargo("rw1", em_state=EM.PROPOSED)
-        case.active_embargo = None
-        dl.create(case)
-        setup_blackboard(dl)
-
-        result_out: dict = {}
-
-        read_node = ReadEmStateNode(case_id=case.id_, result_out=result_out)
-        read_node.datalayer = dl
-        assert read_node.update() == py_trees.common.Status.SUCCESS
-        assert result_out["em_before"] == EM.PROPOSED
-
-        result_out["em_after"] = EM.ACTIVE
-        write_node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
-        write_node.datalayer = dl
-        assert write_node.update() == py_trees.common.Status.SUCCESS
-
-        updated_case = dl.read(case.id_)
-        assert isinstance(updated_case, VulnerabilityCase)
-        assert updated_case.current_status.em.state == EM.ACTIVE

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -727,7 +727,7 @@ class TestSetEmbargoActiveNode:
 
         Patch EmbargoLifecycle.activate_embargo() and confirm it is invoked
         during the PROPOSED → ACTIVE transition, proving that EM writes route
-        through the service layer (not inline mutation or WriteEmStateNode).
+        through the service layer (not inline mutation) (EMB-18-001).
         """
         from unittest.mock import patch
 

--- a/test/core/services/test_embargo_lifecycle.py
+++ b/test/core/services/test_embargo_lifecycle.py
@@ -1133,18 +1133,18 @@ def test_reject_embargo_invite_observed_revise_pxa_bypasses_guard(
 
 
 # ---------------------------------------------------------------------------
-# #1474 AC-1: caller_owns_em_io guard tests
+# Issue #2712: service always writes em_state (caller_owns_em_io removed)
 # ---------------------------------------------------------------------------
 
 
-class TestCallerOwnsEmIo:
-    """When em_before is supplied, the service skips its own em_state read/write."""
+class TestServiceAlwaysWritesEmState:
+    """Service always writes em_state — caller_owns_em_io pattern retired (#2712)."""
 
-    def test_propose_does_not_write_em_state_when_em_before_supplied(
+    def test_propose_writes_em_state_when_em_before_supplied(
         self,
         owner_and_dl: tuple[as_Service, SqliteDataLayer],
     ) -> None:
-        """propose_embargo does not mutate em_state when em_before is supplied."""
+        """propose_embargo always writes em_state even when em_before is supplied."""
         owner, dl = owner_and_dl
         case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
         embargo = _make_embargo(dl, case.id_)
@@ -1159,36 +1159,14 @@ class TestCallerOwnsEmIo:
         )
 
         assert result.em_after == EM.PROPOSED
-        # Service must NOT have written em_state; it stays at the initial value
-        refreshed = cast(VulnerabilityCase, dl.read(case.id_))
-        assert refreshed.current_status.em.state == EM.NONE
-
-    def test_propose_still_writes_em_state_on_legacy_path(
-        self,
-        owner_and_dl: tuple[as_Service, SqliteDataLayer],
-    ) -> None:
-        """propose_embargo writes em_state when em_before is not supplied (legacy)."""
-        owner, dl = owner_and_dl
-        case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
-        embargo = _make_embargo(dl, case.id_)
-
-        lifecycle = EmbargoLifecycle(persistence=dl)
-        result = lifecycle.propose_embargo(
-            case_id=case.id_,
-            embargo_id=embargo.id_,
-            actor_id=owner.id_,
-            transition_mode=TransitionMode.STRICT,
-        )
-
-        assert result.em_after == EM.PROPOSED
         refreshed = cast(VulnerabilityCase, dl.read(case.id_))
         assert refreshed.current_status.em.state == EM.PROPOSED
 
-    def test_reject_does_not_write_em_state_when_em_before_supplied(
+    def test_reject_writes_em_state_when_em_before_supplied(
         self,
         owner_and_dl: tuple[as_Service, SqliteDataLayer],
     ) -> None:
-        """reject_embargo_invite does not mutate em_state when em_before is supplied."""
+        """reject_embargo_invite always writes em_state even when em_before is supplied."""
         owner, dl = owner_and_dl
         case, _ = _make_case(dl, owner.id_, em_state=EM.PROPOSED)
         embargo = _make_embargo(dl, case.id_)
@@ -1204,13 +1182,13 @@ class TestCallerOwnsEmIo:
 
         assert result.em_after == EM.NONE
         refreshed = cast(VulnerabilityCase, dl.read(case.id_))
-        assert refreshed.current_status.em.state == EM.PROPOSED
+        assert refreshed.current_status.em.state == EM.NONE
 
-    def test_terminate_does_not_write_em_state_when_em_before_supplied(
+    def test_terminate_writes_em_state_when_em_before_supplied(
         self,
         owner_and_dl: tuple[as_Service, SqliteDataLayer],
     ) -> None:
-        """terminate_active_embargo does not mutate em_state when em_before is supplied."""
+        """terminate_active_embargo always writes em_state even when em_before is supplied."""
         owner, dl = owner_and_dl
         case, _ = _make_case(dl, owner.id_, em_state=EM.ACTIVE)
         embargo = _make_embargo(dl, case.id_)
@@ -1227,4 +1205,4 @@ class TestCallerOwnsEmIo:
 
         assert result.em_after == EM.EXITED
         refreshed = cast(VulnerabilityCase, dl.read(case.id_))
-        assert refreshed.current_status.em.state == EM.ACTIVE
+        assert refreshed.current_status.em.state == EM.EXITED

--- a/test/wire/as2/factories/test_embargo_factories.py
+++ b/test/wire/as2/factories/test_embargo_factories.py
@@ -23,6 +23,8 @@ Spec coverage:
 - AF-04-002: All factory functions re-exported from factories/__init__.py.
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from vultron.wire.as2.factories import (
@@ -102,6 +104,72 @@ def test_em_propose_embargo_invalid_raises():
             embargo="not-an-embargo"  # type: ignore[arg-type]
         )
     assert exc_info.value.__cause__ is not None
+
+
+# ---------------------------------------------------------------------------
+# em_propose_embargo_activity — RSVP deadline (AC-1, AC-4; issue #2211)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spec("CM-27-001")
+def test_em_propose_embargo_rsvp_deadline_sets_end_time(sample_embargo):
+    """AC-1: rsvp_deadline is placed on activity-level end_time."""
+    deadline = datetime.now(tz=timezone.utc) + timedelta(days=5)
+    result = em_propose_embargo_activity(
+        embargo=sample_embargo,
+        rsvp_deadline=deadline,
+        actor=_ACTOR_URI,
+    )
+    assert result.end_time == deadline
+
+
+@pytest.mark.spec("CM-27-001")
+def test_em_propose_embargo_no_rsvp_deadline_end_time_is_none(sample_embargo):
+    """AC-7 (absent): no rsvp_deadline → end_time not set on activity."""
+    result = em_propose_embargo_activity(
+        embargo=sample_embargo,
+        actor=_ACTOR_URI,
+    )
+    assert result.end_time is None
+
+
+@pytest.mark.spec("EP-07-002")
+def test_em_propose_embargo_rsvp_below_min_window_raises(sample_embargo):
+    """AC-4: deadline below minimum window raises VultronActivityConstructionError."""
+    deadline = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+    with pytest.raises(VultronActivityConstructionError, match="minimum"):
+        em_propose_embargo_activity(
+            embargo=sample_embargo,
+            rsvp_deadline=deadline,
+            actor=_ACTOR_URI,
+        )
+
+
+@pytest.mark.spec("EP-07-002")
+def test_em_propose_embargo_naive_deadline_raises(sample_embargo):
+    """AC-3 (outbound): naive rsvp_deadline raises VultronActivityConstructionError."""
+    naive_deadline = datetime.now() + timedelta(days=5)  # no tzinfo
+    with pytest.raises(
+        VultronActivityConstructionError, match="timezone-aware"
+    ):
+        em_propose_embargo_activity(
+            embargo=sample_embargo,
+            rsvp_deadline=naive_deadline,
+            actor=_ACTOR_URI,
+        )
+
+
+@pytest.mark.spec("EP-07-002")
+def test_em_propose_embargo_custom_min_window_respected(sample_embargo):
+    """AC-4: custom min_rsvp_window is enforced."""
+    deadline = datetime.now(tz=timezone.utc) + timedelta(hours=25)
+    with pytest.raises(VultronActivityConstructionError, match="minimum"):
+        em_propose_embargo_activity(
+            embargo=sample_embargo,
+            rsvp_deadline=deadline,
+            min_rsvp_window=timedelta(days=2),
+            actor=_ACTOR_URI,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/test/wire/as2/test_extractor.py
+++ b/test/wire/as2/test_extractor.py
@@ -362,13 +362,15 @@ def test_invite_rsvp_deadline_distinct_from_embargo_end_time():
     invite = _make_embargo_invite(end_time=rsvp)
     event = extract_event(invite)
 
-    # The nested embargo's end_time is on the object_, not on rsvp_deadline
+    # The nested embargo's end_time is on the activity's object_, not rsvp_deadline
     ev = cast(Any, event)
     assert ev.rsvp_deadline == rsvp.astimezone(timezone.utc)
-    # The embargo expiry is separately accessible via the nested object
-    embargo_end_time = getattr(event.object_, "end_time", None)
-    if embargo_end_time is not None:
-        assert embargo_end_time != ev.rsvp_deadline
+    # The embargo expiry is on event.activity.object_.end_time (90 days out)
+    embargo_end_time = getattr(
+        getattr(ev.activity, "object_", None), "end_time", None
+    )
+    assert embargo_end_time is not None
+    assert embargo_end_time != ev.rsvp_deadline
 
 
 @pytest.mark.spec("EP-07-003")
@@ -383,3 +385,14 @@ def test_invite_rsvp_deadline_clamped_when_below_floor():
     assert ev.rsvp_deadline is not None
     # Clamped up: deadline is >= now (was in the past)
     assert ev.rsvp_deadline > datetime.now(tz=timezone.utc)
+
+
+@pytest.mark.spec("EP-07-002")
+def test_invite_rsvp_deadline_none_when_naive_end_time():
+    """AC-7 (inbound naive): naive end_time on invite is ignored → rsvp_deadline is None."""
+    naive_deadline = datetime.now() + timedelta(days=5)  # no tzinfo
+    invite = _make_embargo_invite(end_time=naive_deadline)
+    event = extract_event(invite)
+
+    assert hasattr(event, "rsvp_deadline")
+    assert cast(Any, event).rsvp_deadline is None

--- a/test/wire/as2/test_extractor.py
+++ b/test/wire/as2/test_extractor.py
@@ -1,6 +1,6 @@
 """Tests for vultron.wire.as2.extractor."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
 import pytest
@@ -299,3 +299,87 @@ def test_extract_intent_participant_status_vfd_state():
     s = cast(Any, event).status
     assert s is not None
     assert s.vfd.state == CS_vfd.Vfd
+
+
+# ---------------------------------------------------------------------------
+# RSVP deadline extraction for InviteToEmbargoOnCase (issue #2211)
+# ---------------------------------------------------------------------------
+
+
+def _make_embargo_invite(end_time=None):
+    """Build an as_Invite(as_EmbargoEvent) with optional activity-level end_time."""
+    from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+        as_Invite,
+    )
+    from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+    from vultron.wire.as2.vocab.objects.vulnerability_case import (
+        as_VulnerabilityCase,
+    )
+
+    embargo = as_EmbargoEvent(
+        context="https://example.org/cases/1",
+        end_time=datetime.now(tz=timezone.utc) + timedelta(days=90),
+    )
+    case = as_VulnerabilityCase(id_="https://example.org/cases/1")
+    kwargs = {
+        "object_": embargo,
+        "context": case,
+        "actor": "https://example.org/alice",
+    }
+    if end_time is not None:
+        kwargs["end_time"] = end_time
+    return as_Invite(**kwargs)
+
+
+@pytest.mark.spec("CM-27-001")
+def test_invite_rsvp_deadline_extracted_when_present():
+    """AC-2: activity-level end_time is extracted as rsvp_deadline on the event."""
+    deadline = datetime.now(tz=timezone.utc) + timedelta(days=5)
+    invite = _make_embargo_invite(end_time=deadline)
+    event = extract_event(invite)
+
+    assert hasattr(event, "rsvp_deadline")
+    ev = cast(Any, event)
+    assert ev.rsvp_deadline is not None
+    # rsvp_deadline carries the invite end_time, NOT the nested embargo end_time
+    assert ev.rsvp_deadline == deadline.astimezone(timezone.utc)
+
+
+@pytest.mark.spec("CM-27-001")
+def test_invite_rsvp_deadline_absent_when_no_end_time():
+    """AC-7 (absent): no end_time on invite → rsvp_deadline is None."""
+    invite = _make_embargo_invite(end_time=None)
+    event = extract_event(invite)
+
+    assert hasattr(event, "rsvp_deadline")
+    assert cast(Any, event).rsvp_deadline is None
+
+
+@pytest.mark.spec("CM-27-001")
+def test_invite_rsvp_deadline_distinct_from_embargo_end_time():
+    """AC-2: invite.end_time and invite.object_.end_time are distinct fields."""
+    rsvp = datetime.now(tz=timezone.utc) + timedelta(days=5)
+    invite = _make_embargo_invite(end_time=rsvp)
+    event = extract_event(invite)
+
+    # The nested embargo's end_time is on the object_, not on rsvp_deadline
+    ev = cast(Any, event)
+    assert ev.rsvp_deadline == rsvp.astimezone(timezone.utc)
+    # The embargo expiry is separately accessible via the nested object
+    embargo_end_time = getattr(event.object_, "end_time", None)
+    if embargo_end_time is not None:
+        assert embargo_end_time != ev.rsvp_deadline
+
+
+@pytest.mark.spec("EP-07-003")
+def test_invite_rsvp_deadline_clamped_when_below_floor():
+    """AC-5: sub-floor rsvp_deadline is clamped up (not rejected)."""
+    # end_time is in the past / far below the 72h floor
+    past_deadline = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    invite = _make_embargo_invite(end_time=past_deadline)
+    event = extract_event(invite)
+
+    ev = cast(Any, event)
+    assert ev.rsvp_deadline is not None
+    # Clamped up: deadline is >= now (was in the past)
+    assert ev.rsvp_deadline > datetime.now(tz=timezone.utc)

--- a/vultron/config/actor.py
+++ b/vultron/config/actor.py
@@ -23,7 +23,10 @@ defaults for the local actor without importing from the demo or adapter layers.
 ``vultron/config/``.
 
 Per ``specs/configuration.yaml`` CFG-07-001, CFG-07-002, CFG-07-005, CFG-07-006.
+RSVP window fields per ``specs/embargo-policy.yaml`` EP-07-001, EP-07-002.
 """
+
+from datetime import timedelta
 
 from pydantic import (
     BaseModel,
@@ -80,6 +83,23 @@ class ActorConfig(BaseModel):
             "{this}/actors/case-actor. Required for actors that create cases; "
             "absence makes the proposal-sending nodes fail rather than guess "
             "(CP-08-001, CP-04-003)."
+        ),
+    )
+
+    min_rsvp_window: timedelta = Field(
+        default=timedelta(hours=72),
+        description=(
+            "Minimum time between now and an RSVP deadline on an outbound "
+            "Invite(EmbargoEvent). Outbound invites below this floor are "
+            "refused at construction time (EP-07-002). Inbound invites below "
+            "this floor are clamped up to the floor (EP-07-003). Default: 72 h."
+        ),
+    )
+    default_rsvp_window: timedelta = Field(
+        default=timedelta(days=7),
+        description=(
+            "Fallback RSVP window used when no explicit deadline is provided "
+            "on an outbound Invite(EmbargoEvent) (EP-07-001). Default: 7 days."
         ),
     )
 

--- a/vultron/core/AGENTS.md
+++ b/vultron/core/AGENTS.md
@@ -167,31 +167,19 @@ directly. Editing `__init__.py` for individual entry additions defeats the
 purpose of the split (reducing merge conflicts) and risks silently corrupting
 the ordering invariant that keeps the `UNKNOWN` fallback last.
 
-### `caller_owns_em_io` Guard: BT/Service Layer Handoff for EM State
+### EM State Writes Are Owned by `EmbargoLifecycle` (EMB-18-001, retired in #2712)
 
-When a BT node needs to read EM state before calling a service and write it
-after, use a `caller_owns_em_io` bool to distinguish two paths:
+The `caller_owns_em_io` guard and the `WriteEmStateNode` BT node are **retired**.
+Do not reintroduce them.
 
-- **BT path** (`em_before` passed): caller already read EM state and will write
-  it via named BT nodes. Service skips its own DataLayer read/write.
-- **Legacy path** (`em_before=None`): service reads and writes internally.
+**Current rule:** `EmbargoLifecycle` service methods always read `em_before` from
+the DataLayer when not supplied and always write `em_after` back. BT nodes call
+service methods directly; they never assign `case.current_status.em` inline.
 
-```python
-caller_owns_em_io = em_before is not None
-if not caller_owns_em_io:
-    em_before = EM(case.current_status.em_state)
-assert em_before is not None  # narrows EM | None → EM for mypy
-# ...compute em_after...
-if not caller_owns_em_io and em_after != em_before:
-    case.current_status.em_state = em_after
-    case_mutated = True
-```
+See also `vultron/core/behaviors/AGENTS.md` § "EM State Reads and Writes Must Use
+Canonical Nodes".
 
-The `assert em_before is not None` after the conditional is required for mypy
-to narrow the type; without it mypy keeps the `EM | None` union and flags
-downstream uses.
-
-<!-- Source: ISSUE-1474 -->
+<!-- Source: ISSUE-1474; pattern retired ISSUE-2712 -->
 
 ---
 

--- a/vultron/core/behaviors/AGENTS.md
+++ b/vultron/core/behaviors/AGENTS.md
@@ -164,18 +164,22 @@ Specs: BTND-07-005, BTND-07-009, BTND-07-010, BTC-01-001.
 
 ---
 
-## EM State Reads and Writes Must Use Canonical Nodes
+## EM State Reads Must Use ReadEmStateNode; Writes Route Through EmbargoLifecycle
 
-**Never read or write `case.current_status.em` inline inside a BT node.**
-All EM state reads MUST go through `ReadEmStateNode`; all writes through
-`WriteEmStateNode`. Both live in
-`vultron/core/behaviors/embargo/nodes/em_state.py`.
+**Never read `case.current_status.em` inline inside a BT node.**
+All EM state reads MUST go through `ReadEmStateNode`
+(`vultron/core/behaviors/embargo/nodes/em_state.py`).
+
+**Never write `case.current_status.em` directly inside a BT node** (EMB-18-001).
+All EM state writes MUST route through `EmbargoLifecycle`
+(`vultron/core/services/embargo_lifecycle.py`) — the service owns the write.
 
 Direct field access (`case.current_status.em.state`) bypasses the canonical
-channel: the read or write is invisible to the BT audit trail and creates
-paths where state can diverge from what the canonical nodes report.
-`ReadEmStateNode` was introduced specifically to centralize this read (AC-1,
-issue #1474).
+channel: the read is invisible to the BT audit trail and creates paths where
+state can diverge from what the canonical nodes report.
+`ReadEmStateNode` was introduced to centralize EM reads (AC-1, issue #1474);
+`WriteEmStateNode` was retired in issue #2712 — all writes now go through the
+service.
 
 **Pattern for reading EM state in an action node:**
 

--- a/vultron/core/behaviors/case/nodes/embargo.py
+++ b/vultron/core/behaviors/case/nodes/embargo.py
@@ -34,7 +34,6 @@ from datetime import datetime, timedelta, timezone
 import isodate  # type: ignore[import-untyped]
 from py_trees.common import Status
 
-from vultron.core.behaviors.embargo.nodes.em_state import WriteEmStateNode
 from vultron.core.behaviors.helpers import (
     DataLayerActionWithPorts,
     PortInformation,
@@ -48,7 +47,6 @@ from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
     TransitionMode,
 )
-from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC, PEC_Trigger
 from vultron.core.models._helpers import _as_id
 from vultron.errors import VultronError
@@ -271,39 +269,19 @@ class AdvanceEMStateToActiveNode(DataLayerActionWithPorts):
         return Status.SUCCESS
 
     def _propose_with_em_io(self, case_id: str, embargo_id: str) -> Status:
-        """Run propose_embargo with ReadEmStateNode / WriteEmStateNode (AC-1)."""
+        """Run propose_embargo via EmbargoLifecycle service."""
         assert (
             self.datalayer is not None
         )  # caller guards; here for type narrowing
         assert self.actor_id is not None
 
-        from vultron.core.behaviors.embargo.nodes.em_state import (
-            ReadEmStateNode,
-            WriteEmStateNode,
-        )
-
-        em_result_out: dict[str, object] = {}
-        read_node = ReadEmStateNode(case_id=case_id, result_out=em_result_out)
-        read_node.datalayer = self.datalayer
-        if read_node.update() != Status.SUCCESS:
-            self.logger.error(
-                "%s: Failed to read em_state for case '%s': %s",
-                self.name,
-                case_id,
-                read_node.feedback_message,
-            )
-            return Status.FAILURE
-        em_before = em_result_out["em_before"]
-        assert isinstance(em_before, EM)
-
         lifecycle = EmbargoLifecycle(persistence=self.datalayer)
         try:
-            result = lifecycle.propose_embargo(
+            lifecycle.propose_embargo(
                 case_id=case_id,
                 embargo_id=embargo_id,
                 actor_id=self.actor_id,
                 transition_mode=TransitionMode.STRICT,
-                em_before=em_before,
             )
         except VultronError as exc:
             self.logger.error(
@@ -314,21 +292,6 @@ class AdvanceEMStateToActiveNode(DataLayerActionWithPorts):
                 exc,
             )
             return Status.FAILURE
-
-        if result.em_after != em_before:
-            em_result_out["em_after"] = result.em_after
-            write_node = WriteEmStateNode(
-                case_id=case_id, result_out=em_result_out
-            )
-            write_node.datalayer = self.datalayer
-            if write_node.update() != Status.SUCCESS:
-                self.logger.error(
-                    "%s: Failed to write em_state for case '%s': %s",
-                    self.name,
-                    case_id,
-                    write_node.feedback_message,
-                )
-                return Status.FAILURE
 
         return Status.SUCCESS
 
@@ -381,16 +344,22 @@ class AttachEmbargoToCaseNode(DataLayerActionWithPorts):
 
         active_embargo_id = _as_id(stored_case.active_embargo)
         if active_embargo_id is None:
-            stored_case.active_embargo = embargo_id
-            self.datalayer.save(stored_case)
-            # AC-1: delegate EM state write to WriteEmStateNode.
-            result_out: dict[str, object] = {"em_after": EM.ACTIVE}
-            write_node = WriteEmStateNode(
-                case_id=case_id, result_out=result_out
-            )
-            write_node.datalayer = self.datalayer
-            if write_node.update() != Status.SUCCESS:
-                self.feedback_message = write_node.feedback_message
+            lifecycle = EmbargoLifecycle(persistence=self.datalayer)
+            try:
+                lifecycle.activate_embargo(
+                    case_id=case_id,
+                    embargo_id=embargo_id,
+                    actor_id=self.actor_id,
+                )
+            except VultronError as exc:
+                self.feedback_message = str(exc)
+                self.logger.error(
+                    "%s: Failed to activate embargo '%s' on case '%s': %s",
+                    self.name,
+                    embargo_id,
+                    case_id,
+                    exc,
+                )
                 return Status.FAILURE
             self.logger.info(
                 "Attached embargo '%s' to case '%s' as active_embargo",

--- a/vultron/core/behaviors/embargo/__init__.py
+++ b/vultron/core/behaviors/embargo/__init__.py
@@ -26,7 +26,6 @@ from vultron.core.behaviors.embargo.nodes import (
     UpdateParticipantEmbargoPecNode,
     ValidateCaseExistsNode,
     ValidateEmbargoRevisionStateNode,
-    WriteEmStateNode,
 )
 
 __all__ = [
@@ -51,5 +50,4 @@ __all__ = [
     "UpdateParticipantEmbargoPecNode",
     "ValidateCaseExistsNode",
     "ValidateEmbargoRevisionStateNode",
-    "WriteEmStateNode",
 ]

--- a/vultron/core/behaviors/embargo/nodes/__init__.py
+++ b/vultron/core/behaviors/embargo/nodes/__init__.py
@@ -21,10 +21,7 @@ Re-exports all public node classes from submodules for backward compatibility.
 from vultron.core.behaviors.embargo.nodes.cascade import (
     PersistEmbargoEventNode,
 )
-from vultron.core.behaviors.embargo.nodes.em_state import (
-    ReadEmStateNode,
-    WriteEmStateNode,
-)
+from vultron.core.behaviors.embargo.nodes.em_state import ReadEmStateNode
 from vultron.core.behaviors.embargo.nodes.conditions import (
     HasActiveEmbargoNode,
     HasCaseStatusesNode,
@@ -73,9 +70,8 @@ __all__ = [
     "HasCaseStatusesNode",
     "LookupParticipantNode",
     "OptionalLookupParticipantNode",
-    # EM state read/write (AC-1 of issue #1474)
+    # EM state read
     "ReadEmStateNode",
-    "WriteEmStateNode",
     # Teardown
     "HasEmbargoActiveNode",
     "ClearActiveEmbargoNode",

--- a/vultron/core/behaviors/embargo/nodes/em_state.py
+++ b/vultron/core/behaviors/embargo/nodes/em_state.py
@@ -13,32 +13,17 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""EM state read/write BT nodes for the embargo lifecycle.
+"""EM state read BT node for the embargo lifecycle.
 
-These nodes extract the em_state guard reads and mutations that previously
-lived in ``vultron/core/services/embargo_lifecycle.py``, moving them into
-the BT layer as named ``DataLayerCondition`` / ``DataLayerAction`` nodes.
-
-AC-1 of issue #1474: the service layer no longer directly inspects or
-mutates ``case.current_status.em_state`` — that responsibility belongs here.
-AC-2: nodes follow the ``DataLayerCondition`` / ``DataLayerAction`` base class
-pattern from ``vultron/core/behaviors/helpers.py``.
-AC-3: ``WriteEmStateNode`` is idempotent — when the current state already
-equals the target it returns SUCCESS without calling ``datalayer.save``.
-Callers that require an active embargo (e.g. terminate / accept) must place
-a ``HasActiveEmbargoNode`` guard earlier in the BT sequence to enforce the
-``EmbargoedCase`` precondition before reaching this node.
+``ReadEmStateNode`` reads the current EM state into result_out so
+downstream nodes and service callers have it without a separate DB read.
+EM state writes are owned by ``EmbargoLifecycle`` (EMB-18-001).
 """
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import (
-    DataLayerActionWithPorts,
-    DataLayerConditionWithPorts,
-)
+from vultron.core.behaviors.helpers import DataLayerConditionWithPorts
 from vultron.core.models.case import VulnerabilityCase
-from vultron.core.models.dimensions import EmDimension
-from vultron.core.states.em import EM
 from vultron.errors import VultronValidationError
 
 
@@ -104,82 +89,4 @@ class ReadEmStateNode(DataLayerConditionWithPorts):
             f"Case '{self._case_id}' em_state={em_state.value}"
         )
         self.logger.debug("%s: %s", self.name, self.feedback_message)
-        return Status.SUCCESS
-
-
-class WriteEmStateNode(DataLayerActionWithPorts):
-    """Write a computed EM state back to the case and persist it.
-
-    Replaces the inline ``case.current_status.em_state = em_after`` mutations
-    that previously appeared in every ``EmbargoLifecycle`` service method.
-
-    Reads the target EM value from ``result_out["em_after"]`` (written by the
-    preceding service-call node) and applies it to the case only when the
-    value differs from the current state (idempotent).
-
-    Returns SUCCESS when:
-    - the case is persisted with the new EM state, or
-    - the current state already equals the target (idempotent no-op).
-
-    Returns FAILURE when:
-    - the DataLayer is unavailable,
-    - the case cannot be found, or
-    - ``result_out["em_after"]`` is absent or not a valid ``EM`` enum value.
-
-    AC-3: where the operation semantics require an active embargo (e.g.
-    ``TerminateEmbargoLifecycleNode``), the caller should wrap the BT
-    sequence with a prior ``HasActiveEmbargoNode`` guard that enforces the
-    ``EmbargoedCase`` precondition before this node is reached.
-
-    Blackboard contract:
-    - Reads: ``datalayer`` (set by BTBridge)
-    - Writes: nothing (DataLayer mutation is the side effect)
-    """
-
-    def __init__(
-        self,
-        case_id: str,
-        result_out: dict[str, object],
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self._case_id = case_id
-        self._result_out = result_out
-
-    def update(self) -> Status:
-        if (f := self._require_datalayer()) is not None:
-            return f
-        assert self.datalayer is not None
-
-        em_after = self._result_out.get("em_after")
-        if not isinstance(em_after, EM):
-            self.feedback_message = (
-                f"result_out['em_after'] missing or not an EM value"
-                f" (got {em_after!r})"
-            )
-            self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return Status.FAILURE
-
-        case = self.datalayer.read(self._case_id)
-        if not isinstance(case, VulnerabilityCase):
-            self.feedback_message = (
-                f"Case '{self._case_id}' not found or invalid."
-            )
-            return Status.FAILURE
-
-        current_em = case.current_status.em.state
-        if current_em == em_after:
-            self.feedback_message = (
-                f"Case '{self._case_id}' em_state already"
-                f" {em_after.value} — no-op"
-            )
-            self.logger.debug("%s: %s", self.name, self.feedback_message)
-            return Status.SUCCESS
-
-        case.current_status.em = EmDimension(state=em_after)
-        self.datalayer.save(case)
-        self.feedback_message = (
-            f"Case '{self._case_id}' em_state {current_em} → {em_after.value}"
-        )
-        self.logger.info("%s: %s", self.name, self.feedback_message)
         return Status.SUCCESS

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -17,10 +17,7 @@
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.embargo.nodes.em_state import (
-    ReadEmStateNode,
-    WriteEmStateNode,
-)
+from vultron.core.behaviors.embargo.nodes.em_state import ReadEmStateNode
 from vultron.core.behaviors.embargo.nodes.reject_proposed import (  # noqa: F401
     ReadProposedEmbargoIdNode,
     RejectProposedEmbargoLifecycleNode,
@@ -105,11 +102,9 @@ class ValidateEmbargoRevisionStateNode(DataLayerActionWithPorts):
 class _EmbargoLifecycleNode(DataLayerActionWithPorts):
     """Base node for EmbargoLifecycle strict-mode transitions.
 
-    Orchestrates the em_state read/compute/write cycle via named BT nodes
-    (AC-1 of issue #1474):
     1. ``ReadEmStateNode`` reads ``em_state`` → ``result_out["em_before"]``.
-    2. The subclass ``_transition()`` calls the service with ``em_before``.
-    3. ``WriteEmStateNode`` writes ``result_out["em_after"]`` back to the case.
+    2. The subclass ``_transition()`` calls the service; the service writes
+       the EM state update directly (EMB-18-001).
     """
 
     def __init__(
@@ -157,17 +152,6 @@ class _EmbargoLifecycleNode(DataLayerActionWithPorts):
 
         self._result_out["lifecycle_result"] = result
         self._result_out["em_after"] = result.em_after
-
-        # AC-1: write em_state via named BT node, not inline service code.
-        if result.em_after != em_before:
-            write_node = WriteEmStateNode(
-                case_id=self._case_id(), result_out=self._result_out
-            )
-            write_node.datalayer = self.datalayer
-            write_status = write_node.update()
-            if write_status != Status.SUCCESS:
-                self.feedback_message = write_node.feedback_message
-                return Status.FAILURE
 
         return Status.SUCCESS
 

--- a/vultron/core/behaviors/embargo/nodes/proposal.py
+++ b/vultron/core/behaviors/embargo/nodes/proposal.py
@@ -217,41 +217,13 @@ class RecordParticipantAcceptanceNode(DataLayerActionWithPorts):
             self.feedback_message = "actor_id not available"
             return Status.FAILURE
 
-        # AC-1: read em_state via named BT node before calling the service.
-        from vultron.core.behaviors.embargo.nodes.em_state import (
-            ReadEmStateNode,
-            WriteEmStateNode,
-        )
-
-        em_result_out: dict[str, object] = {}
-        read_node = ReadEmStateNode(
-            case_id=self.case_id, result_out=em_result_out
-        )
-        read_node.datalayer = self.datalayer
-        if read_node.update() != Status.SUCCESS:
-            self.feedback_message = read_node.feedback_message
-            return Status.FAILURE
-        em_before = em_result_out["em_before"]
-        assert isinstance(em_before, EM)
-
         service = EmbargoLifecycle(persistence=self.datalayer)
         result = service.accept_embargo_invite(
             case_id=self.case_id,
             embargo_id=self.embargo_id,
             actor_id=actor_id,
             transition_mode=TransitionMode.OBSERVED,
-            em_before=em_before,
         )
-
-        if result.em_after != em_before:
-            em_result_out["em_after"] = result.em_after
-            write_node = WriteEmStateNode(
-                case_id=self.case_id, result_out=em_result_out
-            )
-            write_node.datalayer = self.datalayer
-            if write_node.update() != Status.SUCCESS:
-                self.feedback_message = write_node.feedback_message
-                return Status.FAILURE
 
         if result.em_after == EM.ACTIVE and result.em_before not in (
             EM.PROPOSED,

--- a/vultron/core/behaviors/embargo/nodes/reject_proposed.py
+++ b/vultron/core/behaviors/embargo/nodes/reject_proposed.py
@@ -25,10 +25,7 @@ Extracted from lifecycle.py to keep that module under the BTND-07-004
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.embargo.nodes.em_state import (
-    ReadEmStateNode,
-    WriteEmStateNode,
-)
+from vultron.core.behaviors.embargo.nodes.em_state import ReadEmStateNode
 from vultron.core.behaviors.embargo.nodes.emit import _SendEmbargoActivityBase
 from vultron.core.behaviors.helpers import (
     DataLayerActionWithPorts,
@@ -116,16 +113,6 @@ class RejectProposedEmbargoLifecycleNode(DataLayerActionWithPorts):
 
         self._result_out["lifecycle_result"] = result
         self._result_out["em_after"] = result.em_after
-
-        if result.em_after != em_before:
-            write_node = WriteEmStateNode(
-                case_id=self._case_id_value, result_out=self._result_out
-            )
-            write_node.datalayer = self.datalayer
-            write_status = write_node.update()
-            if write_status != Status.SUCCESS:
-                self.feedback_message = write_node.feedback_message
-                return Status.FAILURE
 
         return Status.SUCCESS
 

--- a/vultron/core/models/events/embargo.py
+++ b/vultron/core/models/events/embargo.py
@@ -1,9 +1,15 @@
 """Per-semantic inbound domain event types for embargo activities."""
 
+import logging
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Literal, cast
+
+from pydantic import field_validator
 
 from vultron.core.models.activity import VultronActivity
 from vultron.core.models.events.base import MessageSemantics, VultronEvent
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from vultron.core.models.case import VulnerabilityCase as VultronCase
@@ -102,6 +108,31 @@ class InviteToEmbargoOnCaseReceivedEvent(VultronEvent):
         MessageSemantics.INVITE_TO_EMBARGO_ON_CASE
     )
     activity: VultronActivity  # pyright: ignore[reportGeneralTypeIssues]
+    rsvp_deadline: datetime | None = None
+
+    @field_validator("rsvp_deadline", mode="before")
+    @classmethod
+    def _validate_rsvp_deadline(cls, v: object) -> datetime | None:
+        if v is None:
+            return None
+        if not isinstance(v, datetime):
+            raise ValueError(
+                f"rsvp_deadline must be a datetime, got {type(v).__name__}"
+            )
+        if v.tzinfo is None:
+            raise ValueError(
+                "rsvp_deadline must be timezone-aware"
+                " (naive datetime rejected per EP-07-002)"
+            )
+        return v.astimezone(timezone.utc)
+
+    @property
+    def case_id(self) -> str | None:
+        return self.context_id
+
+    @property
+    def case(self) -> "VultronCase | None":
+        return cast("VultronCase | None", self.context)
 
 
 class AcceptInviteToEmbargoOnCaseReceivedEvent(VultronEvent):

--- a/vultron/core/services/embargo_lifecycle.py
+++ b/vultron/core/services/embargo_lifecycle.py
@@ -188,13 +188,8 @@ class EmbargoLifecycle:
                 ``OBSERVED`` syncs local state even when the transition would
                 not normally be valid, forcing ``PROPOSED`` (or ``REVISE``
                 when the local state is ``ACTIVE``/``REVISE``).
-            em_before: When provided by the caller (e.g. from
-                ``ReadEmStateNode``), the service uses this value directly and
-                skips the internal ``case.current_status.em_state`` read.  The
-                caller is then responsible for writing the returned ``em_after``
-                via ``WriteEmStateNode`` (AC-1 of issue #1474).  When ``None``
-                the service reads ``em_state`` from the case itself (legacy /
-                non-BT callers).
+            em_before: When provided, the service uses this value directly
+                instead of reading it from the case.
 
         Returns:
             :class:`EmbargoLifecycleResult` describing what changed.
@@ -211,12 +206,9 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        # When em_before is supplied by the BT caller (ReadEmStateNode), use it
-        # directly; otherwise read from the case (legacy / non-BT callers).
-        caller_owns_em_io = em_before is not None
-        if not caller_owns_em_io:
+        if em_before is None:
             em_before = case.current_status.em.state
-        assert em_before is not None  # guaranteed by the branch above
+        assert em_before is not None
 
         if transition_mode == TransitionMode.STRICT:
             self._assert_pxa_embargo_eligible(
@@ -243,12 +235,9 @@ class EmbargoLifecycle:
         if em_before == EM.ACTIVE and em_after == EM.REVISE:
             participant_changes = self._cascade_pec_revise(case)
 
-        # Mutate case — track whether anything actually changed.
-        # When the BT caller owns em I/O (caller_owns_em_io), skip the em_state
-        # write here — the caller's WriteEmStateNode handles it.
         case_mutated = False
 
-        if not caller_owns_em_io and em_after != em_before:
+        if em_after != em_before:
             case.current_status.em = EmDimension(state=em_after)
             case_mutated = True
 
@@ -314,9 +303,8 @@ class EmbargoLifecycle:
             embargo_id: ID of the ``EmbargoEvent`` being accepted.
             actor_id: ID of the accepting actor.
             transition_mode: ``STRICT`` (default) or ``OBSERVED``.
-            em_before: When provided by the caller (e.g. from
-                ``ReadEmStateNode``), the service uses this value directly and
-                skips the internal read/write of ``case.current_status.em_state``.
+            em_before: When provided, the service uses this value directly
+                instead of reading it from the case.
 
         Returns:
             :class:`EmbargoLifecycleResult` describing what changed.
@@ -333,12 +321,9 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        # When em_before is supplied by the BT caller (ReadEmStateNode), use it
-        # directly; otherwise read from the case (legacy / non-BT callers).
-        caller_owns_em_io = em_before is not None
-        if not caller_owns_em_io:
+        if em_before is None:
             em_before = case.current_status.em.state
-        assert em_before is not None  # guaranteed by the branch above
+        assert em_before is not None
         em_after = em_before
         case_mutated = False
         case_embargo_changed = False
@@ -365,9 +350,7 @@ class EmbargoLifecycle:
                 fallback_dest=EM.ACTIVE,
                 actor_id=actor_id,
             )
-            # When the BT caller owns em I/O, skip the em_state write here —
-            # the caller's WriteEmStateNode handles it.
-            if not caller_owns_em_io and em_after != em_before:
+            if em_after != em_before:
                 case.current_status.em = EmDimension(state=em_after)
                 case_mutated = True
             # Sync active_embargo independently: handle OBSERVED mode where
@@ -442,9 +425,8 @@ class EmbargoLifecycle:
             embargo_id: ID of the ``EmbargoEvent`` being rejected.
             actor_id: ID of the rejecting actor.
             transition_mode: ``STRICT`` (default) or ``OBSERVED``.
-            em_before: When provided by the caller (e.g. from
-                ``ReadEmStateNode``), the service uses this value directly and
-                skips the internal read/write of ``case.current_status.em_state``.
+            em_before: When provided, the service uses this value directly
+                instead of reading it from the case.
 
         Returns:
             :class:`EmbargoLifecycleResult` describing what changed.
@@ -460,12 +442,9 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        # When em_before is supplied by the BT caller (ReadEmStateNode), use it
-        # directly; otherwise read from the case (legacy / non-BT callers).
-        caller_owns_em_io = em_before is not None
-        if not caller_owns_em_io:
+        if em_before is None:
             em_before = case.current_status.em.state
-        assert em_before is not None  # guaranteed by the branch above
+        assert em_before is not None
         em_after = em_before
         case_mutated = False
 
@@ -493,9 +472,7 @@ class EmbargoLifecycle:
                 fallback_dest=fallback,
                 actor_id=actor_id,
             )
-            # When the BT caller owns em I/O, skip the em_state write here —
-            # the caller's WriteEmStateNode handles it.
-            if not caller_owns_em_io and em_after != em_before:
+            if em_after != em_before:
                 case.current_status.em = EmDimension(state=em_after)
                 case_mutated = True
 
@@ -542,9 +519,8 @@ class EmbargoLifecycle:
             case_id: ID of the ``VulnerabilityCase`` to update.
             actor_id: Optional ID of the terminating actor (logging only).
             transition_mode: ``STRICT`` (default) or ``OBSERVED``.
-            em_before: When provided by the caller (e.g. from
-                ``ReadEmStateNode``), the service uses this value directly and
-                skips the internal read/write of ``case.current_status.em_state``.
+            em_before: When provided, the service uses this value directly
+                instead of reading it from the case.
 
         Returns:
             :class:`EmbargoLifecycleResult` describing what changed.
@@ -560,12 +536,9 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        # When em_before is supplied by the BT caller (ReadEmStateNode), use it
-        # directly; otherwise read from the case (legacy / non-BT callers).
-        caller_owns_em_io = em_before is not None
-        if not caller_owns_em_io:
+        if em_before is None:
             em_before = case.current_status.em.state
-        assert em_before is not None  # guaranteed by the branch above
+        assert em_before is not None
 
         # In STRICT mode, require an active embargo to be identified
         embargo_id = _as_id(case.active_embargo)
@@ -583,10 +556,7 @@ class EmbargoLifecycle:
             actor_id=actor_id,
         )
 
-        # When the BT caller owns em I/O, skip the em_state write here —
-        # the caller's WriteEmStateNode handles it.
-        if not caller_owns_em_io:
-            case.current_status.em = EmDimension(state=em_after)
+        case.current_status.em = EmDimension(state=em_after)
         case.active_embargo = None
 
         participant_changes = self._cascade_pec_reset(case)
@@ -618,7 +588,6 @@ class EmbargoLifecycle:
         embargo_id: str,
         actor_id: str | None = None,
         transition_mode: TransitionMode = TransitionMode.STRICT,
-        em_before: EM | None = None,
     ) -> EmbargoLifecycleResult:
         """Activate an embargo on a case, driving EM state to ACTIVE.
 
@@ -632,9 +601,6 @@ class EmbargoLifecycle:
             embargo_id: ID of the ``EmbargoEvent`` to set as active.
             actor_id: Optional ID of the activating actor (logging only).
             transition_mode: ``STRICT`` (default) or ``OBSERVED``.
-            em_before: When provided by the caller (e.g. from
-                ``ReadEmStateNode``), the service uses this value directly and
-                skips the internal read/write of ``case.current_status.em_state``.
 
         Returns:
             :class:`EmbargoLifecycleResult` describing what changed.
@@ -649,10 +615,7 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        caller_owns_em_io = em_before is not None
-        if not caller_owns_em_io:
-            em_before = case.current_status.em.state
-        assert em_before is not None  # guaranteed by the branch above
+        em_before = case.current_status.em.state
 
         em_after = self._drive_em_transition(
             case_id=case_id,
@@ -663,10 +626,7 @@ class EmbargoLifecycle:
             actor_id=actor_id,
         )
 
-        # When the BT caller owns em I/O, skip the em_state write here —
-        # the caller's WriteEmStateNode handles it.
-        if not caller_owns_em_io:
-            case.current_status.em = EmDimension(state=em_after)
+        case.current_status.em = EmDimension(state=em_after)
 
         case.set_embargo(embargo_id)
         self._persistence.save(case)
@@ -712,8 +672,7 @@ class EmbargoLifecycle:
             embargo_id: Optional ID of the relevant ``EmbargoEvent``; used
                 to maintain ``accepted_embargo_ids`` on ACCEPT/DECLINE.
             em_before: When provided by the caller (e.g. from
-                ``ReadEmStateNode``), the service uses this value directly and
-                skips the internal ``case.current_status.em_state`` read.
+                this value is used directly instead of reading it from the case.
 
         Returns:
             :class:`EmbargoLifecycleResult` with ``em_before == em_after``

--- a/vultron/wire/as2/extractor/_extract.py
+++ b/vultron/wire/as2/extractor/_extract.py
@@ -10,19 +10,18 @@ registry lookup automatically, use ``vultron.semantic_registry.extract_event``.
 """
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from vultron.core.models.events import MessageSemantics, VultronEvent
-from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.extractor._builders import (
     _build_object_kwargs,
     _get_id,
     _to_domain_obj,
 )
+from vultron.wire.as2.factories.embargo import _DEFAULT_MIN_RSVP_WINDOW
+from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 
 logger = logging.getLogger(__name__)
-
-_DEFAULT_MIN_RSVP_WINDOW = timedelta(hours=72)
 
 
 def extract_intent(

--- a/vultron/wire/as2/extractor/_extract.py
+++ b/vultron/wire/as2/extractor/_extract.py
@@ -9,6 +9,9 @@ For a single-call convenience wrapper that performs pattern matching and
 registry lookup automatically, use ``vultron.semantic_registry.extract_event``.
 """
 
+import logging
+from datetime import datetime, timedelta, timezone
+
 from vultron.core.models.events import MessageSemantics, VultronEvent
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.extractor._builders import (
@@ -16,6 +19,10 @@ from vultron.wire.as2.extractor._builders import (
     _get_id,
     _to_domain_obj,
 )
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MIN_RSVP_WINDOW = timedelta(hours=72)
 
 
 def extract_intent(
@@ -68,6 +75,29 @@ def extract_intent(
         actor_id,
         origin,
     )
+
+    # AC-2/AC-3/AC-5 (issue #2211): extract activity-level end_time as
+    # rsvp_deadline for event classes that carry it.  Applies UTC normalization
+    # and clamps sub-floor values up to the default minimum window (EP-07-003).
+    if "rsvp_deadline" in event_class.model_fields:
+        raw_end_time = getattr(activity, "end_time", None)
+        if (
+            isinstance(raw_end_time, datetime)
+            and raw_end_time.tzinfo is not None
+        ):
+            floor = datetime.now(tz=timezone.utc) + _DEFAULT_MIN_RSVP_WINDOW
+            if raw_end_time < floor:
+                logger.info(
+                    "extract_intent: inbound rsvp_deadline %s is below floor"
+                    " %s; clamped to floor (EP-07-003)",
+                    raw_end_time.isoformat(),
+                    floor.isoformat(),
+                )
+                raw_end_time = floor
+            extra_kwargs["rsvp_deadline"] = raw_end_time.astimezone(
+                timezone.utc
+            )
+
     return event_class(
         semantic_type=semantics,
         activity_id=activity.id_,

--- a/vultron/wire/as2/factories/embargo.py
+++ b/vultron/wire/as2/factories/embargo.py
@@ -23,6 +23,7 @@ Spec: ``specs/activity-factories.yaml`` AF-01-001 through AF-04-003.
 """
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Sequence, cast
 
 from pydantic import ValidationError
@@ -60,9 +61,14 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (
 logger = logging.getLogger(__name__)
 
 
+_DEFAULT_MIN_RSVP_WINDOW = timedelta(hours=72)
+
+
 def em_propose_embargo_activity(
     embargo: as_EmbargoEvent,
     context: as_VulnerabilityCaseRef | None = None,
+    rsvp_deadline: datetime | None = None,
+    min_rsvp_window: timedelta = _DEFAULT_MIN_RSVP_WINDOW,
     **kwargs,
 ) -> as_Invite:
     """Build an Invite(as_EmbargoEvent) — the EP/EV message.
@@ -73,15 +79,37 @@ def em_propose_embargo_activity(
         embargo: The ``as_EmbargoEvent`` being proposed.
         context: The ``VulnerabilityCase`` (or its URI) for which the
             embargo is being proposed.
+        rsvp_deadline: Optional RSVP-by deadline set on the activity-level
+            ``end_time`` (CM-27-001, ADR-0065). MUST be timezone-aware and
+            at least ``min_rsvp_window`` in the future (EP-07-002).
+        min_rsvp_window: Minimum time between now and the deadline; defaults
+            to 72 hours (EP-07-002). Pass ``ActorConfig.min_rsvp_window``
+            from the caller to apply the configured floor.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
     Returns:
-        An ``as_Invite`` whose ``object_`` is the embargo event.
+        An ``as_Invite`` whose ``object_`` is the embargo event, with
+        ``end_time`` set to *rsvp_deadline* when provided.
 
     Raises:
-        VultronActivityConstructionError: If Pydantic validation fails.
+        VultronActivityConstructionError: If Pydantic validation fails, or
+            if *rsvp_deadline* is naive or below the minimum window.
     """
+    if rsvp_deadline is not None:
+        if rsvp_deadline.tzinfo is None:
+            raise VultronActivityConstructionError(
+                "em_propose_embargo_activity: rsvp_deadline must be"
+                " timezone-aware (naive datetime rejected per EP-07-002)"
+            )
+        floor = datetime.now(tz=timezone.utc) + min_rsvp_window
+        if rsvp_deadline < floor:
+            raise VultronActivityConstructionError(
+                f"em_propose_embargo_activity: rsvp_deadline"
+                f" {rsvp_deadline.isoformat()} is below the minimum"
+                f" window floor {floor.isoformat()} (EP-07-002)"
+            )
+        kwargs.setdefault("end_time", rsvp_deadline)
     try:
         return _EmProposeEmbargoActivity(
             object_=embargo, context=context, **kwargs


### PR DESCRIPTION
- Closes #2712
- Closes #2211
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Retires `WriteEmStateNode` (EMB-18-001) so `EmbargoLifecycle` service methods exclusively own EM state reads and writes, and adds RSVP deadline support (`rsvp_deadline` / `Invite.end_time`) to the wire layer for embargo proposals per CM-27-001 and EP-07.

## Changes

- **`vultron/core/services/embargo_lifecycle.py`**: Removed `caller_owns_em_io` branch from all five service methods; each now unconditionally reads `em_before` from the DataLayer and writes `em_after` back. Removed `em_before` param from `activate_embargo` (no callers).
- **`vultron/core/behaviors/embargo/nodes/em_state.py`**: `WriteEmStateNode` deleted; module now contains only `ReadEmStateNode`. Updated docstring to reflect EMB-18-001 ownership rule.
- **`vultron/core/behaviors/embargo/nodes/lifecycle.py`**: `_EmbargoLifecycleNode.update()` no longer constructs or calls `WriteEmStateNode`.
- **`vultron/core/behaviors/embargo/nodes/proposal.py`**: `RecordParticipantAcceptanceNode` calls `accept_embargo_invite()` directly without Read/Write dance.
- **`vultron/core/behaviors/embargo/nodes/reject_proposed.py`**: Removed `WriteEmStateNode` call.
- **`vultron/core/behaviors/case/nodes/embargo.py`**: `_propose_with_em_io()` simplified; `AttachEmbargoToCaseNode` now delegates to `EmbargoLifecycle.activate_embargo()`.
- **`vultron/core/behaviors/embargo/__init__.py`** / **`nodes/__init__.py`**: Removed `WriteEmStateNode` exports.
- **`vultron/core/AGENTS.md`**: Replaced stale `caller_owns_em_io` pitfall section with tombstone pointing to the service-always-writes rule.
- **`vultron/core/behaviors/AGENTS.md`**: Updated EM state node section noting `WriteEmStateNode` retired.
- **`vultron/wire/as2/factories/embargo.py`**: `em_propose_embargo_activity()` accepts optional `rsvp_deadline` (tz-aware `datetime`); sets `as_Invite.end_time`. Naive or sub-floor deadline raises `VultronActivityConstructionError` (EP-07-002).
- **`vultron/core/models/events/embargo.py`**: `InviteToEmbargoOnCaseReceivedEvent` gains `rsvp_deadline: datetime | None` with UTC-normalizing field validator; naive values rejected.
- **`vultron/wire/as2/extractor/_extract.py`**: `extract_intent()` extracts activity-level `end_time` as `rsvp_deadline` for event classes that declare it; sub-floor values clamped up and logged (EP-07-003).
- **`vultron/config/actor.py`**: `ActorConfig` gains `min_rsvp_window` (default 72h) and `default_rsvp_window` (default 7d) fields.
- **Tests**: `TestCallerOwnsEmIo` replaced with `TestServiceAlwaysWritesEmState`; all `WriteEmStateNode` test classes removed; 9 new tests for RSVP deadline (factory + extractor).

## Verification

- 1240 unit + 1240 integration tests pass (9 new tests added)
- Black, flake8, mypy, pyright clean