### PR TITLE
feat(cs-invariants): wire ephemeral-state and history-prefix guards into CS receive path

### DIFF
--- a/docs/adr/0060-re-express-legacy-cs-invariants.md
+++ b/docs/adr/0060-re-express-legacy-cs-invariants.md
@@ -177,8 +177,12 @@ analytical model, which is genuinely useful and genuinely non-normative.
   making the legacy module useful precisely as long as it is still present.
 - Neutral: two implementations of the same rules coexist. Acceptable because one
   is explicitly non-normative and the tests pin them together.
-- Neutral: `cs_invariants.py` is a library, not an enforcement point. Wiring it
-  into emit/BT paths is #2236's job; nothing calls it on the protocol path yet.
+- Neutral: `cs_invariants.py` is a library, not an enforcement point. The
+  ephemeral-state (`required_next_cs_events`) and history-prefix
+  (`is_valid_cs_history_prefix`) guards were wired into the CS receive path as
+  precondition guards `CheckCsEphemeralStateNode` and `CheckCsHistoryPrefixNode`
+  in `add_case_status_tree` (issue #2524). Broader emit/BT enforcement
+  (RM/EM × CS cross-machine rules) remains #2236's job.
 - Bad: the retirement of `case_states/` is now a recorded intention with two
   named prerequisites rather than a completed act, so it can still rot if those
   prerequisites are not tracked.

--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -178,14 +178,15 @@ Some ECA rules are not just "do A when B" but "do A *before* B." These use
   ThreatTerminationBranchNode).
 - **Ephemeral states: pX→PX invariant** (CSB-13-001, CSB-17-003, CSB-17-012):
   when the CS PXA state is pXa or pXA (exploit public without public awareness),
-  the next CS event MUST be P. This is normatively specified but **not yet
-  enforced in BT paths** — `cs_invariants.required_next_cs_events()` is not
-  wired into any receive path. See #2524.
+  the next CS event MUST be P. Enforced in `add_case_status_tree` via
+  `CheckCsEphemeralStateNode` (precondition guard, returns FAILURE if asserted
+  PXA does not advance P from a pX state). See #2524, PR #2888.
 - **CS history validity** (CSB-17-004, CSB-17-005): complete CS histories must
   be one of 70 valid histories; incomplete histories must be valid prefixes.
-  Normatively specified but **not yet enforced** — `cs_invariants.is_valid_cs_history()`
-  and `is_valid_cs_history_prefix()` are not wired into any receive path. See
-  #2524.
+  Enforced in `add_case_status_tree` via `CheckCsHistoryPrefixNode` (precondition
+  guard, rejects single-event PXA transitions that produce an invalid prefix).
+  Multi-event advances and PXA regressions are deferred to
+  `FilterCsPxaDimensionNode` (RSH-05). See #2524, PR #2888.
 - **Ledger commit ordering** (from `specs/case-ledger-processing.yaml`
   CLP-10-006): precondition checks → ledger commit → protocol effects.
   Observable from audit replay.

--- a/plan/incoming/learnings/20260831-cs-guard-vfd-baseline-decision.md
+++ b/plan/incoming/learnings/20260831-cs-guard-vfd-baseline-decision.md
@@ -1,0 +1,27 @@
+---
+title: "VFD-complete baseline required when constructing compound CS state in pX/vP guards"
+type: learning
+timestamp: "2026-08-31T00:00:00Z"
+source: ISSUE-2524
+signal: design-question
+---
+
+When wiring `required_next_cs_events()` into the ephemeral-state guard
+(`CheckCsEphemeralStateNode`), the compound CS state must be constructed with a
+VFD-complete baseline (`cs_from_dimensions(CS_vfd.VFD, pxa)`), not the vfd
+baseline (`CS_vfd.vfd`).
+
+With `vfd` as the VFD part, the compound state for PXA=pxa is `CS.vfdpxa`.
+`required_next_cs_events(vfdpxa)` returns `{CSEvent.V}` (vP constraint), causing
+false positives that block every CaseStatus when V has not been observed locally.
+`CaseStatus` carries only PXA data — VFD completion is not knowable from it.
+
+With `VFD` as the VFD part, `required_next_cs_events` only returns `{CSEvent.P}`
+for pX states (`pXa`, `pXA`), which is exactly what `CaseStatus` can validate.
+
+The same reasoning applies to `is_valid_cs_history_prefix`: using `CS.VFDpxa` as
+the start state means the prefix check only validates PXA-axis ordering (P≺X),
+not the full VFD×PXA ordering.
+
+**Implementation**: `cs_from_dimensions(CS_vfd.VFD, current_pxa)` in both guard
+nodes in `vultron/core/behaviors/status/nodes/cs_invariant_guards.py`.

--- a/plan/incoming/learnings/20260831-cs-history-guard-pxa-regression-skip.md
+++ b/plan/incoming/learnings/20260831-cs-history-guard-pxa-regression-skip.md
@@ -1,0 +1,26 @@
+---
+title: "History-prefix guard must skip PXA regressions to avoid false FAILURE"
+type: learning
+timestamp: "2026-08-31T00:00:00Z"
+source: ISSUE-2524
+signal: design-question
+---
+
+`CheckCsHistoryPrefixNode` calls `cs_transition_event(current_cs, asserted_cs)`
+to find the single event between states. For a PXA regression (e.g., current=Pxa,
+asserted=pxa), `cs_transition_event` still returns an event — but in the backward
+direction (e.g., `CSEvent.P` for `Pxa→pxa`). `is_valid_cs_history_prefix([P],
+start=VFDPxa)` then fails because P is not valid from a state where P is already
+true.
+
+Without the pre-check, valid EM-advance + PXA-regression payloads (e.g.,
+`test_valid_em_advance_with_pxa_regression_applies_em_and_refuses_pxa`) caused
+false FAILURE from the history-prefix guard before reaching
+`FilterCsPxaDimensionNode`.
+
+**Fix**: early return `Status.SUCCESS` from `CheckCsHistoryPrefixNode.update()`
+when `is_monotonic_pxa_forward(current_pxa, asserted_pxa)` is False. PXA
+regressions are a monotone-filter concern, not a history-prefix concern.
+
+**Location**: `vultron/core/behaviors/status/nodes/cs_invariant_guards.py`,
+`CheckCsHistoryPrefixNode.update()`.

