### PR TITLE
docs: plan issue #2829 — async round-trip and delivery-confirmation primitive

### DIFF
--- a/docs/adr/0026-caseactor-routed-actor-suggestion.md
+++ b/docs/adr/0026-caseactor-routed-actor-suggestion.md
@@ -146,6 +146,20 @@ Three distinct states must be distinguished when a second `Offer(Actor X)` arriv
 
 ### Trust Rule: Roles Come From the Offer, Not the Accept
 
+> **Generalized by ADR-0080 (2026-08-31).** This rule is not specific to
+> participant roles. ASK-01-004 states it for every ask: **the ask is
+> authoritative and the reply is only a yes.** Whatever action a reply
+> authorizes MUST be read from the stored ask, never from the reply's content —
+> otherwise the answerer can alter what it grants itself, in any exchange, not
+> just this one. ADR-0080 also adds the time dimension: an ask carries a deadline,
+> and for ask kinds whose expiry is *void*, a reply arriving after it does not
+> authorize the action (ASK-03-006). Trusting *when* a reply arrives is the same
+> class of mistake as trusting *what* it claims.
+>
+> The routing tree and stored-ask record described below are the reference
+> implementations the ADR-0080 primitive generalizes; see
+> `notes/protocol-asks.md`.
+
 When the CaseActor processes `Accept(Offer(CaseParticipant))` from the Case
 Owner, the roles assigned to the new participant MUST be taken from the
 **stored outgoing `Offer(CaseParticipant)`** that the CaseActor sent, not

--- a/docs/adr/0046-received-status-authorization.md
+++ b/docs/adr/0046-received-status-authorization.md
@@ -76,6 +76,20 @@ without coupling the trees directly: when StatusAdoptionGate passes, the CaseAct
   implementations must ensure the CASE_MANAGER role check on
   `add_case_status_tree` is satisfied by the CaseActor's own identity
 
+> **Amended by ADR-0080 (2026-08-31).** Both gates become **conversation-state
+> routing subtrees** rather than single-tick Evaluator call-outs (RSH-07-004).
+> The two-gate division of responsibility, the CASE_OWNER structural bypass, and
+> the write-before-side-effect ordering are all unchanged; what changes is that a
+> gate awaiting the Case Owner emits an ask and terminates successfully instead of
+> answering the authorization question inline. See ADR-0080 and
+> `notes/protocol-asks.md`.
+>
+> One consequence of the original design is worth reading in that light: because
+> the gate sits *after* `AppendParticipantStatusNode`, the participant's claim is
+> already recorded while adoption is pending. That is exactly the legitimate
+> not-yet state ASK-02-005 requires an ask to leave behind, so this tree needed no
+> new intermediate state to become askable.
+
 ## Gate Definitions
 
 ### StatusAdoptionGate (`add_participant_status_tree`)

--- a/docs/adr/0049-core-does-not-model-error-message-types.md
+++ b/docs/adr/0049-core-does-not-model-error-message-types.md
@@ -148,6 +148,16 @@ the non-thing, not in building it.
   rejects unprocessable inbound with no sender notification. Whether the
   protocol needs a negative-acknowledgment / error-reply facet is a separate
   design question, not a port of `FollowUpOnErrorMessage`.
+  **Discharged by ADR-0080 (2026-08-31), CONCERN-1880.** That Concern is the
+  Concern this ADR asked to be filed, and the deferral is now resolved with a
+  recorded *yes*: an authenticated sender whose message fails after
+  authentication receives `Create(ProcessingFault)` (ASK-07-001). This ADR's own
+  decision is **unchanged** — core still does not model the RE/EE/CE/GE/GI
+  message family, and `create_inbound_error_followup_tree` is still not created.
+  One dedicated fault object type carried on `Create` is not that family, and it
+  was designed on its own merits (from the need to close an outstanding ask
+  promptly rather than let it expire) rather than reverse-derived from
+  `FollowUpOnErrorMessage`, which is what this ADR required of any later design.
 - BT-18-004 (call-out points are injection seams via backend factories) and
   BT-16-001 (core must not import from `vultron/demo/`) informed the rejection
   of the seam-stub option.

--- a/docs/adr/0076-security-significant-gates-default-require-case-owner-approval.md
+++ b/docs/adr/0076-security-significant-gates-default-require-case-owner-approval.md
@@ -81,6 +81,24 @@ seam that requires Case Owner approval.
 ("is this action approved?"). The internal Offer/Accept/Reject mechanics are
 an implementation detail of the default backend, not a property of the seam.
 
+> **Amended by ADR-0080 (2026-08-31).** The capability-shape assignment above is
+> **incorrect**, and the deny-always stub that satisfied this ADR is the symptom.
+> At the moment authorization is first needed no answer exists, so an Evaluator
+> asked "is this approved?" can only ever answer *no* — which is exactly what
+> `RequireCaseOwnerApprovalNode` does. The round-trip is therefore not an
+> implementation detail hidden behind an Evaluator seam; it determines the shape
+> of the seam. Each gate is a **conversation-state routing subtree**
+> (ASK-02-001, RSH-07-004): it routes on whether authorization has been recorded,
+> refused, requested-and-outstanding, or never requested, and in the last case
+> emits the request and terminates successfully — `SUCCESS` meaning *I asked*.
+>
+> The conservative-default requirement this ADR establishes is **unchanged**, and
+> so is the project-wide floor rule for security-significant call-out points.
+> What changes is that the conservative default is now reachable: before ADR-0080
+> the model specified here was unimplementable by any pathway (CONCERN-2812).
+> See also RSH-07-005 — a blocked gate must not be unblocked by configuring the
+> permissive backend.
+
 **Scope of the conservative-default rule:** This decision establishes a
 project-wide exception to ADR-0025's ceiling/floor rule. For any call-out
 point whose permissive default enables unilateral state change or embargo

--- a/docs/adr/0080-protocol-asks-not-suspended-behaviors.md
+++ b/docs/adr/0080-protocol-asks-not-suspended-behaviors.md
@@ -1,0 +1,267 @@
+---
+status: accepted
+date: 2026-08-31
+deciders: Allen D. Householder
+consulted: Claude Opus 5
+informed: []
+---
+
+# Asking Permission Is a Protocol Message, Not a Suspended Behavior
+
+## Context and Problem Statement
+
+Several independently filed Concerns bottom out on the same missing mechanism:
+core has no established way for an actor to request something it lacks the
+authority to do on its own, wait for an answer that arrives later, and act on
+that answer when it comes.
+
+The most visible symptom is `RequireCaseOwnerApprovalNode`
+(`vultron/core/behaviors/call_out/nodes.py`), the DETERMINISTIC default for both
+authorization gates of ADR-0046. It returns `Status.FAILURE` unconditionally.
+ADR-0076 specifies its intended behavior as an `Offer`/`Accept`/`Reject`
+round-trip with the Case Owner, but records no mechanism for hosting that
+exchange, and CONCERN-2812 filed the resulting gap: *"the Offer/Accept/Reject
+round-trip requires a BT-hosted async request/response pattern that does not
+exist in the framework."*
+
+Three findings reframed the problem during planning:
+
+1. **The framework cannot host in-tree suspension, and never has.**
+   `BTBridge.execute_tree()` ticks in a `while iteration < max_iterations` loop
+   (default 100), treats root `RUNNING` as "keep ticking", logs `ERROR` and
+   returns `FAILURE` when the loop is exhausted, and discards the tree in a
+   `finally: bt.shutdown()`. Meanwhile no node anywhere in `vultron/` returns
+   `Status.RUNNING`. EDF-04-002 requires an external decision node to return
+   `RUNNING` while awaiting input; that requirement has zero implementations,
+   and any node that complied would busy-loop and then fail.
+
+2. **The mechanism already exists in production, built by hand, once.**
+   `create_recommend_actor_to_case_received_tree`
+   (`vultron/core/behaviors/case/suggest_actor_tree.py`, ADR-0026 / CM-16)
+   records receipt, then routes through a Selector whose branches are disjoint:
+   already a participant, invite in flight, Case Owner already asked and not yet
+   answered, or fresh. The fresh branch forwards `Offer(CaseParticipant)` to the
+   Case Owner and stops. Two further trees handle the `Accept` and the `Reject`.
+   `InviteInFlightNode` and `PendingOfferCaseParticipantNode` read open/closed
+   state from the case ledger via `find_protocol_pair`.
+
+3. **The durable per-ask record also exists, built by hand, once.**
+   `VultronOfferRecord` (`vultron/core/models/offer_record.py`) is a
+   DataLayer-backed core record keyed deterministically off an Offer's ID, written
+   by the adapter that calls the factory, registered as wire vocabulary, and
+   usable before a case exists. Its justification (ADR-0035, DL-06-002) is that a
+   domain fact an actor must remember MUST be recorded as core state rather than
+   recovered by re-reading a stored activity.
+
+So the question was never *how* to host an asynchronous exchange. It was: why
+does each instance cost a bespoke implementation, and what is the shape that
+makes the next one cheap?
+
+## Decision Drivers
+
+- Nothing can suspend, so any design premised on suspension is unimplementable
+  in this framework and would require replacing the execution model
+- The pattern recurs (status adoption, embargo teardown, participant admission,
+  ownership transfer, case proposal) and each instance has so far been rebuilt
+  from scratch
+- The current conservative default is not merely unfinished — it is
+  unsatisfiable, so the authorization model of ADR-0046 and ADR-0076 cannot be
+  reached by any pathway
+- An asker that never learns its request failed stalls silently and
+  indefinitely; silence is the failure mode common to every member Concern
+- A Case Owner has no surface on which to discover that a decision is waiting
+  for them, so approval can only happen by accident
+- CLP-11-001 and DL-06-002 already contradict each other on whether outstanding
+  protocol state is derived from the ledger or recorded as core state
+
+## Considered Options
+
+1. **Suspend the behavior tree** — implement `RUNNING` propagation, hold the
+   tree across invocations, and resume it when the reply arrives.
+2. **Replay the original message** — on reply, feed the triggering activity back
+   through the inbox so the same tree runs again and passes the gate.
+3. **Split each gated tree in two** — an ask half and an act half, with the
+   reply handler invoking the act half as a shared subtree.
+4. **Ask and stop; route on conversation state** (chosen) — the ask is an
+   ordinary protocol message that terminates the behavior successfully; each
+   interaction is one tree whose first act is to determine where the
+   conversation stands, with disjoint branches per state.
+
+## Decision Outcome
+
+Chosen option: **ask and stop; route on conversation state.**
+
+An actor that cannot act on its own authority **emits `Offer(Proposal)` and
+terminates successfully**. `SUCCESS` means *I asked*, not *I was told yes*.
+Nothing suspends, because the work is divided at the question rather than
+paused there: asking is one complete behavior, and acting on the answer is
+another, begun by the answer's arrival.
+
+Each gated interaction is **one tree that routes on conversation state before
+doing anything**:
+
+```text
+GatedAction  (first fitting branch wins)
+├── reply in hand      → Accept: perform the action.  Reject: refuse, record, stop.
+├── asked, waiting     → stop.  Do not ask again.
+├── asked, expired     → re-ask with a fresh deadline, stop.
+└── never asked        → record the not-yet state, emit Offer(Proposal), stop.
+```
+
+Because the branches are disjoint, re-entry never retries completed work. This
+is why option 2 fails: a replayed tree re-executes its pre-gate effects and dies
+at the first idempotency guard, which CLP-13-001 requires to return `FAILURE`
+and write nothing — aborting before the gate is ever reached. Option 3 was
+rejected because two halves can drift; a single routing tree cannot.
+
+### The rules that follow
+
+**Authority comes from the stored ask, never from the reply.** ADR-0026's trust
+rule — roles come from the stored `Offer`, not the received `Accept` — is
+generalized: the Proposal is authoritative and the reply is only a yes. An
+asker reads what to do from the ask it stored, never from what the answer
+claims.
+
+**Every ask carries its own deadline** in `end_time`, which is already present
+on every AS2 object and is therefore visible to the answerer.
+
+**Expiry consequence is fixed per ask kind; duration is configurable.** Some
+asks remain useful when answered late (admitting a participant); others must
+not (adopting a case status). Whether a late reply counts is a protocol rule
+fixed in the spec, not a deployment setting — two actors disagreeing about
+whether a late answer authorized something is divergence, not preference. The
+*duration* is safe to configure per actor precisely because it travels on the
+wire, so both parties read the same number from the same object.
+
+**Outstanding asks are recorded, in both directions, durably.** A register
+holds asks an actor is waiting on and asks it owes: appended when an ask is
+emitted and when one is received, removed when the reply lands. It is
+actor-scoped rather than case-scoped, so it works before a case exists. It
+generalizes `VultronOfferRecord`.
+
+**The register never authorizes.** Two questions, two sources: *what am I
+waiting on, and what do I owe?* is answered by the register; *was this
+authorized?* is answered by the case ledger, always. A gate reads the ledger and
+never the register, so a corrupted or forged register entry cannot permit an
+action. This is the same division as `actor_participant_index` (fast index)
+versus the canonical record (authority).
+
+**One register class, two instances.** The create / close-on-named-event /
+time-out lifecycle, its reaping, and its enumeration are implemented once. The
+durable ask register and the existing in-memory `PendingAssertionStore` are two
+instances of it with different durability and different authority: the ask
+register is durable and may block; the suppressor is ephemeral, is forgotten on
+restart by design, and may never block (CLP-06-002, CLP-06-005). CLP-11-002 is
+clarified rather than reversed — do not unify the registers; do share the
+lifecycle.
+
+**Expiry is noticed opportunistically, plus a Sentinel seam.** The next entry
+into a tree observes an expired ask, and a peer's own retry is frequently the
+clock. For prompt reaping, core exposes a general-purpose
+`reap-expired-asks` trigger. Per `notes/coordination-agents.md`, a Sentinel
+operates exclusively on the call-in surface and has no BT call-out point, so
+reaping belongs to an external watcher rather than a loop inside core. The same
+endpoint makes expiry testable causally instead of by elapsed time, which
+EDF-06-001 requires.
+
+**Asks are visible to the case.** An ask is an ordinary canonical entry and
+replicates normally, so an outstanding decision — and a stalled one — is visible
+to participants. Consequently an ask MUST NOT carry content that cannot be
+disclosed to every case participant; private rationale belongs in a
+directly-addressed `Note`. Delivering the fact of an ask while directing its
+detail would require redaction with proofs, which the project does not have —
+`notes/stub-objects.md` describes redaction as future work — and committing a
+stub instead would violate CLP-02-003 and CLP-07-012.
+
+**Failure to process is answered, not left to time out.** An authenticated
+sender whose message fails after authentication receives
+`Create(ProcessingFault)`. This closes the asker's register entry immediately
+rather than costing it a full deadline of silence for a failure that took
+milliseconds. It is a dedicated object type rather than a reason field on an
+existing reply, because SE-08-003 prefers a dedicated type over field-level
+discrimination, and `Create(<minted object>)` is the established idiom
+(`Create(CaseProposal)`) — `Reject` presupposes something rejectable, which
+unreadable traffic does not provide. Unauthenticated or unparseable traffic is
+dropped silently; explaining a parser failure to a stranger is an oracle.
+
+The fault carries a failure class and a pointer, never an echo: in the
+protocol-invalid case a typed copy of the failed activity cannot be
+constructed, because constructing it is what failed. It is structured as
+RFC 9457 Problem Details, with fault types as URIs minted in the Vultron
+namespace (VM-10-001, ADR-0069) — so the canonical list is dereferenceable and
+extensible without a schema change.
+
+The *unreadable message* never enters the ledger; there is no legible assertion
+to record. The *fault statement* does — it is a true, legible statement about a
+message that arrived, replicated like any other recorded entry. It is not
+per-actor observability content, so CLP-07-004 is unaffected: the fact of a
+fault is protocol history, while the diagnosis of why belongs in the actor's own
+log.
+
+**A duplicate request after a reply re-sends the stored reply.** Where a request
+is repeated because the reply was lost, the answerer re-sends the frozen
+original unchanged (VM-08-003), same identity. It reads as the original arriving
+late rather than a second decision, which is what CP-05-005's irrevocability
+rule requires.
+
+### Consequences
+
+- Good: no framework change is needed; the execution model that appeared to be
+  the blocker turns out never to have been on the path
+- Good: `RequireCaseOwnerApprovalNode` becomes reachable, so the ADR-0046 /
+  ADR-0076 authorization model is implementable for the first time
+- Good: the same mechanism serves permission asks, participant admission,
+  ownership transfer, and pre-case proposal handshakes — the register is
+  actor-scoped, so it does not require a case to exist
+- Good: a Case Owner gains an enumerable list of decisions they owe, which is
+  the surface a human, a UI, or an agent acts through
+- Good: silent indefinite stalls become bounded — by a deadline, by a fault, or
+  by a peer's retry
+- Neutral: `RequireCaseOwnerApprovalNode` is deleted rather than completed. It
+  is replaced by an ask subtree at the front of a routing tree and an
+  approval-recorded check ahead of the action
+- Neutral: pending decisions become visible to all case participants. This is
+  intended, but it constrains what an ask may carry
+- Bad: the emit path must be consolidated first. `outbox_append` is called from
+  roughly twenty modules and at least four private `_emit` helpers exist, so
+  there is no single place in which registration can be made structural
+- Bad: expiry is not prompt until a Sentinel is wired; until then an expired ask
+  is noticed only when something next enters the tree or the reap trigger is
+  called
+
+## Validation
+
+- No node in `vultron/` returns `Status.RUNNING`; a gated tree returns `SUCCESS`
+  after emitting its ask, and the emitted ask appears in the actor's outbox
+- Re-entering a gated tree after an ask has been emitted produces no second ask
+  and no repeated pre-gate effect
+- A gate consulted with an `Accept` recorded in the ledger returns `SUCCESS`;
+  with a `Reject` recorded it returns `FAILURE`; with neither recorded it emits
+  the ask and terminates
+- An ask past its deadline under void semantics does not authorize its action
+  even when an `Accept` is subsequently recorded
+- The ask register is readable across restarts; the suppressor is not
+- A gate reads authorization from the ledger; an architecture test confirms no
+  gate node reads the ask register
+
+## More Information
+
+- Supersedes the mechanism implied by EDF-04-002 (`RUNNING` while awaiting
+  input); replaced by ask-and-terminate
+- Amends **ADR-0076**: its capability-shape assignment (Evaluator — "the
+  call-out answers a yes/no question") is incorrect for an approval gate,
+  because at the moment of asking no answer exists and an Evaluator can
+  therefore only ever answer no. The conservative-default requirement it
+  establishes is unaffected
+- Amends **ADR-0046**: the two gates become routing subtrees rather than
+  single-tick evaluator call-outs
+- Discharges the deferral recorded in **ADR-0049**, which asked that sender
+  notification be *"designed on its own merits"* rather than ported from a
+  fuzzer stub. ADR-0049's decision — that core does not model the RE/EE/CE/GE/GI
+  message family — is unchanged; one fault object type is not that family
+- Generalizes the trust rule of **ADR-0026** from participant roles to every ask
+- Sources: CONCERN-2829 (planning group G01), CONCERN-2812, CONCERN-2809,
+  CONCERN-2657, CONCERN-1880, CONCERN-2367, CONCERN-2369, IDEA-2796
+- Specs: `specs/protocol-asks.yaml`; amendments to CLP-11, EDF-04, RSH-07,
+  CP-05, TRIG-04
+- Notes: `notes/protocol-asks.md`

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -149,6 +149,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0077 Scope Ledger Replication Mechanics to a Companion Spec; Single-Hub Fan-Out Is Normative](0077-ledger-replication-companion-spec.md)
 - [ADR-0078 Retire `CVDRole.FINDER` — Reporter Is the Protocol-Salient Role](0078-retire-finder-role.md)
 - [ADR-0079 CaseLedger Causal Ordering: CaseActor Observation Order Is the Canonical Causal Order](0079-case-ledger-causal-ordering.md)
