### PR TITLE
fix(demo): pass timeout_seconds=60.0 to run_direct_path_rm_triage in all multi-container scenarios

### DIFF
--- a/test/demo/test_fccv_extension_demo.py
+++ b/test/demo/test_fccv_extension_demo.py
@@ -572,3 +572,114 @@ class TestFccvExtensionCausalGates:
             )
 
         coverage_wait_called.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression test — ISSUE-2811 timeout fix
+# ---------------------------------------------------------------------------
+
+
+class TestFccvExtensionRmTriageTimeout:
+    """_phase_report_submission must forward timeout_seconds=60.0 to
+    run_direct_path_rm_triage so the causal gate (ADR-0058) does not race
+    under 4-container CI load (ISSUE-2811)."""
+
+    def _actor(self, id_: str = "urn:test:actor"):
+        a = MagicMock()
+        a.id_ = id_
+        return a
+
+    def _case(self, id_: str = "urn:test:case"):
+        c = MagicMock()
+        c.id_ = id_
+        return c
+
+    def _client(self):
+        c = MagicMock()
+        c.get.return_value = {}
+        return c
+
+    def test_phase_report_submission_passes_60s_timeout_to_rm_triage(self):
+        """Regression: fccv_extension CI timed out at 20 s default (ISSUE-2811)."""
+        import contextlib
+
+        finder = self._actor("urn:test:finder")
+        c1 = self._actor("urn:test:c1")
+        c2 = self._actor("urn:test:c2")
+        vendor = self._actor("urn:test:vendor")
+        c1_in_c1 = self._actor("urn:test:c1")
+        c2_in_c2 = self._actor("urn:test:c2")
+        report = MagicMock()
+        offer = MagicMock()
+        offer.id_ = "urn:test:offer"
+        invite = MagicMock()
+        invite.id_ = "urn:test:invite"
+        case = self._case()
+
+        with (
+            patch.object(demo, "reset_containers"),
+            patch.object(
+                demo,
+                "seed_containers_fccv",
+                return_value=(finder, c1, c2, vendor),
+            ),
+            patch.object(
+                demo,
+                "get_actor_by_id",
+                side_effect=[c1_in_c1, c2_in_c2],
+            ),
+            patch.object(
+                demo, "reporter_submits_report", return_value=(report, offer)
+            ),
+            patch.object(
+                demo, "run_direct_path_rm_triage", return_value=case
+            ) as mock_rm_triage,
+            patch.object(demo, "wait_for_case_participants"),
+            patch.object(
+                demo,
+                "post_to_trigger",
+                return_value={"activity": {"id": invite.id_}},
+            ),
+            patch.object(demo, "post_to_inbox_and_wait"),
+            patch.object(demo, "verify_object_stored"),
+            patch.object(demo, "wait_for_case_on_container"),
+            patch.object(demo, "find_case_invite_for_actor"),
+            patch.object(demo, "as_TransitiveActivity") as mock_ta,
+            patch.object(demo, "as_VulnerabilityCase") as mock_vc,
+            patch.object(demo, "run_invite_path_rm_triage"),
+            patch.object(demo, "verify_case_active"),
+            patch.object(
+                demo,
+                "demo_gate",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+            patch.object(
+                demo,
+                "demo_step",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            mock_ta.model_validate.return_value = invite
+            mock_vc.model_validate.return_value = case
+            demo._phase_report_submission(
+                finder_client=self._client(),
+                c1_client=self._client(),
+                c2_client=self._client(),
+                vendor_client=self._client(),
+                finder_id=None,
+                c1_id=None,
+                c2_id=None,
+                vendor_id=None,
+            )
+
+        _call = mock_rm_triage.call_args
+        assert _call is not None
+        assert _call.kwargs.get("timeout_seconds") == 60.0, (
+            "run_direct_path_rm_triage must receive timeout_seconds=60.0; "
+            "the 20-second default races under 4-container CI load (ISSUE-2811)"
+        )

--- a/test/demo/test_fccv_handoff_demo.py
+++ b/test/demo/test_fccv_handoff_demo.py
@@ -1066,3 +1066,93 @@ class TestFccvHandoffCausalGates:
             )
 
         coverage_wait_called.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression test — ISSUE-2811 timeout fix
+# ---------------------------------------------------------------------------
+
+
+class TestFccvHandoffRmTriageTimeout:
+    """_phase_report_submission must forward timeout_seconds=60.0 to
+    run_direct_path_rm_triage so the causal gate (ADR-0058) does not race
+    under 4-container CI load (ISSUE-2811)."""
+
+    def _actor(self, id_: str = "urn:test:actor"):
+        a = MagicMock()
+        a.id_ = id_
+        return a
+
+    def _case(self, id_: str = "urn:test:case"):
+        c = MagicMock()
+        c.id_ = id_
+        return c
+
+    def _client(self):
+        c = MagicMock()
+        c.get.return_value = {}
+        return c
+
+    def test_phase_report_submission_passes_60s_timeout_to_rm_triage(self):
+        """Regression: fccv_handoff CI timed out at 20 s default (ISSUE-2811)."""
+        import contextlib
+
+        finder = self._actor("urn:test:finder")
+        c1 = self._actor("urn:test:c1")
+        c2 = self._actor("urn:test:c2")
+        vendor = self._actor("urn:test:vendor")
+        c1_in_c1 = self._actor("urn:test:c1")
+        c2_in_c2 = self._actor("urn:test:c2")
+        report = MagicMock()
+        offer = MagicMock()
+        offer.id_ = "urn:test:offer"
+        case = self._case()
+
+        with (
+            patch.object(demo, "reset_containers"),
+            patch.object(
+                demo,
+                "seed_containers_fccv",
+                return_value=(finder, c1, c2, vendor),
+            ),
+            patch.object(
+                demo, "get_actor_by_id", side_effect=[c1_in_c1, c2_in_c2]
+            ),
+            patch.object(
+                demo, "reporter_submits_report", return_value=(report, offer)
+            ),
+            patch.object(
+                demo, "run_direct_path_rm_triage", return_value=case
+            ) as mock_rm_triage,
+            patch.object(demo, "wait_for_case_participants"),
+            patch.object(demo, "as_VulnerabilityCase") as mock_vc,
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+            patch.object(
+                demo,
+                "demo_step",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            mock_vc.model_validate.return_value = case
+            demo._phase_report_submission(
+                finder_client=self._client(),
+                c1_client=self._client(),
+                c2_client=self._client(),
+                case_actor_client=self._client(),
+                vendor_client=self._client(),
+                finder_id=None,
+                c1_id=None,
+                c2_id=None,
+                vendor_id=None,
+            )
+
+        _call = mock_rm_triage.call_args
+        assert _call is not None
+        assert _call.kwargs.get("timeout_seconds") == 60.0, (
+            "run_direct_path_rm_triage must receive timeout_seconds=60.0; "
+            "the 20-second default races under 4-container CI load (ISSUE-2811)"
+        )

--- a/test/demo/test_fcvcv_demo.py
+++ b/test/demo/test_fcvcv_demo.py
@@ -505,3 +505,108 @@ class TestFcvcvCausalGates(_Helpers):
             )
 
         coverage_wait_called.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression test — ISSUE-2811 timeout fix
+# ---------------------------------------------------------------------------
+
+
+class TestFcvcvRmTriageTimeout(_Helpers):
+    """_phase_report_submission must forward timeout_seconds=60.0 to
+    run_direct_path_rm_triage so the causal gate (ADR-0058) does not race
+    under 4-container CI load (ISSUE-2811)."""
+
+    def test_phase_report_submission_passes_60s_timeout_to_rm_triage(self):
+        """Regression: fcvcv CI timed out at 20 s default (ISSUE-2811)."""
+        import contextlib
+
+        finder = self._actor("urn:test:finder")
+        c1 = self._actor("urn:test:c1")
+        c1_in_c1 = self._actor("urn:test:c1")
+        v1 = self._actor("urn:test:v1")
+        v1_in_v1 = self._actor("urn:test:v1")
+        c2 = self._actor("urn:test:c2")
+        c2_in_c2 = self._actor("urn:test:c2")
+        report = MagicMock()
+        offer = MagicMock()
+        offer.id_ = "urn:test:offer"
+        invite = MagicMock()
+        invite.id_ = "urn:test:invite"
+        case = self._case()
+
+        with (
+            patch.object(demo, "reset_containers"),
+            patch.object(
+                demo,
+                "seed_containers_fcvcv",
+                return_value=(finder, c1, v1, c2, MagicMock()),
+            ),
+            patch.object(
+                demo,
+                "get_actor_by_id",
+                side_effect=[c1_in_c1, v1_in_v1, c2_in_c2],
+            ),
+            patch.object(
+                demo, "reporter_submits_report", return_value=(report, offer)
+            ),
+            patch.object(
+                demo, "run_direct_path_rm_triage", return_value=case
+            ) as mock_rm_triage,
+            patch.object(demo, "wait_for_case_participants"),
+            patch.object(demo, "verify_case_active"),
+            patch.object(
+                demo,
+                "post_to_trigger",
+                return_value={"activity": {"id": invite.id_, "type": "Offer"}},
+            ),
+            patch.object(demo, "post_to_inbox_and_wait"),
+            patch.object(demo, "verify_object_stored"),
+            patch.object(demo, "wait_for_case_on_container"),
+            patch.object(demo, "run_invite_path_rm_triage"),
+            patch.object(
+                demo,
+                "find_case_invite_for_actor",
+                return_value="urn:test:invite",
+            ),
+            patch.object(demo, "as_TransitiveActivity") as mock_ta,
+            patch.object(demo, "as_VulnerabilityCase") as mock_vc,
+            patch.object(
+                demo,
+                "demo_gate",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+            patch.object(
+                demo,
+                "demo_step",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            mock_ta.model_validate.return_value = MagicMock(
+                id_="urn:test:invite"
+            )
+            mock_vc.model_validate.return_value = case
+            demo._phase_report_submission(
+                finder_client=self._client(),
+                c1_client=self._client(),
+                v1_client=self._client(),
+                c2_client=self._client(),
+                v2_client=self._client(),
+                finder_id=None,
+                c1_id=None,
+                v1_id=None,
+                c2_id=None,
+                v2_id=None,
+            )
+
+        _call = mock_rm_triage.call_args
+        assert _call is not None
+        assert _call.kwargs.get("timeout_seconds") == 60.0, (
+            "run_direct_path_rm_triage must receive timeout_seconds=60.0; "
+            "the 20-second default races under 4-container CI load (ISSUE-2811)"
+        )

--- a/test/demo/test_fvcv_extension_demo.py
+++ b/test/demo/test_fvcv_extension_demo.py
@@ -953,3 +953,107 @@ class TestFvcvExtensionCausalGates:
             )
 
         coverage_wait_called.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Timeout propagation — ISSUE-2811
+# ---------------------------------------------------------------------------
+
+
+class TestFvcvExtensionRmTriageTimeout:
+    """_phase_report_submission must forward timeout_seconds=60.0 to
+    run_direct_path_rm_triage so the causal gate (ADR-0058) does not race
+    under 4-container CI load (ISSUE-2811)."""
+
+    def _actor(self, id_: str = "urn:test:actor"):
+        a = MagicMock()
+        a.id_ = id_
+        return a
+
+    def _client(self):
+        c = MagicMock()
+        c.get.return_value = {}
+        return c
+
+    def _case(self, id_: str = "urn:test:case"):
+        c = MagicMock()
+        c.id_ = id_
+        return c
+
+    def test_phase_report_submission_passes_60s_timeout_to_rm_triage(self):
+        """Regression: fvcv_extension CI timed out at 20 s default (ISSUE-2811)."""
+        import contextlib
+
+        finder = self._actor("urn:test:finder")
+        vendor = self._actor("urn:test:vendor")
+        coordinator = self._actor("urn:test:coordinator")
+        coordinator_in_coordinator = self._actor("urn:test:coordinator")
+        vendor2 = self._actor("urn:test:vendor2")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        report = MagicMock()
+        offer = MagicMock()
+        offer.id_ = "urn:test:offer"
+        invite = MagicMock()
+        invite.id_ = "urn:test:invite"
+        case = self._case()
+
+        with (
+            patch.object(demo, "reset_containers"),
+            patch.object(
+                demo,
+                "seed_containers_fvcv",
+                return_value=(finder, vendor, coordinator, vendor2),
+            ),
+            patch.object(
+                demo,
+                "get_actor_by_id",
+                side_effect=[vendor_in_vendor, coordinator_in_coordinator],
+            ),
+            patch.object(
+                demo, "reporter_submits_report", return_value=(report, offer)
+            ),
+            patch.object(
+                demo, "run_direct_path_rm_triage", return_value=case
+            ) as mock_rm_triage,
+            patch.object(demo, "wait_for_case_participants"),
+            patch.object(
+                demo,
+                "post_to_trigger",
+                return_value={"activity": {"id": invite.id_}},
+            ),
+            patch.object(demo, "find_case_invite_for_actor"),
+            patch.object(demo, "wait_for_case_on_container"),
+            patch.object(demo, "as_TransitiveActivity") as mock_ta,
+            patch.object(demo, "as_VulnerabilityCase") as mock_vc,
+            patch.object(demo, "run_invite_path_rm_triage"),
+            patch.object(demo, "verify_case_active"),
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+            patch.object(
+                demo,
+                "demo_step",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            mock_ta.model_validate.return_value = invite
+            mock_vc.model_validate.return_value = case
+            demo._phase_report_submission(
+                finder_client=self._client(),
+                vendor_client=self._client(),
+                coordinator_client=self._client(),
+                vendor2_client=self._client(),
+                finder_id=None,
+                vendor_id=None,
+                coordinator_id=None,
+                vendor2_id=None,
+            )
+
+        _call = mock_rm_triage.call_args
+        assert _call is not None
+        assert _call.kwargs.get("timeout_seconds") == 60.0, (
+            "run_direct_path_rm_triage must receive timeout_seconds=60.0; "
+            "the 20-second default races under 4-container CI load (ISSUE-2811)"
+        )

--- a/test/demo/test_fvcv_handoff_demo.py
+++ b/test/demo/test_fvcv_handoff_demo.py
@@ -1547,3 +1547,96 @@ class TestFvcvHandoffCausalGates:
             )
 
         coverage_wait_called.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression test — ISSUE-2811 timeout fix
+# ---------------------------------------------------------------------------
+
+
+class TestFvcvHandoffRmTriageTimeout:
+    """_phase_report_submission must forward timeout_seconds=60.0 to
+    run_direct_path_rm_triage so the causal gate (ADR-0058) does not race
+    under 4-container CI load (ISSUE-2811)."""
+
+    def _actor(self, id_: str = "urn:test:actor"):
+        a = MagicMock()
+        a.id_ = id_
+        return a
+
+    def _case(self, id_: str = "urn:test:case"):
+        c = MagicMock()
+        c.id_ = id_
+        return c
+
+    def _client(self):
+        c = MagicMock()
+        c.get.return_value = {}
+        return c
+
+    def test_phase_report_submission_passes_60s_timeout_to_rm_triage(self):
+        """Regression: fvcv_handoff CI timed out at 20 s default (ISSUE-2811)."""
+        import contextlib
+
+        finder = self._actor("urn:test:finder")
+        vendor = self._actor("urn:test:vendor")
+        coordinator = self._actor("urn:test:coordinator")
+        coordinator_in_coordinator = self._actor("urn:test:coordinator")
+        vendor2 = self._actor("urn:test:vendor2")
+        vendor_in_vendor = self._actor("urn:test:vendor")
+        report = MagicMock()
+        offer = MagicMock()
+        offer.id_ = "urn:test:offer"
+        case = self._case()
+
+        with (
+            patch.object(demo, "reset_containers"),
+            patch.object(
+                demo,
+                "seed_containers_fvcv",
+                return_value=(finder, vendor, coordinator, vendor2),
+            ),
+            patch.object(
+                demo,
+                "get_actor_by_id",
+                side_effect=[vendor_in_vendor, coordinator_in_coordinator],
+            ),
+            patch.object(
+                demo, "reporter_submits_report", return_value=(report, offer)
+            ),
+            patch.object(
+                demo, "run_direct_path_rm_triage", return_value=case
+            ) as mock_rm_triage,
+            patch.object(demo, "wait_for_case_participants"),
+            patch.object(demo, "wait_for_case_on_container"),
+            patch.object(demo, "as_VulnerabilityCase") as mock_vc,
+            patch.object(
+                demo,
+                "demo_check",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+            patch.object(
+                demo,
+                "demo_step",
+                side_effect=lambda _: contextlib.nullcontext(),
+            ),
+        ):
+            mock_vc.model_validate.return_value = case
+            demo._phase_report_submission(
+                finder_client=self._client(),
+                vendor_client=self._client(),
+                coordinator_client=self._client(),
+                case_actor_client=self._client(),
+                vendor2_client=self._client(),
+                finder_id=None,
+                vendor_id=None,
+                coordinator_id=None,
+                vendor2_id=None,
+            )
+
+        _call = mock_rm_triage.call_args
+        assert _call is not None
+        assert _call.kwargs.get("timeout_seconds") == 60.0, (
+            "run_direct_path_rm_triage must receive timeout_seconds=60.0; "
+            "the 20-second default races under 4-container CI load (ISSUE-2811)"
+        )

--- a/vultron/demo/scenario/fccv_extension_demo.py
+++ b/vultron/demo/scenario/fccv_extension_demo.py
@@ -233,6 +233,7 @@ def _phase_report_submission(
         receiver_client=c1_client,
         receiver=c1_in_c1,
         offer=offer,
+        timeout_seconds=60.0,
     )
 
     # Wait for the initial participants (Finder + C1 + CaseActor) before

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -228,6 +228,7 @@ def _phase_report_submission(
         receiver_client=c1_client,
         receiver=c1_in_c1,
         offer=offer,
+        timeout_seconds=60.0,
     )
 
     # Wait for initial participants (Finder + C1 + CaseActor).

--- a/vultron/demo/scenario/fcvcv_demo.py
+++ b/vultron/demo/scenario/fcvcv_demo.py
@@ -241,6 +241,7 @@ def _phase_report_submission(
         receiver_client=c1_client,
         receiver=c1_in_c1,
         offer=offer,
+        timeout_seconds=60.0,
     )
 
     # Wait for the initial participants (Finder + C1 + CaseActor) before

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -213,6 +213,7 @@ def _phase_report_submission(
         receiver_client=vendor_client,
         receiver=vendor_in_vendor,
         offer=offer,
+        timeout_seconds=60.0,
     )
 
     # Wait for the initial participants (Finder + Vendor1 + CaseActor) before

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -218,6 +218,7 @@ def _phase_report_submission(
         receiver_client=vendor_client,
         receiver=vendor_in_vendor,
         offer=offer,
+        timeout_seconds=60.0,
     )
 
     # Wait for initial participants (Finder + Vendor1 + CaseActor).


### PR DESCRIPTION
- Closes #2811
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

The causal gate added in #2548 polls until the `VulnerabilityCase` replica arrives in the receiver's store before `validate-report` proceeds (ADR-0058 / ADR-0041 / PCR-01-003). It uses `timeout_seconds=20.0` by default; in a 4-container Docker CI run the async delivery chain exceeded 20 seconds, causing the `demo_gate` to fire. All other cross-container waits in the affected scenarios already use 60 seconds — this one call alone used the 20-second default.

## Changes

- **`vultron/demo/scenario/fvcv_extension_demo.py`**: add `timeout_seconds=60.0` to `run_direct_path_rm_triage` call (primary failing scenario)
- **`vultron/demo/scenario/fccv_extension_demo.py`**: same fix
- **`vultron/demo/scenario/fvcv_handoff_demo.py`**: same fix
- **`vultron/demo/scenario/fccv_handoff_demo.py`**: same fix
- **`vultron/demo/scenario/fcvcv_demo.py`**: same fix
- **`test/demo/test_fvcv_extension_demo.py`**: add `TestFvcvExtensionRmTriageTimeout::test_phase_report_submission_passes_60s_timeout_to_rm_triage` — confirmed failing before fix, passing after

## Verification

- All 99 affected-scenario integration tests pass
- Full unit suite passes
- Full integration suite passes
- Black, flake8, mypy clean