--- a/test/architecture/test_receive_side_bt_commit_ordering.py
+++ b/test/architecture/test_receive_side_bt_commit_ordering.py
@@ -101,6 +101,8 @@ def test_no_direct_calls_to_guarded_commit_outside_lifecycle() -> None:
 REJECTION_VALIDATORS = {
     "ValidateRMTransitionNode",
     "CheckCaseStatusIdempotencyNode",
+    "CheckCsEphemeralStateNode",
+    "CheckCsHistoryPrefixNode",
     "FinalizeCsFilterNode",
 }
 

--- a/test/core/behaviors/status/nodes/test_cs_invariant_guards.py
+++ b/test/core/behaviors/status/nodes/test_cs_invariant_guards.py
@@ -132,8 +132,13 @@ class TestCheckCsEphemeralStateNode:
         assert _run(bridge, node) == Status.SUCCESS
 
     def test_first_ever_status_succeeds(self, dl, bridge):
-        """No current status (first ever) → SUCCESS; no constraint applies."""
-        # Bare case with no materialized CaseStatus objects
+        """No current status (first ever) → SUCCESS; no constraint applies.
+
+        VulnerabilityCase without attributed_to does not trigger
+        _init_case_statuses auto-seeding, so case_statuses is empty and
+        current_status raises ValueError → guard returns SUCCESS.
+        """
+        # attributed_to intentionally absent to suppress auto-seeding
         bare_case = VulnerabilityCase(id_=CASE_ID, context=ACTOR_ID)
         dl.create(bare_case)
         asserted = as_CaseStatus(
@@ -264,9 +269,13 @@ class TestCheckCsHistoryPrefixNode:
         assert _run(bridge, node) == Status.SUCCESS
 
     def test_first_ever_status_succeeds(self, dl, bridge):
-        """No current status (first ever) → SUCCESS."""
-        from vultron.core.models.case import VulnerabilityCase
+        """No current status (first ever) → SUCCESS.
 
+        VulnerabilityCase without attributed_to does not trigger
+        _init_case_statuses auto-seeding, so current_status raises ValueError
+        → guard returns SUCCESS.
+        """
+        # attributed_to intentionally absent to suppress auto-seeding
         bare_case = VulnerabilityCase(id_=CASE_ID, context=ACTOR_ID)
         dl.create(bare_case)
         asserted = as_CaseStatus(

--- a/test/core/behaviors/status/nodes/test_cs_invariant_guards.py
+++ b/test/core/behaviors/status/nodes/test_cs_invariant_guards.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for CS invariant precondition guards.
+
+Covers issue #2524 AC-1, AC-2, AC-3:
+  (a) A-event rejected from pX state      — CheckCsEphemeralStateNode
+  (b) P-event accepted from pX state      — CheckCsEphemeralStateNode
+  (c) History-prefix rejection on invalid sequence — CheckCsHistoryPrefixNode
+  (d) Valid partial history accepted       — CheckCsHistoryPrefixNode
+
+Per CSB-17-012 (ephemeral pX→P) and CSB-17-005 (history prefix).
+"""
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.status.nodes.cs_invariant_guards import (
+    CheckCsEphemeralStateNode,
+    CheckCsHistoryPrefixNode,
+)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.states.cs import CS_pxa
+from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
+
+ACTOR_ID = "https://example.org/actors/vendor"
+CASE_ID = "https://example.org/cases/inv-guards-01"
+STATUS_ID = "https://example.org/cases/inv-guards-01/statuses/asserted"
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+@pytest.fixture
+def dl():
+    return SqliteDataLayer("sqlite:///:memory:", actor_id=ACTOR_ID)
+
+
+@pytest.fixture
+def bridge(dl):
+    return BTBridge(datalayer=dl)
+
+
+def _make_case_with_pxa(pxa_state: CS_pxa) -> VulnerabilityCase:
+    """Return a core VulnerabilityCase whose current PXA state is *pxa_state*."""
+    case = VulnerabilityCase(
+        id_=CASE_ID, name="Invariant Guard Test", attributed_to=ACTOR_ID
+    )
+    if pxa_state != CS_pxa.pxa:
+        case.append_case_status(pxa_state=pxa_state)
+    return case
+
+
+def _run(bridge: BTBridge, node: py_trees.behaviour.Behaviour) -> Status:
+    result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+    return result.status
+
+
+# ---------------------------------------------------------------------------
+# CheckCsEphemeralStateNode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCsEphemeralStateNode:
+    """AC-1: ephemeral pX state requires P next (CSB-17-012)."""
+
+    @pytest.mark.spec("CSB-17-012")
+    def test_a_event_rejected_from_pX_state(self, dl, bridge):
+        """AC-3a: A-event from pXa → FAILURE (pX is ephemeral, P required)."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.pXA
+        )
+        dl.create(asserted)
+
+        node = CheckCsEphemeralStateNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.FAILURE
+
+    @pytest.mark.spec("CSB-17-012")
+    def test_p_event_accepted_from_pX_state(self, dl, bridge):
+        """AC-3b: P-event from pXa → SUCCESS (satisfies ephemeral requirement)."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.PXa
+        )
+        dl.create(asserted)
+
+        node = CheckCsEphemeralStateNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_p_and_a_together_from_pX_state(self, dl, bridge):
+        """P+A together from pXa → SUCCESS (P advances regardless of A)."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.PXA
+        )
+        dl.create(asserted)
+
+        node = CheckCsEphemeralStateNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_non_ephemeral_state_passes(self, dl, bridge):
+        """Non-pX current state → SUCCESS (no ephemeral constraint)."""
+        case = _make_case_with_pxa(CS_pxa.Pxa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.PXa
+        )
+        dl.create(asserted)
+
+        node = CheckCsEphemeralStateNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_first_ever_status_succeeds(self, dl, bridge):
+        """No current status (first ever) → SUCCESS; no constraint applies."""
+        # Bare case with no materialized CaseStatus objects
+        bare_case = VulnerabilityCase(id_=CASE_ID, context=ACTOR_ID)
+        dl.create(bare_case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.pXA
+        )
+        dl.create(asserted)
+
+        node = CheckCsEphemeralStateNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_case_not_found_succeeds(self, bridge):
+        """Case not in DataLayer → SUCCESS (cannot evaluate constraint)."""
+        node = CheckCsEphemeralStateNode(
+            case_id="https://example.org/cases/nonexistent",
+            status_id=STATUS_ID,
+        )
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_unresolvable_asserted_defers(self, dl, bridge):
+        """Status not in DL and no fallback → SUCCESS (deferred to FilterCsEm)."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        # Do NOT create the asserted status in DL
+
+        node = CheckCsEphemeralStateNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_fallback_used_when_not_in_dl(self, dl, bridge):
+        """Core CaseStatus fallback used when status not in DL; ephemeral check runs."""
+        from vultron.core.models.case_status import CaseStatus
+        from vultron.core.models.dimensions import PxaDimension
+
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        # Core CaseStatus (not wire as_CaseStatus) is recognised by _resolve_asserted.
+        fallback = CaseStatus(
+            id_=STATUS_ID,
+            context=CASE_ID,
+            pxa=PxaDimension(state=CS_pxa.pXA),
+        )
+        # Do NOT put fallback in DL; pass as status_obj_fallback.
+
+        node = CheckCsEphemeralStateNode(
+            case_id=CASE_ID,
+            status_id=STATUS_ID,
+            status_obj_fallback=fallback,
+        )
+        # pXA asserted from pXa (A-event, P not advancing) → FAILURE
+        assert _run(bridge, node) == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# CheckCsHistoryPrefixNode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCsHistoryPrefixNode:
+    """AC-2: proposed CS transition must yield a valid history prefix (CSB-17-005)."""
+
+    @pytest.mark.spec("CSB-17-005")
+    def test_invalid_prefix_rejected(self, dl, bridge):
+        """AC-3c: A-event from pXa → FAILURE (pX→A violates CSB-17-005)."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.pXA
+        )
+        dl.create(asserted)
+
+        node = CheckCsHistoryPrefixNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.FAILURE
+
+    @pytest.mark.spec("CSB-17-005")
+    def test_valid_partial_history_accepted(self, dl, bridge):
+        """AC-3d: P-event from pXa → SUCCESS (pX→P is a valid prefix step)."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.PXa
+        )
+        dl.create(asserted)
+
+        node = CheckCsHistoryPrefixNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_x_event_from_pxa_accepted(self, dl, bridge):
+        """X-event from baseline pxa → SUCCESS (pX state is valid prefix)."""
+        case = _make_case_with_pxa(CS_pxa.pxa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.pXa
+        )
+        dl.create(asserted)
+
+        node = CheckCsHistoryPrefixNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_no_pxa_change_passes(self, dl, bridge):
+        """Identical PXA state → SUCCESS (no event to validate)."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.pXa
+        )
+        dl.create(asserted)
+
+        node = CheckCsHistoryPrefixNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_multi_event_skip_deferred(self, dl, bridge):
+        """Multi-event advance (pxa→PXA) → SUCCESS (deferred to monotone filter)."""
+        case = _make_case_with_pxa(CS_pxa.pxa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.PXA
+        )
+        dl.create(asserted)
+
+        node = CheckCsHistoryPrefixNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_case_not_found_succeeds(self, bridge):
+        """Case not in DataLayer → SUCCESS."""
+        node = CheckCsHistoryPrefixNode(
+            case_id="https://example.org/cases/nonexistent",
+            status_id=STATUS_ID,
+        )
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_first_ever_status_succeeds(self, dl, bridge):
+        """No current status (first ever) → SUCCESS."""
+        from vultron.core.models.case import VulnerabilityCase
+
+        bare_case = VulnerabilityCase(id_=CASE_ID, context=ACTOR_ID)
+        dl.create(bare_case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.pXA
+        )
+        dl.create(asserted)
+
+        node = CheckCsHistoryPrefixNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS
+
+    def test_unresolvable_asserted_defers(self, dl, bridge):
+        """Status not in DL and no fallback → SUCCESS (deferred to FilterCsEm)."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+
+        node = CheckCsHistoryPrefixNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.SUCCESS

--- a/test/core/behaviors/status/test_add_case_status_bt.py
+++ b/test/core/behaviors/status/test_add_case_status_bt.py
@@ -536,6 +536,47 @@ class TestAddCaseStatusTree:
         status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
         assert STATUS_ID not in status_ids
 
+    @pytest.mark.spec("CSB-17-012")
+    def test_px_ephemeral_a_event_rejected_no_ledger_write(
+        self, dl, make_payload
+    ):
+        """Full tree rejects A-event from pX state; no ledger write (CSB-17-012, ISSUE-2524).
+
+        When the current PXA state is pXa (exploit public, public unaware),
+        the CheckCsEphemeralStateNode guard must return FAILURE for any asserted
+        CaseStatus that does not advance P.  The full tree must return FAILURE
+        and no CaseStatus entry should be appended to the case.
+        """
+        case = VulnerabilityCase(
+            id_=CASE_ID, name="Ephemeral pX Guard", attributed_to=ACTOR_ID
+        )
+        # Auto-seeded baseline is pxa; advance to pXa (X exploit published,
+        # P still false — the ephemeral state that requires P next).
+        case.append_case_status(pxa_state=CS_pxa.pXa)
+        dl.create(case)
+
+        # Asserted status fires A-event only (pXa → pXA); P is NOT advanced.
+        asserted = as_CaseStatus(
+            id_=STATUS_ID,
+            context=CASE_ID,
+            pxa_state=CS_pxa.pXA,
+        )
+        dl.create(asserted)
+
+        activity = add_status_to_case_activity(
+            asserted, target=case.id_, actor=ACTOR_ID
+        )
+        event = make_payload(activity)
+
+        tree = add_case_status_tree(request=event)
+        bridge = BTBridge(datalayer=dl)
+        result = bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
+        status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
+        assert STATUS_ID not in status_ids
+
     @pytest.mark.spec("RSH-05-015")
     @pytest.mark.spec("RSH-05-016")
     def test_valid_em_advance_with_pxa_regression_applies_em_and_refuses_pxa(

--- a/vultron/core/behaviors/case/nodes/vfd_role_guards.py
+++ b/vultron/core/behaviors/case/nodes/vfd_role_guards.py
@@ -18,14 +18,14 @@
 Nodes enforce CVD protocol correctness for received-side status authorization
 (RSH-01-002):
 
+- :class:`CheckVendorRoleNode` — gates vf→VF (vf_state=Vf): actor MUST hold
+  ``CVDRole.VENDOR`` (CSB-15-001)
+- :class:`CheckDeployerRoleNode` — gates d→D (vfd_state=VFD): actor MUST hold
+  ``CVDRole.DEPLOYER`` (CSB-15-002; causal-gate enforcement pending #2593)
 - :class:`CheckNotSoleObserverVfdNode` — gates v→V (vf_state=Vf): actor
   MUST NOT hold ``CVDRole.OBSERVER`` as their only role (CM-25-005)
 - :class:`CheckIsCaseOwnerNode` — hard bypass in ``StatusAdoptionGate``:
   sender MUST hold ``CVDRole.CASE_OWNER`` (RSH-01-002)
-
-Note: :class:`CheckVendorRoleNode` and :class:`CheckDeployerRoleNode` were
-removed in #2664; their role is now enforced structurally through the
-VF/D dimension split (ADR-0075).
 """
 
 import logging

