### PR TITLE
refactor(ownership-transfer): move ForwardOffer outbox write into BT effect node

### DIFF
--- a/docs/adr/0053-ownership-transfer-routed-via-caseactor.md
+++ b/docs/adr/0053-ownership-transfer-routed-via-caseactor.md
@@ -102,9 +102,13 @@ Accepting actor triggers accept-case-ownership-transfer
   handshake (ADR-0026); developers can apply the same mental model.
 - Bad, because this is a breaking change to the wire routing for both
   activities; existing devlogs and test fixtures must be updated.
-- Bad, because `OfferCaseOwnershipTransferReceivedUseCase` must be
+- ~~Bad, because `OfferCaseOwnershipTransferReceivedUseCase` must be
   extended to forward the Offer to the transferee — currently it only
-  stores the offer object.
+  stores the offer object.~~ Resolved by #2067:
+  `ForwardOfferToTransfereeNode` (wrapped in `create_case_manager_gated_tree`)
+  is now an effect node in `create_offer_ownership_transfer_tree`, called
+  from `OfferCaseOwnershipTransferReceivedUseCase.execute()` via
+  `BTBridge(trigger_activity=...)` (CM-21-005, CLP-10-005).
 
 ## Validation
 
@@ -116,6 +120,8 @@ Accepting actor triggers accept-case-ownership-transfer
   receives an `Announce(CaseLedgerEntry)` for the transfer automatically.
 - Unit tests confirm `EmitOfferCaseOwnershipTransferNode` and
   `EmitAcceptCaseOwnershipTransferNode` address the CaseActor.
