### PR TITLE
feat(cs): wire SM-09-001/CSB-16-002 — PXA+CS compound-state enforcement at persistence boundary

### DIFF
--- a/docs/adr/0060-re-express-legacy-cs-invariants.md
+++ b/docs/adr/0060-re-express-legacy-cs-invariants.md
@@ -177,8 +177,11 @@ analytical model, which is genuinely useful and genuinely non-normative.
   making the legacy module useful precisely as long as it is still present.
 - Neutral: two implementations of the same rules coexist. Acceptable because one
   is explicitly non-normative and the tests pin them together.
-- Neutral: `cs_invariants.py` is a library, not an enforcement point. Wiring it
-  into emit/BT paths is #2236's job; nothing calls it on the protocol path yet.
+- Good: `cs_invariants.py` is now wired into the BT write paths. Completed in
+  #2479: `CreateParticipantStatusNode` enforces AC-3 compound-transition
+  validation (`is_valid_cs_transition`) and AC-1 ephemeral-state promotion
+  (`pXa→PXa`, `pXA→PXA`, `vP→VP`); `AppendCaseStatusToCaseNode` and
+  `EmitCaseStatusUpdateNode` enforce AC-1 promotion for `CaseStatus` writes.
 - Bad: the retirement of `case_states/` is now a recorded intention with two
   named prerequisites rather than a completed act, so it can still rot if those
   prerequisites are not tracked.

--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -178,9 +178,12 @@ Some ECA rules are not just "do A when B" but "do A *before* B." These use
   ThreatTerminationBranchNode).
 - **Ephemeral states: pX→PX invariant** (CSB-13-001, CSB-17-003, CSB-17-012):
   when the CS PXA state is pXa or pXA (exploit public without public awareness),