--- a/vultron/core/behaviors/status/add_case_status_tree.py
+++ b/vultron/core/behaviors/status/add_case_status_tree.py
@@ -24,6 +24,8 @@ signals a threat (P=True OR X=True OR A=True).
 
     AddCaseStatusToCaseBT (Sequence)
     ├─ CheckCaseStatusIdempotencyNode              # precondition guard (CLP-10-009)
+    ├─ CheckCsEphemeralStateNode                   # pX ephemeral guard (CSB-17-012, ISSUE-2524)
+    ├─ CheckCsHistoryPrefixNode                    # history prefix guard (CSB-17-005, ISSUE-2524)
     ├─ FilterCsEmDimensionNode                     # per-dim EM adjudication (RSH-05, ISSUE-2256)
     ├─ FilterCsPxaDimensionNode                    # per-dim PXA adjudication (RSH-05, ISSUE-2256)
     ├─ FinalizeCsFilterNode                        # whole-refusal gate; FAILURE if nothing new
@@ -35,6 +37,8 @@ signals a threat (P=True OR X=True OR A=True).
 
 Per issue #758 (BT-SM Integration: AddCaseStatusToCaseReceivedUseCase),
 RSH-02-001 to RSH-03-003, ADR-0046, CLP-10-006, CLP-10-009.
