### PR TITLE
fix(docker): chown /app/.venv to vscode in dev stage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,11 +456,13 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
 - **`uv run` Pre-Commit Hooks Fail With "Permission Denied" — Use `UV_NO_SYNC=1`** —
   when `/app/.venv/bin/adr-index` (or any devcontainer venv binary) is owned by
   root, `uv run` tries to sync the venv before executing and fails immediately
-  with `Permission denied`. Prefix with `UV_NO_SYNC=1` to skip the sync step:
-  `UV_NO_SYNC=1 uv run spec-dump`. This is safe inside the devcontainer because
-  the venv is already built; it bypasses only the sync, not the execution. Apply
-  to any `uv run` command that fails at the sync step rather than the tool itself.
-  *Source: CONCERN-2321*
+  with `Permission denied`. The root cause (`.venv` left root-owned in the `dev`
+  Docker stage) was fixed in Bug #2713 — rebuild the image with `./start-dev.sh
+  <slot> --rebuild`. For containers built before that fix, prefix with
+  `UV_NO_SYNC=1`: `UV_NO_SYNC=1 uv run spec-dump`. This is safe because the venv
+  is already built; it bypasses only the sync. Apply to any `uv run` command that
+  fails at the sync step rather than the tool itself.
+  *Source: CONCERN-2321, Bug #2713*
 - **Walrus Operator for Single-Assignment Guard Blocks** —
   `if (f := self._require_factory()) is not None: return f`.
 - **Silent `None` Returns and Fake `SUCCESS` Are the Same Bug** — raise

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -167,11 +167,10 @@ RUN su - vscode -c "curl -fsSL https://claude.ai/install.sh | bash"
 
 # /app is owned by root from the earlier COPY and git steps; hand it to vscode so
 # the git reset in poststart.sh doesn't fail on dubious-ownership checks.
-# Exclude .venv — inherited from dep-layer as root-owned, contains thousands of
-# files, and is bind-mounted over at runtime. World-readable/executable via root's
-# default umask (022) so vscode can run Python without owning them.
-RUN chown vscode:vscode /app \
-    && find /app -mindepth 1 -maxdepth 1 ! -name '.venv' -exec chown -R vscode:vscode {} +
+# .venv is included: start-dev.sh does not bind-mount a host venv over it, so the
+# baked venv is the runtime venv and must be writable by vscode for `uv run` to
+# succeed (uv syncs the venv before executing, which requires write access).
+RUN chown -R vscode:vscode /app
 
 WORKDIR /app
 USER vscode

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ FROM base AS dep-layer
 # Install all third-party + dev packages (but not the project package itself) so
 # that a source-only change never busts this expensive layer.
 COPY pyproject.toml uv.lock /app/
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --dev
 
 FROM dep-layer AS dependencies
@@ -35,7 +35,7 @@ COPY --exclude=.git --exclude=.agents \
      --exclude=docker/Dockerfile \
      . /app/
 ENV PYTHONPATH=/app
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv sync --frozen
 
 FROM dep-layer AS test
@@ -47,7 +47,7 @@ COPY --exclude=.git --exclude=.agents \
      --exclude=docker/Dockerfile \
      . /app/
 ENV PYTHONPATH=/app
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv sync --frozen --dev
 CMD ["uv", "run", "pytest"]
 
@@ -152,10 +152,6 @@ RUN git -C /app rev-parse --verify --quiet refs/remotes/origin/main >/dev/null \
     && git -C /app reflog expire --expire=all --all \
     && git -C /app gc --prune=now --quiet
 
-ENV PYTHONPATH=/app
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --dev
-
 # Create non-root developer user matching the VS Code devcontainer convention
 RUN groupadd --gid 1000 vscode \
     && useradd --uid 1000 --gid 1000 -m -s /bin/zsh vscode \
@@ -165,12 +161,18 @@ RUN groupadd --gid 1000 vscode \
 # Claude Code CLI (installed as vscode user so it lands in ~/.local)
 RUN su - vscode -c "curl -fsSL https://claude.ai/install.sh | bash"
 
-# /app is owned by root from the earlier COPY and git steps; hand it to vscode so
-# the git reset in poststart.sh doesn't fail on dubious-ownership checks.
-# .venv is included: start-dev.sh does not bind-mount a host venv over it, so the
-# baked venv is the runtime venv and must be writable by vscode for `uv run` to
-# succeed (uv syncs the venv before executing, which requires write access).
-RUN chown -R vscode:vscode /app
+# Delete the inherited root-owned .venv before chowning /app so the chown
+# recurses over source files only — not thousands of venv entries (cheap).
+# uv sync below, running as vscode, recreates .venv with vscode ownership.
+RUN rm -rf /app/.venv \
+    && chown -R vscode:vscode /app
 
 WORKDIR /app
 USER vscode
+
+# Install the project into a fresh vscode-owned .venv. The shared cache
+# (id=uv-cache) is populated by the dep-layer build so packages come from
+# the local cache rather than the network.
+ENV PYTHONPATH=/app
+RUN --mount=type=cache,uid=1000,gid=1000,id=uv-cache,target=/home/vscode/.cache/uv \
+    uv sync --frozen --dev

--- a/notes/docker-build.md
+++ b/notes/docker-build.md
@@ -31,12 +31,25 @@ Copy `pyproject.toml` and `uv.lock` first, run `uv sync --frozen`, then copy
 the rest of the source. This allows Docker to reuse the dependency layer on
 rebuilds that only change source files.
 
-Use BuildKit cache mounts for the uv/pip cache to speed up repeated installs:
+Use BuildKit cache mounts for the uv/pip cache to speed up repeated installs.
+Use a consistent `id` across all stages so they share one backing store:
 
 ```dockerfile
-RUN --mount=type=cache,id=pycache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv sync --frozen
 ```
+
+When a stage runs as a non-root user (e.g. `vscode`, uid=1000), add
+`uid=NNN,gid=NNN` so that user can read the cache populated by root stages.
+The `target` path should be the non-root user's cache location:
+
+```dockerfile
+RUN --mount=type=cache,uid=1000,gid=1000,id=uv-cache,target=/home/vscode/.cache/uv \
+    uv sync --frozen --dev
+```
+
+The `id` is what links the mounts — BuildKit serves the same backing store
+regardless of which `target` path each stage mounts it at.
 
 ### Multi-Stage Build
 


### PR DESCRIPTION
- Closes #2713
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

The `dev` Docker stage left `/app/.venv` owned by root, causing every
`uv run` in the devcontainer to fail with `Permission denied`. Rather
than chowning thousands of pre-existing venv files, delete the inherited
root-owned `.venv` before the chown (making it cheap), then run `uv sync`
as the `vscode` user — the new `.venv` lands owned by vscode from creation.

## Changes

- **`docker/Dockerfile`** — `dep-layer`/`dependencies`/`test` stages: add
  `id=uv-cache` to cache mounts so the dev stage shares the same BuildKit
  cache backing store (no network re-download).
- **`docker/Dockerfile`** — `dev` stage: move user creation before `uv sync`;
  add `rm -rf /app/.venv` before `chown` so it only recurses over source files;
  switch to `USER vscode`; run `uv sync` as vscode with the shared cache.
- **`AGENTS.md`**: update the `UV_NO_SYNC=1` pitfall to reference the fix and
  direct users to rebuild instead of using the workaround.

## Verification

- 7877 unit tests pass, 1248 integration tests pass
- Black, flake8, mypy, pyright clean