### PR TITLE
fix(ci): don't open failure issue when run is cancelled by concurrency group

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -303,7 +303,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Notify CI failure
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        if: contains(needs.*.result, 'failure')
         uses: ./.github/actions/notify-failure
         with:
           mode: notify


### PR DESCRIPTION
- Fixes #2913
- Closes #2915

## Summary

- Removes `cancelled` from the `notify` step condition in the `demo-integration.yml` `notify` job
- When a new commit on main triggers the concurrency group to cancel an in-progress run, the cancelled jobs produce `result: cancelled` — which was incorrectly treated as a failure and filed a spurious issue (see #2913)
- Only genuine `failure` results now open an issue; concurrency-group cancellations are silently ignored

**Timeout edge case:** A job timeout also produces `cancelled` in GitHub Actions, but if `demo` times out the `invariant-harness` still runs against the uploaded artifacts and will likely fail, keeping the `failure` signal alive. The `close` step condition is untouched — a cancelled run cannot falsely close an open failure issue.

## Changes

- ``.github/workflows/demo-integration.yml``: Removed `|| contains(needs.*.result, 'cancelled')` from the `notify` step `if:` condition so only genuine `failure` results open an issue. The `close` step condition is unchanged.

## Test plan

- [ ] Merge to main while another push is in-flight and confirm no new issue is filed for the cancelled run
- [ ] Confirm a genuine test failure still opens an issue

🤖 Generated with [Claude Code](https://claude.ai/claude-code)