+- `ForwardOfferToTransfereeNode` and `create_offer_ownership_transfer_tree`
+  are covered by `test_offer_ownership_transfer_tree.py` (#2067).
 
 ## More Information
 

--- a/notes/ownership-transfer.md
+++ b/notes/ownership-transfer.md
@@ -121,13 +121,16 @@ CaseActor inbox receives Accept
 
 ### OfferCaseOwnershipTransferReceivedUseCase
 
-Extend to:
+Implemented by #2067. The use case now calls `create_offer_ownership_transfer_tree()`
+and passes `trigger_activity=self._trigger_activity` to `BTBridge`. All three
+steps run inside the BT:
 
-1. Store the Offer object (existing behaviour — keep it).
-2. Commit a `CaseLedgerEntry` recording the offer.
-3. Forward the Offer to the transferee's inbox.
+1. Store the Offer object via `create_receive_activity_tree`'s idempotency guard.
+2. Commit a `CaseLedgerEntry` via the guarded-commit node (CaseActor only).
+3. Forward the Offer to the transferee via `ForwardOfferToTransfereeNode`,
+   wrapped in `create_case_manager_gated_tree` (CaseActor only, CM-21-005).
 
-**Forwarded-Offer wire format** (CM-21-005, mirrors Invite-flow analogy):
+**Forwarded-Offer wire format** (CM-21-005):
 
 ```text
 Offer(VulnerabilityCase,
@@ -138,10 +141,9 @@ Offer(VulnerabilityCase,
 )
 ```
 
-`attributed_to` must be threaded through `TriggerActivityPort.offer_case_ownership_transfer`
-so the factory can stamp it on the wire object.
-
-Use the guarded-commit pattern: only runs when `receiving_actor_id == case_actor_id`.
+`attributed_to` is threaded through `TriggerActivityPort.offer_case_ownership_transfer`
+so the factory stamps it on the wire object. `ForwardOfferToTransfereeNode` logs
+WARNING and returns FAILURE when `trigger_activity_factory` is absent.
 
 ### AcceptCaseOwnershipTransferReceivedUseCase / ownership_transfer_tree.py
 

--- a/plan/incoming/learnings/20260831-2067-pr2882-code-review-deferred-findings.md
+++ b/plan/incoming/learnings/20260831-2067-pr2882-code-review-deferred-findings.md
@@ -1,0 +1,21 @@
+---
+title: "PR #2882 code-review findings — all pre-existing, out of scope"
+date: 2026-08-31
+source: ISSUE-2067
+---
+
+## Context
+
+Code review for PR #2882 (refactor(ownership-transfer): move ForwardOffer outbox write into BT effect node).
+All 6 findings were in files **outside** the PR diff (`git diff origin/main...HEAD` showed only 5 files, none matching any finding).
+
+## Filed as issues
+
+- **#2892** — `dimensions.py`: `_coerce_vf/_coerce_d` raise `KeyError` instead of `ValueError` on unknown names; causes 500-class error instead of clean 422 `ValidationError` (size:S Bug).
+- **#2893** — `trigger_validation.py` + `_adjudication.py`: VF↔D cross-dimension entailment not enforced; `d=D` is allowed when `vf≠VF`, producing invalid compound state (size:M Bug).
+
+## Remaining findings (not yet filed)
+
+1. **`status.py` ~line 232** — `_check_d_precondition` only enforces DEPLOYER role for `CS_d.D`, not for `CS_d.d`; direct node instantiation bypasses the BT-level `CheckDeployerRoleNode` guard.
+2. **`test/ci/invariants/conftest.py` ~line 94** — `_ACCEPTED_STATUS` and `_CLOSED_STATUS` fixtures have FINDER participant with `vfState="VF"` — semantically invalid per ADR-0075; could mask future invariant tests.
+3. **`test/architecture/test_validate_assignment_ratchet.py` ~line 23** — docstring code example has unbalanced parenthesis (`# accepted)` comment swallows the closing `)` of `object.__setattr__`); any reader copying into a REPL gets `SyntaxError`.

--- a/test/core/behaviors/case/nodes/test_offer_ownership_transfer_tree.py
+++ b/test/core/behaviors/case/nodes/test_offer_ownership_transfer_tree.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for ForwardOfferToTransfereeNode and create_offer_ownership_transfer_tree.
+
+Verifies CM-21-005 / ADR-0053: when the CaseActor receives an
+Offer(VulnerabilityCase) ownership-transfer activity it MUST build a new
+forwarded Offer via trigger_activity_factory and queue it in its own outbox.
+Non-CaseManager actors MUST skip the forwarding step cleanly (role gate).
+"""
+
+import pytest
+from py_trees.common import Status
+from unittest.mock import patch
+
+from vultron.core.behaviors.case.nodes.ownership_transfer import (
+    ForwardOfferToTransfereeNode,
+)
+from vultron.core.behaviors.case.ownership_transfer_tree import (
+    create_offer_ownership_transfer_tree,
+)
+from vultron.core.models.vultron_types import VultronCase, VultronParticipant
+from vultron.enums.roles import CVDRole
+from test.core.behaviors.bt_harness import BTTestScenario
+
+CASE_ID = "https://example.org/cases/case-fwd"
+CASE_ACTOR_ID = "https://example.org/actors/case-actor-fwd"
+VENDOR_ID = "https://example.org/actors/vendor-fwd"
+TRANSFEREE_ID = "https://example.org/actors/transferee-fwd"
+OFFER_ID = "https://example.org/activities/offer-fwd"
+
+
+def _seed_case(bt_scenario: BTTestScenario) -> None:
+    case_actor_participant = VultronParticipant(
+        id_="https://example.org/participants/case-actor-fwd-cp",
+        attributed_to=CASE_ACTOR_ID,
+        context=CASE_ID,
+        case_roles=[CVDRole.CASE_MANAGER, CVDRole.COORDINATOR],
+    )
+    case = VultronCase(
+        id_=CASE_ID,
+        name="ForwardOffer test case",
+        attributed_to=VENDOR_ID,
+        case_participants=[case_actor_participant.id_],
+        actor_participant_index={
+            CASE_ACTOR_ID: case_actor_participant.id_,
+        },
+    )
+    bt_scenario.seed(case_actor_participant, case)
+
+
+class _FakeOfferActivity:
+    activity_id = OFFER_ID
+
+    class activity:
+        @staticmethod
+        def model_dump(**_: object) -> dict:
+            return {
+                "id": OFFER_ID,
+                "type": "Offer",
+                "actor": VENDOR_ID,
+                "object": {"id": CASE_ID, "type": "VulnerabilityCase"},
+                "target": {"id": TRANSFEREE_ID, "type": "Service"},
+            }
+
+
+@pytest.mark.spec("CM-21-005")
+@pytest.mark.executes_as(CASE_ACTOR_ID)
+def test_forward_offer_to_transferee_queues_in_case_actor_outbox(
+    bt_scenario: BTTestScenario,
+) -> None:
+    """CaseActor's ForwardOfferToTransfereeNode enqueues a forwarded offer.
+
+    Verifies that when the CaseActor executes the offer-ownership-transfer BT
+    with trigger_activity wired up, the factory is called and the forwarded
+    offer ID lands in the CaseActor's outbox (CM-21-005).
+    """
+    _seed_case(bt_scenario)
+    tree = create_offer_ownership_transfer_tree(
+        case_id=CASE_ID,
+        transferee_id=TRANSFEREE_ID,
+        original_actor_id=VENDOR_ID,
+    )
+
+    result = bt_scenario.run(
+        tree, actor_id=CASE_ACTOR_ID, activity=_FakeOfferActivity()
+    )
+
+    assert result.status == Status.SUCCESS
+    # The real TriggerActivityAdapter creates the activity; check outbox non-empty.
+    outbox = bt_scenario.dl.outbox_list()
+    assert (
+        len(outbox) == 1
+    ), f"Expected exactly 1 forwarded offer in CaseActor outbox; got {outbox}"
+
+
+@pytest.mark.spec("CM-21-005")
+def test_non_case_manager_skips_forward(bt_scenario_factory) -> None:
+    """Non-CaseManager actor skips ForwardOfferToTransfereeNode (role gate).
+
+    The create_case_manager_gated_tree wrapper returns SUCCESS for actors
+    without CASE_MANAGER — no factory call, no outbox write.
+    """
+    bt_scenario: BTTestScenario = bt_scenario_factory(VENDOR_ID)
+    _seed_case(bt_scenario)
+    tree = create_offer_ownership_transfer_tree(
+        case_id=CASE_ID,
+        transferee_id=TRANSFEREE_ID,
+        original_actor_id=VENDOR_ID,
+    )
+
+    with patch.object(
+        ForwardOfferToTransfereeNode, "update", autospec=True
+    ) as mock_update:
+        result = bt_scenario.run(
+            tree, actor_id=VENDOR_ID, activity=_FakeOfferActivity()
+        )
+
+    assert result.status == Status.SUCCESS
+    mock_update.assert_not_called()
+
+
+@pytest.mark.spec("CM-21-005")
+@pytest.mark.executes_as(CASE_ACTOR_ID)
+def test_forward_offer_warns_when_no_factory(
+    bt_scenario: BTTestScenario, caplog
+) -> None:
+    """ForwardOfferToTransfereeNode warns and returns FAILURE when factory absent.
+
+    When BTBridge is not given a trigger_activity port, the node must emit a
+    WARNING containing 'no trigger_activity' and leave the outbox untouched.
+    """
+    _seed_case(bt_scenario)
+
+    node = ForwardOfferToTransfereeNode(
+        case_id=CASE_ID,
+        transferee_id=TRANSFEREE_ID,
+        original_actor_id=VENDOR_ID,
+    )
+    # Inject datalayer and actor_id manually; leave trigger_activity_factory None.
+    node.datalayer = bt_scenario.dl
+    node.actor_id = CASE_ACTOR_ID
+    node.trigger_activity_factory = None
+
+    with caplog.at_level("WARNING"):
+        status = node.update()
+
+    assert status == Status.FAILURE
+    assert any("no trigger_activity" in r.message for r in caplog.records)
+    assert bt_scenario.dl.outbox_list() == []
+
+
+@pytest.mark.spec("CM-21-005")
+def test_tree_factory_omits_forward_node_when_transferee_id_is_none() -> None:
+    """No ForwardOfferToTransfereeNode is added when transferee_id is None.
+
+    The ledger-commit gate must still fire, but no forwarding occurs.
+    """
+    tree = create_offer_ownership_transfer_tree(
+        case_id=CASE_ID,
+        transferee_id=None,
+        original_actor_id=VENDOR_ID,
+    )
+
+    # Walk the tree: ForwardOfferToTransfereeNode must not appear anywhere.
+    def _collect(node):
+        nodes = [node]
+        for child in getattr(node, "children", []):
+            nodes.extend(_collect(child))
+        return nodes
+
+    all_nodes = _collect(tree)
+    fwd_nodes = [
+        n for n in all_nodes if isinstance(n, ForwardOfferToTransfereeNode)
+    ]
+    assert (
+        len(fwd_nodes) == 0
+    ), "ForwardOfferToTransfereeNode must not appear when transferee_id is None"
+
+
+@pytest.mark.spec("CM-21-005")
+def test_tree_factory_omits_forward_node_when_original_actor_id_is_none() -> (
+    None
+):
+    """No ForwardOfferToTransfereeNode is added when original_actor_id is None."""
+    tree = create_offer_ownership_transfer_tree(
+        case_id=CASE_ID,
+        transferee_id=TRANSFEREE_ID,
+        original_actor_id=None,
+    )
+
+    def _collect(node):
+        nodes = [node]
+        for child in getattr(node, "children", []):
+            nodes.extend(_collect(child))
+        return nodes
+
+    all_nodes = _collect(tree)
+    fwd_nodes = [
+        n for n in all_nodes if isinstance(n, ForwardOfferToTransfereeNode)
+    ]
+    assert (
+        len(fwd_nodes) == 0
+    ), "ForwardOfferToTransfereeNode must not appear when original_actor_id is None"

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -119,6 +119,7 @@ from vultron.core.behaviors.case.nodes.suggest_actor import (
 from vultron.core.behaviors.case.nodes.ownership_transfer import (
     EmitAcceptCaseOwnershipTransferNode,
     EmitOfferCaseOwnershipTransferNode,
+    ForwardOfferToTransfereeNode,
 )
 from vultron.core.behaviors.case.nodes.role_gates import (
     create_case_manager_gated_tree,
@@ -195,6 +196,7 @@ __all__ = [
     # ownership_transfer (leaf nodes)
     "EmitOfferCaseOwnershipTransferNode",
     "EmitAcceptCaseOwnershipTransferNode",
+    "ForwardOfferToTransfereeNode",
     # role_gates (gated composites)
     "create_case_manager_gated_tree",
     # vfd_role_guards (condition nodes)

--- a/vultron/core/behaviors/case/nodes/ownership_transfer.py
+++ b/vultron/core/behaviors/case/nodes/ownership_transfer.py
@@ -27,6 +27,9 @@ Provides:
 - :class:`AcceptCaseOwnershipTransferNode` — applies the accepted
   ownership transfer to the DataLayer: updates ``case.attributed_to``
   and grants ``CVDRole.CASE_OWNER`` to the new owner's participant record.
+- :class:`ForwardOfferToTransfereeNode` — CaseActor-only effect node that
+  builds a new ``Offer(VulnerabilityCase)`` addressed to the transferee and
+  queues it in the CaseActor's outbox (CM-21-005, ADR-0053).
 
 These leaf nodes are assembled into trigger/receive trees in the parent
 ``actor_trigger_trees.py`` and ``ownership_transfer_tree.py`` modules per
@@ -34,7 +37,7 @@ BTND-07-003.
 """
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from py_trees.common import Status
 
@@ -45,6 +48,7 @@ from vultron.core.behaviors.helpers import (
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models._helpers import _as_id
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 from vultron.enums.roles import CVDRole
 
@@ -142,6 +146,78 @@ class EmitAcceptCaseOwnershipTransferNode(_EmitSingleActivityBase):
             "Actor '%s' accepted case ownership transfer offer '%s'",
             self.actor_id,
             self.offer_id,
+        )
+
+
+class ForwardOfferToTransfereeNode(_EmitSingleActivityBase):
+    """CaseActor effect node: build and enqueue a forwarded ownership-transfer Offer.
+
+    Implements CM-21-005 / ADR-0053: after the CaseActor records the ledger
+    entry for an incoming ``Offer(VulnerabilityCase)``, it MUST forward a new
+    ``Offer(VulnerabilityCase, actor=case_actor, attributed_to=original_offerer,
+    to=[transferee])`` to the transferee's inbox via the CaseActor's own outbox.
+
+    Must be wrapped in ``create_case_manager_gated_tree`` so that non-CaseManager
+    actors skip this node cleanly (they should never forward the offer).
+
+    Logs WARNING and returns FAILURE when ``trigger_activity_factory`` is absent
+    from the blackboard — this leaves all outboxes untouched.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        transferee_id: str,
+        original_actor_id: str,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(captured=captured, name=name)
+        self.case_id = case_id
+        self.transferee_id = transferee_id
+        self.original_actor_id = original_actor_id
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "%s: no trigger_activity port — cannot forward offer"
+                " to transferee (CM-21-005)",
+                self.name,
+            )
+            return Status.FAILURE
+        try:
+            activity_id, activity_blob = self._call_factory()
+            cast(CaseOutboxPersistence, self.datalayer).outbox_append(
+                activity_id
+            )
+        except Exception as e:
+            self.feedback_message = f"ForwardOfferToTransfereeNode failed: {e}"
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
+        self._on_success(activity_id, activity_blob)
+        return Status.SUCCESS
+
+    def _call_factory(self) -> tuple[str, str]:
+        assert self.trigger_activity_factory is not None
+        assert self.actor_id is not None
+        return self.trigger_activity_factory.offer_case_ownership_transfer(
+            case_id=self.case_id,
+            transferee_id=self.transferee_id,
+            actor=self.actor_id,
+            to=[self.transferee_id],
+            attributed_to=self.original_actor_id,
+        )
+
+    def _on_success(self, activity_id: str, activity_blob: str) -> None:
+        self.logger.info(
+            "%s: CaseActor '%s' forwarded ownership-transfer offer '%s'"
+            " to transferee '%s' (CM-21-005)",
+            self.name,
+            self.actor_id,
+            activity_id,
+            self.transferee_id,
         )
 
 

--- a/vultron/core/behaviors/case/ownership_transfer_tree.py
+++ b/vultron/core/behaviors/case/ownership_transfer_tree.py
@@ -13,10 +13,16 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Tree factory for Accept(OfferCaseOwnershipTransfer) received activities.
+"""Tree factories for ownership-transfer received activities.
 
-Wraps ``AcceptCaseOwnershipTransferNode`` in the standard guarded-commit
-pattern for use with ``BTBridge.execute_with_setup()``.
+Provides:
+
+- :func:`create_accept_ownership_transfer_tree` — BT for
+  ``AcceptCaseOwnershipTransferReceivedUseCase``.
+- :func:`create_offer_ownership_transfer_tree` — BT for
+  ``OfferCaseOwnershipTransferReceivedUseCase``; wraps
+  ``ForwardOfferToTransfereeNode`` in a ``create_case_manager_gated_tree``
+  so only the CaseActor forwards the offer (CM-21-005, ADR-0053).
 """
 
 import logging
@@ -28,6 +34,10 @@ from vultron.core.behaviors.case.nodes.lifecycle import (
 )
 from vultron.core.behaviors.case.nodes.ownership_transfer import (
     AcceptCaseOwnershipTransferNode,
+    ForwardOfferToTransfereeNode,
+)
+from vultron.core.behaviors.case.nodes.role_gates import (
+    create_case_manager_gated_tree,
 )
 
 logger = logging.getLogger(__name__)
@@ -65,5 +75,60 @@ def create_accept_ownership_transfer_tree(
         "Created AcceptOwnershipTransferBT for case='%s' new_owner='%s'",
         case_id,
         new_owner_id,
+    )
+    return tree
+
+
+def create_offer_ownership_transfer_tree(
+    case_id: str,
+    transferee_id: str | None,
+    original_actor_id: str | None,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for ``OfferCaseOwnershipTransferReceivedUseCase``.
+
+    Builds a ``create_receive_activity_tree`` whose effect section contains a
+    ``create_case_manager_gated_tree`` wrapping ``ForwardOfferToTransfereeNode``
+    so that only the CaseActor forwards the offer to the transferee (CM-21-005,
+    ADR-0053, CLP-10-006).
+
+    When ``transferee_id`` or ``original_actor_id`` is ``None`` the forwarding
+    node is omitted: the ledger-commit gate still fires but no outbox write
+    occurs.
+
+    Args:
+        case_id: URI of the case whose ownership is being offered.
+        transferee_id: URI of the intended new owner; ``None`` skips forwarding.
+        original_actor_id: URI of the actor who originated the offer (vendor).
+
+    Returns:
+        A ``py_trees`` ``Behaviour`` ready for ``BTBridge.execute_with_setup()``.
+    """
+    effect_nodes: list[py_trees.behaviour.Behaviour] = []
+    if transferee_id is not None and original_actor_id is not None:
+        effect_nodes = [
+            create_case_manager_gated_tree(
+                name="ForwardOfferToTransfereeCMGated",
+                case_id=case_id,
+                children=[
+                    ForwardOfferToTransfereeNode(
+                        case_id=case_id,
+                        transferee_id=transferee_id,
+                        original_actor_id=original_actor_id,
+                    ),
+                ],
+            ),
+        ]
+    tree = create_receive_activity_tree(
+        name="OfferOwnershipTransferBT",
+        case_id=case_id,
+        precondition_guards=[],
+        effect_nodes=effect_nodes,
+    )
+    logger.debug(
+        "Created OfferOwnershipTransferBT for case='%s'"
+        " transferee='%s' original_actor='%s'",
+        case_id,
+        transferee_id,
+        original_actor_id,
     )
     return tree

--- a/vultron/core/use_cases/received/actor/ownership.py
+++ b/vultron/core/use_cases/received/actor/ownership.py
@@ -6,14 +6,11 @@ from typing import TYPE_CHECKING
 from py_trees.common import Status
 
 from vultron.core.behaviors.bridge import BTBridge
-from vultron.core.behaviors.case.nodes.lifecycle import (
-    create_receive_activity_tree,
-)
 from vultron.core.behaviors.case.ownership_transfer_tree import (
     create_accept_ownership_transfer_tree,
+    create_offer_ownership_transfer_tree,
 )
 from vultron.core.models._helpers import _as_id
-from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.events.actor import (
     AcceptCaseOwnershipTransferReceivedEvent,
     OfferCaseOwnershipTransferReceivedEvent,
@@ -23,8 +20,6 @@ from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.use_cases._helpers import (
     _idempotent_create,
-    _resolve_case_manager_id,
-    add_activity_to_outbox,
     resolve_receiving_actor_id,
 )
 
@@ -72,16 +67,16 @@ class OfferCaseOwnershipTransferReceivedUseCase:
             return
 
         transferee_id = _as_id(request.activity.target)
+        original_actor_id = request.actor_id
 
-        # Guarded-commit: CommitCaseLedgerEntryNode fires only when
-        # receiving_actor_id is the CaseActor (CheckIsCaseManagerNode gate).
-        tree = create_receive_activity_tree(
-            name="OfferOwnershipTransferBT",
+        tree = create_offer_ownership_transfer_tree(
             case_id=case_id,
-            precondition_guards=[],
-            effect_nodes=[],
+            transferee_id=transferee_id,
+            original_actor_id=original_actor_id,
         )
-        bridge = BTBridge(datalayer=self._dl)
+        bridge = BTBridge(
+            datalayer=self._dl, trigger_activity=self._trigger_activity
+        )
         result = bridge.execute_with_setup(
             tree=tree,
             actor_id=receiving_actor_id,
@@ -95,47 +90,6 @@ class OfferCaseOwnershipTransferReceivedUseCase:
                 case_id,
                 BTBridge.get_failure_reason(tree),
             )
-            return
-
-        # Forward the Offer to the transferee — CaseActor only (CM-21-005).
-        # Only runs when BT succeeded (ledger entry committed).
-        # CaseActor builds a NEW Offer: actor=case_actor_id,
-        # attributed_to=original_offerer, to=[transferee_id].
-        # Queued in CaseActor's own outbox so the registered outbox monitor
-        # delivers it to the transferee's inbox.
-        if self._trigger_activity is None:
-            logger.warning(
-                "OfferCaseOwnershipTransferReceived: no trigger_activity"
-                " port — cannot forward offer to transferee (CM-21-005)"
-            )
-            return
-        case = self._dl.read(case_id)
-        if isinstance(case, VulnerabilityCase):
-            case_actor_id = _resolve_case_manager_id(case, self._dl)
-            original_actor_id = request.actor_id
-            if (
-                case_actor_id is not None
-                and case_actor_id == receiving_actor_id
-                and transferee_id
-                and original_actor_id is not None
-            ):
-                forwarded_id, _ = (
-                    self._trigger_activity.offer_case_ownership_transfer(
-                        case_id=case_id,
-                        transferee_id=transferee_id,
-                        actor=case_actor_id,
-                        to=[transferee_id],
-                        attributed_to=original_actor_id,
-                    )
-                )
-                add_activity_to_outbox(case_actor_id, forwarded_id, self._dl)
-                logger.info(
-                    "OfferCaseOwnershipTransferReceived: forwarded"
-                    " offer '%s' (as '%s') to transferee '%s' (CM-21-005)",
-                    forwarded_id,
-                    case_actor_id,
-                    transferee_id,
-                )
 
 
 class AcceptCaseOwnershipTransferReceivedUseCase:


### PR DESCRIPTION
- Closes #2067
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Eliminates the procedural `add_activity_to_outbox` call in `OfferCaseOwnershipTransferReceivedUseCase.execute()` that violated ADR-0022/CLP-10-005, moving the CaseActor's forwarding responsibility into a proper BT effect node (`ForwardOfferToTransfereeNode`) wrapped by `create_case_manager_gated_tree`.

## Changes

- **`vultron/core/behaviors/case/nodes/ownership_transfer.py`**: Adds `ForwardOfferToTransfereeNode` extending `_EmitSingleActivityBase`. Overrides `update()` to log WARNING with "no trigger_activity" and return FAILURE when `trigger_activity_factory` is absent from the blackboard. `_call_factory()` calls `offer_case_ownership_transfer()` with `actor=self.actor_id`, `to=[transferee_id]`, `attributed_to=original_actor_id` (CM-21-005, ADR-0053).
- **`vultron/core/behaviors/case/ownership_transfer_tree.py`**: Adds `create_offer_ownership_transfer_tree(case_id, transferee_id, original_actor_id)` factory. Wraps `ForwardOfferToTransfereeNode` in `create_case_manager_gated_tree` and passes it as `effect_nodes` to `create_receive_activity_tree`. Omits the forwarding node when `transferee_id` or `original_actor_id` is `None` so the ledger-commit gate still fires.
- **`vultron/core/use_cases/received/actor/ownership.py`**: Refactors `execute()` to use `create_offer_ownership_transfer_tree` and pass `trigger_activity=self._trigger_activity` to `BTBridge`. Removes all procedural forwarding code, `_resolve_case_manager_id`, `add_activity_to_outbox`, and `VulnerabilityCase` imports from this file.
- **`vultron/core/behaviors/case/nodes/__init__.py`**: Exports `ForwardOfferToTransfereeNode`.
- **`test/core/behaviors/case/nodes/test_offer_ownership_transfer_tree.py`**: 5 new tests — CaseActor forward queues in outbox, non-CM role gate skips node, absent factory warning, and two tree-factory None-argument guards.

## Verification

- 15 tests pass for ownership-transfer paths (10 pre-existing + 5 new)
- 7882 unit tests pass, integration suite passes
- Black, flake8, mypy, pyright clean