+Per issue #2524 (CS invariants: ephemeral-state and history guards), CSB-17-012,
+CSB-17-005.
 """
 
 import logging
@@ -58,6 +62,10 @@ from vultron.core.behaviors.status.nodes.cs_dimension_filter import (
     FilterCsPxaDimensionNode,
     FinalizeCsFilterNode,
 )
+from vultron.core.behaviors.status.nodes.cs_invariant_guards import (
+    CheckCsEphemeralStateNode,
+    CheckCsHistoryPrefixNode,
+)
 from vultron.core.behaviors.status.nodes.threat_termination import (
     ThreatTerminationBranchNode,
 )
@@ -72,20 +80,24 @@ def add_case_status_tree(
     """Create the behavior tree for the AddCaseStatusToCase workflow.
 
     Handles receipt of an ``Add(CaseStatus, VulnerabilityCase)`` activity.
-    Implements seven nodes in a Sequence:
+    Implements nine nodes in a Sequence:
 
     1. Idempotency check — fail fast if the status is already present.
-    2. Per-dimension EM adjudication — accept valid advances, carry forward
+    2. Ephemeral-state guard — rejects CaseStatus that violates the pX→P
+       constraint (CSB-17-012, ISSUE-2524).
+    3. History-prefix guard — rejects single-step PXA transitions that would
+       produce an invalid CS history prefix (CSB-17-005, ISSUE-2524).
+    4. Per-dimension EM adjudication — accept valid advances, carry forward
        refused EM; always returns SUCCESS (RSH-05, ISSUE-2256).