-  the next CS event MUST be P. This is normatively specified but **not yet
-  enforced in BT paths** — `cs_invariants.required_next_cs_events()` is not
-  wired into any receive path. See #2524.
+  the next CS event MUST be P. **Write-boundary enforcement is in place** (AC-1,
+  PR #2479): `_promote_pxa()` in `AppendCaseStatusToCaseNode` and
+  `EmitCaseStatusUpdateNode`, and `_apply_ac1_promotions()` in
+  `CreateParticipantStatusNode`, prevent pXa/pXA from being persisted. However,
+  **receive-path sequencing** (`cs_invariants.required_next_cs_events()`) is not
+  yet wired into any receive path — that is #2524's scope.
 - **CS history validity** (CSB-17-004, CSB-17-005): complete CS histories must
   be one of 70 valid histories; incomplete histories must be valid prefixes.
   Normatively specified but **not yet enforced** — `cs_invariants.is_valid_cs_history()`

--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -158,8 +158,12 @@ deliberately deferred and gated on two migrations:
    `case_states.patterns.potential_actions` — which is also the live
    `actors_get_action_rules` endpoint's only source.
 
-Note that `cs_invariants.py` is a **library, not an enforcement point**. Wiring
-it into the emit / BT paths is issue #2236's scope.
+As of PR #2479, `cs_invariants.py` is wired into the BT write paths:
+`is_valid_cs_transition` (AC-3 / SM-09-002) is enforced in
+`CreateParticipantStatusNode`, and pX→PX / vP→VP promotion (AC-1 / SM-09-001)
+is enforced in `CreateParticipantStatusNode`, `AppendCaseStatusToCaseNode`, and
+`EmitCaseStatusUpdateNode`. Receive-path history validation
+(`is_valid_cs_history`) remains unwired — see #2524.
 
 ---
 

--- a/plan/incoming/learnings/20260831-ac3-before-ac1-ordering.md
+++ b/plan/incoming/learnings/20260831-ac3-before-ac1-ordering.md
@@ -1,0 +1,17 @@
+---
+title: "AC-3 compound-transition check runs on REQUESTED state, before AC-1 promotion"
+type: learning
+timestamp: "2026-08-31T00:00:00Z"
+source: ISSUE-2479
+signal: spec-ambiguity
+---
+
+Issue #2479 AC-3 said to validate compound transitions with `is_valid_cs_transition()`, but was
+silent on whether the validation uses the requested value or the post-promotion (AC-1) value.
+
+**Interpretation adopted**: validate the REQUESTED compound state first (before promotion), then
+apply AC-1 promotion to the value that gets written. Rationale: the transition `pxa → pXa` (X
+fires) must be structurally valid before the system promotes `pXa → PXa`. If we promoted first,
+`pxa → PXa` would look like a 2-dimension simultaneous jump and be rejected incorrectly.
+
+This ordering is tested explicitly by `test_ephemeral_pXa_promoted_before_write`.

--- a/plan/incoming/learnings/20260831-precommit-hook-timeout.md
+++ b/plan/incoming/learnings/20260831-precommit-hook-timeout.md
@@ -1,0 +1,16 @@
+---
+title: "Pre-commit flake8 hook times out during git commit without UV_NO_SYNC=1 and 10min timeout"
+type: learning
+timestamp: "2026-08-31T00:00:00Z"
+source: ISSUE-2479
+signal: tooling-issue
+---
+
+`git commit` timed out (2min default) because the pre-commit `flake8 (with CC gate)` hook
+runs on all staged files and takes >2 minutes on the full codebase.
+
+**Fix**: always prefix `git commit` with `UV_NO_SYNC=1` AND use a 600000ms (10min) timeout:
+`UV_NO_SYNC=1 git commit ...` with `timeout: 600000`.
+
+The separate `UV_NO_SYNC=1 uv run flake8` passes quickly; it is the pre-commit framework's
+overhead (hook environment management) that slows it down.

--- a/plan/incoming/learnings/20260831-status-py-complexity-extraction.md
+++ b/plan/incoming/learnings/20260831-status-py-complexity-extraction.md
@@ -1,0 +1,15 @@
+---
+title: "AC-1 promotions extracted to _apply_ac1_promotions() to stay under C901 limit"
+type: learning
+timestamp: "2026-08-31T00:00:00Z"
+source: ISSUE-2479
+signal: design-question
+---
+
+Adding AC-1 pX/vP promotion logic inline in `CreateParticipantStatusNode.update()` pushed McCabe
+complexity to 14 (limit: 12, C901). Extracted the 4-branch promotion block into
+`_apply_ac1_promotions(eff_vf, eff_pxa)` helper returning `(CS_vf | None, CS_pxa)`.
+
+This keeps `update()` under the limit and makes the promotion logic independently testable.
+The oversize backlog entry for `status.py` (525 lines) notes that `_check_compound_transition()`
+is a natural candidate for a future `_compound_guards.py` submodule.

--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -58,8 +58,10 @@ from test.architecture import _corpus
 AUDITED_SITES: list[tuple[str, str]] = sorted(
     [
         # PROTECTED — CreateParticipantStatusNode (trigger + received paths)
+        # Third VfDimension: AC-1 vP-promoted effective VF at persistence boundary (SM-09-001)
         ("case/nodes/participant/status.py", "PxaDimension"),
         ("case/nodes/participant/status.py", "RmDimension"),
+        ("case/nodes/participant/status.py", "VfDimension"),
         ("case/nodes/participant/status.py", "VfDimension"),
         ("case/nodes/participant/status.py", "VfDimension"),
         ("case/nodes/participant/status.py", "DDimension"),
@@ -100,6 +102,10 @@ AUDITED_SITES: list[tuple[str, str]] = sorted(
         # FILTER — CaseStatus per-dimension carry-forward (ISSUE-2256)
         ("status/nodes/cs_dimension_filter.py", "PxaDimension"),
         # SNAPSHOT — EmitCaseStatusUpdateNode: post-mutation CaseStatus snapshot (ISSUE-2175)
+        # Two more PxaDimension: AC-1 pX→PX forced promotion in AppendCaseStatusToCaseNode
+        # (pXa→PXa branch and pXA→PXA branch, SM-09-001)
+        ("status/nodes/case_status.py", "PxaDimension"),
+        ("status/nodes/case_status.py", "PxaDimension"),
         ("status/nodes/case_status.py", "PxaDimension"),
         # REPLICATE — participant_status_effect.py: monotonic RM ratchet
         ("sync/nodes/participant_status_effect.py", "RmDimension"),

--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -102,9 +102,7 @@ AUDITED_SITES: list[tuple[str, str]] = sorted(
         # FILTER — CaseStatus per-dimension carry-forward (ISSUE-2256)
         ("status/nodes/cs_dimension_filter.py", "PxaDimension"),
         # SNAPSHOT — EmitCaseStatusUpdateNode: post-mutation CaseStatus snapshot (ISSUE-2175)
-        # Two more PxaDimension: AC-1 pX→PX forced promotion in AppendCaseStatusToCaseNode
-        # (pXa→PXa branch and pXA→PXA branch, SM-09-001)
-        ("status/nodes/case_status.py", "PxaDimension"),
+        # Second PxaDimension: AC-1 _promote_pxa() result applied in AppendCaseStatusToCaseNode
         ("status/nodes/case_status.py", "PxaDimension"),
         ("status/nodes/case_status.py", "PxaDimension"),
         # REPLICATE — participant_status_effect.py: monotonic RM ratchet

--- a/test/core/behaviors/status/test_add_case_status_bt.py
+++ b/test/core/behaviors/status/test_add_case_status_bt.py
@@ -223,6 +223,41 @@ class TestAppendCaseStatusToCaseNode:
         status_ids = [getattr(s, "id_", s) for s in case.case_statuses]
         assert STATUS_ID in status_ids
 
+    def test_ephemeral_pXa_promoted_before_append(self, dl):
+        """AC-1 / SM-09-001: pXa PXA is promoted to PXa before appending."""
+        from vultron.core.models.dimensions import PxaDimension
+
+        case = as_VulnerabilityCase(id_=CASE_ID, name="Promotion Case")
+        dl.create(case)
+
+        # em defaults to EmDimension() via default_factory
+        ephemeral_status = CaseStatus(
+            id_=STATUS_ID,
+            context=CASE_ID,
+            attributed_to=ACTOR_ID,
+            pxa=PxaDimension(state=CS_pxa.pXa),
+        )
+        dl.save(ephemeral_status)
+
+        bridge = BTBridge(datalayer=dl)
+        node = AppendCaseStatusToCaseNode(
+            case_id=CASE_ID,
+            status_id=STATUS_ID,
+            status_obj_fallback=None,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+        reloaded_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
+        promoted = [
+            s
+            for s in reloaded_case.case_statuses
+            if isinstance(s, CaseStatus)
+            and getattr(s, "id_", None) == STATUS_ID
+        ]
+        assert promoted, "Promoted CaseStatus must be appended to case"
+        assert promoted[0].pxa.state is CS_pxa.PXa
+
 
 # ---------------------------------------------------------------------------
 # FilterCsEmDimensionNode — Bug #2704 (CLP-10-009)
@@ -1326,3 +1361,73 @@ class TestCaseLedgerEntryCreation:
             "An invalid Add(CaseStatus) rejected by a precondition guard must"
             " produce zero CaseLedgerEntries (CLP-10-009)"
         )
+
+
+# ---------------------------------------------------------------------------
+# EmitCaseStatusUpdateNode — AC-1 pX promotion (SM-09-001)
+# ---------------------------------------------------------------------------
+
+EMIT_ACTOR_ID = "https://example.org/actors/emit-node-actor"
+EMIT_PARTICIPANT_ID = f"{CASE_ID}/participants/emit-node-actor"
+
+
+class TestEmitCaseStatusUpdateNodePromotion:
+    """AC-1 / SM-09-001: EmitCaseStatusUpdateNode promotes pX states before write."""
+
+    def _build_dl(self):
+        from vultron.enums.roles import CVDRole
+
+        dl = SqliteDataLayer("sqlite:///:memory:", actor_id=EMIT_ACTOR_ID)
+        participant = CaseParticipant(
+            id_=EMIT_PARTICIPANT_ID,
+            context=CASE_ID,
+            attributed_to=EMIT_ACTOR_ID,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            name="Emit Promotion Test",
+            attributed_to=EMIT_ACTOR_ID,
+        )
+        case.add_participant(participant)
+        dl.create(case)
+        dl.create(participant)
+        return dl
+
+    def test_pXa_promoted_to_PXa_by_emit_node(self):
+        """AC-1 / SM-09-001: pXa in case.current_status is promoted to PXa."""
+        from vultron.core.behaviors.status.nodes.case_status import (
+            EmitCaseStatusUpdateNode,
+        )
+        from vultron.core.models.dimensions import EmDimension, PxaDimension
+
+        dl = self._build_dl()
+
+        # Seed a pXa CaseStatus — simulating a pre-AC-1 state or in-flight
+        # transition where the exploit just became public (X fired).
+        case_obj = dl.read(CASE_ID)
+        assert isinstance(case_obj, VulnerabilityCase)
+        pxa_seed = CaseStatus(
+            context=CASE_ID,
+            attributed_to=EMIT_ACTOR_ID,
+            em=EmDimension(state=EM.NONE),
+            pxa=PxaDimension(state=CS_pxa.pXa),
+        )
+        dl.create(pxa_seed)
+        # Clear auto-seeded statuses so current_status resolves to the pXa seed
+        case_obj.case_statuses.clear()
+        case_obj.case_statuses.append(pxa_seed)
+        dl.save(case_obj)
+
+        node = EmitCaseStatusUpdateNode(case_id=CASE_ID)
+        bridge = BTBridge(datalayer=dl)
+        result = bridge.execute_with_setup(tree=node, actor_id=EMIT_ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+        updated_case = dl.read(CASE_ID)
+        assert isinstance(updated_case, VulnerabilityCase)
+        last = updated_case.case_statuses[-1]
+        if isinstance(last, str):
+            last = dl.read(last)
+        assert isinstance(last, CaseStatus)
+        assert last.pxa.state is CS_pxa.PXa

--- a/test/core/behaviors/test_btnd07_structure.py
+++ b/test/core/behaviors/test_btnd07_structure.py
@@ -41,6 +41,9 @@ _OVERSIZE_BACKLOG: frozenset[str] = frozenset(
         # (e.g., owner_create.py + owner_lifecycle.py).
         "vultron/core/behaviors/case/nodes/participant/owner.py",
         "vultron/core/behaviors/case/nodes/participant/participant_add.py",
+        # Pushed over 500 lines by AC-1/AC-3 compound-state enforcement (issue #2479).
+        # Candidate for decomposition into _compound_guards.py.
+        "vultron/core/behaviors/case/nodes/participant/status.py",
     ]
 )
 

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -29,7 +29,7 @@ from typing import cast
 import pytest
 
 from vultron.core.models.dimensions import DDimension, RmDimension, VfDimension
-from vultron.core.states.cs import CS_d, CS_vf
+from vultron.core.states.cs import CS_d, CS_pxa, CS_vf
 from vultron.core.states.rm import RM
 from vultron.errors import VultronValidationError
 
@@ -560,6 +560,34 @@ class TestCreateParticipantStatusNode:
             participant.add_participant_status(seed)
             self.dl.save(participant)
 
+    def _seed_participant_pxa_state(self, pxa_target: CS_pxa) -> None:
+        """Directly persist a ParticipantStatus with an embedded CaseStatus."""
+        from vultron.core.models.case_participant import CaseParticipant
+        from vultron.core.models.case_status import (
+            CaseStatus as CoreCaseStatus,
+        )
+        from vultron.core.models.dimensions import EmDimension, PxaDimension
+        from vultron.core.models.participant_status import ParticipantStatus
+        from vultron.core.states.em import EM as _EM
+
+        case_status = CoreCaseStatus(
+            context=self.case.id_,
+            attributed_to=self.actor.id_,
+            em=EmDimension(state=_EM.NONE),
+            pxa=PxaDimension(state=pxa_target),
+        )
+        seed = ParticipantStatus(
+            context=self.case.id_,
+            attributed_to=self.actor.id_,
+            rm=RmDimension(state=RM.START),
+            case_status=case_status,
+        )
+        self.dl.create(seed)
+        participant = self.dl.read(self.actor_participant.id_)
+        if isinstance(participant, CaseParticipant):
+            participant.add_participant_status(seed)
+            self.dl.save(participant)
+
     def test_node_succeeds_and_populates_result_out(self):
         """CreateParticipantStatusNode returns SUCCESS and sets result_out keys."""
         from py_trees.common import Status
@@ -690,7 +718,14 @@ class TestCreateParticipantStatusNode:
 
         records = self._cs_narrative_records(caplog)
         assert records, "Expected a CS narrative line at INFO for PXA advance"
-        message = records[0].getMessage()
+        # vP promotion may fire a VF narrative first; search all records for PXA
+        pxa_records = [r for r in records if "pxa → Pxa" in r.getMessage()]
+        assert (
+            pxa_records
+        ), "Expected CS narrative containing 'pxa → Pxa'; got: " + str(
+            [r.getMessage() for r in records]
+        )
+        message = pxa_records[0].getMessage()
         assert f"Actor '{self.actor.id_}' CS: pxa → Pxa" in message
         assert "(publicly known)" in message
 
@@ -916,6 +951,116 @@ class TestCreateParticipantStatusNode:
         assert bt_result.status == Status.FAILURE
         assert "status_id" not in result_out
         assert "CSB-15-002" in bt_result.feedback_message
+
+    # ------------------------------------------------------------------
+    # AC-1: ephemeral-state promotion at write boundary (SM-09-001)
+    # ------------------------------------------------------------------
+
+    def test_ephemeral_pxa_pXa_promoted_before_write(self):
+        """AC-1 / SM-09-001: pXa is promoted to PXa before writing."""
+        from py_trees.common import Status
+        from vultron.core.models.participant_status import ParticipantStatus
+        from vultron.core.states.cs import CS_pxa
+
+        bt_result, result_out = self._run_node(
+            rm_state=None, vf_state=None, d_state=None, pxa_state=CS_pxa.pXa
+        )
+
+        assert bt_result.status == Status.SUCCESS
+        stored = self.dl.read(result_out["status_id"])
+        assert isinstance(stored, ParticipantStatus)
+        assert stored.case_status is not None
+        assert stored.case_status.pxa.state is CS_pxa.PXa
+
+    def test_ephemeral_pxa_pXA_promoted_before_write(self):
+        """AC-1 / SM-09-001: pXA is promoted to PXA before writing.
+
+        pXA is reachable from pxA via the X event.  The test seeds pxA as the
+        prior PXA state so the per-dimension precondition passes, then verifies
+        the ephemeral pXA is promoted to PXA at the write boundary.
+        """
+        from py_trees.common import Status
+        from vultron.core.models.participant_status import ParticipantStatus
+        from vultron.core.states.cs import CS_pxa
+
+        # pxA (attacks observed) is a valid non-ephemeral prior state.
+        # From pxA, X fires → pXA (exploit public, attacks, but public unaware).
+        self._seed_participant_pxa_state(CS_pxa.pxA)
+
+        bt_result, result_out = self._run_node(
+            rm_state=None, vf_state=None, d_state=None, pxa_state=CS_pxa.pXA
+        )
+
+        assert bt_result.status == Status.SUCCESS
+        stored = self.dl.read(result_out["status_id"])
+        assert isinstance(stored, ParticipantStatus)
+        assert stored.case_status is not None
+        assert stored.case_status.pxa.state is CS_pxa.PXA
+
+    def test_ephemeral_vP_promotes_vf_when_writing_pxa(self):
+        """AC-1 / SM-09-001: vP compound state forces VF promotion to Vf.
+
+        When writing PXA=Pxa (P fires) while VF is still vf, the resulting
+        vP compound state is ephemeral (vendor unaware, public aware).
+        The write boundary must auto-promote VF to Vf before persisting.
+        """
+        from py_trees.common import Status
+        from vultron.core.models.participant_status import ParticipantStatus
+        from vultron.core.states.cs import CS_pxa, CS_vf
+
+        self._seed_participant_vf_state(CS_vf.vf)
+
+        bt_result, result_out = self._run_node(
+            rm_state=None, vf_state=None, d_state=None, pxa_state=CS_pxa.Pxa
+        )
+
+        assert bt_result.status == Status.SUCCESS
+        stored = self.dl.read(result_out["status_id"])
+        assert isinstance(stored, ParticipantStatus)
+        assert stored.vf is not None
+        assert stored.vf.state is CS_vf.Vf
+        assert stored.case_status is not None
+        assert stored.case_status.pxa.state is CS_pxa.Pxa
+
+    # ------------------------------------------------------------------
+    # AC-3: compound CS transition validation at write boundary (SM-09-002)
+    # ------------------------------------------------------------------
+
+    def test_compound_transition_rejected_when_two_dims_change(self):
+        """AC-3 / SM-09-002: simultaneous VF+PXA change is rejected.
+
+        A single CS event changes exactly one of the six dimensions.
+        Attempting to advance both VF (vf→Vf) and PXA (pxa→Pxa) in one
+        write must be refused at the persistence boundary.
+        """
+        from py_trees.common import Status
+        from vultron.core.states.cs import CS_pxa, CS_vf
+
+        self._seed_participant_vf_state(CS_vf.vf)
+
+        bt_result, result_out = self._run_node(
+            rm_state=None,
+            vf_state=CS_vf.Vf,
+            d_state=None,
+            pxa_state=CS_pxa.Pxa,
+        )
+
+        assert bt_result.status == Status.FAILURE
+        assert "status_id" not in result_out
+
+    def test_single_vf_step_passes_compound_check(self):
+        """AC-3 / SM-09-002: a valid single-dimension VF advance is accepted."""
+        from py_trees.common import Status
+        from vultron.core.states.cs import CS_vf
+
+        self._seed_participant_vf_state(CS_vf.vf)
+
+        bt_result, result_out = self._run_node(
+            rm_state=None, vf_state=CS_vf.Vf, d_state=None, pxa_state=None
+        )
+
+        assert bt_result.status == Status.SUCCESS
+        assert "status_id" in result_out
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -45,13 +45,27 @@ from vultron.core.states.cs import (
     CS_d,
     CS_pxa,
     CS_vf,
+    CS_vfd,
+    is_pxa_public_aware,
     is_valid_d_transition,
     is_valid_pxa_transition,
     is_valid_vf_transition,
 )
+from vultron.core.states.cs_invariants import (
+    cs_from_dimensions,
+    is_valid_cs_transition,
+)
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
+
+
+def _vf_d_to_vfd(vf: CS_vf, d: CS_d) -> CS_vfd | None:
+    """Map a (CS_vf, CS_d) pair to the equivalent CS_vfd member, or None."""
+    try:
+        return CS_vfd[f"{vf}{d}"]
+    except KeyError:
+        return None
 
 
 def _resolve_em_state(case: object) -> EM:
@@ -283,6 +297,71 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
             return Status.FAILURE
         return None
 
+    def _check_compound_transition(
+        self,
+        prev_vf: "CS_vf | None",
+        prev_d: "CS_d | None",
+        prev_pxa: CS_pxa,
+        next_vf: "CS_vf | None",
+        next_d: "CS_d | None",
+        next_pxa: CS_pxa,
+    ) -> "Status | None":
+        """SM-09-002 / AC-3: reject compound transitions that change >1 dimension."""
+        if prev_vf is None or next_vf is None:
+            return None  # no VF history; per-dimension checks suffice
+        prev_d = prev_d or CS_d.d
+        next_d = next_d or CS_d.d
+        prev_vfd = _vf_d_to_vfd(prev_vf, prev_d)
+        next_vfd = _vf_d_to_vfd(next_vf, next_d)
+        if next_vfd is None:
+            self.logger.warning(
+                "%s: impossible compound VF+D state (%s, %s) for actor '%s'"
+                " (SM-09-002)",
+                self.name,
+                next_vf,
+                next_d,
+                self._actor_id,
+            )
+            self.feedback_message = (
+                f"Impossible compound VF+D state ({next_vf!r}, {next_d!r})"
+            )
+            return Status.FAILURE
+        if prev_vfd is None:
+            return None
+        prev_cs = cs_from_dimensions(prev_vfd, prev_pxa)
+        next_cs = cs_from_dimensions(next_vfd, next_pxa)
+        if not is_valid_cs_transition(prev_cs, next_cs, allow_null=True):
+            self.logger.warning(
+                "%s: invalid compound CS transition %s → %s for actor '%s'"
+                " (SM-09-002)",
+                self.name,
+                prev_cs.name,
+                next_cs.name,
+                self._actor_id,
+            )
+            self.feedback_message = (
+                f"Invalid compound CS transition"
+                f" {prev_cs.name!r} → {next_cs.name!r}"
+            )
+            return Status.FAILURE
+        return None
+
+    def _apply_ac1_promotions(
+        self,
+        eff_vf: "CS_vf | None",
+        eff_pxa: CS_pxa,
+    ) -> "tuple[CS_vf | None, CS_pxa]":
+        """Apply SM-09-001 pX→PX and vP→VP forced promotions."""
+        if self._pxa_state is None:
+            return eff_vf, eff_pxa
+        if eff_pxa is CS_pxa.pXa:
+            eff_pxa = CS_pxa.PXa
+        elif eff_pxa is CS_pxa.pXA:
+            eff_pxa = CS_pxa.PXA
+        if eff_vf is CS_vf.vf and is_pxa_public_aware(eff_pxa):
+            eff_vf = CS_vf.Vf
+        return eff_vf, eff_pxa
+
     def update(self) -> Status:
         dl = self.datalayer
         if dl is None:
@@ -327,24 +406,47 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
         if guard is not None:
             return guard
 
-        case_status: CaseStatus | None = None
-        pxa_before: CS_pxa | None = None
+        pxa_before = _resolve_pxa_state(case, participant_obj)
+
         if self._pxa_state is not None:
-            pxa_before = _resolve_pxa_state(case, participant_obj)
             guard = self._check_pxa_precondition(pxa_before)
             if guard is not None:
                 return guard
+
+        # Effective states before promotion (what the caller requested)
+        eff_vf = self._vf_state if self._vf_state is not None else current_vf
+        eff_d = self._d_state if self._d_state is not None else current_d
+        eff_pxa = (
+            self._pxa_state if self._pxa_state is not None else pxa_before
+        )
+
+        # AC-3: validate compound CS transition (SM-09-002)
+        guard = self._check_compound_transition(
+            current_vf, current_d, pxa_before, eff_vf, eff_d, eff_pxa
+        )
+        if guard is not None:
+            return guard
+
+        # AC-1: pX → PX and vP → VP forced promotions (SM-09-001)
+        eff_vf, eff_pxa = self._apply_ac1_promotions(eff_vf, eff_pxa)
+
+        case_status: CaseStatus | None = None
+        if self._pxa_state is not None:
             case_status = CaseStatus(
                 context=self._case_id,
                 attributed_to=self._actor_id,
                 em=EmDimension(state=_resolve_em_state(case)),
-                pxa=PxaDimension(state=self._pxa_state),
+                pxa=PxaDimension(state=eff_pxa),
             )
 
         status_roles, consent_dim = self._build_participant_metadata(
             participant_obj
         )
-        vf_dim, d_dim = self._build_dimensions(current_vf, current_d)
+
+        vf_dim: VfDimension | None = (
+            VfDimension(state=eff_vf) if eff_vf is not None else None
+        )
+        _, d_dim = self._build_dimensions(current_vf, current_d)
 
         status = ParticipantStatus(
             context=self._case_id,
@@ -374,7 +476,9 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
             self._actor_id,
             self._case_id,
         )
-        self._log_transitions(current_rm, current_vf, current_d, pxa_before)
+        self._log_transitions(
+            current_rm, current_vf, current_d, pxa_before, eff_pxa, eff_vf
+        )
         return Status.SUCCESS
 
     def _log_transitions(
@@ -382,7 +486,9 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
         rm_before: RM,
         vf_before: CS_vf | None,
         d_before: CS_d | None,
-        pxa_before: CS_pxa | None,
+        pxa_before: CS_pxa,
+        effective_pxa: "CS_pxa | None" = None,
+        effective_vf: "CS_vf | None" = None,
     ) -> None:
         """Emit narrative INFO lines for the dimensions this node advanced."""
         if self._rm_state is not None:
@@ -393,13 +499,17 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
                 rm_before,
                 self._rm_state,
             )
-        if self._vf_state is not None:
+        # Log VF: if explicitly requested OR if vP promotion forced a change
+        vf_written = (
+            effective_vf if effective_vf is not None else self._vf_state
+        )
+        if vf_written is not None:
             log_cs_transition(
                 self.logger,
                 self._actor_id,
                 self._case_id,
                 vf_before if vf_before is not None else CS_vf.vf,
-                self._vf_state,
+                vf_written,
             )
         if self._d_state is not None:
             log_cs_transition(
@@ -409,11 +519,16 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
                 d_before if d_before is not None else CS_d.d,
                 self._d_state,
             )
-        if self._pxa_state is not None and pxa_before is not None:
+        # Log PXA using the effective (possibly promoted) value
+        if self._pxa_state is not None:
             log_cs_transition(
                 self.logger,
                 self._actor_id,
                 self._case_id,
                 pxa_before,
-                self._pxa_state,
+                (
+                    effective_pxa
+                    if effective_pxa is not None
+                    else self._pxa_state
+                ),
             )

--- a/vultron/core/behaviors/status/nodes/case_status.py
+++ b/vultron/core/behaviors/status/nodes/case_status.py
@@ -41,6 +41,7 @@ from vultron.core.models._helpers import _as_id
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.dimensions import EmDimension, PxaDimension
+from vultron.core.states.cs import CS_pxa
 from vultron.core.models.protocols import PersistableModel
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
@@ -186,11 +187,12 @@ class AppendCaseStatusToCaseNode(DataLayerActionWithPorts):
 
         # Use the per-dimension-filtered status when available; otherwise fall
         # back to the raw asserted object (no filtering was needed or applied).
+        from_filter = False
         status_obj: CaseStatus | PersistableModel | None = (
             self._resolve_filtered()
         )
         if status_obj is not None:
-            self.datalayer.save(status_obj)
+            from_filter = True
         else:
             status_obj = self._resolve_status()
 
@@ -209,6 +211,24 @@ class AppendCaseStatusToCaseNode(DataLayerActionWithPorts):
                 "AppendCaseStatusToCase: %s", self.feedback_message
             )
             return Status.FAILURE
+
+        # AC-1: pX → PX forced promotion at persistence boundary (SM-09-001)
+        if status_obj.pxa is not None:
+            pxa_state = status_obj.pxa.state
+            if pxa_state is CS_pxa.pXa:
+                status_obj = status_obj.model_copy(
+                    update={"pxa": PxaDimension(state=CS_pxa.PXa)}
+                )
+                from_filter = True
+            elif pxa_state is CS_pxa.pXA:
+                status_obj = status_obj.model_copy(
+                    update={"pxa": PxaDimension(state=CS_pxa.PXA)}
+                )
+                from_filter = True
+
+        if from_filter:
+            self.datalayer.save(status_obj)
+
         case.add_case_status(status_obj)
         self.datalayer.save(case)
         self.logger.info(
@@ -274,11 +294,17 @@ class EmitCaseStatusUpdateNode(DataLayerActionWithPorts):
             )
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
+        # AC-1: pX → PX forced promotion at persistence boundary (SM-09-001)
+        pxa_state = current.pxa.state
+        if pxa_state is CS_pxa.pXa:
+            pxa_state = CS_pxa.PXa
+        elif pxa_state is CS_pxa.pXA:
+            pxa_state = CS_pxa.PXA
         new_status = CaseStatus(
             context=self.case_id,
             attributed_to=self.actor_id,
             em=EmDimension(state=current.em.state),
-            pxa=PxaDimension(state=current.pxa.state),
+            pxa=PxaDimension(state=pxa_state),
         )
 
         status_dict: dict[str, Any] = new_status.model_dump(

--- a/vultron/core/behaviors/status/nodes/case_status.py
+++ b/vultron/core/behaviors/status/nodes/case_status.py
@@ -53,6 +53,15 @@ logger = logging.getLogger(__name__)
 CASE_STATUS_ALREADY_PRESENT = "case_status_already_present"
 
 
+def _promote_pxa(pxa: CS_pxa) -> CS_pxa:
+    """SM-09-001: promote ephemeral pX states at the persistence boundary."""
+    if pxa is CS_pxa.pXa:
+        return CS_pxa.PXa
+    if pxa is CS_pxa.pXA:
+        return CS_pxa.PXA
+    return pxa
+
+
 class CheckCaseStatusIdempotencyNode(
     SilentIdempotencyGuardMixin, DataLayerConditionWithPorts
 ):
@@ -214,15 +223,10 @@ class AppendCaseStatusToCaseNode(DataLayerActionWithPorts):
 
         # AC-1: pX → PX forced promotion at persistence boundary (SM-09-001)
         if status_obj.pxa is not None:
-            pxa_state = status_obj.pxa.state
-            if pxa_state is CS_pxa.pXa:
+            promoted = _promote_pxa(status_obj.pxa.state)
+            if promoted is not status_obj.pxa.state:
                 status_obj = status_obj.model_copy(
-                    update={"pxa": PxaDimension(state=CS_pxa.PXa)}
-                )
-                from_filter = True
-            elif pxa_state is CS_pxa.pXA:
-                status_obj = status_obj.model_copy(
-                    update={"pxa": PxaDimension(state=CS_pxa.PXA)}
+                    update={"pxa": PxaDimension(state=promoted)}
                 )
                 from_filter = True
 
@@ -295,11 +299,7 @@ class EmitCaseStatusUpdateNode(DataLayerActionWithPorts):
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
         # AC-1: pX → PX forced promotion at persistence boundary (SM-09-001)
-        pxa_state = current.pxa.state
-        if pxa_state is CS_pxa.pXa:
-            pxa_state = CS_pxa.PXa
-        elif pxa_state is CS_pxa.pXA:
-            pxa_state = CS_pxa.PXA
+        pxa_state = _promote_pxa(current.pxa.state)
         new_status = CaseStatus(
             context=self.case_id,
             attributed_to=self.actor_id,

--- a/vultron/core/models/dimensions.py
+++ b/vultron/core/models/dimensions.py
@@ -109,7 +109,10 @@ def _coerce_vfd(v: object) -> CS_vfd:
     if isinstance(v, CS_vfd):
         return v
     if isinstance(v, str):
-        return CS_vfd[v]
+        try:
+            return CS_vfd[v]
+        except KeyError:
+            raise ValueError(f"Unknown CS_vfd value: {v!r}") from None
     if isinstance(v, (list, tuple)) and len(v) == 3:
         return CS_vfd(VfdState(*v))
     raise ValueError(f"Cannot coerce {v!r} to CS_vfd")
@@ -119,7 +122,10 @@ def _coerce_vf(v: object) -> CS_vf:
     if isinstance(v, CS_vf):
         return v
     if isinstance(v, str):
-        return CS_vf[v]
+        try:
+            return CS_vf[v]
+        except KeyError:
+            raise ValueError(f"Unknown CS_vf value: {v!r}") from None
     raise ValueError(f"Cannot coerce {v!r} to CS_vf")
 
 
@@ -127,7 +133,10 @@ def _coerce_d(v: object) -> CS_d:
     if isinstance(v, CS_d):
         return v
     if isinstance(v, str):
-        return CS_d[v]
+        try:
+            return CS_d[v]
+        except KeyError:
+            raise ValueError(f"Unknown CS_d value: {v!r}") from None
     raise ValueError(f"Cannot coerce {v!r} to CS_d")
 
 

--- a/vultron/wire/as2/extractor/_builders.py
+++ b/vultron/wire/as2/extractor/_builders.py
@@ -387,7 +387,10 @@ def _coerce_vf(raw: object) -> CS_vf | None:
     if isinstance(raw, CS_vf):
         return raw
     if isinstance(raw, str):
-        return CS_vf[raw]
+        try:
+            return CS_vf[raw]
+        except KeyError:
+            raise ValueError(f"Unknown CS_vf value: {raw!r}") from None
     return None
 
 
@@ -397,7 +400,10 @@ def _coerce_d(raw: object) -> CS_d | None:
     if isinstance(raw, CS_d):
         return raw
     if isinstance(raw, str):
-        return CS_d[raw]
+        try:
+            return CS_d[raw]
+        except KeyError:
+            raise ValueError(f"Unknown CS_d value: {raw!r}") from None
     return None
 
 

--- a/vultron/wire/as2/vocab/objects/case_status.py
+++ b/vultron/wire/as2/vocab/objects/case_status.py
@@ -41,6 +41,7 @@ from vultron.core.states.cs import CS_d, CS_pxa, CS_vf
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.enums.roles import CVDRole
 from vultron.core.models.base import NonEmptyString
+from vultron.errors import VultronProtocolViolationError
 from vultron.core.models.enums import VultronObjectType as VO_type
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef, as_Link
 from vultron.wire.as2.vocab.base.objects.base import as_Object
@@ -245,7 +246,7 @@ class as_ParticipantStatus(VultronAS2Object):
         """
         if isinstance(data, dict):
             if "vfd_state" in data or "vfdState" in data:
-                raise ValueError(
+                raise VultronProtocolViolationError(
                     "vfd_state/vfdState is retired (ADR-0075). Use vf_state"
                     " for vendor participants and d_state for deployer"
                     " participants instead."


### PR DESCRIPTION
- Closes #2479
- Closes #2892
- Closes #2900

## Summary

Wires `cs_invariants.py` into every BT write path for `CaseStatus` and `ParticipantStatus`, enforcing SM-09-001 (ephemeral-state promotion) and SM-09-002 (compound-transition validation) at the persistence boundary. Also fixes two pre-existing bugs (#2892, #2900) discovered during code review.

## Changes

- **`vultron/core/behaviors/case/nodes/participant/status.py`**: Added `_check_compound_transition()` (AC-3 / SM-09-002) and `_apply_ac1_promotions()` (AC-1 / SM-09-001).
- **`vultron/core/behaviors/status/nodes/case_status.py`**: Extracted `_promote_pxa()` helper (DRY); `AppendCaseStatusToCaseNode` and `EmitCaseStatusUpdateNode` both use it for pX→PX promotion at write time.
- **`vultron/wire/as2/extractor/_builders.py`**: `_coerce_vf`/`_coerce_d` wrap `KeyError` as `ValueError` so unrecognised strings reach the permanent-failure handler, not the re-queue branch (#2892).
- **`vultron/wire/as2/vocab/objects/case_status.py`**: `_reject_retired_vfd_keys` raises `VultronProtocolViolationError` instead of `ValueError` (#2900).
- **Tests + architecture audit**: 7 new tests; write-site audit updated.
- **`docs/adr/0060-re-express-legacy-cs-invariants.md`**: Notes the wiring as complete.

## Verification

- 7884 unit tests pass (7 new), 1248 integration tests pass
- Black, flake8, mypy, pyright all clean

## [ADVISORY] Remaining pre-existing finding

- **#2901** — `inbox_pipeline.py` re-queues `VultronValidationError` with no retry limit (design decision required; deferred).