+- [ADR-0080 Asking Permission Is a Protocol Message, Not a Suspended Behavior](0080-protocol-asks-not-suspended-behaviors.md)
 
 ## Proposed ADRs
 

--- a/docs/topics/capability_model/index.md
+++ b/docs/topics/capability_model/index.md
@@ -26,6 +26,18 @@ But some steps require judgment that Vultron cannot make by itself:
 
 These are **call-out points** — places where the BT pauses and waits for an answer from an external service before it can continue.
 
+!!! note "A call-out point is answerable now; asking another actor is not"
+
+    A call-out point waits for a service *you* run, so it can be answered while
+    the BT is still running. That is what makes pausing viable.
+
+    Some questions cannot be answered that way, because they need a **decision
+    from another actor in the case** — for example, whether the case owner permits
+    a change to the case's agreed state. No service can answer that on the owner's
+    behalf, and the answer may take days. There the actor does not pause: it sends
+    a request and finishes, and the reply starts new work when it arrives. See
+    [Protocol Event Flow](../protocol_flow.md#when-an-actor-must-ask-permission).
+
 During development and simulation, call-out points are filled by **fuzzer nodes** — stubs that return a random success or failure based on a probability. In production, you replace a fuzzer node with a real service: a **capability implementation**.
 
 ---

--- a/docs/topics/protocol_flow.md
+++ b/docs/topics/protocol_flow.md
@@ -1,0 +1,234 @@
+# Protocol Event Flow
+
+## Overview
+
+This page explains how events move through Vultron at run time. It is for implementers who want to understand *why* the protocol behaves as it does, in any programming language.
+
+Read this page to learn three things:
+
+- Each actor works like a worker that reads messages from a queue.
+- One message can cause a chain of further messages. This is a **cascade**.
+- Some steps stop because the actor must ask another actor for permission. The actor asks, and then it stops. It does not wait.
+
+---
+
+## An actor is a worker with two queues
+
+Each actor in Vultron has an **inbox** and an **outbox**.
+
+- The inbox holds messages that other actors sent to this actor.
+- The outbox holds messages that this actor sends to other actors.
+
+The actor takes one message from its inbox. It processes that message. If the result is that other actors must be told something, the actor puts new messages in its outbox. Delivery then moves each outbox message to the inbox of the actor it is addressed to.
+
+```text
+   ┌────────── Actor A ──────────┐          ┌────────── Actor B ──────────┐
+   │  inbox → process → outbox   │  ──────► │  inbox → process → outbox   │
+   └─────────────────────────────┘          └─────────────────────────────┘
+```
+
+This model has one important consequence. **An actor never reaches into another actor's state.** It can only send a message. The other actor decides what that message means and what to do about it. Every rule in the protocol follows from this limit.
+
+!!! note "The queue model is a way to think, not a required design"
+
+    Vultron does not require message-broker software. The reference
+    implementation is a single process and uses ordinary HTTP requests for
+    delivery. The queue model is useful because it shows the intended flow of
+    information, and because it keeps a distributed implementation possible
+    later.
+
+---
+
+## Primary events and cascades
+
+Two kinds of things happen in Vultron, and the difference matters.
+
+A **primary event** comes from outside the protocol. Something in the world changed, and a person, a service, or another organisation must tell Vultron. Examples:
+
+- A finder submits a vulnerability report.
+- A vendor decides the report is valid.
+- A participant proposes an embargo period.
+
+A **cascade** is everything that follows automatically from a primary event. The actor that received the primary event updates its own state and sends the messages the protocol requires. Each actor that receives one of those messages runs its own cascade. Together these form a chain.
+
+For example, one primary event — a finder submits a report — causes this chain:
+
+```text
+finder submits report
+   └── vendor records the report
+         └── vendor opens a case
+               └── vendor adds the finder as a participant
+                     └── vendor tells the finder the case exists
+```
+
+Nobody instructs the vendor to open a case. The vendor does it because it received a report. This is the central design rule: **supply the primary event only, and let the protocol produce the consequences.**
+
+### Why this rule is useful
+
+The rule gives you a test for correctness. If you must send a second message by hand to make the process continue, then one of two things is true:
+
+- That step is genuinely a new primary event, because new information from outside was needed.
+- Or the implementation has a gap, because the step should have happened automatically.
+
+The test tells you which kind of problem you have. It is the reason Vultron test scenarios inject only primary events and then check the resulting state.
+
+---
+
+## Causal order, not time order
+
+It is natural to describe a process as a list of steps in time: *A, then B, then C*. The protocol is not built on time. It is built on cause: *A, and therefore B, and therefore C*.
+
+The difference is not a matter of style. Delivery and processing take time, and they can fail. So "B happened five seconds after A" tells you almost nothing, while "B happened because A happened" tells you the process is correct.
+
+A single step between two actors is really a chain of smaller events:
+
+```text
+A addresses → A sends → arrives at B → B processes → B records → B replies
+                                                          ▲
+                                                   the only proof
+```
+
+Only the last links prove anything. That a message was *sent* proves only that the sender tried. That it *arrived* proves only that the network worked. That the receiver **recorded** it proves the receiver accepted it and acted.
+
+If you write tests or monitoring for a Vultron implementation, check the recorded state of the actor that owns the effect, and read it from that actor. Do not accept elapsed time as evidence, and do not accept an acknowledgement of receipt as evidence that processing succeeded.
+
+---
+
+## When an actor must ask permission
+
+Some steps in a cascade cannot be automatic, because the actor is not allowed to decide alone. A participant may report that a vulnerability is now public. Whether that report becomes the shared, agreed state of the case is not the reporting participant's decision. The case owner decides.
+
+Here Vultron does something that surprises people. The actor **asks, and then it stops.**
+
+```text
+1. Actor needs permission.
+2. Actor sends the case owner a request that carries a deadline.
+3. Actor finishes.  Its work succeeded, because asking was the work.
+4. Later, the case owner replies: agreed, or refused.
+5. That reply is a new message. It arrives in an inbox, and it starts new work.
+```
+
+Step 3 is the part worth understanding. **Success means "I asked", not "I was told yes."** Nothing is left waiting or held open. The work is divided at the question rather than paused there. Asking is one complete piece of work; acting on the answer is another piece of work, and the answer's arrival is what starts it.
+
+This is why the request carries a **deadline**. The deadline is part of the message, so the case owner can see how long they have, and the asking actor knows when the question has gone stale.
+
+### What happens while the actor waits
+
+Nothing is held open, so the case must be in a sensible state during the wait. It usually already is. In the example above, the participant's report is recorded as *what that participant claims*. Only its promotion to *what the case agrees* waits for permission. Those are two different facts, and recording the first while the second is undecided is honest and useful.
+
+This gives a rule for implementers: **you may only ask about an action whose not-yet-done state can be described.** If "not yet decided" cannot be represented, the actor must refuse instead of asking, because there is nowhere for the case to rest.
+
+### Asking twice, and not asking twice
+
+Because an actor stops after asking, it may reach the same point again later — for instance, when the same participant reports the same thing again. So an actor that reaches a step needing permission first works out **where the conversation stands**:
+
+| What the actor finds | What it does |
+|---|---|
+| A reply agreeing | Do the action. |
+| A reply refusing | Do not do the action. Record the refusal. |
+| A request already sent, deadline not passed | Nothing. Do not ask twice. |
+| A request already sent, deadline passed | Ask again, with a new deadline. |
+| No request yet | Record the not-yet state, ask, and stop. |
+
+These situations do not overlap, so returning to this step is always safe. The actor never repeats work it has already done, because it never enters that path a second time.
+
+### What a late reply means
+
+Some questions are still worth answering late. Whether to admit a new participant to a case is one — the answer is as useful next week as it is today.
+
+Other questions are not. Permission to change the agreed state of a case is granted against the case as it was when the question was asked. If the reply arrives after the deadline, the case may have moved on: an embargo may have been agreed, or another participant may have published. Acting on that permission would apply an old decision to a new situation.
+
+So each kind of request declares which it is. For requests of the second kind, **a late reply does not grant permission**, and the asking actor must ask again if it still wants to act. This is the same caution applied to time that the protocol already applies to identity: the request, not the reply, is the authority for what was permitted.
+
+### The request is the authority
+
+When a reply arrives, the asking actor reads what to do from **the request it sent**, and not from the contents of the reply.
+
+This matters for security. If the actor took its instructions from the reply, the actor answering could change what it was agreeing to — granting broader permissions than were requested, and granting them to itself. A reply is only a yes or a no. The request states what was asked.
+
+---
+
+## Keeping track of open questions
+
+An actor may have several questions outstanding at once, in both directions: questions it asked and is waiting on, and questions others asked that it owes an answer to.
+
+Both lists matter, for different reasons.
+
+The **questions I asked** list stops an actor asking the same thing twice, and lets it notice when a deadline has passed.
+
+The **questions I owe** list is more important than it first appears. It is the list a person, an interface, or an automated service works from. Without it, a case owner has no way to discover that a decision is waiting for them, so permission could only ever be granted by accident. This list is what makes the case owner's role something they can actually perform.
+
+Both lists are working notes. They say what is outstanding. They never say what was permitted — for that, an actor reads the recorded history of the case, which is the shared, verifiable record. Keeping these apart matters: a working note could be rebuilt or damaged, and it must never be able to authorise anything on its own.
+
+---
+
+## Deadlines need something to notice them
+
+A deadline passing is not an event. No message arrives when time runs out. So something must look.
+
+Vultron uses two mechanisms, and neither is a timer inside the protocol.
+
+**Looking when you pass by.** The next time an actor reaches the step that asked the question, it notices the deadline has passed. This is often enough. When a message is lost, the sender usually sends it again, and that repeat is what causes both actors to look. In that case the other party's retry is the clock.
+
+**An external watcher.** For prompt handling, an implementation can run a service that watches for passed deadlines and notifies the actor. This is deliberately outside the protocol: watching the clock is not a protocol behaviour, and keeping it outside means an implementation can choose how attentive to be. It also means deadline behaviour can be tested by asking for a check directly, rather than by waiting.
+
+Noticing an expired request never sends it again by itself. Expiry is information. Whether the actor still wants to act is a fresh decision, and only the actor's own logic can make it.
+
+---
+
+## When a message cannot be understood
+
+Messages sometimes arrive that an actor cannot process. The message may be malformed, or it may refer to something the actor does not know about, or the sender may not be permitted to send it.
+
+Silence is a poor answer. A sender waiting for a reply would wait for its whole deadline over a failure that took a fraction of a second.
+
+So an actor that cannot process a message from a **known, authenticated** sender tells that sender so. The reply says what kind of failure it was — enough for the sender to judge whether sending it differently would help. It does not describe the receiver's internal workings. Two reasons: those details are useless to the sender, and explaining exactly why a message was refused helps an attacker probe the receiver.
+
+An actor does **not** answer a message it cannot authenticate. It cannot trust the sender's identity, so it has no reliable address to reply to, and answering would tell an unknown party how the receiver behaves.
+
+There are three different situations here that are easy to confuse:
+
+| Situation | Meaning |
+|---|---|
+| "I read what you claimed and I refuse it" | A decision. The receiver understood and declined. |
+| "I read your question and my answer is no" | A decision. A reply that closes the question. |
+| "I could not read what you sent" | Not a decision. Nothing was judged. |
+
+Only the first two are decisions about content. The third is a report that communication failed.
+
+This distinction decides what gets recorded in the shared history of a case. A message that could not be read is **not** recorded — there is nothing understood to record. But the statement *"I could not process the message you sent"* **is** recorded, because it is a clear and true statement about a message that arrived. It also explains something a later reader would otherwise find puzzling: why the same message was sent twice.
+
+---
+
+## Requests are visible to the case
+
+A request for permission is recorded in the case's shared history, like other case events. Every participant can see that a decision is outstanding, and who owes it.
+
+This is intentional. A stalled decision is something participants should be able to see, because it affects everyone in the case.
+
+It also sets a limit: **a request must not contain anything that cannot be shown to every participant in the case.** If an actor needs to explain something privately, it sends a separate message addressed to one participant instead.
+
+---
+
+## Summary
+
+| Idea | Statement |
+|---|---|
+| Actor model | Each actor reads messages from an inbox and sends messages from an outbox. No actor touches another's state. |
+| Primary event | New information from outside the protocol. This is all you supply. |
+| Cascade | Everything the protocol does automatically as a result. |
+| Causal order | *A therefore B*, not *A then B*. Recorded state is the only proof. |
+| Asking | The actor asks and stops. Success means "I asked". |
+| Deadline | Part of the request, so both parties can see it. |
+| Late reply | For some kinds of request it grants nothing. Ask again. |
+| Authority | The request says what was asked. The reply is only yes or no. |
+| Open questions | Two working lists: what I await, and what I owe. Neither authorises anything. |
+| Faults | Tell an authenticated sender that a message could not be processed. Say little. |
+
+---
+
+## Further reading
+
+- [Behavior Logic](behavior_logic/index.md) — how an actor decides what to do when a message arrives
+- [Capability Model](capability_model/index.md) — how external services supply the judgements an actor cannot make alone
+- [The Case Model](case_model.md) — the shared record that actors coordinate around

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Interoperability: 'topics/background/interoperability.md'
       - Defining CVD Success: 'topics/background/cvd_success.md'
     - The Case Model: 'topics/case_model.md'
+    - Protocol Event Flow: 'topics/protocol_flow.md'
     - Process Models:
       - 'topics/process_models/index.md'
       - Report Management:
@@ -314,6 +315,7 @@ nav:
       - 'Scope Ledger Replication Mechanics to a Companion Spec; Single-Hub Fan-Out Is Normative': 'adr/0077-ledger-replication-companion-spec.md'
       - "Retire CVDRole.FINDER — Reporter Is the Protocol-Salient Role": 'adr/0078-retire-finder-role.md'
       - 'CaseLedger Causal Ordering: CaseActor Observation Order Is the Canonical Causal Order': 'adr/0079-case-ledger-causal-ordering.md'
+      - 'Asking Permission Is a Protocol Message, Not a Suspended Behavior': 'adr/0080-protocol-asks-not-suspended-behaviors.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/README.md
+++ b/notes/README.md
@@ -351,6 +351,21 @@ bundles. Derived from #1631 planning; implemented by #1152.
 demo scenarios or tests; designing the bundle/singleton layout in
 `vultron/demo/fuzzer/bundles/`; understanding the three-mode backend model.
 
+**`protocol-asks.md`**
+The protocol-ask primitive: why an actor asks and terminates rather than
+suspending (nothing in the codebase returns `RUNNING`, and the bridge cannot host
+it), the conversation-state routing tree shape, the outstanding-ask register and
+why it never authorizes anything, per-ask-kind expiry with a Sentinel reaping
+seam, and `Create(ProcessingFault)`. Names the two hand-built reference
+implementations to generalise (`suggest_actor_tree.py`, `VultronOfferRecord`) and
+the missing shared emit path that blocks all of it. Normative requirements:
+`specs/protocol-asks.yaml` (ASK-01 through ASK-08). ADR: ADR-0080.
+**Load when**: implementing or reviewing any gate that needs another actor's
+permission, working on `RequireCaseOwnerApprovalNode` or the status authorization
+gates, adding an ask/reply exchange, touching `find_protocol_pair` or
+`PendingAssertionStore`, or implementing processing-fault notification.
+Source: CONCERN-2829.
+
 **`received-status-authorization.md`**
 Two-gate design for received-side CaseStatus canonicalization: StatusAdoptionGate
 (in `add_participant_status_tree`) for status adoption authorization,

--- a/notes/bt-canonical-reference.md
+++ b/notes/bt-canonical-reference.md
@@ -175,8 +175,15 @@ misimplemented patterns. The canonical structure is:
 `a_EvaluatePriority_520` is a fuzzer node — a stub for real-world
 prioritization logic. In the prototype this becomes the
 **priority-check node** described in IDEA-26041004: a node that returns
-SUCCESS (engage), FAILURE (defer), or RUNNING (evaluation pending). The
-default implementation returns SUCCESS to preserve current demo behavior.
+SUCCESS (engage) or FAILURE (defer). The default implementation returns
+SUCCESS to preserve current demo behavior.
+
+It MUST NOT return RUNNING for "evaluation pending" — EDF-04-002 and
+ASK-01-003 forbid representing a wait that way, and `BTBridge.execute_tree`
+cannot host it. A prioritization judgment that a locally-run capability can
+answer is an ordinary call-out point answered within the tick; one that needs
+another actor's decision is a protocol ask, so the node emits the ask and
+terminates. See [protocol-asks.md](protocol-asks.md) and ADR-0080.
 
 This subtree MUST be a child of the validate BT (or its parent), not a
 procedural function called after `bt.run()` returns.

--- a/notes/event-driven-control-flow.md
+++ b/notes/event-driven-control-flow.md
@@ -255,9 +255,24 @@ represented as **fuzzer nodes** — nodes that return a random success or
 failure to simulate the uncertain outcome of a real-world decision. The PRNG
 roll stands in for the actual information the actor would need.
 
-In the prototype, external decision nodes are placeholders that return
-`RUNNING` until the required input arrives via a trigger endpoint or inbox
-message.
+In the prototype, an external decision node **requests the input it needs and
+terminates**. It does not return `RUNNING` and it does not wait: EDF-04-002
+forbids that (reversed by ADR-0080), and the framework could never have honoured
+it — `BTBridge.execute_tree` treats root `RUNNING` as "keep ticking", exhausts
+its iteration budget, logs `ERROR`, returns `FAILURE`, and then discards the tree
+in `finally: bt.shutdown()`, so there is no instance left to resume. No node in
+`vultron/` returns `Status.RUNNING`.
+
+The required input arrives later as a trigger invocation or an inbox message,
+and its arrival drives a **fresh** evaluation (EDF-04-003) whose first act is to
+determine where the exchange stands (ASK-02-001). Where the input is another
+actor's decision, this is the protocol-ask primitive: emit the ask, terminate
+with `SUCCESS` meaning *I asked* (ASK-01-002), and let the reply start new work.
+See [protocol-asks.md](protocol-asks.md) and ADR-0080.
+
+A terminal status with **no request emitted** is the silent failure EDF-04-005
+forbids — the emitted request is the observable that distinguishes "asked and
+waiting" from "gave up".
 
 ### Candidates for Future Automation
 
@@ -300,7 +315,7 @@ step that should be automated.
 | Cascade scope | Always within a single actor | Simplifies reasoning; each actor owns its own state machine |
 | Cascade mechanism | BT subtrees only | BT structure is the auditable, explainable record of what happened |
 | Outbox emissions | BT leaf-node actions | Keeps the full causal chain visible in the tree |
-| External stops | Explicit `RUNNING` nodes | Absence of code is invisible; explicit nodes document the intent |
+| External stops | Explicit ask-and-terminate nodes | Absence of code is invisible; an emitted request documents the intent and is observable (EDF-04-002, ASK-01-002) |
 | Demo role | Inject primary events + verify state | Demos prove protocol correctness, not API accessibility |
 | Queue/worker model | Conceptual only (no broker) | Preserves future optionality without over-engineering the prototype |
 
@@ -362,15 +377,25 @@ class SuggestActorReceivedUseCase:
 ```
 
 ```python
-# ✅ CORRECT — BT runs, external decision node pauses for owner input
+# ✅ CORRECT — BT runs, routes on conversation state, asks and terminates
 class SuggestActorReceivedUseCase:
     def execute(self) -> None:
         _idempotent_create(self._request)
-        tree = create_suggest_actor_tree(...)
+        tree = create_recommend_actor_to_case_received_tree(...)
         bridge.execute_with_setup(tree, actor_id=case_owner_id)
-        # tree contains AwaitCaseOwnerDecisionNode that returns RUNNING
-        # until the owner responds via trigger or inbox
+        # The tree's Selector routes on where the exchange stands — already a
+        # participant / invite in flight / owner asked and unanswered / fresh —
+        # reading open/closed state from the ledger via find_protocol_pair.
+        # The fresh branch emits Offer(CaseParticipant) to the owner and returns
+        # SUCCESS, meaning "I asked". Nothing returns RUNNING and nothing waits;
+        # the owner's Accept or Reject arrives as its own inbound message and
+        # drives its own tree.
 ```
+
+`create_recommend_actor_to_case_received_tree`
+(`vultron/core/behaviors/case/suggest_actor_tree.py`, ADR-0026 / CM-16) is the
+working reference implementation of this shape — see
+[protocol-asks.md](protocol-asks.md), which describes generalising it.
 
 ---
 

--- a/notes/protocol-asks.md
+++ b/notes/protocol-asks.md
@@ -1,0 +1,294 @@
+---
+title: Protocol Asks and Outstanding-Ask Registers
+status: active
+description: >
+  Design guidance for the protocol-ask primitive: asking and terminating rather
+  than suspending, conversation-state routing, the outstanding-ask register, ask
+  expiry, and processing faults.
+related_specs:
+  - specs/protocol-asks.yaml
+  - specs/case-ledger-processing.yaml
+  - specs/event-driven-control-flow.yaml
+  - specs/received-status-handling.yaml
+related_notes:
+  - notes/bt-integration.md
+  - notes/event-driven-control-flow.md
+  - notes/received-status-authorization.md
+  - notes/case-communication-model.md
+  - notes/coordination-agents.md
+relevant_packages:
+  - vultron/core/behaviors
+  - vultron/core/models
+---
+
+# Protocol Asks and Outstanding-Ask Registers
+
+Normative requirements: `specs/protocol-asks.yaml` (ASK-01 through ASK-08).
+Decision record: ADR-0080. Source: CONCERN-2829 (planning group G01).
+
+## The one-sentence version
+
+An actor that cannot act on its own authority **emits a request and finishes**.
+`SUCCESS` at that point means *I asked*, not *I was told yes*. The reply, when
+it comes, starts new work.
+
+## Why there is nothing to suspend
+
+The recurring instinct is to make the behavior tree wait: return `RUNNING`, hold
+the tree, resume it when the answer arrives. The framework cannot do this, and
+the evidence is unambiguous:
+
+- `BTBridge.execute_tree()` ticks in `while iteration < max_iterations`
+  (default 100) and treats root `RUNNING` as "keep ticking". Exhausting the loop
+  logs `ERROR` and returns `FAILURE`.
+- `finally: bt.shutdown()` discards the tree at the end of every invocation, so
+  there is no instance to resume.
+- `grep -r "return Status.RUNNING" vultron/` returns **nothing**. EDF-04-002
+  used to require `RUNNING` while awaiting input; it had zero implementations,
+  and any node that had complied would have busy-looped and then failed.
+
+So the design that looked blocked on a missing framework feature was never on
+that path. Dividing the work at the question — asking is one behavior, acting on
+the answer is another — needs no suspension at all.
+
+## Conversation-state routing
+
+A gated interaction is **one tree whose first act is to work out where the
+conversation stands**. Branches are disjoint, so re-entry never retries
+completed work:
+
+```text
+GatedAction  (first fitting branch wins)
+├── reply in hand      → Accept: do the thing.  Reject: refuse, record, stop.
+├── asked, waiting     → stop.  Do not ask again.
+├── asked, expired     → re-ask with a fresh deadline, stop.
+└── never asked        → record the not-yet state, emit the ask, stop.
+```
+
+### Why not just replay the original message
+
+Tempting and wrong: on reply, feed the triggering activity back through the
+inbox so the same tree runs again and passes the gate. The first run already
+appended state and committed a ledger entry, and CLP-13-001 requires an
+idempotency guard that detects a duplicate to return `FAILURE` and write
+nothing. The replayed tree therefore dies at its first guard, before reaching
+the gate. Disjoint branches avoid this by never attempting the completed work in
+the first place.
+
+### Why not split the tree in two
+
+Also tempting: an ask half and an act half, with the reply handler invoking the
+act half. It works, but two halves drift; one routing tree cannot disagree with
+itself. The reply still gets its own tree (it is a different inbound message
+with its own dispatch key) — but the *state* question lives in one place.
+
+## Prior art: this is built, once, by hand
+
+`create_recommend_actor_to_case_received_tree`
+(`vultron/core/behaviors/case/suggest_actor_tree.py`, ADR-0026 / CM-16) is the
+reference implementation:
+
+```text
+RecommendActorToCaseBT
+├── GuardedCommitCaseLedgerEntryBT        — record receipt (CLP-10-006)
+└── DuplicateOrFreshSelector
+    ├── already a participant   → auto-accept to the recommender
+    ├── invite in flight        → auto-accept to the recommender
+    ├── owner asked, no answer  → send a Note; do NOT ask twice
+    └── fresh                   → evaluate roles, Offer(CaseParticipant) to owner
+```
+
+`InviteInFlightNode` and `PendingOfferCaseParticipantNode`
+(`case/nodes/suggest_actor/conditions.py`) read open/closed state from the
+ledger via `find_protocol_pair`. Two sibling trees handle the `Accept` and the
+`Reject`.
+
+`VultronOfferRecord` (`vultron/core/models/offer_record.py`) is the reference
+per-ask record: durable, DataLayer-backed, keyed deterministically by
+`build_id(offer_id)`, written by the adapter that calls the factory, registered
+as wire vocabulary, and usable **before a case exists**. Its justification
+(ADR-0035, DL-06-002) is the argument for the register generally — a domain fact
+an actor must remember is recorded as core state, not re-derived by re-reading a
+stored activity.
+
+**Read both before implementing anything here.** The work is generalising them,
+not inventing a mechanism.
+
+## What the working instance is missing
+
+| Gap | Consequence |
+|---|---|
+| No deadline on the ask | "Pending" has no duration; an unanswered ask is pending forever |
+| Nothing enumerates | Deadlines cannot be swept; a Case Owner cannot see decisions they owe |
+| Bespoke throughout | Every node is hand-written for one flow; the next instance costs the same |
+
+The third gap is why `RequireCaseOwnerApprovalNode` is a deny-always stub. The
+mechanism was known; generalising it was never done, so the second instance cost
+more than anyone wanted to pay.
+
+## Rules worth internalising
+
+**Authority comes from the stored ask, never the reply.** ADR-0026 states this
+for participant roles and calls it a security boundary: read the roles from the
+stored `Offer`, not from the `CaseParticipant` embedded in the received
+`Accept`, or the accepting actor can escalate what it grants itself. ASK-01-004
+generalises it to every ask.
+
+**Expiry consequence is per ask kind and is not configurable.** Admitting a
+participant stays useful when authorized late; adopting a case status does not —
+by then the case state the decision was made against has moved on. Whether a
+late reply authorizes is a protocol rule fixed in the spec (ASK-03-003), because
+two actors disagreeing about it is divergence in canonical case state, not a
+deployment preference. The *duration* is tunable per actor precisely because it
+travels on the wire in `end_time`, so both parties read the same number off the
+same object.
+
+**The register never authorizes.** Two questions, two sources:
+
+| Question | Answered by |
+|---|---|
+| What am I waiting on? What do I owe? | the outstanding-ask register |
+| Was this authorized? | the case ledger, always |
+
+A gate reads the ledger and never the register (ASK-02-004), so a corrupted or
+rebuilt register cannot permit an action. Same division as
+`actor_participant_index` (fast index) versus the canonical record (authority).
+
+**One register class, two instances.** The create / close-on-named-event /
+time-out lifecycle, its reaping and its enumeration are written once
+(ASK-04-007). The durable ask register may block; `PendingAssertionStore` is
+ephemeral, is forgotten on restart *by design*, and may never block (CLP-06-002,
+CLP-06-005). CLP-11-002 forbids unifying the registers, not sharing the
+lifecycle — and both already share `ProtocolPair` as their key type
+(CLP-11-003).
+
+Ephemerality is a safety property, not an oversight: a suppressor entry that
+survived a restart would suppress a re-send that *should* happen. Forgetting
+fails **open** (you might duplicate, which idempotency handles) rather than
+**closed** (you stay silent forever).
+
+**An ask may only park an action whose not-yet state is legitimate.** Nothing
+suspends, so the case sits in the pre-authorization state for the whole
+deadline. `add_participant_status_tree` already satisfies this — the
+participant's claim is appended, and only *adoption as canonical* is gated
+(RSH-01). An action with no representable not-yet state must be refused rather
+than asked about (ASK-02-005).
+
+**Asks are visible to the whole case.** An ask is an ordinary recorded entry and
+replicates normally (ASK-06-001), so a stalled decision is visible to
+participants. Consequently an ask must carry nothing undisclosable to them
+(ASK-06-002); private rationale goes in a directed `Note`, which CLP-05-001
+already establishes as a delivery shape. Delivering the *fact* of an ask while
+directing its *detail* would need redaction with proofs — `notes/stub-objects.md`
+describes redaction as future work, and committing a stub instead would break
+CLP-02-003 and CLP-07-012.
+
+## Expiry has no clock, and that is deliberate
+
+Time passing delivers no message, so nothing runs a tree unprompted. Two
+mechanisms, neither a loop inside core:
+
+1. **Opportunistic** — the next entry into the tree observes the expired ask
+   (ASK-05-001). Frequently sufficient: for a lost `Accept(CaseProposal)` the
+   peer's own retry is the clock, and that retry is also what lets the answerer
+   recover (CP-05-006).
+2. **A Sentinel seam** — a general-purpose `reap-expired-asks` trigger
+   (ASK-05-002). Per `notes/coordination-agents.md`, a Sentinel *"operates
+   exclusively on the call-in surface"* and **has no BT call-out point**, so
+   reaping belongs to an external watcher, not to core. The same endpoint makes
+   expiry testable causally instead of by elapsed time, which EDF-06-001
+   requires.
+
+Reaping never re-emits (ASK-05-004), mirroring CLP-06-005: a timeout is a
+signal, not an instruction to retry. Only the tree knows whether the action is
+still wanted.
+
+## Processing faults
+
+`Create(ProcessingFault)` tells an **authenticated** sender that its message
+could not be processed. This discharges the deferral ADR-0049 recorded — that
+ADR declined to port the RE/EE/CE/GE/GI message family from the simulation but
+explicitly asked that sender notification be *"designed on its own merits"*
+later. One fault object type is not that family, so ADR-0049's decision stands.
+
+Design points that are easy to get wrong:
+
+- **`Create`, not `Reject`.** `Reject` presupposes something rejectable;
+  unreadable traffic provides no such object. `Create(<minted object>)` is the
+  established idiom (`Create(CaseProposal)`).
+- **A dedicated object type, not a reason field.** SE-08-003 prefers a dedicated
+  object type over field-level discrimination — the lesson CONCERN-2322 taught.
+- **A pointer, never a required echo.** When a payload fails validation, a typed
+  copy of it cannot be constructed, because constructing it is what failed.
+  Echoing sender-supplied content is also a reflection hazard.
+- **Authenticated senders only** (ASK-07-002). Explaining a parse failure to a
+  stranger is a parser oracle, and an unauthenticated identity is not a
+  trustworthy reply address.
+- **RFC 9457 Problem Details, with failure classes as URIs** minted in the
+  Vultron namespace (VM-10-001, ADR-0069). The canonical list is then
+  dereferenceable and extensible without a schema change.
+- **No implementation diagnostics** (ASK-07-006). Faults replicate to every
+  participant. Stack traces and parser internals go in the actor's own log,
+  governed by `specs/structured-logging.yaml`.
+
+### What is recorded, and what is not
+
+Three things that look alike and are not:
+
+| Situation | Where it lands |
+|---|---|
+| I read your assertion, understood it, refuse it | ledger, `disposition="rejected"` |
+| I read your ask, my answer is no | `Reject` reply, ordinary recorded entry |
+| I could not read what you sent | a fault; the unreadable message is **not** recorded |
+
+The third is not a decision — nothing was adjudicated, so there is no legible
+assertion to snapshot, and CLP-03-002 already excludes unrouteable inbound from
+the ledger. Do **not** reach for `disposition="rejected"` here: that mechanism
+records an assertion that was *understood and refused*.
+
+The **fault statement itself** is different. "B could not process A's message" is
+a true, legible statement about a message that arrived, so it is recorded as an
+ordinary entry (ASK-07-008) and it explains a subsequent retransmission. It is
+not per-actor observability content, so CLP-07-004 is unaffected: the *fact* of a
+fault is protocol history; the *diagnosis* is not.
+
+## Pitfalls
+
+**There is no shared emit path yet.** `outbox_append` is called from roughly
+twenty modules, and at least four private emit helpers exist independently:
+
+```text
+case/nodes/actor.py:142                        _emit()
+case/nodes/accept_invite.py:141                _emit_activity()
+case/nodes/delegation.py:213                   _emit()
+case/nodes/suggest_actor/accept_offer.py:53    _emit()
+```
+
+Registration that each call site must remember to perform will be forgotten
+(ASK-04-008), so consolidating the emit path is a prerequisite — for this work
+and for the CONCERN-2657 correlation. It **cannot** live in the AS2 factory:
+factories are wire-layer, have no DataLayer, and wire must not import core. It
+belongs on the core side, alongside the shared BT node base classes in
+`behaviors/helpers.py`.
+
+**Delivery receipt is not agreement.** "Your message arrived" and "I agree to
+what your message said" are different layers and must not be conflated.
+CONCERN-2657 is the former; everything else here is the latter. The ledger keeps
+recording what an actor decided and observed at the time it happened
+(OX-14-002) — gating a commit on delivery would make an actor's own history
+hostage to the network, invert CLP-10-006's ordering, and raise an unanswerable
+partial-delivery question. What was missing is the *link* from a dead-lettered
+activity to the entry claiming its event happened (OX-14-001).
+
+**`Question` is not the verb for an authorization ask.** `as_Question` exists and
+is used for polls (`choose_preferred_embargo`, `oneOf` over embargo options), but
+it is an `IntransitiveActivity` — it has **no `object`**, as the code comment
+says outright. The thing being asked about has nowhere to live, and
+`find_protocol_pair` keys on an object ID. Use `Offer` for "may I", `Question`
+for "which one".
+
+**Do not relax a gate to make a blocked path proceed** (RSH-07-005).
+`STATUS_AUTHORIZATION_PERMISSIVE` is for trusted-participant and demo
+deployments. Using it to route around an unreachable gate converts a protocol
+guarantee back into a configuration posture, which is the defect CONCERN-2092
+filed.

--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -71,7 +71,8 @@ AddParticipantStatusBT (Sequence)
 ├─ AppendParticipantStatusNode          ← records the accepted portion
 ├─ StatusAdoptionGate (Fallback)         ← NEW
 │   ├─ CheckIsCaseOwnerNode             ← hard bypass: CASE_OWNER = gospel
-│   └─ CaseOwnerApprovesStatusUpdate    ← Evaluator call-out (RequireCaseOwnerApproval)
+│   └─ CaseOwnerApprovesStatusUpdate    ← authorization seam (as-built: RequireCaseOwnerApproval;
+│                                          RSH-07-004 replaces the shape — see below)
 ├─ EmitCaseStatusUpdateNode             ← direct ledger write (RSH-04-004, #2857)
 ├─ TeardownEffectsOrSkip (FailureIsSuccess)
 │   └─ TeardownEffects (Sequence)
@@ -178,12 +179,35 @@ updates would be circular. The BT Fallback structure makes this a hard
 structural skip: if `CheckIsCaseOwnerNode` succeeds, the approval call-out is
 never reached.
 
-For all other senders, the `CaseOwnerApprovesStatusUpdate` Evaluator call-out
-provides the hook. The default backend is `RequireCaseOwnerApproval` — an
-Evaluator that performs an Offer/Accept/Reject round-trip with the Case Owner
-before allowing the assertion to be adopted as canonical. A permissive backend
-(e.g., `AlwaysSucceed`) MAY be configured for trusted-participant or demo
-deployments but MUST be explicitly configured (RSH-07-003, ADR-0076).
+For all other senders, `CaseOwnerApprovesStatusUpdate` is the seam that requires
+explicit Case Owner authorization before the assertion is adopted as canonical.
+A permissive backend (e.g., `AlwaysSucceed`) MAY be configured for
+trusted-participant or demo deployments but MUST be explicitly configured
+(RSH-07-003, ADR-0076) — and MUST NOT be used to route around a gate that is
+blocking (RSH-07-005).
+
+> **Mechanism amended by ADR-0080 (2026-08-31).** The seam is **not** a
+> single-tick Evaluator that "performs an Offer/Accept/Reject round-trip and
+> waits", and `RequireCaseOwnerApproval` is **not** the default backend to
+> implement. RSH-07-004 requires each gate be composed as a
+> **conversation-state routing subtree**, and forbids the Evaluator shape: at the
+> moment authorization is first needed no answer exists, so an Evaluator asked
+> "is this approved?" can only ever answer *no*. That is precisely why
+> `RequireCaseOwnerApprovalNode` is a deny-always stub, and why the
+> ADR-0046/ADR-0076 model was unreachable by any pathway (CONCERN-2812,
+> CONCERN-2809). The node is **deleted rather than completed**.
+>
+> The gate instead routes on whether authorization has been *recorded*,
+> *refused*, *requested-and-outstanding*, or *never requested* — emitting
+> `Offer(Proposal)` to the Case Owner and terminating with `SUCCESS` in the last
+> case, where `SUCCESS` means *I asked* (ASK-01-002). Authorization is always
+> read from the case ledger, never from the outstanding-ask register
+> (ASK-02-004). The conservative default posture that ADR-0076 establishes is
+> **unchanged**; only its shape is.
+>
+> See [protocol-asks.md](protocol-asks.md), `specs/protocol-asks.yaml`
+> (ASK-01 through ASK-08), and RSH-07-004/RSH-07-005. The replacement work is
+> tracked by #2885.
 
 ### Direct-write canonicalization pattern (#2857)
 
@@ -230,7 +254,7 @@ AddCaseStatusToCaseBT (Sequence)
 ├─ FinalizeCsFilterNode                 ← FAILURE on whole-refusal; publishes filter
 ├─ GuardedCommitOrSkip                  ← canonical ledger commit (CLP-10-006)
 ├─ AppendCaseStatusToCaseNode           ← records accepted portion
-├─ EmbargoTeardownAuthorizationGate     ← call-out (RequireCaseOwnerApproval)
+├─ EmbargoTeardownAuthorizationGate     ← authorization seam (as-built; RSH-07-004)
 └─ ThreatTerminationBranchNode          ← fires teardown on CS.P, CS.X, CS.A
 ```
 
@@ -285,17 +309,24 @@ in `_RECOGNIZED_OVERRIDE_PRODUCERS` per RSH-05-014.
 ```text
 AddCaseStatusToCaseBT (Sequence) — effect nodes only
 ├─ AppendCaseStatusToCaseNode           ← canonical write
-├─ EmbargoTeardownAuthorizationGate     ← Evaluator call-out (RequireCaseOwnerApproval)
+├─ EmbargoTeardownAuthorizationGate     ← authorization seam (as-built; RSH-07-004)
 └─ ThreatTerminationBranchNode          ← fires teardown on CS.P, CS.X, CS.A
 ```
 
 ### EmbargoTeardownAuthorizationGate
 
-An Evaluator call-out that gates the entire side-effects block. Default:
-`RequireCaseOwnerApproval` (conservative: blocks until Case Owner approves,
-RSH-07-002, ADR-0076). An implementation MAY configure a permissive backend
-(e.g., `AlwaysSucceed` via `STATUS_AUTHORIZATION_PERMISSIVE`) for trusted or
-demo deployments (RSH-07-003).
+Gates the entire side-effects block, requiring explicit Case Owner authorization
+before teardown runs (RSH-07-002, ADR-0076). An implementation MAY configure a
+permissive backend (e.g., `AlwaysSucceed` via
+`STATUS_AUTHORIZATION_PERMISSIVE`) for trusted or demo deployments (RSH-07-003),
+but MUST NOT do so to unblock a gate that is refusing (RSH-07-005).
+
+As built, the seam is an Evaluator call-out whose default backend is
+`RequireCaseOwnerApproval`, which returns `FAILURE` unconditionally. Per
+ADR-0080 / RSH-07-004 that shape is superseded: the gate becomes a
+conversation-state routing subtree, and `RequireCaseOwnerApprovalNode` is
+deleted rather than completed. See the amendment note under **StatusAdoptionGate**
+above and [protocol-asks.md](protocol-asks.md); tracked by #2885.
 
 Note: the self-addressed `Add(CaseStatus)` path arrives with the CaseActor as
 sender (CASE_MANAGER role). This means even when `EmbargoTeardownAuthorizationGate` requires
@@ -330,9 +361,13 @@ class StatusAuthorizationCallOutBundle:
     embargo_teardown_authorization_gate_factory: CallOutBackendFactory = ...  # RequireCaseOwnerApproval
 ```
 
-Both fields default to `RequireCaseOwnerApproval` (RSH-07-001, RSH-07-002,
-ADR-0076). Demo and trusted-participant deployments that need automated
-adoption MUST explicitly configure a permissive backend — e.g.:
+As built, both fields default to `RequireCaseOwnerApproval` (RSH-07-001,
+RSH-07-002, ADR-0076). Under ADR-0080 / RSH-07-004 that default is retired along
+with the node: no `CallOutBackendFactory` may return an unconditional `FAILURE`
+node as the conservative default, because the conservative posture is expressed
+by the routing subtree's branches, not by a backend that always refuses. Demo and
+trusted-participant deployments that need automated adoption MUST explicitly
+configure a permissive backend — e.g.:
 
 ```python
 STATUS_AUTHORIZATION_PERMISSIVE = StatusAuthorizationCallOutBundle(

--- a/plan/history/2608/learning/CONCERN-2829.md
+++ b/plan/history/2608/learning/CONCERN-2829.md
@@ -1,0 +1,114 @@
+---
+source: CONCERN-2829
+timestamp: '2026-08-31T17:27:14.107908+00:00'
+title: 'G01: async round-trip and delivery-confirmation primitive'
+type: learning
+---
+
+Planning group **G01** of 19 (parent umbrella #2828), covering members #2657, #1880, #2367, #2369, #2812, #2809 and #2796.
+
+## Original concern
+
+Six issues filed independently across six Epics all bottomed out on the same missing
+mechanism: core had no way to (a) suspend a behavior and resume it when a delayed
+external response arrives, and (b) get delivery confirmation back from the wire into a
+commit decision. The umbrella asked for one ADR establishing the async-response /
+delivery-confirmation model, a yes/no verdict on the NACK question (not another
+deferral), spec amendments, a docs page, and Tasks sequenced primitive-first.
+
+## What the investigation found
+
+Three findings reframed the session.
+
+**1. The framework could never host suspension, and the requirement mandating it had
+zero implementations.** `BTBridge.execute_tree()` busy-loops on root `RUNNING` for 100
+ticks, logs `ERROR`, returns `FAILURE`, then discards the tree in
+`finally: bt.shutdown()`. Meanwhile `grep -r "return Status.RUNNING" vultron/` returns
+nothing — EDF-04-002 required an external decision node to return `RUNNING` while
+awaiting input, and no node in the codebase had ever complied. Any node that had would
+have busy-looped and then failed.
+
+**2. The mechanism was already in production, hand-built, once.**
+`create_recommend_actor_to_case_received_tree` (`suggest_actor_tree.py`, ADR-0026 /
+CM-16) records receipt then routes through disjoint branches — already a participant /
+invite in flight / owner asked and unanswered / fresh — reading open-closed state from
+the ledger via `find_protocol_pair`, with sibling trees for the `Accept` and `Reject`.
+
+**3. The durable per-ask record was too.** `VultronOfferRecord` is DataLayer-backed,
+keyed by `build_id(offer_id)`, written by the adapter that calls the factory, and works
+**before a case exists**.
+
+So the question was never how to host an asynchronous exchange. It was why each
+instance cost a bespoke implementation. `RequireCaseOwnerApprovalNode` is a
+deny-always stub because nobody generalised the first instance — not because the design
+was unknown.
+
+## Decision recorded (ADR-0080)
+
+An actor that cannot act on its own authority **emits a request and terminates
+successfully** — `SUCCESS` means *I asked*. The reply starts new work. Nothing
+suspends, because the work is divided at the question rather than paused there.
+
+Each gated interaction is one tree that routes on conversation state before acting,
+with disjoint branches (reply in hand / asked and waiting / asked and expired / never
+asked). Replaying the original message was rejected: CLP-13-001 requires an idempotency
+guard that detects a duplicate to return FAILURE and write nothing, so a replayed tree
+dies before reaching the gate. Splitting each tree into ask and act halves was rejected
+because two halves drift.
+
+Authority comes from the stored ask, never the reply — ADR-0026's trust rule
+generalised, plus its time dimension. Expiry consequence is fixed per ask kind in the
+spec; only the duration is configurable, and that is safe because the deadline travels
+on the wire in `end_time`. One register class implements the create / close / time-out
+lifecycle and is instantiated twice: the durable two-directional ask register (may
+block) and the existing in-memory suppressor (never blocks, forgotten on restart by
+design). The register never authorises — a gate always reads the ledger. Expiry is
+noticed opportunistically plus via a `reap-expired-asks` trigger for an external
+Sentinel, which is also what makes expiry testable causally rather than by elapsed
+time.
+
+**NACK verdict: yes, narrowly.** `Create(ProcessingFault)` — one dedicated object type,
+`Create` rather than `Reject` (which presupposes something rejectable), pointer never
+echo (an invalid payload cannot be re-typed), authenticated senders only (a parser
+oracle otherwise), RFC 9457 Problem Details with failure classes as namespace URIs.
+This **discharges** the deferral ADR-0049 recorded rather than overturning it: that ADR
+explicitly asked for sender notification to be "designed on its own merits" later, and
+its own decision (no RE/EE/CE/GE/GI message family) stands.
+
+**#2657 reframed.** Gating the ledger commit on delivery is declined: the ledger records
+what an actor decided and observed at the time it happened, gating it would make an
+actor's history hostage to the network, it inverts CLP-10-006's ordering, and it raises
+an unanswerable partial-delivery question. The real defect is that nothing links a
+dead-lettered activity to the entry claiming its event happened.
+
+## Specs found to be wrong
+
+- **EDF-04-002** — mandated a mechanism the executor cannot host, with zero
+  implementations. Reversed.
+- **CLP-11-001** — over-reached from "don't infer protocol state from the outbox" into
+  "the ledger is the only source", which contradicted DL-06-002 and forbade a
+  working-set register. Narrowed to the authorization question.
+- **ADR-0076's capability-shape assignment** — an Evaluator asked "is this approved?"
+  when no answer yet exists can only answer no, which is precisely the stub's
+  behaviour. The conservative default it establishes is unaffected.
+- **CP-05-006** — said to answer a duplicate proposal with a *new* Accept, which the
+  vendor cannot distinguish from a second decision. Corrected to re-send the stored
+  original, and raised SHOULD → MUST.
+
+## Prerequisite discovered
+
+There is **no shared emit path**. `outbox_append` is called from ~20 modules and at
+least four private `_emit` helpers exist independently, so "built into the thing that
+emits an Offer" had nowhere to live. It cannot be the AS2 factory (wire layer, no
+DataLayer). This blocks the whole chain — and #2657's premise assumed a shared path
+that is in fact copy-pasted.
+
+**Resolved**: 2026-08-31 — implementation tracked in #2881, #2883, #2884, #2885, #2886, #2887, #2889, #2890, #2891.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2880>.
+Spec: `specs/protocol-asks.yaml`, plus amendments to CLP-11, EDF-04, RSH-07, CP-05,
+OX-14 and TRIG-04.
+Notes: `notes/protocol-asks.md`.
+ADR: ADR-0080 (amends ADR-0076, ADR-0046, ADR-0026; discharges ADR-0049's deferral).
+Docs: `docs/topics/protocol_flow.md` (for #2796).
+Remaining open: #2369 stays open, re-scoped to outcome observability for behaviours
+that fail without asking.

--- a/specs/README.md
+++ b/specs/README.md
@@ -78,6 +78,7 @@ Load additional files only when the task touches the relevant area. See the
 | Status dimension objects (per-machine EM/PXA/RM/VFD/PEC decomposition) | `status-dimension-objects.yaml`, `notes/status-dimension-objects.md` |
 | Received-side status authorization (StatusAdoptionGate, EmbargoTeardownAuthorizationGate, ThreatTerminationBranchNode) | `received-status-handling.yaml`, `notes/received-status-authorization.md` |
 | CaseProposal protocol (distributed case actor initialization) | `case-proposal.yaml` |
+| Protocol asks (ask-and-terminate, outstanding-ask registers, expiry, processing faults) | `protocol-asks.yaml`, `notes/protocol-asks.md` |
 | Protocol conformance | `vultron-protocol-spec.yaml`, `vultron-as2-mapping.yaml`, `message-semantics-mapping.yaml` |
 | Wire vocabulary | `vocabulary-model.yaml` |
 | Activity factory functions | `activity-factories.yaml` |
@@ -442,6 +443,7 @@ is reserved for `testability.yaml`).
 | `ARCH` | `architecture.yaml` |
 | `AKM` | `actor-knowledge-model.yaml` |
 | `AR` | `agentic-readiness.yaml` |
+| `ASK` | `protocol-asks.yaml` |
 | `BT` | `behavior-tree-integration.yaml` |
 | `BTC` | `bt-composability.yaml` |
 | `BTND` | `behavior-tree-node-design.yaml` |

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -963,17 +963,27 @@ groups:
   - id: CLP-11-001
     priority: MUST
     kind: protocol
-    statement: Open/closed state for a protocol request/reply pair (e.g., `Offer(CaseParticipant)`
-      awaiting `Accept` or `Reject`) MUST be determined by querying the case ledger
-      via `CasePersistence.find_protocol_pair()`, not by inspecting the outbox.
+    statement: Whether a protocol request/reply pair (e.g., `Offer(CaseParticipant)`
+      awaiting `Accept` or `Reject`) has been authorized MUST be determined by querying
+      the case ledger via `CasePersistence.find_protocol_pair()`, and MUST NOT be determined
+      by inspecting the outbox.
     rationale: 'The outbox is a delivery queue: entries are removed when the activity
       is sent and MUST NOT be used to infer protocol state. The case ledger is the
       canonical append-only protocol history and survives actor restarts. Any code
       that reads the outbox to determine whether a request is still in-flight is architecturally
       incorrect and MUST be replaced.'
+    note: >-
+      Narrowed by ADR-0080. This requirement governs the *authorization* question
+      ("was this permitted?"), which only the ledger may answer. It does not forbid an
+      actor-scoped working-set register of outstanding asks (ASK-04), which answers the
+      distinct question "what am I waiting on, and what do I owe?" — and which
+      DL-06-002 requires be recorded as core state rather than re-derived. A register
+      MUST NOT be consulted for authorization (ASK-02-004).
     verification: A unit test confirms that `CasePersistence.find_protocol_pair()`
-      queries the `CaseLedgerEntry` log to determine open/closed state, and that no
-      code path reads the outbox to make this determination.
+      queries the `CaseLedgerEntry` log to determine authorization state, and that no
+      code path reads the outbox or an outstanding-ask register to make this determination.
+    adr:
+    - ADR-0080
     stories:
     - story_2022_045
     - story_2022_088
@@ -986,6 +996,14 @@ groups:
       ledger; `PendingAssertionStore` suppresses duplicate near-term re-emits while
       waiting for the `CaseLedgerEntry` round-trip. Merging them would conflate durable
       protocol state with short-lived emit-suppression state.'
+    note: >-
+      Clarified by ADR-0080. This prohibition is on unifying the *registers*, not on
+      sharing their machinery. The create / close-on-named-event / time-out lifecycle,
+      its reaping and its enumeration are implemented once and instantiated separately
+      per use (ASK-04-007) — the durable ask register may block, the ephemeral
+      suppressor may not (CLP-06-002, CLP-06-005).
+    adr:
+    - ADR-0080
   - id: CLP-11-003
     priority: MUST
     kind: protocol

--- a/specs/case-proposal.yaml
+++ b/specs/case-proposal.yaml
@@ -304,13 +304,51 @@ groups:
     lint_suppress:
     - missing_story_reference
   - id: CP-05-006
-    priority: SHOULD
+    priority: MUST
     kind: protocol
-    statement: 'The case-actor service SHOULD handle duplicate `Create(as_CaseProposal)` idempotently: if a proposal for the
-      same report has already been accepted and a `VulnerabilityCase` created, it SHOULD respond with a new `Accept(as_CaseProposal)`
-      referencing the existing `VulnerabilityCase` rather than creating a second one.'
-    rationale: Network retries and at-least-once delivery semantics mean the vendor may resend the proposal. Idempotent handling
-      prevents duplicate cases.
+    statement: 'The case-actor service MUST handle duplicate `Create(as_CaseProposal)` idempotently: if a proposal for the
+      same report has already been accepted, it MUST re-send the stored `Accept(as_CaseProposal)` unchanged, with its
+      original identifier, and MUST NOT create a second `VulnerabilityCase`.'
+    rationale: >-
+      A duplicate proposal is the only signal the case-actor gets that its acceptance
+      was lost, so answering it is the recovery path CONCERN-2367 found missing.
+      Re-sending the frozen original (VM-08-003) reads as the first acceptance arriving
+      late; a *new* `Accept` is indistinguishable from a second, independent decision,
+      which CP-05-005's irrevocability rule precludes.
+    note: >-
+      Raised from SHOULD to MUST and changed from "a new Accept" to the stored original
+      by ADR-0080 (CONCERN-2367).
+    verification: A duplicate `Create(as_CaseProposal)` after acceptance produces an outbound `Accept(as_CaseProposal)`
+      identical to the stored original including its `id`, and no second `VulnerabilityCase`.
+    adr:
+    - ADR-0080
+    relationships:
+    - rel_type: refines
+      spec_id: ASK-08-001
+    lint_suppress:
+    - missing_story_reference
+  - id: CP-05-007
+    priority: MUST
+    kind: protocol
+    statement: A vendor that has sent `Create(as_CaseProposal)` and received neither `Accept(as_CaseProposal)` nor
+      `Reject(as_CaseProposal)` by the proposal's deadline MUST treat the proposal as expired and MUST NOT continue waiting
+      indefinitely.
+    rationale: >-
+      CONCERN-2367 found that a silently lost `Accept` stalls the handshake
+      permanently, because no party holds a timeout. The proposal is an ask
+      (ASK-01-001), so it carries a deadline (ASK-03-004) and sits in the vendor's
+      outstanding-ask register (ASK-04-001), which is actor-scoped and therefore works
+      before a case exists. Re-proposal is a later decision, not an automatic retry
+      (ASK-05-004) — and it is also what lets the case-actor recover (CP-05-006).
+    verification: With no reply recorded past the proposal's deadline, the vendor's proposal register entry is expired and
+      the vendor emits no further activity until a behaviour decides to re-propose.
+    adr:
+    - ADR-0080
+    relationships:
+    - rel_type: depends_on
+      spec_id: ASK-05-001
+    lint_suppress:
+    - missing_story_reference
 - id: CP-06
   title: Protocol Flow — Receiving (Vendor Side)
   specs:

--- a/specs/event-driven-control-flow.yaml
+++ b/specs/event-driven-control-flow.yaml
@@ -102,16 +102,44 @@ groups:
     statement: When a cascade reaches a point where the actor cannot proceed autonomously, the stopping point MUST be represented
       as an explicit external decision node in the BT.
   - id: EDF-04-002
-    priority: MUST
+    priority: MUST_NOT
     kind: project
     statement: >-
-      An external decision node MUST return `py_trees.common.Status.RUNNING` while
-      awaiting input.
+      An external decision node MUST NOT return `py_trees.common.Status.RUNNING` to
+      represent awaiting input; it MUST request the input it needs and terminate.
+    rationale: >-
+      The execution model cannot host `RUNNING`: `BTBridge.execute_tree` treats root
+      `RUNNING` as "continue ticking", exhausts its budget, logs `ERROR`, returns
+      `FAILURE`, then discards the tree — so no node survives to be resumed. Waiting is
+      instead expressed by requesting the input and terminating (ASK-01-002).
+    note: >-
+      Reversed by ADR-0080. The previous form mandated `RUNNING` while awaiting input.
+      It had zero implementations — no node in `vultron/` returns `RUNNING` — and any
+      node that had complied would have busy-looped and then failed.
+    verification: >-
+      A repository-wide search finds no `return Status.RUNNING` in `vultron/`, and a
+      gated tree returns `SUCCESS` after emitting its request.
+    adr:
+    - ADR-0080
+    relationships:
+    - rel_type: refines
+      spec_id: ASK-01-003
   - id: EDF-04-003
     priority: MUST
     kind: architecture
     statement: The arrival of the required external input (a trigger invocation, an inbox message, or a UI response) MUST
-      cause the external decision node to re-evaluate and return `SUCCESS` or `FAILURE` on the next BT tick.
+      cause a fresh evaluation that determines where the exchange stands and proceeds
+      accordingly.
+    rationale: >-
+      Amended by ADR-0080. The previous form required the awaiting node to re-evaluate
+      "on the next BT tick", which presumes the node survived to be ticked again; it
+      does not. The arriving input drives a new evaluation whose first act is to
+      determine the state of the exchange (ASK-02-001).
+    verification: >-
+      Delivering the awaited input causes a fresh evaluation that resolves the
+      exchange, without any prior tree instance being retained.
+    adr:
+    - ADR-0080
   - id: EDF-04-004
     priority: MUST
     kind: project
@@ -123,11 +151,16 @@ groups:
     priority: MUST_NOT
     kind: project
     statement: >-
-      An external decision node MUST NOT silently succeed or fail while awaiting
-      input.
+      An external decision node MUST NOT succeed or fail without having requested the
+      input it needs.
     rationale: >-
-      Silent success or failure hides the fact that input was not received, causing
-      the BT to proceed as if the decision was made when it was not.
+      Silent success or failure hides the fact that input was never solicited, causing
+      the BT to proceed as if the decision was made when it was not. Amended by
+      ADR-0080: because a decision point terminates rather than waits, the observable
+      that distinguishes "asked and waiting" from "gave up" is the emitted request —
+      a terminal status with no request emitted is the silent failure this forbids.
+      This is the defect `RequireCaseOwnerApprovalNode` exhibits: it returns FAILURE
+      without ever asking.
     relationships:
     - rel_type: refines
       spec_id: EDF-04-002

--- a/specs/outbox.yaml
+++ b/specs/outbox.yaml
@@ -545,3 +545,73 @@ groups:
       spec_id: OX-13-006
     adr:
     - ADR-0066
+- id: OX-14
+  title: Undelivered-Activity Correlation
+  description: >
+    Requirements linking a permanently undelivered activity back to the canonical case
+    ledger entry that recorded the event the activity carries, so that divergence
+    between the canonical log and a participant's replica is observable rather than
+    silent. Derived from CONCERN-2657 and ADR-0080.
+  specs:
+  - id: OX-14-001
+    priority: MUST
+    kind: architecture
+    statement: >-
+      A dead-lettered activity MUST be correlatable to the canonical `CaseLedgerEntry`
+      whose event it carries, where such an entry exists.
+    rationale: >-
+      CONCERN-2657 observed that a permanently undelivered activity leaves the canonical
+      log asserting an event a participant never received. The defect is not the write
+      ordering (see OX-14-002) but that nothing connects the dead-letter store
+      (OX-13-008) to the entry claiming the event happened, so replica divergence is
+      undetectable.
+    verification: >-
+      Given a dead-lettered activity carrying a committed event, the corresponding
+      ledger entry is resolvable from the dead-letter record.
+    adr:
+    - ADR-0080
+    - ADR-0066
+    tags:
+    - observability
+    lint_suppress:
+    - missing_story_reference
+  - id: OX-14-002
+    priority: MUST_NOT
+    kind: protocol
+    statement: >-
+      A canonical `CaseLedgerEntry` commit MUST NOT be deferred until delivery of the
+      corresponding outbound activity is confirmed.
+    rationale: >-
+      Gating the commit on delivery makes an actor's own decision history hostage to
+      the network, inverts the guards-then-commit-then-effects ordering CLP-10-006
+      requires, and creates an unanswerable partial-delivery question when some
+      recipients succeed and others fail. Delivery confirmation is a transport-level
+      receipt and is not agreement to the delivered content; the two layers stay
+      separate.
+    verification: >-
+      A committed entry is present in the canonical ledger before any delivery attempt
+      for its activity is made.
+    adr:
+    - ADR-0080
+    lint_suppress:
+    - missing_story_reference
+  - id: OX-14-003
+    priority: MUST
+    kind: architecture
+    statement: >-
+      Exhaustion of an activity's delivery budget MUST produce an observable that names
+      the recipients that never received it and the canonical entry the activity was
+      replicating, where one exists.
+    rationale: >-
+      A participant whose replica is missing an entry cannot ask for it if it does not
+      know the entry exists; naming the unreached recipients is what makes targeted
+      replay (SBT-03-002) possible instead of a full resynchronisation.
+    verification: >-
+      The exhaustion observable includes the unreached recipient identifiers and the
+      associated canonical entry reference.
+    adr:
+    - ADR-0080
+    tags:
+    - observability
+    lint_suppress:
+    - missing_story_reference

--- a/specs/protocol-asks.yaml
+++ b/specs/protocol-asks.yaml
@@ -1,0 +1,757 @@
+id: ASK
+title: Protocol Asks and Outstanding-Ask Registers
+description: >
+  Requirements for the protocol-ask primitive: how an actor requests something it
+  lacks authority to do, how outstanding asks are recorded and enumerated in both
+  directions, how asks expire, and how a receiver reports that it could not
+  process an inbound message. Derived from ADR-0080 and the G01 planning session
+  (CONCERN-2829).
+version: 1.0.0
+scope:
+- prototype
+- production
+tags:
+- protocol
+- messaging
+- behavior-tree
+groups:
+- id: ASK-01
+  title: Ask and Terminate
+  description: >
+    An ask is an ordinary protocol message that completes the asking behavior.
+    Nothing suspends awaiting a reply.
+  specs:
+  - id: ASK-01-001
+    stories:
+    - story_2022_010
+    - story_2022_047
+    - story_2022_053
+    priority: MUST
+    kind: protocol
+    statement: >
+      An actor that cannot perform an action on its own authority MUST request
+      authorization by emitting an ask activity addressed to the authorizing
+      actor, and MUST NOT perform the action before a reply authorizing it has
+      been recorded.
+    rationale: >
+      Separates requesting authority from holding it, so the action cannot occur
+      on the asker's own initiative.
+    verification: >
+      A gated tree executed by a non-authorized actor emits the ask and produces
+      no protocol effect from the gated action.
+    adr:
+    - ADR-0080
+    tags:
+    - protocol
+    - security
+  - id: ASK-01-002
+    priority: MUST
+    kind: architecture
+    statement: >
+      A behavior that emits an ask MUST terminate with SUCCESS on the strength of
+      having emitted it; SUCCESS at an ask point means the ask was emitted and
+      MUST NOT be read as authorization having been granted.
+    rationale: >
+      The behavior is divided at the question rather than paused there, which is
+      what makes an asynchronous exchange hostable in a single-shot executor.
+    verification: >
+      A gated tree whose ask branch fires returns SUCCESS and the ask appears in
+      the emitting actor's outbox.
+    adr:
+    - ADR-0080
+  - id: ASK-01-003
+    priority: MUST_NOT
+    kind: architecture
+    statement: >
+      A BT node MUST NOT return RUNNING to represent waiting for an external
+      reply.
+    rationale: >
+      `BTBridge.execute_tree` treats root RUNNING as "continue ticking", exhausts
+      its iteration budget, logs ERROR and returns FAILURE, then discards the
+      tree; no tree survives an invocation, so no node can be resumed.
+    verification: >
+      A repository-wide search finds no `return Status.RUNNING` in `vultron/`.
+    adr:
+    - ADR-0080
+    tags:
+    - behavior-tree
+  - id: ASK-01-004
+    stories:
+    - story_2022_048
+    - story_2022_053
+    priority: MUST
+    kind: protocol
+    statement: >
+      The action authorized by a reply MUST be determined from the ask the
+      answerer was responding to, and MUST NOT be determined from the content of
+      the reply.
+    rationale: >
+      Generalizes ADR-0026's trust rule; reading the action from the reply lets
+      the answerer unilaterally alter what it authorizes.
+    verification: >
+      A reply whose embedded object differs from the stored ask's object does not
+      change the action performed.
+    adr:
+    - ADR-0080
+    - ADR-0026
+    tags:
+    - security
+- id: ASK-02
+  title: Conversation-State Routing
+  description: >
+    A gated interaction is one tree that determines where the conversation stands
+    before taking any action.
+  specs:
+  - id: ASK-02-001
+    priority: MUST
+    kind: architecture
+    statement: >
+      A tree implementing a gated interaction MUST determine the state of the
+      ask/reply exchange before executing any branch that produces a protocol
+      effect.
+    rationale: >
+      State-first routing is what makes repeated entry safe without relying on
+      per-node duplicate detection.
+    verification: >
+      Inspection of a gated tree confirms the state-determining nodes precede
+      every effect-producing branch.
+    adr:
+    - ADR-0080
+    tags:
+    - behavior-tree
+  - id: ASK-02-002
+    priority: MUST
+    kind: architecture
+    statement: >
+      The branches of a gated interaction tree MUST be mutually exclusive, such
+      that at most one branch is applicable for any state of the exchange.
+    rationale: >
+      Disjoint branches mean a later entry does not re-attempt work an earlier
+      entry completed, so no idempotency guard is required to abort it.
+    verification: >
+      For each state of the exchange, exactly one branch of the tree executes.
+    adr:
+    - ADR-0080
+    tags:
+    - behavior-tree
+    - idempotency
+  - id: ASK-02-003
+    stories:
+    - story_2022_053
+    - story_2022_074
+    priority: MUST
+    kind: protocol
+    statement: >
+      When an ask for the same kind and subject is already outstanding and
+      unexpired, the tree MUST NOT emit a second ask.
+    rationale: >
+      Re-asking an open question produces duplicate decisions for the answerer
+      and duplicate register entries for the asker.
+    verification: >
+      A second entry into a gated tree while an unexpired ask is outstanding adds
+      no activity to the outbox.
+    adr:
+    - ADR-0080
+  - id: ASK-02-004
+    priority: MUST_NOT
+    kind: protocol
+    statement: >
+      A gated interaction tree MUST NOT read authorization state from an
+      outstanding-ask register; it MUST read it from the case ledger.
+    rationale: >
+      The register is a working set that may be rebuilt or corrupted; making it
+      authoritative for authorization would let a forged entry permit an action.
+    verification: >
+      An architecture test confirms no gate node reads an outstanding-ask
+      register.
+    adr:
+    - ADR-0080
+    tags:
+    - security
+  - id: ASK-02-005
+    stories:
+    - story_2022_045
+    - story_2022_053
+    priority: MUST
+    kind: protocol
+    statement: >
+      A branch that records the state of an action not yet authorized MUST leave
+      the case in a state the protocol defines; an action whose not-yet state
+      cannot be represented MUST be refused rather than asked about.
+    rationale: >
+      An ask suspends nothing, so the case sits in the pre-authorization state
+      for the whole deadline; that state must be legitimate.
+    verification: >
+      For each gated action, the state after the ask branch runs is a defined
+      protocol state.
+    adr:
+    - ADR-0080
+    tags:
+    - state-machine
+- id: ASK-03
+  title: Ask Kinds
+  description: >
+    Each kind of ask declares the replies that close it, its expiry consequence,
+    and a default deadline.
+  specs:
+  - id: ASK-03-001
+    stories:
+    - story_2022_010
+    - story_2022_048
+    priority: MUST
+    kind: protocol
+    statement: >
+      Each ask kind MUST declare the set of reply event types that close it.
+    rationale: >
+      Pairing a reply to an ask requires a declared closing set rather than
+      hard-coded reply names at call sites; `ProtocolPair` already carries this
+      field.
+    verification: >
+      Every registered ask kind exposes a non-empty set of closing reply event
+      types.
+    adr:
+    - ADR-0080
+  - id: ASK-03-002
+    stories:
+    - story_2022_032
+    - story_2022_074
+    priority: MUST
+    kind: protocol
+    statement: >
+      Each ask kind MUST declare whether a reply arriving after the ask's
+      deadline authorizes the action (stale) or does not (void).
+    rationale: >
+      Admitting a participant remains useful when authorized late; adopting a
+      case status does not, because the case state the decision was made against
+      has moved on.
+    verification: >
+      Every registered ask kind declares an expiry consequence.
+    adr:
+    - ADR-0080
+    tags:
+    - security
+  - id: ASK-03-003
+    priority: MUST_NOT
+    kind: protocol
+    statement: >
+      The expiry consequence of an ask kind MUST NOT be deployment-configurable,
+      and MUST NOT be carried on the ask activity.
+    rationale: >
+      Two actors disagreeing about whether a late reply authorized an action is a
+      divergence in canonical case state, not a deployment preference; letting
+      the asker declare it would let the asker extend its own authorization.
+    verification: >
+      No configuration key sets an ask kind's expiry consequence, and no ask
+      activity field carries it.
+    adr:
+    - ADR-0080
+    tags:
+    - security
+    - configuration
+  - id: ASK-03-004
+    stories:
+    - story_2022_032
+    - story_2022_074
+    priority: MUST
+    kind: protocol
+    statement: >
+      An ask activity MUST carry its own deadline in the AS2 `endTime` field.
+    rationale: >
+      Placing the deadline on the wire means the answerer reads the same value as
+      the asker, so a configurable duration cannot cause disagreement.
+    verification: >
+      Every emitted ask activity has a non-null `endTime`.
+    adr:
+    - ADR-0080
+    tags:
+    - wire-format
+  - id: ASK-03-005
+    priority: MUST
+    kind: project
+    statement: >
+      The default deadline duration for each ask kind MUST be configurable
+      through `ActorConfig`, with a documented fallback default for kinds that
+      declare no override.
+    rationale: >
+      Urgency differs by kind and by deployment; the duration is safe to
+      configure because it travels on the wire (ASK-03-004).
+    verification: >
+      `ActorConfig` exposes a per-kind deadline mapping and a fallback default.
+    adr:
+    - ADR-0080
+    tags:
+    - configuration
+  - id: ASK-03-006
+    priority: MUST_NOT
+    kind: protocol
+    statement: >
+      An action gated by an ask whose kind declares void expiry MUST NOT be
+      performed on the strength of a reply recorded after the ask's deadline.
+    rationale: >
+      An authorization granted against a case state that no longer holds is a
+      standing permission, which is the hazard ADR-0026's trust rule addresses in
+      the identity dimension.
+    verification: >
+      With a void-expiry ask past its deadline and an Accept recorded, the gated
+      action does not execute.
+    adr:
+    - ADR-0080
+    tags:
+    - security
+- id: ASK-04
+  title: Outstanding-Ask Register
+  description: >
+    A durable, actor-scoped record of asks outstanding in both directions.
+  specs:
+  - id: ASK-04-001
+    priority: MUST
+    kind: architecture
+    statement: >
+      An actor MUST record an entry in its outstanding-ask register when it emits
+      an ask, and MUST record an entry when it receives an ask addressed to it.
+    rationale: >
+      The asker needs the entry to avoid re-asking and to notice expiry; the
+      answerer's entries are the queue of decisions it owes, which is the surface
+      a human, UI, or agent acts through.
+    verification: >
+      Emitting an ask and receiving an ask each produce a register entry in the
+      respective actor's store.
+    adr:
+    - ADR-0080
+  - id: ASK-04-002
+    priority: MUST
+    kind: architecture
+    statement: >
+      An outstanding-ask register entry MUST be removed when a reply that closes
+      its ask is recorded.
+    rationale: >
+      Presence in the register means outstanding, which keeps the working set
+      small and the invariant checkable; history lives in the case ledger.
+    verification: >
+      Recording a closing reply removes the corresponding register entry.
+    adr:
+    - ADR-0080
+  - id: ASK-04-003
+    priority: MUST
+    kind: architecture
+    statement: >
+      The outstanding-ask register MUST be durable across process restarts.
+    rationale: >
+      An in-memory register would orphan every outstanding ask on restart,
+      producing a permanent stall worse than the one the register prevents.
+    verification: >
+      Register entries written before a restart are readable after it.
+    adr:
+    - ADR-0080
+    tags:
+    - persistence
+  - id: ASK-04-004
+    priority: MUST
+    kind: architecture
+    statement: >
+      The outstanding-ask register MUST be actor-scoped rather than case-scoped,
+      so that asks exchanged before a case exists are recorded.
+    rationale: >
+      Pre-case handshakes such as `Create(CaseProposal)` have no case ledger to
+      derive state from; `VultronOfferRecord` already demonstrates the
+      actor-scoped form.
+    verification: >
+      An ask emitted before any case exists produces a readable register entry.
+    adr:
+    - ADR-0080
+  - id: ASK-04-005
+    priority: MUST
+    kind: architecture
+    statement: >
+      The outstanding-ask register MUST support enumeration of an actor's
+      outstanding asks in each direction, without the caller supplying the
+      identity of a specific ask.
+    rationale: >
+      Reaping deadlines and presenting a decision queue both require listing
+      entries; a keyed query cannot answer "what am I waiting on".
+    verification: >
+      Enumeration returns all outstanding entries for an actor, separable by
+      direction.
+    adr:
+    - ADR-0080
+  - id: ASK-04-006
+    priority: MUST
+    kind: architecture
+    statement: >
+      The outstanding-ask register MUST be reconstructible from the case ledger
+      for case-scoped asks, and the ledger MUST prevail where the two disagree.
+    rationale: >
+      A register that cannot be rebuilt makes lost entries unrecoverable; the
+      same index-plus-authority division governs `actor_participant_index`.
+    verification: >
+      A register rebuilt from the ledger yields the same outstanding case-scoped
+      entries as the maintained register.
+    adr:
+    - ADR-0080
+  - id: ASK-04-007
+    priority: MUST
+    kind: architecture
+    statement: >
+      The create, close-on-named-event, and time-out lifecycle shared by
+      outstanding-ask tracking and pending-assertion suppression MUST be
+      implemented once as a reusable register, instantiated separately for each
+      use.
+    rationale: >
+      Both uses already share `ProtocolPair` as their key type and both need
+      reaping and enumeration; two implementations of one lifecycle drift.
+    verification: >
+      The ask register and the pending-assertion store are instances of one
+      register implementation.
+    adr:
+    - ADR-0080
+    relationships:
+    - rel_type: refines
+      spec_id: CLP-11-002
+  - id: ASK-04-008
+    priority: MUST
+    kind: architecture
+    statement: >
+      Registration of an emitted ask MUST occur on the single shared emit path,
+      so that no call site can emit an ask without recording it.
+    rationale: >
+      Registration that each call site must remember to perform is registration
+      that will be forgotten; the wire factory cannot do it because the wire
+      layer has no DataLayer access.
+    verification: >
+      Every emitted ask has a register entry, with no per-call-site registration
+      code.
+    adr:
+    - ADR-0080
+  - id: ASK-04-009
+    priority: MUST
+    kind: architecture
+    statement: >
+      An actor MUST expose its outstanding asks as a dereferenceable
+      ActivityStreams collection in each direction.
+    rationale: >
+      A collection is the ActivityStreams idiom for the set of things belonging
+      to an actor, so no new activity verb is needed to answer "what decisions do
+      I owe"; the answerer already holds the underlying data in its ledger
+      replica.
+    verification: >
+      Each direction is retrievable as an `OrderedCollection` of outstanding
+      asks.
+    adr:
+    - ADR-0080
+    tags:
+    - wire-format
+- id: ASK-05
+  title: Expiry and Reaping
+  description: >
+    How an expired ask is noticed, given that elapsed time is not an event.
+  specs:
+  - id: ASK-05-001
+    priority: MUST
+    kind: architecture
+    statement: >
+      A gated interaction tree MUST treat an outstanding ask past its deadline as
+      expired at the next entry into the tree, without requiring a prior reaping
+      pass.
+    rationale: >
+      Time passing delivers no message, so opportunistic evaluation is the only
+      mechanism guaranteed to run; a peer's own retry is frequently the clock.
+    verification: >
+      Entering a gated tree with an expired outstanding ask takes the expired
+      branch.
+    adr:
+    - ADR-0080
+  - id: ASK-05-002
+    priority: MUST
+    kind: project
+    statement: >
+      The system MUST expose a general-purpose trigger that reaps expired
+      outstanding asks for an actor.
+    rationale: >
+      Reaping is a Sentinel concern, and a Sentinel operates on the call-in
+      surface with no BT call-out point, so the reaper belongs outside core.
+    verification: >
+      A trigger endpoint exists that transitions expired entries and is mounted
+      in production mode.
+    adr:
+    - ADR-0080
+    tags:
+    - observability
+  - id: ASK-05-003
+    priority: MUST_NOT
+    kind: architecture
+    statement: >
+      Reaping expired asks MUST NOT be implemented as a periodic loop inside
+      core.
+    rationale: >
+      A timer-driven reaper inside core makes expiry behaviour observable only by
+      waiting, which EDF-06-001 forbids treating as evidence, and misplaces a
+      call-in concern.
+    verification: >
+      No core module schedules periodic expiry evaluation.
+    adr:
+    - ADR-0080
+  - id: ASK-05-004
+    stories:
+    - story_2022_032
+    - story_2022_074
+    priority: MUST
+    kind: protocol
+    statement: >
+      Reaping an expired ask MUST NOT automatically re-emit it; re-asking MUST be
+      decided by a subsequent evaluation of the gated interaction tree.
+    rationale: >
+      Mirrors CLP-06-005 — a timeout is a signal, not an instruction to retry;
+      the tree owns the decision because only it knows whether the action is
+      still wanted.
+    verification: >
+      Reaping an expired ask adds no activity to the outbox.
+    adr:
+    - ADR-0080
+- id: ASK-06
+  title: Ask Visibility
+  description: >
+    Asks replicate like any other canonical entry, which constrains what they may
+    carry.
+  specs:
+  - id: ASK-06-001
+    stories:
+    - story_2022_041
+    - story_2022_045
+    priority: MUST
+    kind: protocol
+    statement: >
+      A case-scoped ask MUST be recorded as a canonical `CaseLedgerEntry` with
+      disposition `recorded` and MUST replicate to case participants on the
+      normal fan-out path.
+    rationale: >
+      An outstanding decision, and a stalled one, is protocol-relevant to every
+      participant; a directed-delivery variant would require redaction with
+      proofs, which does not exist.
+    verification: >
+      An emitted case-scoped ask appears as a recorded entry and is announced to
+      participants.
+    adr:
+    - ADR-0080
+  - id: ASK-06-002
+    priority: MUST_NOT
+    kind: protocol
+    statement: >
+      An ask MUST NOT carry content that cannot be disclosed to every
+      participant of its case.
+    rationale: >
+      Asks replicate to all participants (ASK-06-001), so private rationale must
+      travel by a directed `Note` instead.
+    verification: >
+      Ask factories accept no field intended for restricted disclosure.
+    adr:
+    - ADR-0080
+    tags:
+    - security
+- id: ASK-07
+  title: Processing Faults
+  description: >
+    How a receiver tells an authenticated sender that it could not process what
+    was sent.
+  specs:
+  - id: ASK-07-001
+    stories:
+    - story_2022_039
+    - story_2022_077
+    priority: MUST
+    kind: protocol
+    statement: >
+      An actor that cannot process an inbound activity from an authenticated
+      sender MUST notify that sender by emitting `Create(ProcessingFault)`.
+    rationale: >
+      Discharges the deferral recorded in ADR-0049; without it a failure that
+      took milliseconds costs the sender its full ask deadline in silence.
+    verification: >
+      An authenticated sender whose activity is dead-lettered or rejected
+      receives a `Create(ProcessingFault)`.
+    adr:
+    - ADR-0080
+    - ADR-0049
+    tags:
+    - error-handling
+  - id: ASK-07-002
+    priority: MUST_NOT
+    kind: protocol
+    statement: >
+      An actor MUST NOT emit a processing fault in response to an inbound
+      activity whose sender is not authenticated, or whose failure occurred
+      before authentication.
+    rationale: >
+      Explaining a parse or validation failure to an unauthenticated sender is a
+      parser oracle, and an unauthenticated sender identity cannot be trusted as
+      a reply address.
+    verification: >
+      Unauthenticated malformed input produces no outbound activity.
+    adr:
+    - ADR-0080
+    tags:
+    - security
+  - id: ASK-07-003
+    stories:
+    - story_2022_039
+    priority: MUST
+    kind: protocol
+    statement: >
+      `ProcessingFault` MUST be a single dedicated object type carrying a
+      machine-readable failure class, rather than a reason field on an existing
+      reply activity.
+    rationale: >
+      SE-08-003 prefers a dedicated object type over field-level discrimination;
+      `Reject` additionally presupposes a rejectable object, which unreadable
+      traffic does not provide.
+    verification: >
+      A registered `ProcessingFault` object type exists with a required failure
+      class, and its pattern does not compete with reply patterns.
+    adr:
+    - ADR-0080
+    tags:
+    - wire-format
+  - id: ASK-07-004
+    stories:
+    - story_2022_039
+    priority: MUST
+    kind: protocol
+    statement: >
+      `ProcessingFault` MUST identify the activity that failed by reference, and
+      MUST NOT require an inline copy of it.
+    rationale: >
+      When a payload fails validation, a typed copy of it cannot be constructed —
+      constructing it is what failed — and echoing sender-supplied content is a
+      reflection hazard.
+    verification: >
+      A `ProcessingFault` for an unparseable payload validates without an inline
+      failed activity.
+    adr:
+    - ADR-0080
+  - id: ASK-07-005
+    stories:
+    - story_2022_036
+    - story_2022_039
+    priority: MUST
+    kind: protocol
+    statement: >
+      The failure classes of `ProcessingFault` MUST be identified by URIs minted
+      in the Vultron namespace, and the fault MUST be structured according to
+      RFC 9457 Problem Details.
+    rationale: >
+      A URI-identified, dereferenceable problem type is extensible without a
+      schema change and lets a receiver that does not recognise a class resolve
+      its meaning; RFC 9457 is the standard for machine-readable error reporting
+      over HTTP.
+    verification: >
+      Each failure class resolves to a documented URI under the Vultron
+      namespace, and fault payloads carry the RFC 9457 members.
+    adr:
+    - ADR-0080
+    - ADR-0069
+    tags:
+    - wire-format
+  - id: ASK-07-006
+    priority: MUST_NOT
+    kind: protocol
+    statement: >
+      `ProcessingFault` MUST NOT carry implementation diagnostics such as stack
+      traces, parser internals, or the identity of the failing code path.
+    rationale: >
+      Faults replicate to all case participants and are also read by an
+      untrusted-by-default peer; the diagnosis of a failure belongs in the
+      actor's own log, governed by `specs/structured-logging.yaml`.
+    verification: >
+      The `ProcessingFault` schema admits no field for implementation
+      diagnostics.
+    adr:
+    - ADR-0080
+    tags:
+    - security
+    - logging
+  - id: ASK-07-007
+    stories:
+    - story_2022_039
+    - story_2022_074
+    priority: MUST
+    kind: protocol
+    statement: >
+      Receiving a processing fault that refers to an outstanding ask MUST close
+      that ask's register entry.
+    rationale: >
+      The exchange cannot complete, so leaving the entry open costs the asker its
+      whole deadline for a failure already reported.
+    verification: >
+      A fault naming an outstanding ask removes the corresponding register entry.
+    adr:
+    - ADR-0080
+  - id: ASK-07-008
+    stories:
+    - story_2022_045
+    - story_2022_074
+    priority: MUST
+    kind: protocol
+    statement: >
+      A processing fault that can be attributed to a case MUST be recorded as a
+      canonical `CaseLedgerEntry` with disposition `recorded`.
+    rationale: >
+      The statement that a message arrived and could not be processed is true,
+      legible protocol history, and it explains why a subsequent retransmission
+      occurred; it is not per-actor observability content, so CLP-07-004 does not
+      exclude it.
+    verification: >
+      A case-attributable fault appears as a recorded entry in the case ledger.
+    adr:
+    - ADR-0080
+  - id: ASK-07-009
+    priority: MUST_NOT
+    kind: protocol
+    statement: >
+      The activity that could not be processed MUST NOT be recorded as a
+      canonical `CaseLedgerEntry`.
+    rationale: >
+      There is no legible assertion to record; a snapshot of an unreadable
+      payload cannot satisfy CLP-02-003, and CLP-03-002 already excludes
+      unrouteable inbound from the ledger.
+    verification: >
+      No ledger entry is committed for an activity that failed processing.
+    adr:
+    - ADR-0080
+- id: ASK-08
+  title: Lost-Reply Recovery
+  description: >
+    What an answerer does when a request is repeated because its reply was lost.
+  specs:
+  - id: ASK-08-001
+    stories:
+    - story_2022_010
+    - story_2022_053
+    priority: MUST
+    kind: protocol
+    statement: >
+      An actor that receives a duplicate request it has already replied to MUST
+      re-send its stored reply unchanged, with its original identity, rather than
+      producing a new reply.
+    rationale: >
+      Re-sending the frozen original (VM-08-003) reads to the requester as the
+      original arriving late rather than a second decision, which is what
+      CP-05-005's irrevocability rule requires.
+    verification: >
+      A duplicate request produces an outbound reply identical to the stored
+      original, including its identifier.
+    adr:
+    - ADR-0080
+  - id: ASK-08-002
+    priority: MUST_NOT
+    kind: protocol
+    statement: >
+      An actor that receives a duplicate request it has already replied to MUST
+      NOT create a second instance of the object the request concerned.
+    rationale: >
+      A repeated proposal after acceptance is a re-send, not a new request;
+      treating it as new produces duplicate cases or duplicate participants.
+    verification: >
+      A duplicate `Create(CaseProposal)` after acceptance creates no second case.
+    adr:
+    - ADR-0080
+    tags:
+    - idempotency

--- a/specs/received-status-handling.yaml
+++ b/specs/received-status-handling.yaml
@@ -737,46 +737,95 @@ groups:
   title: Conservative Default Authorization Policy for Status Gates
   description: >
     Both StatusAdoptionGate and EmbargoTeardownAuthorizationGate MUST default to
-    `RequireCaseOwnerApproval` — an Evaluator that performs an Offer/Accept/Reject
-    round-trip with the Case Owner before allowing PXA assertion adoption or
-    embargo teardown side-effects. Permissive backends are valid but MUST be
-    explicitly configured.
-    Derived from CONCERN-2092 and ADR-0076.
+    requiring explicit Case Owner authorization before allowing PXA assertion
+    adoption or embargo teardown side-effects. Permissive backends are valid but
+    MUST be explicitly configured.
+    Derived from CONCERN-2092 and ADR-0076; the mechanism is amended by ADR-0080
+    (CONCERN-2812, CONCERN-2809) — see RSH-07-004.
   specs:
   - id: RSH-07-001
     priority: MUST
     kind: protocol
     statement: >
-      The default backend for the `CaseOwnerApprovesStatusUpdate` Evaluator
-      call-out in `StatusAdoptionGate` MUST be `RequireCaseOwnerApproval` —
-      an Evaluator that sends an `Offer` to the Case Owner and waits for
-      `Accept` or `Reject` before allowing the PXA assertion to be adopted
-      as canonical case state.
+      `StatusAdoptionGate` MUST default to requiring explicit Case Owner
+      authorization before a non-owner participant's PXA assertion is adopted as
+      canonical case state.
     rationale: >
       A permissive default (e.g., `AlwaysSucceed`) means any admitted
       participant — including a hostile or malfunctioning Observer admitted
       as a sentinel — can force PXA adoption and thereby trigger embargo
       teardown without any Case Owner confirmation. The default posture must
       be conservative; permissive behavior requires explicit opt-in. See ADR-0076.
+      Amended by ADR-0080: the conservative default stands, but the mechanism is
+      no longer an Evaluator that "waits for" a reply — see RSH-07-004.
     verification: >
-      Inspection of `StatusAuthorizationCallOutBundle` confirms
-      `status_adoption_gate_factory` defaults to `RequireCaseOwnerApproval`,
-      not `AlwaysSucceed`.
+      With the default bundle and a non-owner sender, no `Add(CaseStatus)` is
+      emitted until Case Owner authorization is recorded in the case ledger.
+    adr:
+    - ADR-0076
+    - ADR-0080
     lint_suppress:
     - missing_story_reference
   - id: RSH-07-002
     priority: MUST
     kind: protocol
     statement: >
-      The default backend for `EmbargoTeardownAuthorizationGate` MUST be
-      `RequireCaseOwnerApproval`. See also RSH-02-002.
+      `EmbargoTeardownAuthorizationGate` MUST default to requiring explicit Case
+      Owner authorization before embargo teardown side-effects execute. See also
+      RSH-02-002.
     rationale: >
       Belt-and-suspenders: both gates default conservatively. See RSH-02-002
-      rationale and ADR-0076 for full justification.
+      rationale and ADR-0076 for full justification. Amended by ADR-0080 for the
+      mechanism only; the conservative default is unchanged.
     verification: >
-      Inspection of `StatusAuthorizationCallOutBundle` confirms
-      `embargo_teardown_authorization_gate_factory` defaults to
-      `RequireCaseOwnerApproval`, not `AlwaysSucceed`.
+      With the default bundle, `ThreatTerminationBranchNode` does not execute until
+      Case Owner authorization is recorded in the case ledger.
+    adr:
+    - ADR-0076
+    - ADR-0080
+    lint_suppress:
+    - missing_story_reference
+  - id: RSH-07-004
+    priority: MUST
+    kind: protocol
+    statement: >
+      Each status authorization gate MUST be composed as a conversation-state
+      routing subtree per ASK-02-001, and MUST NOT be composed as a single-tick
+      Evaluator call-out that answers the authorization question inline.
+    rationale: >
+      At the moment authorization is first needed, no answer exists, so an
+      Evaluator asked "is this approved?" can only ever answer no. This is why
+      `RequireCaseOwnerApprovalNode` returns `FAILURE` unconditionally and why the
+      ADR-0046/ADR-0076 authorization model was unreachable by any pathway
+      (CONCERN-2812). The gate instead routes on whether authorization has been
+      recorded, refused, requested-and-outstanding, or never requested, emitting
+      the request and terminating in the last case.
+    verification: >
+      Inspection confirms each gate is a routing subtree whose branches cover
+      authorized, refused, outstanding, and not-yet-asked, and that no
+      `CallOutBackendFactory` returns an unconditional `FAILURE` node as the
+      conservative default.
+    adr:
+    - ADR-0080
+    lint_suppress:
+    - missing_story_reference
+  - id: RSH-07-005
+    priority: MUST_NOT
+    kind: protocol
+    statement: >
+      A status authorization gate MUST NOT be satisfied by relaxing its default to a
+      permissive backend in order to make a blocked path proceed.
+    rationale: >
+      `STATUS_AUTHORIZATION_PERMISSIVE` exists for trusted-participant and demo
+      deployments (RSH-07-003). Using it to work around an unreachable gate
+      converts a protocol guarantee into a configuration posture, which is the
+      defect CONCERN-2092 filed in the first place.
+    verification: >
+      The production default bundle is the conservative one, and permissive
+      injection sites are enumerated and documented.
+    adr:
+    - ADR-0076
+    - ADR-0080
     lint_suppress:
     - missing_story_reference
   - id: RSH-07-003

--- a/specs/triggerable-behaviors.yaml
+++ b/specs/triggerable-behaviors.yaml
@@ -124,6 +124,30 @@ groups:
     relationships:
     - rel_type: depends_on
       spec_id: AR-04-001
+  - id: TRIG-04-003
+    priority: MUST
+    kind: project
+    statement: When a triggered behavior terminates because it emitted an authorization request rather than completing the
+      requested action, the trigger response MUST identify the request it emitted.
+    rationale: >-
+      A trigger returns 202 and runs the behavior in the background, so a caller cannot
+      otherwise distinguish "done" from "waiting on someone else's decision"
+      (CONCERN-2369). Under ASK-01-002 success means the request was emitted, so success
+      alone is ambiguous; naming the request lets the caller resolve the outcome against
+      the outstanding-ask collection (ASK-04-009).
+    note: >-
+      This closes the CONCERN-2369 gap only for behaviors that stop to ask. Outcomes of
+      behaviors that fail for other reasons remain unobservable and are tracked
+      separately on CONCERN-2369.
+    verification: A trigger whose behavior emits an authorization request returns a response identifying that request, and the
+      identified request is retrievable from the actor's outstanding-ask collection.
+    adr:
+    - ADR-0080
+    relationships:
+    - rel_type: depends_on
+      spec_id: ASK-04-009
+    lint_suppress:
+    - missing_story_reference
 - id: TRIG-05
   title: BT Integration
   specs:

--- a/test/architecture/test_protocol_asks_specs.py
+++ b/test/architecture/test_protocol_asks_specs.py
@@ -1,0 +1,828 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Spec coverage for the protocol-ask primitive (ADR-0080, ASK-01..ASK-08).
+
+Every ``kind: protocol`` requirement introduced by ADR-0080 is marked here, so
+the spec-coverage ratchet (`test_spec_coverage_ratchet.py`) does not grow when
+the requirements land ahead of their implementations.
+
+Two kinds of test live in this module:
+
+**Passing tests** assert a requirement the codebase already satisfies. These are
+structural assertions chosen so they stay meaningful *after* the ask machinery is
+built — they are not vacuous restatements of "the thing does not exist yet".
+
+**Strict-xfail tests** assert a requirement that is not yet implemented, against
+an artifact the requirement names. Each carries the G01 implementation issue in
+its ``reason=``. When the feature lands the test XPASSes, ``strict=True`` fails
+the build, and whoever landed it must replace the placeholder assertion with a
+real behavioural one. That promotion is the point: this module is a ratchet, not
+a substitute for testing the feature.
+
+Specs: ASK-01 through ASK-08, CP-05-007, OX-14-002, RSH-07-004, RSH-07-005.
+See `notes/protocol-asks.md` and ADR-0080.
+"""
+
+import importlib
+
+import pytest
+
+from test.architecture import _corpus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VULTRON = _corpus.REPO_ROOT / "vultron"
+
+#: Candidate import paths for the outstanding-ask register (ASK-04). The
+#: register does not exist yet; #2883 creates it. Listed as candidates rather
+#: than one path so the tests here promote on whichever module name is chosen.
+_ASK_REGISTER_CANDIDATES = (
+    ("vultron.core.models.ask_register", "OutstandingAskRegister"),
+    ("vultron.core.models.outstanding_ask", "OutstandingAskRegister"),
+    ("vultron.core.models.ask_record", "OutstandingAskRecord"),
+)
+
+#: Candidate import paths for the ProcessingFault object type (ASK-07). #2889
+#: creates it.
+_FAULT_CANDIDATES = (
+    ("vultron.core.models.processing_fault", "ProcessingFault"),
+    ("vultron.wire.as2.vocab.objects.processing_fault", "as_ProcessingFault"),
+)
+
+
+def _first_available(candidates: tuple[tuple[str, str], ...]) -> type | None:
+    """Return the first importable class among *candidates*, else ``None``."""
+    for module_name, class_name in candidates:
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        obj = getattr(module, class_name, None)
+        if isinstance(obj, type):
+            return obj
+    return None
+
+
+def _ask_register() -> type | None:
+    """Return the outstanding-ask register class, or ``None`` if absent."""
+    return _first_available(_ASK_REGISTER_CANDIDATES)
+
+
+def _processing_fault() -> type | None:
+    """Return the ProcessingFault type, or ``None`` if absent."""
+    return _first_available(_FAULT_CANDIDATES)
+
+
+def _field_names(model: type) -> frozenset[str]:
+    """Return the declared field names of a pydantic model or dataclass."""
+    fields = getattr(model, "model_fields", None)
+    if fields is not None:
+        return frozenset(fields)
+    dc_fields = getattr(model, "__dataclass_fields__", None)
+    if dc_fields is not None:
+        return frozenset(dc_fields)
+    return frozenset(getattr(model, "__annotations__", {}))
+
+
+# ---------------------------------------------------------------------------
+# ASK-01 — Ask and Terminate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-01-001: the conservative status-adoption default is "
+        "RequireCaseOwnerApprovalNode, which refuses unconditionally and emits "
+        "no ask, so authorization can never be requested. Tracked by #2885."
+    ),
+)
+@pytest.mark.spec("ASK-01-001")
+def test_status_adoption_default_requests_authorization() -> None:
+    """The default status-adoption backend MUST ask, not merely refuse (ASK-01-001).
+
+    Asserts against the production default bundle rather than a stub: an actor
+    that lacks authority has to *emit* the request, and a backend that returns
+    FAILURE without emitting anything cannot satisfy that.
+    """
+    from vultron.core.behaviors.call_out.bundles.status_authorization import (
+        STATUS_AUTHORIZATION_DETERMINISTIC,
+    )
+    from vultron.core.behaviors.call_out.nodes import (
+        RequireCaseOwnerApprovalNode,
+    )
+
+    node = STATUS_AUTHORIZATION_DETERMINISTIC.status_adoption_gate_factory(
+        "CaseOwnerApprovesStatusUpdate"
+    )
+    assert not isinstance(node, RequireCaseOwnerApprovalNode), (
+        "The conservative default is an unconditional-FAILURE stub; it must be "
+        "a backend that emits Offer(Proposal) and terminates (ASK-01-002)."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-01-004: no outstanding-ask register exists, so there is no stored "
+        "ask to read the authorized action from — an implementation today could "
+        "only read it from the reply. Tracked by #2883."
+    ),
+)
+@pytest.mark.spec("ASK-01-004")
+def test_ask_register_entry_records_the_requested_subject() -> None:
+    """A stored ask MUST carry the action it requested (ASK-01-004).
+
+    Authority comes from the ask, never the reply, so the register entry has to
+    record the subject of the request; otherwise the only available source is
+    the reply's own content, which lets the answerer alter what it grants.
+    """
+    register = _ask_register()
+    assert (
+        register is not None
+    ), "No outstanding-ask register type is importable."
+    names = _field_names(register)
+    assert names & {
+        "object_id",
+        "subject_id",
+        "requested_object_id",
+    }, f"Register entry declares no requested-subject field; got {sorted(names)}."
+
+
+# ---------------------------------------------------------------------------
+# ASK-02 — Conversation-State Routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-02-003: nothing tracks an outstanding ask, so a gate has no way to "
+        "recognise that it already asked and must not ask again. Tracked by "
+        "#2883."
+    ),
+)
+@pytest.mark.spec("ASK-02-003")
+def test_ask_register_can_report_an_unexpired_outstanding_ask() -> None:
+    """Suppressing a duplicate ask requires an outstanding-and-unexpired query (ASK-02-003)."""
+    register = _ask_register()
+    assert (
+        register is not None
+    ), "No outstanding-ask register type is importable."
+    assert any(
+        hasattr(register, name)
+        for name in ("is_pending", "is_outstanding", "is_open")
+    ), "Register exposes no outstanding-ask predicate."
+
+
+@pytest.mark.spec("ASK-02-004")
+def test_no_gate_reads_authorization_from_an_ask_register() -> None:
+    """Gates MUST read authorization from the ledger, never a register (ASK-02-004).
+
+    Authorization is answered by the case ledger via ``find_protocol_pair``; the
+    register only answers "what am I waiting on". This currently holds because no
+    register exists, and it must keep holding once #2883 lands one — a forged or
+    rebuilt register entry must never be able to permit an action.
+    """
+    register_names = {class_name for _, class_name in _ASK_REGISTER_CANDIDATES}
+    offenders: list[str] = []
+    gate_dir = _VULTRON / "core" / "behaviors"
+    for path, source in _corpus.all_sources(under=gate_dir):
+        if not any(name in source for name in register_names):
+            continue
+        offenders.append(str(path.relative_to(_corpus.REPO_ROOT)))
+    assert not offenders, (
+        "Behavior-tree modules reference an outstanding-ask register: "
+        f"{offenders}. Authorization must come from the case ledger "
+        "(find_protocol_pair), not the register."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-02-005: the gate that would park an unauthorized action is the "
+        "deny-always stub, so no not-yet state is ever recorded and the "
+        "requirement has no implementation to check. Tracked by #2885."
+    ),
+)
+@pytest.mark.spec("ASK-02-005")
+def test_gate_records_a_defined_not_yet_state_before_asking() -> None:
+    """The ask branch MUST leave the case in a defined protocol state (ASK-02-005)."""
+    from vultron.core.behaviors.call_out.bundles.status_authorization import (
+        STATUS_AUTHORIZATION_DETERMINISTIC,
+    )
+    from vultron.core.behaviors.call_out.nodes import (
+        RequireCaseOwnerApprovalNode,
+    )
+
+    node = STATUS_AUTHORIZATION_DETERMINISTIC.status_adoption_gate_factory(
+        "gate"
+    )
+    assert not isinstance(
+        node, RequireCaseOwnerApprovalNode
+    ), "An unconditional-FAILURE backend records no not-yet state."
+
+
+# ---------------------------------------------------------------------------
+# ASK-03 — Ask Kinds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-03-001: ask kinds are not modelled. ProtocolPair carries "
+        "reply_event_types per instance, but no registry of ask kinds declares "
+        "the closing set. Tracked by #2884."
+    ),
+)
+@pytest.mark.spec("ASK-03-001")
+def test_ask_kinds_declare_their_closing_reply_types() -> None:
+    """Each ask kind MUST declare the replies that close it (ASK-03-001)."""
+    kinds = _first_available(
+        (
+            ("vultron.core.models.ask_kind", "AskKind"),
+            ("vultron.core.models.ask_kinds", "AskKind"),
+        )
+    )
+    assert kinds is not None, "No AskKind descriptor type is importable."
+    assert "reply_event_types" in _field_names(kinds)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-03-002: no ask-kind descriptor exists, so no kind declares whether "
+        "a late reply is stale or void. Tracked by #2884."
+    ),
+)
+@pytest.mark.spec("ASK-03-002")
+def test_ask_kinds_declare_an_expiry_consequence() -> None:
+    """Each ask kind MUST declare stale-vs-void expiry (ASK-03-002)."""
+    kinds = _first_available(
+        (
+            ("vultron.core.models.ask_kind", "AskKind"),
+            ("vultron.core.models.ask_kinds", "AskKind"),
+        )
+    )
+    assert kinds is not None, "No AskKind descriptor type is importable."
+    assert _field_names(kinds) & {"expiry_consequence", "on_expiry"}
+
+
+@pytest.mark.spec("ASK-03-003")
+def test_expiry_consequence_is_not_deployment_configurable() -> None:
+    """Expiry consequence MUST NOT be configurable or carried on the wire (ASK-03-003).
+
+    Two actors disagreeing about whether a late reply authorized an action is
+    divergence in canonical case state, not a deployment preference. This holds
+    today and must keep holding once #2884 adds the *duration* knob beside it —
+    the duration is configurable precisely because the consequence is not.
+    """
+    from vultron.config.actor import ActorConfig
+    from vultron.wire.as2.vocab.base.objects.base import as_Object
+
+    forbidden = ("expiry_consequence", "on_expiry", "late_reply_authorizes")
+    config_fields = _field_names(ActorConfig)
+    assert not config_fields & set(
+        forbidden
+    ), f"ActorConfig exposes an expiry-consequence key: {sorted(config_fields & set(forbidden))}"
+    wire_fields = _field_names(as_Object)
+    assert not wire_fields & set(
+        forbidden
+    ), f"An AS2 object field carries the expiry consequence: {sorted(wire_fields & set(forbidden))}"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-03-004: no ask is emitted at all yet, so no emitted ask carries a "
+        "deadline in end_time. The AS2 field already exists; the emit path does "
+        "not set it. Tracked by #2884."
+    ),
+)
+@pytest.mark.spec("ASK-03-004")
+def test_emitted_ask_carries_its_deadline_in_end_time() -> None:
+    """An ask MUST carry its deadline in the AS2 endTime field (ASK-03-004)."""
+    ask_factory = _first_available(
+        (
+            (
+                "vultron.wire.as2.factories.asks",
+                "offer_authorization_activity",
+            ),
+            ("vultron.wire.as2.factories.ask", "offer_authorization_activity"),
+        )
+    )
+    assert ask_factory is not None, "No ask factory is importable."
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-03-006: void expiry is not modelled and no gate consults a "
+        "deadline, so a late Accept would authorize its action. Tracked by "
+        "#2884."
+    ),
+)
+@pytest.mark.spec("ASK-03-006")
+def test_void_expiry_ask_refuses_a_late_reply() -> None:
+    """A void-expiry ask MUST NOT be authorized by a late reply (ASK-03-006)."""
+    kinds = _first_available(
+        (
+            ("vultron.core.models.ask_kind", "AskKind"),
+            ("vultron.core.models.ask_kinds", "AskKind"),
+        )
+    )
+    assert kinds is not None, "No AskKind descriptor type is importable."
+    assert _field_names(kinds) & {"expiry_consequence", "on_expiry"}
+
+
+# ---------------------------------------------------------------------------
+# ASK-05 — Expiry and Reaping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-05-004: there is no reaper, so there is nothing that could "
+        "re-emit on expiry and nothing to assert refrains from it. Tracked by "
+        "#2887."
+    ),
+)
+@pytest.mark.spec("ASK-05-004")
+def test_reaping_an_expired_ask_does_not_re_emit_it() -> None:
+    """Reaping MUST NOT automatically re-emit an expired ask (ASK-05-004).
+
+    Mirrors CLP-06-005: a timeout is a signal, not an instruction to retry. Only
+    the gated tree knows whether the action is still wanted.
+    """
+    reaper = _first_available(
+        (
+            (
+                "vultron.core.use_cases.triggers.reap_expired_asks",
+                "ReapExpiredAsksUseCase",
+            ),
+            (
+                "vultron.core.use_cases.triggers.svcreapasks",
+                "SvcReapExpiredAsksUseCase",
+            ),
+        )
+    )
+    assert (
+        reaper is not None
+    ), "No reap-expired-asks trigger use case is importable."
+
+
+# ---------------------------------------------------------------------------
+# ASK-06 — Ask Visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-06-001: no ask is emitted, so no ask is recorded as a canonical "
+        "entry or replicated to participants. Tracked by #2883."
+    ),
+)
+@pytest.mark.spec("ASK-06-001")
+def test_case_scoped_ask_is_recorded_as_a_canonical_entry() -> None:
+    """A case-scoped ask MUST be a recorded CaseLedgerEntry (ASK-06-001)."""
+    register = _ask_register()
+    assert (
+        register is not None
+    ), "No outstanding-ask register type is importable."
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-06-002: no ask factory exists, so there is no field set to check "
+        "for restricted-disclosure content. Tracked by #2883."
+    ),
+)
+@pytest.mark.spec("ASK-06-002")
+def test_ask_carries_no_restricted_disclosure_field() -> None:
+    """An ask MUST NOT carry undisclosable content (ASK-06-002).
+
+    Asks replicate to every participant (ASK-06-001), so private rationale has
+    to travel by a directed ``Note`` instead.
+    """
+    ask_factory = _first_available(
+        (
+            (
+                "vultron.wire.as2.factories.asks",
+                "offer_authorization_activity",
+            ),
+            ("vultron.wire.as2.factories.ask", "offer_authorization_activity"),
+        )
+    )
+    assert ask_factory is not None, "No ask factory is importable."
+
+
+# ---------------------------------------------------------------------------
+# ASK-07 — Processing Faults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-07-001: an unresolvable inbound activity is dead-lettered and a "
+        "protocol-invalid payload is rejected, and in neither case is the "
+        "sender notified (CONCERN-1880). Tracked by #2889."
+    ),
+)
+@pytest.mark.spec("ASK-07-001")
+def test_processing_fault_type_exists_for_sender_notification() -> None:
+    """An unprocessable activity MUST notify an authenticated sender (ASK-07-001)."""
+    assert _processing_fault() is not None, (
+        "No ProcessingFault type is importable, so no sender notification can "
+        "be emitted."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-07-002: no ProcessingFault type exists, so the "
+        "authenticated-senders-only guard has no subject. Asserting the "
+        "prohibition today would pass vacuously. Tracked by #2889."
+    ),
+)
+@pytest.mark.spec("ASK-07-002")
+def test_processing_fault_is_gated_on_sender_authentication() -> None:
+    """A fault MUST NOT be emitted to an unauthenticated sender (ASK-07-002).
+
+    Explaining a parse failure to a stranger is a parser oracle, and an
+    unauthenticated identity is not a trustworthy reply address.
+    """
+    assert (
+        _processing_fault() is not None
+    ), "No ProcessingFault type is importable."
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-07-003: no dedicated ProcessingFault object type is registered. "
+        "Tracked by #2889."
+    ),
+)
+@pytest.mark.spec("ASK-07-003")
+def test_processing_fault_is_a_dedicated_type_with_a_failure_class() -> None:
+    """ProcessingFault MUST be a dedicated type carrying a failure class (ASK-07-003).
+
+    SE-08-003 prefers a dedicated object type over field-level discrimination,
+    and ``Reject`` presupposes a rejectable object that unreadable traffic does
+    not provide.
+    """
+    fault = _processing_fault()
+    assert fault is not None, "No ProcessingFault type is importable."
+    assert _field_names(fault) & {"failure_class", "type_", "problem_type"}
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-07-004: no ProcessingFault type exists, so nothing yet identifies "
+        "the failed activity by reference. Tracked by #2889."
+    ),
+)
+@pytest.mark.spec("ASK-07-004")
+def test_processing_fault_references_the_failed_activity() -> None:
+    """ProcessingFault MUST identify the failed activity by reference (ASK-07-004).
+
+    A typed copy of a payload that failed validation cannot be constructed —
+    constructing it is what failed — and echoing sender content is a reflection
+    hazard.
+    """
+    fault = _processing_fault()
+    assert fault is not None, "No ProcessingFault type is importable."
+    names = _field_names(fault)
+    assert names & {"in_reply_to", "instance", "failed_activity_id"}
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-07-005: no ProcessingFault type exists, so no failure classes are "
+        "minted as Vultron-namespace URIs and no RFC 9457 members are carried. "
+        "Tracked by #2889."
+    ),
+)
+@pytest.mark.spec("ASK-07-005")
+def test_processing_fault_uses_rfc9457_with_namespaced_failure_classes() -> (
+    None
+):
+    """Failure classes MUST be Vultron-namespace URIs in RFC 9457 form (ASK-07-005)."""
+    fault = _processing_fault()
+    assert fault is not None, "No ProcessingFault type is importable."
+    names = _field_names(fault)
+    assert {
+        "title",
+        "detail",
+    } <= names, f"ProcessingFault lacks RFC 9457 members; got {sorted(names)}."
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-07-006: no ProcessingFault schema exists to check for diagnostic "
+        "fields. Asserting their absence today would pass vacuously. Tracked "
+        "by #2889."
+    ),
+)
+@pytest.mark.spec("ASK-07-006")
+def test_processing_fault_admits_no_implementation_diagnostics() -> None:
+    """ProcessingFault MUST NOT carry stack traces or parser internals (ASK-07-006).
+
+    Faults replicate to every case participant. Diagnosis belongs in the actor's
+    own log, governed by `specs/structured-logging.yaml`.
+    """
+    fault = _processing_fault()
+    assert fault is not None, "No ProcessingFault type is importable."
+    forbidden = {"traceback", "stack_trace", "exception", "code_path"}
+    assert not _field_names(fault) & forbidden
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-07-007: neither the fault type nor the ask register exists, so a "
+        "fault cannot close an outstanding ask. Tracked by #2889."
+    ),
+)
+@pytest.mark.spec("ASK-07-007")
+def test_processing_fault_closes_the_outstanding_ask_it_names() -> None:
+    """A fault naming an outstanding ask MUST close its register entry (ASK-07-007)."""
+    assert (
+        _processing_fault() is not None
+    ), "No ProcessingFault type is importable."
+    assert (
+        _ask_register() is not None
+    ), "No outstanding-ask register is importable."
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-07-008: no fault is emitted, so no case-attributable fault is "
+        "recorded as a canonical entry. Tracked by #2889."
+    ),
+)
+@pytest.mark.spec("ASK-07-008")
+def test_case_attributable_fault_is_recorded_in_the_ledger() -> None:
+    """A case-attributable fault MUST be a recorded CaseLedgerEntry (ASK-07-008).
+
+    "B could not process A's message" is a true, legible statement about a
+    message that arrived, and it explains a later retransmission.
+    """
+    assert (
+        _processing_fault() is not None
+    ), "No ProcessingFault type is importable."
+
+
+@pytest.mark.spec("ASK-07-009")
+def test_unprocessable_activity_is_not_committed_to_the_ledger() -> None:
+    """The activity that failed processing MUST NOT be recorded (ASK-07-009).
+
+    There is no legible assertion to snapshot, so a ledger entry could not
+    satisfy CLP-02-003. This holds today — the dead-letter path stores the
+    activity without committing a canonical entry — and must keep holding once
+    #2889 adds the *fault* entry beside it (ASK-07-008); it is the fault
+    statement that is recorded, never the unreadable message.
+    """
+    dead_letter = (
+        _VULTRON / "core" / "behaviors" / "inbox" / "dead_letter_tree.py"
+    )
+    assert dead_letter.is_file(), f"{dead_letter} not found"
+    source = dead_letter.read_text(encoding="utf-8")
+    assert "CommitCaseLedgerEntryNode" not in source, (
+        "The dead-letter tree commits a canonical ledger entry for an activity "
+        "that could not be processed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# ASK-08 — Lost-Reply Recovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-08-001: CP-05-006 previously specified a *new* Accept and no "
+        "re-send of the stored one is implemented, so a duplicate request "
+        "produces nothing. Tracked by #2890."
+    ),
+)
+@pytest.mark.spec("ASK-08-001")
+def test_duplicate_request_resends_the_stored_reply_unchanged() -> None:
+    """A duplicate request MUST re-send the stored reply unchanged (ASK-08-001).
+
+    Re-sending the frozen original (VM-08-003) reads as the first acceptance
+    arriving late; a new Accept is indistinguishable from a second, independent
+    decision, which CP-05-005's irrevocability rule precludes.
+    """
+    resend = _first_available(
+        (
+            (
+                "vultron.core.behaviors.case.nodes.proposal",
+                "ResendStoredAcceptNode",
+            ),
+            (
+                "vultron.core.behaviors.case.proposal_tree",
+                "ResendStoredAcceptNode",
+            ),
+        )
+    )
+    assert resend is not None, "No stored-reply re-send node is importable."
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "ASK-08-002: behaviour on a duplicate Create(CaseProposal) after "
+        "acceptance is undefined (CONCERN-2367); no guard prevents a second "
+        "object being created. Tracked by #2890."
+    ),
+)
+@pytest.mark.spec("ASK-08-002")
+def test_duplicate_request_creates_no_second_object() -> None:
+    """A duplicate request MUST NOT create a second object (ASK-08-002)."""
+    resend = _first_available(
+        (
+            (
+                "vultron.core.behaviors.case.nodes.proposal",
+                "ResendStoredAcceptNode",
+            ),
+            (
+                "vultron.core.behaviors.case.proposal_tree",
+                "ResendStoredAcceptNode",
+            ),
+        )
+    )
+    assert resend is not None, "No stored-reply re-send node is importable."
+
+
+# ---------------------------------------------------------------------------
+# CP-05-007 — Vendor-side proposal deadline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "CP-05-007: no party holds a timeout on Create(CaseProposal), so a "
+        "silently lost Accept stalls the handshake permanently "
+        "(CONCERN-2367). Tracked by #2890."
+    ),
+)
+@pytest.mark.spec("CP-05-007")
+def test_vendor_treats_an_unanswered_proposal_as_expired() -> None:
+    """A vendor MUST treat an unanswered proposal as expired at its deadline (CP-05-007).
+
+    The proposal is an ask, so it carries a deadline (ASK-03-004) and sits in the
+    vendor's actor-scoped register (ASK-04-001), which works before a case
+    exists.
+    """
+    assert _ask_register() is not None, (
+        "No outstanding-ask register is importable, so a vendor cannot hold a "
+        "proposal deadline before a case exists."
+    )
+
+
+# ---------------------------------------------------------------------------
+# OX-14-002 — Commit ordering is not changed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spec("OX-14-002")
+def test_ledger_commit_is_not_gated_on_delivery_confirmation() -> None:
+    """A canonical commit MUST NOT wait for delivery confirmation (OX-14-002).
+
+    CONCERN-2657 asked for the opposite. It is declined: gating the commit makes
+    an actor's own decision history hostage to the network, inverts
+    CLP-10-006's guards-then-commit-then-effects ordering, and raises an
+    unanswerable partial-delivery question. Delivery confirmation is a transport
+    receipt, not agreement to the delivered content. This test pins the ordering
+    so #2891 adds *correlation* without quietly adding a gate.
+    """
+    commit_module = (
+        _VULTRON / "core" / "behaviors" / "case" / "nodes" / "ledger.py"
+    )
+    if not commit_module.is_file():
+        matches = [
+            path
+            for path, source in _corpus.sources_mentioning(
+                "class CommitCaseLedgerEntryNode", under=_VULTRON
+            )
+        ]
+        assert matches, "CommitCaseLedgerEntryNode not found in vultron/"
+        commit_module = matches[0]
+    source = commit_module.read_text(encoding="utf-8")
+    forbidden = ("delivery_confirmed", "await_delivery", "delivery_receipt")
+    present = [token for token in forbidden if token in source]
+    assert not present, (
+        f"The canonical commit path references delivery confirmation: {present}. "
+        "OX-14-002 forbids deferring the commit until delivery is confirmed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# RSH-07 — Status gate composition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "RSH-07-004: both gates are single-tick Evaluator call-outs whose "
+        "conservative default is RequireCaseOwnerApprovalNode, an "
+        "unconditional-FAILURE node. Tracked by #2885."
+    ),
+)
+@pytest.mark.spec("RSH-07-004")
+def test_no_status_gate_default_is_an_unconditional_failure_node() -> None:
+    """Status gates MUST be routing subtrees, not deny-always Evaluators (RSH-07-004).
+
+    At the moment authorization is first needed no answer exists, so an
+    Evaluator asked "is this approved?" can only ever answer no. That is why the
+    ADR-0046/ADR-0076 model was unreachable by any pathway.
+    """
+    from vultron.core.behaviors.call_out.bundles.status_authorization import (
+        STATUS_AUTHORIZATION_DETERMINISTIC,
+    )
+    from vultron.core.behaviors.call_out.nodes import (
+        RequireCaseOwnerApprovalNode,
+    )
+
+    bundle = STATUS_AUTHORIZATION_DETERMINISTIC
+    nodes = [
+        bundle.status_adoption_gate_factory("StatusAdoptionGate"),
+        bundle.embargo_teardown_authorization_gate_factory(
+            "EmbargoTeardownAuthorizationGate"
+        ),
+    ]
+    offenders = [
+        type(node).__name__
+        for node in nodes
+        if isinstance(node, RequireCaseOwnerApprovalNode)
+    ]
+    assert (
+        not offenders
+    ), f"Gate defaults are unconditional-FAILURE nodes: {offenders}."
+
+
+@pytest.mark.spec("RSH-07-005")
+def test_production_status_authorization_default_is_conservative() -> None:
+    """A gate MUST NOT be relaxed to permissive to unblock a path (RSH-07-005).
+
+    ``STATUS_AUTHORIZATION_PERMISSIVE`` exists for trusted-participant and demo
+    deployments (RSH-07-003). Using it to route around a gate that is refusing
+    converts a protocol guarantee into a configuration posture — the defect
+    CONCERN-2092 filed. This asserts the *default* stays conservative, which is
+    what makes permissive an explicit opt-in rather than a fallback.
+    """
+    from vultron.core.behaviors.call_out.bundles.status_authorization import (
+        STATUS_AUTHORIZATION_DETERMINISTIC,
+        STATUS_AUTHORIZATION_PERMISSIVE,
+        StatusAuthorizationCallOutBundle,
+    )
+    from vultron.core.behaviors.call_out.nodes import AlwaysSucceed
+
+    default_bundle = StatusAuthorizationCallOutBundle()
+    for name in (
+        "status_adoption_gate_factory",
+        "embargo_teardown_authorization_gate_factory",
+    ):
+        node = getattr(default_bundle, name)(name)
+        assert not isinstance(node, AlwaysSucceed), (
+            f"{name} defaults to a permissive backend; the conservative default "
+            "must require explicit Case Owner authorization."
+        )
+        deterministic = getattr(STATUS_AUTHORIZATION_DETERMINISTIC, name)(name)
+        assert not isinstance(
+            deterministic, AlwaysSucceed
+        ), f"STATUS_AUTHORIZATION_DETERMINISTIC.{name} is permissive."
+        permissive = getattr(STATUS_AUTHORIZATION_PERMISSIVE, name)(name)
+        assert isinstance(permissive, AlwaysSucceed), (
+            f"STATUS_AUTHORIZATION_PERMISSIVE.{name} is not permissive; the "
+            "opt-in bundle must be the only permissive one."
+        )

--- a/test/architecture/test_spec_coverage_ratchet.py
+++ b/test/architecture/test_spec_coverage_ratchet.py
@@ -34,10 +34,16 @@ from vultron.metadata.specs.coverage import SPEC_MARKER_RE
 # on main without a @pytest.mark.spec marker (merged into this branch).
 # Lowered to 946 after xfail test with @pytest.mark.spec("CSB-15-004") was
 # added, reducing the uncovered count from 948 to 946 (Bug #2607).
+# Lowered to 937 — the actual uncovered count — when ADR-0080 added 28
+# kind=protocol requirements (ASK-01..ASK-08, CP-05-007, OX-14-002, RSH-07-004,
+# RSH-07-005) and covered all 28 in test_protocol_asks_specs.py, closing the
+# 9-ID slack that had accumulated between the count and the ceiling (#2880).
 # Lower this constant as more @pytest.mark.spec markers are added;
-# never raise it to hide regressions in your own PR.
+# never raise it to hide regressions in your own PR. Keep it pinned to the
+# actual count — slack between the two is room for uncovered specs to grow
+# unnoticed, which is the regression this ratchet exists to prevent.
 # ---------------------------------------------------------------------------
-MAX_UNCOVERED_PROTOCOL_SPECS = 946
+MAX_UNCOVERED_PROTOCOL_SPECS = 937
 
 _TEST_ROOT = _corpus.REPO_ROOT / "test"
 _SPEC_DIR = _corpus.REPO_ROOT / "specs"


### PR DESCRIPTION
- Closes #2829
- Closes #2812
- Closes #2809
- Closes #2657
- Closes #1880
- Closes #2367
- Closes #2796

## Summary

Records the async round-trip / delivery-confirmation primitive for planning group
**G01** (#2829). The design question the group was convened to answer — how to host
an asynchronous request/response inside a synchronous behaviour tree — dissolved
under investigation: **nothing needs to suspend.** An actor that lacks authority
emits a request and terminates successfully; the reply arrives later as an ordinary
message and starts new work.

Three findings shaped the outcome:

1. **The framework never could host suspension.** `BTBridge.execute_tree()` busy-loops
   on root `RUNNING` for 100 ticks, logs `ERROR`, returns `FAILURE`, then discards the
   tree in `finally: bt.shutdown()`. And `grep -r "return Status.RUNNING" vultron/`
   returns nothing — EDF-04-002 mandated `RUNNING` while awaiting input and had **zero
   implementations**. Any node that had complied would have busy-looped and failed.
2. **The mechanism is already in production, built by hand, once.**
   `create_recommend_actor_to_case_received_tree` (ADR-0026 / CM-16) records receipt
   then routes through disjoint branches — already a participant / invite in flight /
   owner asked and unanswered / fresh — reading state from the ledger via
   `find_protocol_pair`.
3. **The durable per-ask record is too.** `VultronOfferRecord` is DataLayer-backed,
   keyed off an Offer's ID, written by the adapter that calls the factory, and works
   **before a case exists**.

So the deliverable is generalising two working implementations, not inventing a
mechanism. `RequireCaseOwnerApprovalNode` is a deny-always stub because nobody
generalised the first instance — not because the design was unknown.

## Changes

- **`docs/adr/0080-protocol-asks-not-suspended-behaviors.md`** (new): ask-and-terminate;
  conversation-state routing; authority from the stored ask; per-ask-kind expiry
  (consequence spec-fixed, duration config-tunable); the two-directional
  outstanding-ask register that never authorises; opportunistic expiry plus a Sentinel
  reaping seam; `Create(ProcessingFault)`; lost-reply recovery.
- **`specs/protocol-asks.yaml`** (new, `ASK`): ASK-01 through ASK-08.
- **`specs/case-ledger-processing.yaml`**: CLP-11-001 narrowed to the *authorization*
  question so it no longer forecloses an actor-scoped working-set register — resolving
  its standing contradiction with DL-06-002. CLP-11-002 clarified: do not unify the
  registers, do share the lifecycle.
- **`specs/event-driven-control-flow.yaml`**: EDF-04-002 reversed (`RUNNING` is not the
  waiting mechanism); EDF-04-003 and EDF-04-005 amended to match. EDF-04-005 now names
  the observable that distinguishes "asked and waiting" from "gave up".
- **`specs/received-status-handling.yaml`**: RSH-07 rewritten; RSH-07-004 makes each gate
  a routing subtree; RSH-07-005 forbids relaxing a gate to unblock a path.
- **`specs/case-proposal.yaml`**: CP-05-006 raised SHOULD→MUST and corrected to re-send
  the *stored* acceptance rather than a new one (a new one is indistinguishable from a
  second decision, which CP-05-005's irrevocability rule precludes). CP-05-007 adds the
  vendor-side deadline.
- **`specs/outbox.yaml`**: OX-14 — undelivered-activity correlation.
- **`specs/triggerable-behaviors.yaml`**: TRIG-04-003 — a trigger response names the
  request it emitted.
- **`docs/adr/0076-…`**: capability-shape assignment corrected. An Evaluator asked "is
  this approved?" at the moment of asking can only answer *no*, which is exactly the
  stub's behaviour. The conservative-default requirement is unchanged.
- **`docs/adr/0049-…`**: deferral discharged. Its decision (no RE/EE/CE/GE/GI message
  family) **stands** — one fault object type is not that family, and it was designed on
  its own merits as that ADR required.
- **`docs/adr/0026-…`**: trust rule generalised from participant roles to every ask, plus
  the time dimension.
- **`docs/adr/0046-…`**: gates become routing subtrees; notes that the existing
  claim-recorded-before-adoption split already satisfies ASK-02-005.
- **`notes/protocol-asks.md`** (new): rationale, the two reference implementations to
  generalise, the rejected alternatives and why, and pitfalls.
- **`docs/topics/protocol_flow.md`** (new): Explanation page for #2796, written from
  this session's conclusions. Language-neutral, no class or node names.
- **`docs/topics/capability_model/index.md`**: distinguishes a call-out answerable
  within one tick from a decision that needs another actor.

## Notes on member disposition

**#2657 is reframed, not implemented as filed.** It asked for the ledger commit to be
gated on delivery confirmation. That is declined (OX-14-002): the ledger records what
an actor decided and observed at the time it happened, gating it would make an actor's
own history hostage to the network, it inverts CLP-10-006's guards→commit→effects
ordering, and it raises an unanswerable partial-delivery question. The real defect is
narrower and concrete — nothing links a dead-lettered activity to the entry claiming
its event happened, so replica divergence is silent (OX-14-001, OX-14-003).

**#2809 and #2812 are the same issue filed twice** (AC-3). #2809 is closed as a
duplicate of #2812; neither body's content is lost — both are covered by ADR-0080 and
its Tasks. #2809's premise (that a blocking stub exists) was stale when the umbrella
was written and is now **true**: #2675/#2807 landed it. AC-4's current-state finding is
recorded in ADR-0080's Context.

**#2369 stays open**, re-scoped. This session makes "stopped, waiting for permission"
observable (TRIG-04-003). Work that fails for *other* reasons still vanishes silently;
that needs a job/progress record and remains a design question, so #2369 continues as a
Concern rather than becoming a Task.

## Verification

- `spec-lint specs/` exits 0 — no hard errors; no new warnings on any added or amended ID
- `spec-coverage`: **937 uncovered protocol-kind specs — identical to `main`.** All 28
  `kind: protocol` requirements added here are covered by
  `test/architecture/test_protocol_asks_specs.py` (5 passing, 23 strict-xfail), and
  `MAX_UNCOVERED_PROTOCOL_SPECS` is lowered 946 → 937 to pin the ceiling to the actual
  count. See "Spec coverage" below.
- `pytest test/architecture/` passes; full unit suite passes
- `markdownlint-cli2` clean across all changed files
- All pre-commit hooks pass (notes frontmatter, ADR frontmatter, ADR index/nav sync,
  flake8, spec-lint)
- `black`, `flake8` and `mypy` clean on the added test module
- `mkdocs build` succeeds and the `docs-build-check` job is green. Note: `mkdocs build
  **--strict**` exits 1 with 101 warnings, but all 101 are pre-existing on `main` —
  `markdown_exec` blocks failing on a frozen-model assignment in
  `vultron/wire/as2/vocab/examples/_base.py`, unrelated to this PR and filed separately.
  CI's `docs-build-check` does not pass `--strict`. An earlier revision of this section
  claimed `--strict` was clean; that was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Implementation Issues

Sequenced primitive-first, each parented to its domain epic (never to the umbrella),
with `blockedBy` wired so the ordering is enforced rather than described:

```text
#2881  Consolidate the outbound emit path into a single shared seam        → #2693
├── #2883  Reusable outstanding-request register; generalise               → #2693
│          VultronOfferRecord
│   ├── #2884  Ask kinds: closing replies, expiry consequence, deadlines   → #2685
│   │   ├── #2885  Replace RequireCaseOwnerApprovalNode with a routing gate → #2685
│   │   ├── #2887  reap-expired-asks trigger (Sentinel seam)               → #2682
│   │   └── #2890  CaseProposal lost-acceptance recovery                   → #2687
│   ├── #2886  Outstanding-ask collections; name the ask in responses      → #2682
│   └── #2889  Create(ProcessingFault) sender notification                 → #2693
└── #2891  Correlate undelivered activities to their ledger entries        → #2693
```

`#2881` is first because nothing else can be made structural until there is one place
to make it structural — and it is the prerequisite for `#2891` as well.

### Which member Concern each issue discharges

The tree above parents each issue to its **domain epic**. This is the orthogonal view —
which of #2829's members each issue answers, so the umbrella's "lose nothing" guarantee
is auditable:

| Member Concern | Discharged by | Note |
|---|---|---|
| #2657 — ledger written before wire delivery | **#2881** (shared emit seam), **#2891** (undelivered→ledger correlation) | Reframed, not implemented as filed — OX-14-002 declines the commit gating; #2891 is the narrower real defect |
| #2812 — RequireCaseOwnerApproval has no implementation path | **#2885** | |
| #2809 — blocking stub; implement the round-trip | **#2885** | Closed as a duplicate of #2812 (AC-3); both bodies are covered by ADR-0080 |
| #1880 — no sender notification for unprocessable inbound | **#2889** | Discharges ADR-0049's deferral; that ADR's decision stands |
| #2367 — no recovery when `Accept(CaseProposal)` is lost | **#2890** | Both halves: answerer re-sends the stored Accept (CP-05-006), vendor holds a deadline (CP-05-007) |
| #2796 — Explanation page for protocol event flow | **this PR** — `docs/topics/protocol_flow.md` | No implementation issue needed |
| #2369 — trigger outcome observability | **#2886** (partial) | Stays **open**, re-scoped. #2886/TRIG-04-003 covers only behaviors that stop to ask; other silent failures still need a job/progress record |

**#2883**, **#2884** and **#2887** discharge no single member — they build the primitive
itself (register, ask kinds, reaping seam) that the others consume, which is why the
group was convened rather than the six issues being fixed locally.

## Spec coverage

`test/architecture/test_spec_coverage_ratchet.py` counts uncovered `kind: protocol`
specs and its ceiling comment says *never raise it*. The 28 protocol requirements added
here (24 `ASK-*`, plus `CP-05-007`, `OX-14-002`, `RSH-07-004`, `RSH-07-005`) would have
pushed the count from 937 to 965. This was invisible to CI: `python-app.yml`'s `paths:`
filter omits `specs/**`, so no specs-only PR runs the suite that owns the ratchet — the
breakage would have surfaced on the next unrelated PR touching `vultron/**`. Filed
separately.

`test/architecture/test_protocol_asks_specs.py` covers all 28:

- **5 passing** — requirements the codebase already satisfies, asserted structurally so
  they stay meaningful after the machinery lands: `ASK-02-004` (no gate reads the
  register), `ASK-03-003` (expiry consequence is neither configurable nor on the wire),
  `ASK-07-009` (the unreadable message is not committed), `OX-14-002` (the commit is not
  gated on delivery), `RSH-07-005` (the production default stays conservative).
- **23 strict-xfail** — each asserts an artifact its requirement names and carries the
  G01 issue in `reason=`. `strict=True` means the test flips to a build failure the
  moment the feature lands, forcing the placeholder to be replaced with a real
  behavioural assertion. That promotion is the mechanism, not a loophole.

The ceiling is lowered to **937**, pinned to the actual count rather than left with the
9 IDs of slack it had accumulated — slack is room for uncovered specs to grow unnoticed.

## Verification note on pyright

`pyright` cannot be run in this dev container: it exits **247 with no output at all**
on `origin/main` as well, consistent with the process being killed rather than
producing findings. CI will run it. `mypy` did run and is clean, including on the one
added test module. The three `flake8` findings in `scripts/` are pre-existing and
outside this diff.

The only Python in this PR is `test/architecture/` — `test_protocol_asks_specs.py`
(new) and the ratchet-ceiling constant. No `vultron/` source is touched, so runtime
behaviour is unchanged.