-    3. Per-dimension PXA adjudication — accepts monotone-forward PXA moves,
+    5. Per-dimension PXA adjudication — accepts monotone-forward PXA moves,
        carries forward refused PXA; always returns SUCCESS (RSH-05, ISSUE-2256).
-    4. Whole-refusal gate — returns FAILURE if no dimension carries new state;
+    6. Whole-refusal gate — returns FAILURE if no dimension carries new state;
        returns SUCCESS otherwise, publishing the filtered CaseStatus.
-    5. Append and persist — write the filtered CaseStatus to the case record.
-    6. ``EmbargoTeardownAuthorizationGate`` (Selector) — call-out gate (RSH-02-001).
+    7. Append and persist — write the filtered CaseStatus to the case record.
+    8. ``EmbargoTeardownAuthorizationGate`` (Selector) — call-out gate (RSH-02-001).
        Default is ``AlwaysSucceed``; production adapters may inject a gate
        that blocks side-effects for certain actors or scenarios.
-    7. ``ThreatTerminationBranchNode`` — fires embargo teardown when the
+    9. ``ThreatTerminationBranchNode`` — fires embargo teardown when the
        CaseStatus has at least one of P=True, X=True, or A=True and the case
        has an active embargo (RSH-03-001 to RSH-03-003).
 
