### PR TITLE
docs(#2525): fix formal_protocol/messages.md and documentation-strategy.md stale content

### DIFF
--- a/docs/reference/formal_protocol/messages.md
+++ b/docs/reference/formal_protocol/messages.md
@@ -252,4 +252,13 @@ For convenience, we collected these into the table below.
             \end{array}
             \right\}\text{ where } i \neq j \text{; } \varnothing \text{ otherwise; for } i,j \leq N$$
 
-Message *formats* are left as future work.
+Message *formats* are implemented using the
+[ActivityStreams 2.0](https://www.w3.org/TR/activitystreams-core/){:target="_blank"} vocabulary.
+See [ActivityPub Activities](../../howto/activitypub/activities/index.md) for details on the wire format.
+
+!!! note "AS2 Implementation Note"
+
+    The ActivityStreams-based wire format collapses the revision-negotiation message types:
+    $EV$ is sent as $EP$, $EC$ is sent as $EA$, and $EJ$ is sent as $ER$.
+    The formal message type set above remains normative for protocol semantics;
+    the AS2 mapping is an implementation detail of the current prototype.

--- a/notes/documentation-strategy.md
+++ b/notes/documentation-strategy.md
@@ -97,8 +97,8 @@ evaluate:
 definitions disagree on state names or valid states, the enum code wins.
 Update the documentation to match the enum, never the reverse (unless the
 enum itself is explicitly identified as a bug by a maintainer). Canonical
-enum files: `vultron/bt/report_management/states.py` (RM),
-`vultron/bt/embargo_management/states.py` (EM),
+enum files: `vultron/core/states/rm.py` (RM),
+`vultron/core/states/em.py` (EM),
 `vultron/core/states/cs.py` (CS/VFD/PXA).
 
 ---

--- a/plan/incoming/learnings/20260831-mkdocs-strict-101-pre-existing-warnings.md
+++ b/plan/incoming/learnings/20260831-mkdocs-strict-101-pre-existing-warnings.md
@@ -1,0 +1,23 @@
+---
+title: mkdocs build --strict has 101 pre-existing warnings from markdown_exec failures
+type: learning
+timestamp: 2026-08-31T18:45:00Z
+source: ISSUE-2525
+signal: concern
+---
+
+During #2525, `uv run mkdocs build --strict` was run to verify the site builds cleanly.
+It aborts with 101 warnings in strict mode. All warnings are from `markdown_exec` —
+Python code blocks embedded in howto documentation pages that fail at build time with
+Pydantic errors:
+
+- `ValidationError` for frozen instances (e.g., `_UpdateCaseActivity.published`)
+- `AttributeError` for missing attributes (e.g., `as_VulnerabilityCase.add_report`)
+- `ValidationError` for frozen fields in `as_CaseStatus`, `as_CaseParticipant`, etc.
+
+These are NOT caused by the current PR's changes. The `docs/reference/formal_protocol/`
+pages build cleanly. The failures are in `docs/howto/activitypub/` code blocks that use
+AS2 model objects whose API has drifted from the embedded examples.
+
+This should be tracked as a Concern: the strict build cannot pass until the code
+examples in the howto docs are updated to match the current AS2 model API.


### PR DESCRIPTION
- Closes #2525
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Corrects two divergences found during issue #2525 verification of `docs/reference/formal_protocol/` against the current implementation.

## Changes

- **`docs/reference/formal_protocol/messages.md`**: The closing line "Message *formats* are left as future work." was outdated — the ActivityStreams 2.0 wire format is now implemented. Replaced with a reference to the AS2 activities docs and a note that the AS2 layer collapses EV/EC/EJ into EP/EA/ER.
- **`notes/documentation-strategy.md`**: Two canonical enum file paths were stale, referencing the old `vultron/bt/` simulator tree instead of the current `vultron/core/states/` files. Updated to `vultron/core/states/rm.py` and `vultron/core/states/em.py`.

No changes were required to `states.md`, `transitions.md`, or `conclusion.md` — state enumerations, transition tables, and Mermaid diagrams all match the current implementation. The duplicate `[RMB-13]` citation in `transitions.md` was investigated and confirmed intentional (RMB-13-001 and RMB-13-002 respectively).

## Verification

- All 7877 unit tests pass
- `uv run mkdocs build --strict` — 101 pre-existing warnings (markdown_exec code block failures in howto/ docs, unrelated to this change); `formal_protocol/` pages build cleanly with no new warnings
- Internal link `../../howto/activitypub/activities/index.md` verified to exist
- AS2 EV→EP, EC→EA, EJ→ER mapping verified in `vultron/wire/as2/vocab/activities/embargo.py`
- New canonical paths `vultron/core/states/rm.py` and `vultron/core/states/em.py` verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)