@@ -109,6 +121,16 @@ def add_case_status_tree(
             CheckCaseStatusIdempotencyNode(
                 case_id=case_id,
                 status_id=status_id,
+            ),
+            CheckCsEphemeralStateNode(
+                case_id=case_id,
+                status_id=status_id,
+                status_obj_fallback=status_obj,
+            ),
+            CheckCsHistoryPrefixNode(
+                case_id=case_id,
+                status_id=status_id,
+                status_obj_fallback=status_obj,
             ),
             FilterCsEmDimensionNode(
                 case_id=case_id,

--- a/vultron/core/behaviors/status/nodes/__init__.py
+++ b/vultron/core/behaviors/status/nodes/__init__.py
@@ -40,6 +40,9 @@ Submodules:
 - ``case_status``: Idempotency guard and append nodes for the
   AddCaseStatusToCase workflow, plus EmitCaseStatusUpdateNode for direct
   ledger writes after EM/PXA mutations (RSH-04-002, RSH-04-003)
+- ``cs_invariant_guards``: CS ordering invariant precondition guards
+  (CheckCsEphemeralStateNode, CheckCsHistoryPrefixNode; CSB-17-012,
+  CSB-17-005, ISSUE-2524)
 """
 
 from vultron.core.behaviors.status.nodes.case_status import (
@@ -53,6 +56,10 @@ from vultron.core.behaviors.status.nodes.cs_dimension_filter import (
     FilterCsEmDimensionNode,
     FilterCsPxaDimensionNode,
     FinalizeCsFilterNode,
+)
+from vultron.core.behaviors.status.nodes.cs_invariant_guards import (
+    CheckCsEphemeralStateNode,
+    CheckCsHistoryPrefixNode,
 )
 from vultron.core.behaviors.status.nodes.conditions import (
     AllParticipantsRMClosedConditionNode,
@@ -116,4 +123,7 @@ __all__ = [
     "FinalizeCsFilterNode",
     "AppendCaseStatusToCaseNode",
     "EmitCaseStatusUpdateNode",
+    # cs_invariant_guards
+    "CheckCsEphemeralStateNode",
+    "CheckCsHistoryPrefixNode",
 ]

--- a/vultron/core/behaviors/status/nodes/cs_dimension_filter.py
+++ b/vultron/core/behaviors/status/nodes/cs_dimension_filter.py
@@ -70,7 +70,37 @@ _BB_CS_FILTER_ACC = "cs_dim_filter_accumulator"
 _BB_CS_FILTER_ACC_WRITE = "cs_dim_filter_accumulator_write"
 
 
-class FilterCsEmDimensionNode(DataLayerConditionWithPorts):
+class _CsStatusGuardBase(DataLayerConditionWithPorts):
+    """Shared init and _resolve_asserted for CS status guard nodes.
+
+    Subclasses accept ``(case_id, status_id, status_obj_fallback, name)`` and
+    can resolve the asserted :class:`~vultron.core.models.case_status.CaseStatus`
+    from the DataLayer, falling back to ``status_obj_fallback`` when not found.
+    Private; not part of the public API.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        status_id: str,
+        status_obj_fallback: PersistableModel | None = None,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.status_id = status_id
+        self.status_obj_fallback = status_obj_fallback
+
+    def _resolve_asserted(self) -> CaseStatus | None:
+        assert self.datalayer is not None
+        obj = self.datalayer.read(self.status_id)
+        if isinstance(obj, CaseStatus):
+            return obj
+        obj = self.status_obj_fallback
+        return obj if isinstance(obj, CaseStatus) else None
+
+
+class FilterCsEmDimensionNode(_CsStatusGuardBase):
     """Adjudicates the EM dimension of a received CaseStatus (RSH-05, ISSUE-2256).
 
     Read-only precondition guard (CLP-10-006).  Initialises the per-tick
@@ -91,18 +121,6 @@ class FilterCsEmDimensionNode(DataLayerConditionWithPorts):
     Must run before ``FilterCsPxaDimensionNode`` and ``FinalizeCsFilterNode``
     in the precondition_guards sequence.
     """
-
-    def __init__(
-        self,
-        case_id: str,
-        status_id: str,
-        status_obj_fallback: PersistableModel | None = None,
-        name: str | None = None,
-    ):
-        super().__init__(name=name or self.__class__.__name__)
-        self.case_id = case_id
-        self.status_id = status_id
-        self.status_obj_fallback = status_obj_fallback
 
     @classmethod
     def output_ports(cls) -> dict[str, PortInformation]:
@@ -130,14 +148,6 @@ class FilterCsEmDimensionNode(DataLayerConditionWithPorts):
         self._set_output(_BB_CS_FILTER_ACC, None)
         self._set_output(BB_CASE_STATUS_DIM_FILTER, None)
         self._set_output(BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE, None)
-
-    def _resolve_asserted(self) -> CaseStatus | None:
-        assert self.datalayer is not None
-        obj = self.datalayer.read(self.status_id)
-        if isinstance(obj, CaseStatus):
-            return obj
-        obj = self.status_obj_fallback
-        return obj if isinstance(obj, CaseStatus) else None
 
     def update(self) -> Status:
         self._clear()  # BT-17-003

--- a/vultron/core/behaviors/status/nodes/cs_invariant_guards.py
+++ b/vultron/core/behaviors/status/nodes/cs_invariant_guards.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""CS invariant precondition guards for the AddCaseStatusToCase receive path.
+
+Two hard-reject guards enforcing the normatively-specified CS ordering
+invariants (CSB-17-012, CSB-17-005):
+
+1. :class:`CheckCsEphemeralStateNode` — pX ephemeral guard (CSB-17-012): when
+   the current PXA state is pX (exploit public, public unaware), the incoming
+   CaseStatus MUST advance P.  Returns FAILURE otherwise.
+
+2. :class:`CheckCsHistoryPrefixNode` — history prefix guard (CSB-17-005):
+   derives the single CS event implied by a current-to-asserted PXA state
+   change and verifies it produces a valid CS history prefix.  Multi-event
+   advances (remote peers that skip states) are deferred to
+   :class:`FilterCsPxaDimensionNode` (RSH-05).  Returns FAILURE when the
+   derived event would create an invalid prefix.
+
+Both nodes are placed before :class:`FilterCsEmDimensionNode` in
+``precondition_guards`` and return FAILURE to abort the Sequence before any
+ledger write (CLP-10-009).
+"""
+
+import logging
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerConditionWithPorts
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_status import CaseStatus
+from vultron.core.models.protocols import PersistableModel
+from vultron.core.states.cs import (
+    CS_vfd,
+    is_monotonic_pxa_forward,
+    is_pxa_public_aware,
+)
+from vultron.core.states.cs_invariants import (
+    CSEvent,
+    cs_from_dimensions,
+    cs_transition_event,
+    is_valid_cs_history_prefix,
+    required_next_cs_events,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CheckCsEphemeralStateNode(DataLayerConditionWithPorts):
+    """Guard: from a pX state the next CS event MUST be P (CSB-17-012).
+
+    When the current compound CS state is pX (exploit public, public
+    unaware), ``required_next_cs_events`` returns ``frozenset({CSEvent.P})``.
+    This node returns FAILURE if the asserted PXA state does not advance P —
+    aborting the Sequence before any ledger write (CLP-10-009).
+
+    The VFD dimension is not present in :class:`~vultron.core.models.case_status.CaseStatus`.
+    A ``CS_vfd.VFD``-complete baseline is used when constructing the compound
+    state, which suppresses false vP positives (vendor-unaware + public-aware)
+    while preserving the pX check that depends only on PXA.
+
+    Returns SUCCESS when:
+
+    - The case is not found in the DataLayer.
+    - No materialized :class:`CaseStatus` exists yet (first-ever status).
+    - The asserted status is unresolvable (deferred to
+      :class:`FilterCsEmDimensionNode`, which will abort with FAILURE).
+    - The current state is not ephemeral.
+    - The asserted state satisfies the required-next-event constraint.
+
+    Returns FAILURE when the current state is pX and the asserted PXA does
+    not have P=True.
+
+    Must run before :class:`FilterCsEmDimensionNode` in ``precondition_guards``.
+    Per issue #2524 AC-1, CSB-17-012.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        status_id: str,
+        status_obj_fallback: PersistableModel | None = None,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.status_id = status_id
+        self.status_obj_fallback = status_obj_fallback
+
+    def _resolve_asserted(self) -> CaseStatus | None:
+        assert self.datalayer is not None
+        obj = self.datalayer.read(self.status_id)
+        if isinstance(obj, CaseStatus):
+            return obj
+        obj = self.status_obj_fallback
+        return obj if isinstance(obj, CaseStatus) else None
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self.case_id)
+        if not isinstance(case, VulnerabilityCase):
+            return Status.SUCCESS
+
+        try:
+            current = case.current_status
+        except ValueError:
+            return (
+                Status.SUCCESS
+            )  # first CaseStatus ever — no ephemeral constraint
+
+        asserted = self._resolve_asserted()
+        if asserted is None:
+            # Unresolvable assertion: FilterCsEmDimensionNode will abort.
+            return Status.SUCCESS
+
+        current_pxa = current.pxa.state
+        # VFD-complete baseline avoids false vP positives; only pX is detectable
+        # from PXA-only data (CSB-17-012).
+        current_cs = cs_from_dimensions(CS_vfd.VFD, current_pxa)
+        required = required_next_cs_events(current_cs)
+        if not required:
+            return Status.SUCCESS  # not ephemeral
+
+        # With VFD-complete baseline, only pX produces required == {CSEvent.P}.
+        asserted_pxa = asserted.pxa.state
+        if CSEvent.P in required and not is_pxa_public_aware(asserted_pxa):
+            self.feedback_message = (
+                f"Ephemeral CS state {current_cs.name!r} requires P next"
+                f" (CSB-17-012); asserted PXA {asserted_pxa.name!r}"
+                " does not advance P"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        return Status.SUCCESS
+
+
+class CheckCsHistoryPrefixNode(DataLayerConditionWithPorts):
+    """Guard: proposed single-event PXA transition must yield a valid CS history prefix (CSB-17-005).
+
+    Derives the single CS event implied by the current-to-asserted PXA state
+    change via :func:`~vultron.core.states.cs_invariants.cs_transition_event`
+    and checks whether applying it from the current state produces a valid CS
+    history prefix via
+    :func:`~vultron.core.states.cs_invariants.is_valid_cs_history_prefix`.
+
+    Multi-event advances (``cs_transition_event`` returns ``None``) are
+    returned as SUCCESS: remote peers may skip states, and the monotone filter
+    (:class:`FilterCsPxaDimensionNode`) handles partial-accept for those
+    (RSH-05, CSB-16-002).
+
+    The VFD dimension is not present in CaseStatus; a ``CS_vfd.VFD``-complete
+    baseline is used to avoid vP false positives (same rationale as
+    :class:`CheckCsEphemeralStateNode`).
+
+    Returns FAILURE when the single proposed event would produce an invalid CS
+    history prefix (e.g. A from pXa violates CSB-17-012).
+    Returns SUCCESS in all other cases (no change, multi-event, or valid step).
+
+    Must run before :class:`FilterCsEmDimensionNode` in ``precondition_guards``.
+    Per issue #2524 AC-2, CSB-17-005.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        status_id: str,
+        status_obj_fallback: PersistableModel | None = None,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.status_id = status_id
+        self.status_obj_fallback = status_obj_fallback
+
+    def _resolve_asserted(self) -> CaseStatus | None:
+        assert self.datalayer is not None
+        obj = self.datalayer.read(self.status_id)
+        if isinstance(obj, CaseStatus):
+            return obj
+        obj = self.status_obj_fallback
+        return obj if isinstance(obj, CaseStatus) else None
+
+    def update(self) -> Status:
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
+
+        case = self.datalayer.read(self.case_id)
+        if not isinstance(case, VulnerabilityCase):
+            return Status.SUCCESS
+
+        try:
+            current = case.current_status
+        except ValueError:
+            return Status.SUCCESS  # first CaseStatus ever
+
+        asserted = self._resolve_asserted()
+        if asserted is None:
+            return Status.SUCCESS
+
+        current_pxa = current.pxa.state
+        asserted_pxa = asserted.pxa.state
+        if current_pxa == asserted_pxa:
+            return Status.SUCCESS  # no PXA change; nothing to validate
+
+        if not is_monotonic_pxa_forward(current_pxa, asserted_pxa):
+            # PXA regression: deferred to FilterCsPxaDimensionNode (RSH-05).
+            return Status.SUCCESS
+
+        # VFD-complete baseline: only PXA bits can change between these two states.
+        current_cs = cs_from_dimensions(CS_vfd.VFD, current_pxa)
+        asserted_cs = cs_from_dimensions(CS_vfd.VFD, asserted_pxa)
+
+        event = cs_transition_event(current_cs, asserted_cs)
+        if event is None:
+            # Multi-event skip: deferred to FilterCsPxaDimensionNode (RSH-05).
+            return Status.SUCCESS
+
+        if not is_valid_cs_history_prefix([event], start=current_cs):
+            self.feedback_message = (
+                f"CS history prefix violation: event {event!r} from"
+                f" {current_cs.name!r} produces an invalid prefix"
+                f" (CSB-17-005)"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        return Status.SUCCESS

--- a/vultron/core/behaviors/status/nodes/cs_invariant_guards.py
+++ b/vultron/core/behaviors/status/nodes/cs_invariant_guards.py
@@ -38,10 +38,10 @@ import logging
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerConditionWithPorts
+from vultron.core.behaviors.status.nodes.cs_dimension_filter import (
+    _CsStatusGuardBase,
+)
 from vultron.core.models.case import VulnerabilityCase
-from vultron.core.models.case_status import CaseStatus
-from vultron.core.models.protocols import PersistableModel
 from vultron.core.states.cs import (
     CS_vfd,
     is_monotonic_pxa_forward,
@@ -58,7 +58,7 @@ from vultron.core.states.cs_invariants import (
 logger = logging.getLogger(__name__)
 
 
-class CheckCsEphemeralStateNode(DataLayerConditionWithPorts):
+class CheckCsEphemeralStateNode(_CsStatusGuardBase):
     """Guard: from a pX state the next CS event MUST be P (CSB-17-012).
 
     When the current compound CS state is pX (exploit public, public
@@ -86,26 +86,6 @@ class CheckCsEphemeralStateNode(DataLayerConditionWithPorts):
     Must run before :class:`FilterCsEmDimensionNode` in ``precondition_guards``.
     Per issue #2524 AC-1, CSB-17-012.
     """
-
-    def __init__(
-        self,
-        case_id: str,
-        status_id: str,
-        status_obj_fallback: PersistableModel | None = None,
-        name: str | None = None,
-    ):
-        super().__init__(name=name or self.__class__.__name__)
-        self.case_id = case_id
-        self.status_id = status_id
-        self.status_obj_fallback = status_obj_fallback
-
-    def _resolve_asserted(self) -> CaseStatus | None:
-        assert self.datalayer is not None
-        obj = self.datalayer.read(self.status_id)
-        if isinstance(obj, CaseStatus):
-            return obj
-        obj = self.status_obj_fallback
-        return obj if isinstance(obj, CaseStatus) else None
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:
@@ -150,7 +130,7 @@ class CheckCsEphemeralStateNode(DataLayerConditionWithPorts):
         return Status.SUCCESS
 
 
-class CheckCsHistoryPrefixNode(DataLayerConditionWithPorts):
+class CheckCsHistoryPrefixNode(_CsStatusGuardBase):
     """Guard: proposed single-event PXA transition must yield a valid CS history prefix (CSB-17-005).
 
     Derives the single CS event implied by the current-to-asserted PXA state
@@ -175,26 +155,6 @@ class CheckCsHistoryPrefixNode(DataLayerConditionWithPorts):
     Must run before :class:`FilterCsEmDimensionNode` in ``precondition_guards``.
     Per issue #2524 AC-2, CSB-17-005.
     """
-
-    def __init__(
-        self,
-        case_id: str,
-        status_id: str,
-        status_obj_fallback: PersistableModel | None = None,
-        name: str | None = None,
-    ):
-        super().__init__(name=name or self.__class__.__name__)
-        self.case_id = case_id
-        self.status_id = status_id
-        self.status_obj_fallback = status_obj_fallback
-
-    def _resolve_asserted(self) -> CaseStatus | None:
-        assert self.datalayer is not None
-        obj = self.datalayer.read(self.status_id)
-        if isinstance(obj, CaseStatus):
-            return obj
-        obj = self.status_obj_fallback
-        return obj if isinstance(obj, CaseStatus) else None
 
     def update(self) -> Status:
         if (f := self._require_datalayer()) is not None:


### PR DESCRIPTION
- Closes #2524
- Closes #2894
- Closes #2895

## Summary

Wires two CS ordering invariants from `cs_invariants.py` into the
`AddCaseStatusToCaseBT` receive path as hard-reject precondition guards
(issue #2524, CSB-17-012, CSB-17-005).

- **`CheckCsEphemeralStateNode`** (AC-1): if the current PXA state is pX
  (exploit public, public unaware), `required_next_cs_events` returns
  `{CSEvent.P}`; the guard returns FAILURE if the asserted CaseStatus does
  not advance P.

- **`CheckCsHistoryPrefixNode`** (AC-2): derives the single CS event implied
  by the current-to-asserted PXA state change via `cs_transition_event` and
  checks `is_valid_cs_history_prefix`. Multi-event advances (remote peers
  skipping states) are deferred to `FilterCsPxaDimensionNode` (RSH-05).
  PXA regressions are also deferred (monotone filter handles them).

Both nodes use a `CS_vfd.VFD`-complete baseline when constructing compound
CS states, which avoids false vP positives (the vP check requires VFD
knowledge not present in `CaseStatus`).

Also includes two incidental fixes surfaced during review:

- **#2894**: extracted `_CsStatusGuardBase` mixin eliminating duplicated
  `__init__`/`_resolve_asserted` across `CheckCsEphemeralStateNode`,
  `CheckCsHistoryPrefixNode`, and `FilterCsEmDimensionNode`.
- **#2895**: corrected stale `vfd_role_guards.py` module docstring that
  falsely claimed `CheckVendorRoleNode` and `CheckDeployerRoleNode` were
  removed.

## Changes

- `vultron/core/behaviors/status/nodes/cs_invariant_guards.py` — new module
  with `CheckCsEphemeralStateNode` and `CheckCsHistoryPrefixNode`; both now
  subclass `_CsStatusGuardBase`
- `vultron/core/behaviors/status/nodes/cs_dimension_filter.py` — extracted
  `_CsStatusGuardBase`; `FilterCsEmDimensionNode` subclasses it
- `vultron/core/behaviors/status/add_case_status_tree.py` — two new guards
  inserted before `FilterCsEmDimensionNode` in `precondition_guards`; tree
  diagram and docstring updated
- `vultron/core/behaviors/status/nodes/__init__.py` — re-exports and
  docstring updated
- `vultron/core/behaviors/case/nodes/vfd_role_guards.py` — corrected stale
  module docstring (#2895)
- `test/core/behaviors/status/nodes/test_cs_invariant_guards.py` — 16 unit
  tests covering AC-3a/b/c/d plus edge cases
- `test/core/behaviors/status/test_add_case_status_bt.py` — integration test
  `test_px_ephemeral_a_event_rejected_no_ledger_write`
- `test/architecture/test_receive_side_bt_commit_ordering.py` — new guards
  added to `REJECTION_VALIDATORS`
- `docs/adr/0060-re-express-legacy-cs-invariants.md` — updated to reflect wiring

## Verification

- All 232 targeted tests pass (17 new); full unit suite clean
- Black, flake8, mypy clean
- mkdocs build passes