### PR TITLE
fix(actors): reject foreign-authority ids at POST /actors/; add POST /actors/{id}/peers/

### DIFF
--- a/docs/adr/0081-peer-knowledge-in-hosted-actor-store.md
+++ b/docs/adr/0081-peer-knowledge-in-hosted-actor-store.md
@@ -1,0 +1,91 @@
+---
+status: accepted
+date: 2026-08-31
+deciders: Allen D. Householder
+consulted: Claude Sonnet 4.6
+informed: []
+---
+
+# Peer Knowledge Lives in the Hosted Actor's Own Store, Not as a Hosted Actor
+
+## Context and Problem Statement
+
+`POST /actors/` minted a local store and actor record for every id it received,
+including ids that belonged to actors on remote nodes.  Because `actor_slug()`
+strips scheme and authority, two ids with the same final path segment but
+different authorities (e.g. `http://finder:7999/.../alice` and
+`http://vendor:7999/.../alice`) mapped to the same SQLite file.  The collision
+was logged as a warning and the second write silently returned the first actor's
+record, so `hosted_actor_ids()` reported remote actors as locally hosted and
+subsequent delivery attempts failed in surprising ways.
+
+Issue #2549 identified the root cause as two separate confusions:
+
+1. **Route confusion** — `POST /actors/` should only create actors whose
+   authority matches the serving node's `base_url`.  Foreign-authority ids
+   describe actors that live elsewhere; registering them as hosted actors is
+   wrong.
+
+2. **Concept confusion** — the mechanism that nodes use to know about remote
+   peers (address-book entries) was not distinguished from the mechanism that
+   makes an actor hosted on this node (a store + actor record).  The only reason
+   to call `POST /actors/` with a foreign id was to get an address-book entry,
+   but the route created a phantom store instead.
+
+## Decision
+
+**Foreign-authority ids are rejected at `POST /actors/`.**
+
+An `actor_id` whose scheme and authority do not match the serving node's
+configured `base_url` returns `422 Unprocessable Content`.  The check is at the
+route layer; `canonical_actor_uri()` and `actor_slug()` are not changed.
+
+**Peer knowledge is stored as a `CoreActor` record in the *host* actor's own store
+via a new `POST /actors/{actor_id}/peers/` endpoint.**
+
+The new endpoint:
+
+- Validates that `actor_id` (the path parameter) names an actor hosted on this
+  node (returns 404 otherwise).
+- Accepts `{ "id": "<peer_uri>", "name": "...", "actor_type": "..." }`.
+- Writes a `CoreActor` record into the host actor's DataLayer (not as a
+  separately hosted actor).
+- Is idempotent: a second call with the same peer id returns 200 with the
+  existing record.
+
+The peer record lives in the host actor's store.  It cannot be read by other
+actors (ADR-0073); it is an address-book entry, not a claim that this node
+hosts the peer.
+
+## Consequences
+
+### Positive
+
+- `hosted_actor_ids()` only reports actors that are genuinely hosted on this
+  node.
+- The store-collision path in `get_actor_engine` becomes unreachable for
+  correctly behaved production callers; the guard logs a WARNING and remains
+  permissive so the test harness (which legitimately runs multiple nodes in
+  one process) continues to function.
+- Demo seeding helpers (`seed_containers*`) now use `seed_peer(...)` for Phase 2
+  cross-container registrations.
+
+### Negative
+
+- Callers that previously called `POST /actors/` with a foreign id to register
+  a peer must be updated to call `POST /actors/{id}/peers/` instead.  The demo
+  CLI and all `seed_containers*` helpers have been updated; external clients
+  may need updating.
+
+### Neutral
+
+- `canonical_actor_uri()` is unchanged.  It still returns foreign-authority ids
+  verbatim, which is correct for outbound delivery addressing.
+- `actor_slug()` is unchanged.  Its authority-stripping behavior is now only
+  reachable for local actors, so cross-authority collisions are unreachable in
+  practice.
+
+## References
+
+- Issue #2549 — root-cause analysis and reproduction steps
+- ADR-0073 — per-actor store isolation (each actor gets its own SQLite file)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -150,6 +150,7 @@ General information about architectural decision records is available at <https:
 - [ADR-0078 Retire `CVDRole.FINDER` — Reporter Is the Protocol-Salient Role](0078-retire-finder-role.md)
 - [ADR-0079 CaseLedger Causal Ordering: CaseActor Observation Order Is the Canonical Causal Order](0079-case-ledger-causal-ordering.md)
 - [ADR-0080 Asking Permission Is a Protocol Message, Not a Suspended Behavior](0080-protocol-asks-not-suspended-behaviors.md)
+- [ADR-0081 Peer Knowledge Lives in the Hosted Actor's Own Store, Not as a Hosted Actor](0081-peer-knowledge-in-hosted-actor-store.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -316,7 +316,7 @@ nav:
       - "Retire CVDRole.FINDER — Reporter Is the Protocol-Salient Role": 'adr/0078-retire-finder-role.md'
       - 'CaseLedger Causal Ordering: CaseActor Observation Order Is the Canonical Causal Order': 'adr/0079-case-ledger-causal-ordering.md'
       - 'Asking Permission Is a Protocol Message, Not a Suspended Behavior': 'adr/0080-protocol-asks-not-suspended-behaviors.md'
-      - 'Peer Knowledge Lives in the Hosted Actor Store, Not as a Hosted Actor': 'adr/0081-peer-knowledge-in-hosted-actor-store.md'
+      - "Peer Knowledge Lives in the Hosted Actor's Own Store, Not as a Hosted Actor": 'adr/0081-peer-knowledge-in-hosted-actor-store.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -316,6 +316,7 @@ nav:
       - "Retire CVDRole.FINDER — Reporter Is the Protocol-Salient Role": 'adr/0078-retire-finder-role.md'
       - 'CaseLedger Causal Ordering: CaseActor Observation Order Is the Canonical Causal Order': 'adr/0079-case-ledger-causal-ordering.md'
       - 'Asking Permission Is a Protocol Message, Not a Suspended Behavior': 'adr/0080-protocol-asks-not-suspended-behaviors.md'
+      - 'Peer Knowledge Lives in the Hosted Actor Store, Not as a Hosted Actor': 'adr/0081-peer-knowledge-in-hosted-actor-store.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/test/adapters/driven/datalayer_sqlite/test_engine.py
+++ b/test/adapters/driven/datalayer_sqlite/test_engine.py
@@ -22,14 +22,11 @@ reads, which store a BT node writes — is that resolution applied.
 
 Covers ``actor_slug``, ``actor_db_url``, ``_is_memory_url``,
 ``_memory_base_name``, ``get_actor_engine`` (including the ``_STORE_CLAIMANTS``
-cross-authority collision warning) and ``dispose_actor_engines``.
+cross-authority collision guard) and ``dispose_actor_engines``.
 """
-
-import logging
 
 import pytest
 
-from vultron.adapters.driven.datalayer_sqlite import engine as engine_mod
 from vultron.adapters.driven.datalayer_sqlite.engine import (
     _ENGINES,
     _STORE_CLAIMANTS,
@@ -111,13 +108,16 @@ class TestActorSlug:
             actor_slug(bad)
 
     def test_two_authorities_with_one_segment_collide(self):
-        """Documented limitation, not an accident — see issue #2549.
+        """``actor_slug`` still collapses authority — the collision is now unreachable.
 
-        The scheme and netloc are dropped, so a co-hosted ``case-actor`` and a
-        *peer* whose URI also ends in ``case-actor`` produce one slug. The bug in
-        that scenario is opening a store for a foreign id at all;
-        ``get_actor_engine`` is what notices (see
-        :class:`TestGetActorEngineCollisionWarning`).
+        The scheme and netloc are dropped, so two ids that differ only in
+        authority but share the same final path segment produce one slug.  No
+        legitimate path reaches ``actor_slug`` with a foreign id after ADR-0081:
+        ``POST /actors/`` rejects foreign-authority ids, and ``POST
+        /actors/{id}/peers/`` stores peer knowledge in the hosted actor's own
+        store without opening a separate engine for the peer.  The collision is
+        caught by ``get_actor_engine`` which now warns (see
+        :class:`TestGetActorEngineCollisionGuard`).
         """
         assert actor_slug(
             "http://vendor:7999/api/v2/actors/case-actor"
@@ -248,47 +248,64 @@ class TestGetActorEngine:
         )
 
 
-class TestGetActorEngineCollisionWarning:
-    """The ``_STORE_CLAIMANTS`` guard for the issue-#2549 slug collision."""
+class TestGetActorEngineCollisionGuard:
+    """The ``_STORE_CLAIMANTS`` guard logs a warning on a cross-authority slug collision.
+
+    After ADR-0081 no legitimate *production* path opens a store for a
+    foreign-authority id: ``POST /actors/`` rejects foreign ids, and peer
+    knowledge lives inside a hosted actor's own store.  The guard stays a
+    warning (not an exception) because the demo test harness legitimately runs
+    multiple nodes in one process and nodes that share a slug would otherwise
+    fail to start.
+    """
 
     _FOREIGN = "http://case-actor:7999/api/v2/actors/eng-collide"
     _LOCAL = "http://vendor:7999/api/v2/actors/eng-collide"
 
     def test_warns_when_a_second_authority_claims_the_same_store(self, caplog):
-        get_actor_engine("sqlite:///:memory:", self._LOCAL)
-        with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
-            get_actor_engine("sqlite:///:memory:", self._FOREIGN)
+        import logging
 
+        get_actor_engine("sqlite:///:memory:", self._LOCAL)
+        with caplog.at_level(logging.WARNING):
+            get_actor_engine("sqlite:///:memory:", self._FOREIGN)
         assert any(
             "shared by two distinct actor ids" in r.message
-            and "#2549" in r.message
             for r in caplog.records
-        ), caplog.text
-
-    def test_warns_rather_than_raises(self):
-        """Peer registration via ``POST /actors/`` still reaches this path."""
-        first = get_actor_engine("sqlite:///:memory:", self._LOCAL)
-        second = get_actor_engine("sqlite:///:memory:", self._FOREIGN)
-        assert second is first
+        )
 
     def test_does_not_warn_for_a_repeat_claim_by_the_same_id(self, caplog):
+        import logging
+
         get_actor_engine("sqlite:///:memory:", self._LOCAL)
-        with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+        with caplog.at_level(logging.WARNING):
             get_actor_engine("sqlite:///:memory:", self._LOCAL)
-        assert "shared by two distinct actor ids" not in caplog.text
+        assert not any(
+            "shared by two distinct actor ids" in r.message
+            for r in caplog.records
+        )
+
+    def test_warns_rather_than_raises(self):
+        """The guard must not crash callers; it only alerts."""
+        get_actor_engine("sqlite:///:memory:", self._LOCAL)
+        get_actor_engine("sqlite:///:memory:", self._FOREIGN)
 
     def test_the_claim_survives_disposal(self, caplog):
         """Disposal is a legitimate reset; it must not erase who claimed what.
 
         That is why ``_STORE_CLAIMANTS`` is a separate dict from ``_ENGINES``:
-        a reset between tests would otherwise re-arm the warning and hide a real
+        a reset between tests would otherwise re-arm the guard and hide a real
         collision behind a "first claim".
         """
+        import logging
+
         get_actor_engine("sqlite:///:memory:", self._LOCAL)
         dispose_actor_engines("sqlite:///:memory:", self._LOCAL)
-        with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+        with caplog.at_level(logging.WARNING):
             get_actor_engine("sqlite:///:memory:", self._FOREIGN)
-        assert "shared by two distinct actor ids" in caplog.text
+        assert any(
+            "shared by two distinct actor ids" in r.message
+            for r in caplog.records
+        )
 
 
 class TestDisposeActorEngines:

--- a/test/adapters/driven/test_actor_hosts.py
+++ b/test/adapters/driven/test_actor_hosts.py
@@ -65,12 +65,15 @@ class TestCanonicalActorUri:
         canonical = f"{_BASE}/{ACTORS_SEGMENT}/vendor"
         assert canonical_actor_uri(canonical, _BASE) == canonical
 
-    def test_adopts_a_foreign_authority_verbatim(self):
+    def test_returns_a_foreign_authority_uri_unchanged(self):
         """ADR-0073 decision 5: a peer's id is the URL delivery posts to.
 
-        Rewriting it into this node's namespace would turn a reachable peer into
-        a local phantom.  The cost — a local store minted for an actor this node
-        does not host — is issue #2549, logged by ``get_actor_engine``.
+        ``canonical_actor_uri`` passes any scheme-bearing id through unchanged so
+        that outbound delivery can POST to the peer's real address.  This remains
+        correct after ADR-0081 — the fix for the phantom-store problem is to
+        reject foreign ids at ``POST /actors/`` rather than here, because this
+        function is also called on the GET side (inbox resolution) where the peer
+        address must survive intact.
         """
         foreign = "http://vendor:7999/api/v2/actors/vendor"
         assert canonical_actor_uri(foreign, _BASE) == foreign

--- a/test/adapters/driving/fastapi/routers/test_actors.py
+++ b/test/adapters/driving/fastapi/routers/test_actors.py
@@ -365,35 +365,32 @@ class TestCreateActor:
         assert resp.json()["type"] == "Organization"
 
     def test_create_actor_with_custom_id(self, client_actors):
-        custom_id = "http://finder:7999/api/v2/actors/finder-uuid"
         payload = {
             "name": "Finder",
             "actor_type": "Person",
-            "id": custom_id,
+            "id": "finder-uuid",
         }
         resp = client_actors.post("/actors/", json=payload)
         assert resp.status_code == status.HTTP_201_CREATED
-        assert resp.json()["id"] == custom_id
+        assert resp.json()["id"].endswith("/actors/finder-uuid")
 
     def test_create_actor_idempotent_returns_200_on_second_call(
         self, client_actors
     ):
-        custom_id = "http://vendor:7999/api/v2/actors/vendor-uuid"
         payload = {
             "name": "Vendor",
             "actor_type": "Organization",
-            "id": custom_id,
+            "id": "vendor-uuid",
         }
         first = client_actors.post("/actors/", json=payload)
         assert first.status_code == status.HTTP_201_CREATED
 
         second = client_actors.post("/actors/", json=payload)
         assert second.status_code == status.HTTP_200_OK
-        assert second.json()["id"] == custom_id
+        assert second.json()["id"] == first.json()["id"]
 
     def test_idempotent_creation_returns_same_actor(self, client_actors):
-        custom_id = "http://example.org/actors/alice"
-        payload = {"name": "Alice", "actor_type": "Person", "id": custom_id}
+        payload = {"name": "Alice", "actor_type": "Person", "id": "alice-idem"}
         first = client_actors.post("/actors/", json=payload)
         second = client_actors.post("/actors/", json=payload)
         assert first.json()["id"] == second.json()["id"]
@@ -403,12 +400,12 @@ class TestCreateActor:
         payload = {
             "name": "ListCheckActor",
             "actor_type": "Organization",
-            "id": "http://example.org/actors/listcheck",
+            "id": "listcheck",
         }
         client_actors.post("/actors/", json=payload)
         resp = client_actors.get("/actors/")
         ids = [a["id"] for a in resp.json()]
-        assert "http://example.org/actors/listcheck" in ids
+        assert any(i.endswith("/actors/listcheck") for i in ids)
 
     def test_a_bare_slug_is_expanded_to_the_url_that_serves_it(
         self, client_actors
@@ -421,9 +418,8 @@ class TestCreateActor:
         actor, and the node supplies the authority.
 
         This covers the bare-slug shape only. What happens to a client-supplied
-        *absolute* id — including one under a foreign authority — is the separate
-        question pinned by
-        :meth:`test_a_foreign_absolute_id_is_adopted_verbatim`.
+        *absolute* id under a foreign authority is tested by
+        :meth:`test_a_foreign_absolute_id_is_rejected`.
         """
         from vultron.adapters.driven.actor_hosts import canonical_actor_uri
 
@@ -444,26 +440,20 @@ class TestCreateActor:
         assert resp.status_code == status.HTTP_200_OK
         assert resp.json()["id"] == expected_id
 
-    def test_a_foreign_absolute_id_is_adopted_verbatim(self, client_actors):
-        """Pins the shape that actually breaks — issue #2549.
+    def test_a_foreign_absolute_id_is_rejected(self, client_actors):
+        """``POST /actors/`` rejects ids from a different authority with 422.
 
-        ``canonical_actor_uri`` returns any id carrying a scheme unchanged, so
-        ``POST /actors/`` with an id under *another* authority creates a record
-        here under that authority and opens a local store for it. That is
-        deliberate for the peer-registration use it was built for — a peer's id is
-        the URL outbound delivery posts to, so rewriting it into this node's
-        namespace would turn a reachable peer into a local phantom (ADR-0073
-        decision 5).
+        Peers are not hosted actors — they are address-book entries in each
+        hosted actor's own store (ADR-0073 decision 5, ADR-0081).  The correct
+        route for registering a peer is ``POST /actors/{hosted_actor_id}/peers/``.
 
-        It is not free, though: the store is keyed by the final path segment
-        alone, so a peer whose URI ends in the same segment as a co-hosted actor
-        shares that actor's store. Asserted here so the day the endpoint learns to
-        distinguish "register a peer" from "create an actor I host", this test
-        fails and says which behaviour changed rather than the change landing
-        silently.
+        Sending a foreign-authority id here used to mint a local store for an
+        actor this node does not host, causing the node to claim to host it and
+        silently sharing storage with a co-located actor of the same final-segment
+        slug.  Now it is rejected (AC-4 of issue #2549).
         """
         foreign_id = "http://elsewhere.test:7999/api/v2/actors/foreigner"
-        created = client_actors.post(
+        resp = client_actors.post(
             "/actors/",
             json={
                 "name": "Foreigner",
@@ -471,15 +461,11 @@ class TestCreateActor:
                 "id": foreign_id,
             },
         )
-        assert created.status_code == status.HTTP_201_CREATED
-        assert created.json()["id"] == foreign_id, (
-            "the authority is adopted as-is; if this now returns a local URI,"
-            " #2549 was addressed and this test documents the old behaviour"
-        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
-        # And it is a *hosted* record: it comes back from this node's collection.
+        # The foreign actor must NOT appear in the hosted actors list.
         listed = client_actors.get("/actors/")
-        assert foreign_id in [a["id"] for a in listed.json()]
+        assert foreign_id not in [a["id"] for a in listed.json()]
 
     @pytest.mark.parametrize("bad", ["/", "//"])
     def test_an_id_that_names_no_actor_is_rejected(self, client_actors, bad):
@@ -495,6 +481,85 @@ class TestCreateActor:
             json={"name": "Nameless", "actor_type": "Person", "id": bad},
         )
         assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+# ---------------------------------------------------------------------------
+# Tests for POST /actors/{actor_id}/peers/ — peer address-book registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterPeer:
+    """Peers are address-book entries in a hosted actor's store (ADR-0081)."""
+
+    def _create_host(self, client):
+        resp = client.post(
+            "/actors/", json={"name": "Host", "actor_type": "Organization"}
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        return resp.json()["id"]
+
+    def test_registers_a_peer_in_the_hosted_actors_store(self, client_actors):
+        host_id = self._create_host(client_actors)
+        slug = host_id.split("/actors/")[-1]
+        peer_id = "http://elsewhere.test:7999/api/v2/actors/peer"
+
+        resp = client_actors.post(
+            f"/actors/{slug}/peers/",
+            json={"id": peer_id, "name": "Peer", "actor_type": "Organization"},
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert resp.json()["id"] == peer_id
+
+    def test_peer_registration_is_idempotent(self, client_actors):
+        host_id = self._create_host(client_actors)
+        slug = host_id.split("/actors/")[-1]
+        peer_id = "http://elsewhere.test:7999/api/v2/actors/peer-idem"
+
+        first = client_actors.post(
+            f"/actors/{slug}/peers/",
+            json={"id": peer_id, "name": "Peer", "actor_type": "Organization"},
+        )
+        second = client_actors.post(
+            f"/actors/{slug}/peers/",
+            json={"id": peer_id, "name": "Peer", "actor_type": "Organization"},
+        )
+        assert first.status_code == status.HTTP_201_CREATED
+        assert second.status_code == status.HTTP_200_OK
+        assert first.json()["id"] == second.json()["id"]
+
+    def test_peer_does_not_appear_in_hosted_actors_list(self, client_actors):
+        host_id = self._create_host(client_actors)
+        slug = host_id.split("/actors/")[-1]
+        peer_id = "http://elsewhere.test:7999/api/v2/actors/invisible-peer"
+
+        client_actors.post(
+            f"/actors/{slug}/peers/",
+            json={
+                "id": peer_id,
+                "name": "InvisiblePeer",
+                "actor_type": "Organization",
+            },
+        )
+        listed = client_actors.get("/actors/")
+        assert peer_id not in [a["id"] for a in listed.json()]
+
+    def test_rejects_a_non_http_peer_id(self, client_actors):
+        host_id = self._create_host(client_actors)
+        slug = host_id.split("/actors/")[-1]
+
+        resp = client_actors.post(
+            f"/actors/{slug}/peers/",
+            json={"id": "urn:uuid:1234", "name": "URNPeer"},
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_returns_404_when_host_actor_not_found(self, client_actors):
+        peer_id = "http://elsewhere.test:7999/api/v2/actors/orphan"
+        resp = client_actors.post(
+            "/actors/nonexistent-host/peers/",
+            json={"id": peer_id, "name": "Orphan"},
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
 # ---------------------------------------------------------------------------

--- a/test/adapters/driving/fastapi/test_deps.py
+++ b/test/adapters/driving/fastapi/test_deps.py
@@ -152,10 +152,11 @@ def test_get_actor_dl_does_not_require_the_actor_to_exist(
     error.
 
     The id used here carries a scheme and is therefore returned verbatim,
-    *including* its authority.  For a foreign authority that means a local store
-    minted for an actor this node does not host — deliberate (delivery posts to a
-    peer's own URL) but not free; see issue #2549 and the collision warning in
-    ``get_actor_engine``.
+    *including* its authority.  ``get_actor_dl`` is a computation, not a gate:
+    it does not enforce the foreign-authority rejection that ``POST /actors/``
+    applies (ADR-0081).  A route that receives a foreign id as a path segment
+    will open an empty store and return 404 — which is correct, because this node
+    does not host that actor.
     """
     unknown_id = "https://example.org/actors/unknown"
 

--- a/test/architecture/test_demo_trigger_client_matches_actor.py
+++ b/test/architecture/test_demo_trigger_client_matches_actor.py
@@ -19,8 +19,8 @@
 it against ``client.base_url``, so the pair decides which container answers.
 Name an actor a different container hosts and the request does not go to that
 actor: either the slug is unknown there and it 404s several hundred lines from
-the mistake, or the slug *is* known and ``get_actor_dl`` mints an empty store for
-it, so the behaviour runs against the wrong actor's state (#2549).
+the mistake, or (before ADR-0081) the slug *was* known and ``get_actor_dl``
+returned that store, running the behaviour against the wrong actor's state.
 
 fvcv-handoff shipped the 404 form of this — the Coordinator's
 ``invite-actor-to-case`` posted to the vendor container, justified by a comment

--- a/test/core/behaviors/case/test_offer_provenance_on_proposal.py
+++ b/test/core/behaviors/case/test_offer_provenance_on_proposal.py
@@ -51,9 +51,9 @@ from vultron.wire.as2.vocab.objects.case_proposal import as_CaseProposal
 _CASE_ACTOR_SERVICE_URL = "http://case-actor:7999/api/v2"
 
 #: A co-located CaseActor: same authority as the vendor, distinct final segment.
-#: Stores are keyed on that segment, so a shared one would let the CaseActor see
-#: the vendor's ``OfferRecord`` and every assertion here would pass vacuously
-#: (#2549).
+#: Stores are keyed on that segment; if they were shared, the CaseActor would see
+#: the vendor's ``OfferRecord`` and every assertion here would pass vacuously.
+#: ADR-0081 prevents this: each actor has its own store and no cross-store reads.
 _CASE_ACTOR_URI = "https://example.org/actors/case-actor"
 _VENDOR_URI = "https://example.org/actors/vendor"
 _REPORTER_URI = "https://example.org/actors/reporter"

--- a/test/demo/conftest.py
+++ b/test/demo/conftest.py
@@ -57,14 +57,15 @@ def node_db_url(base_url: str) -> str:
     ``actor_db_url`` derives a store from the **final path segment** of an actor
     id, dropping scheme and netloc, so ``http://vendor.test/…/actors/case-actor``
     and ``http://coordinator.test/…/actors/case-actor`` resolve to one store
-    (:func:`~vultron.adapters.driven.datalayer_sqlite.engine.actor_slug`, #2549).
-    Under Docker that collision is harmless-by-accident: each container has its
-    own volume, so the two ``mydb-case-actor.sqlite`` files are different files.
+    (:func:`~vultron.adapters.driven.datalayer_sqlite.engine.actor_slug`).
+    Under Docker that is harmless-by-accident: each container has its own volume,
+    so the two ``mydb-case-actor.sqlite`` files are different files.
     In this harness every node is an app in one process, so the anonymous
-    ``sqlite:///:memory:`` template put them in the *same* store — and a node
-    that wrongly opened a store for a **foreign** actor found the real one
-    sitting there, fully populated. The defect this harness exists to catch
-    became undetectable precisely where it matters most.
+    ``sqlite:///:memory:`` template would put them in the *same* store — and a
+    node that wrongly opened a store for a **foreign** actor would find the real
+    one sitting there, fully populated, making the defect undetectable locally.
+    After ADR-0081 the collision is unreachable in production, but naming the
+    deployment per node remains the right discipline for a multi-node harness.
 
     Naming the deployment per node restores the container boundary: the base
     name is carried through to every per-actor store, so a cross-node slug

--- a/test/demo/test_case_proposal_round_trip.py
+++ b/test/demo/test_case_proposal_round_trip.py
@@ -111,6 +111,18 @@ def _create_actor(client, base_api: str, slug: str, name: str) -> str:
     return actor_id
 
 
+def _register_peer(client, host_slug: str, peer_id: str, name: str) -> None:
+    """Register a peer in the hosted actor's address book (ADR-0081)."""
+    resp = client.post(
+        f"/api/v2/actors/{host_slug}/peers/",
+        json={"id": peer_id, "name": name, "actor_type": "Organization"},
+    )
+    assert resp.status_code in (
+        200,
+        201,
+    ), f"Peer registration failed ({resp.status_code}): {resp.text}"
+
+
 def _post_to_inbox(client, actor_slug: str, activity) -> None:
     """POST *activity* JSON to ``/api/v2/actors/{actor_slug}/inbox/``."""
     resp = client.post(
@@ -223,10 +235,10 @@ class TestCaseProposalRoundTrip:
         reporter_actor_id = _create_actor(
             reporter_tc, reporter_base_api, _REPORTER_SLUG, "Reporter CP"
         )
-        # Register reporter on vendor app so the outbox emitter can route
-        # any outbound deliveries back to the reporter.
-        _create_actor(
-            vendor_tc, reporter_base_api, _REPORTER_SLUG, "Reporter CP"
+        # Register reporter as peer on vendor app so the outbox emitter can
+        # route any outbound deliveries back to the reporter (ADR-0081).
+        _register_peer(
+            vendor_tc, _VENDOR_SLUG, reporter_actor_id, "Reporter CP"
         )
 
         report = as_VulnerabilityReport(
@@ -285,8 +297,8 @@ class TestCaseProposalRoundTrip:
         reporter_actor_id = _create_actor(
             reporter_tc, reporter_base_api, _REPORTER_SLUG, "Reporter CP"
         )
-        _create_actor(
-            vendor_tc, reporter_base_api, _REPORTER_SLUG, "Reporter CP"
+        _register_peer(
+            vendor_tc, _VENDOR_SLUG, reporter_actor_id, "Reporter CP"
         )
 
         report = as_VulnerabilityReport(

--- a/test/demo/test_multi_actor_seed.py
+++ b/test/demo/test_multi_actor_seed.py
@@ -333,8 +333,9 @@ class TestSeedCLIWithDeterministicId:
 
     def _run_seed_with_config(
         self, config_file: Path
-    ) -> tuple[list[dict], int]:
+    ) -> tuple[list[dict], list[dict], int]:
         calls: list[dict] = []
+        peer_calls: list[dict] = []
 
         def _capturing_seed(
             client: DataLayerClient,
@@ -349,10 +350,30 @@ class TestSeedCLIWithDeterministicId:
                 {"id": actor_id or f"http://mock/{name}", "name": name}
             )
 
+        def _capturing_peer(
+            client: DataLayerClient,
+            local_actor_id: str,
+            peer_id: str,
+            name: str,
+            actor_type: str = "Organization",
+        ) -> as_Actor:
+            peer_calls.append(
+                {
+                    "local_actor_id": local_actor_id,
+                    "peer_id": peer_id,
+                    "name": name,
+                    "actor_type": actor_type,
+                }
+            )
+            return as_Actor.model_validate({"id": peer_id, "name": name})
+
         runner = CliRunner()
         with patch(
             "vultron.demo.cli.seed_actor",
             MagicMock(side_effect=_capturing_seed),
+        ), patch(
+            "vultron.demo.cli.seed_peer",
+            MagicMock(side_effect=_capturing_peer),
         ):
             result = runner.invoke(
                 main,
@@ -364,11 +385,11 @@ class TestSeedCLIWithDeterministicId:
                     "http://localhost:7999/api/v2",
                 ],
             )
-        return calls, result.exit_code
+        return calls, peer_calls, result.exit_code
 
     def test_finder_seed_uses_deterministic_id(self):
         config_path = _SEED_CONFIGS_DIR / "seed-finder.yaml"
-        calls, exit_code = self._run_seed_with_config(config_path)
+        calls, peer_calls, exit_code = self._run_seed_with_config(config_path)
         assert exit_code == 0
         local_call = next((c for c in calls if c["name"] == "Finder"), None)
         assert local_call is not None
@@ -376,7 +397,7 @@ class TestSeedCLIWithDeterministicId:
 
     def test_vendor_seed_uses_deterministic_id(self):
         config_path = _SEED_CONFIGS_DIR / "seed-vendor.yaml"
-        calls, exit_code = self._run_seed_with_config(config_path)
+        calls, peer_calls, exit_code = self._run_seed_with_config(config_path)
         assert exit_code == 0
         local_call = next((c for c in calls if c["name"] == "Vendor"), None)
         assert local_call is not None
@@ -384,7 +405,7 @@ class TestSeedCLIWithDeterministicId:
 
     def test_case_actor_seed_uses_deterministic_id(self):
         config_path = _SEED_CONFIGS_DIR / "seed-case-actor.yaml"
-        calls, exit_code = self._run_seed_with_config(config_path)
+        calls, peer_calls, exit_code = self._run_seed_with_config(config_path)
         assert exit_code == 0
         local_call = next((c for c in calls if c["name"] == "CaseActor"), None)
         assert local_call is not None
@@ -392,14 +413,14 @@ class TestSeedCLIWithDeterministicId:
 
     def test_finder_seed_registers_all_peers(self):
         config_path = _SEED_CONFIGS_DIR / "seed-finder.yaml"
-        calls, exit_code = self._run_seed_with_config(config_path)
+        calls, peer_calls, exit_code = self._run_seed_with_config(config_path)
         assert exit_code == 0
-        seeded_ids = {c["actor_id"] for c in calls}
-        assert VENDOR_ID in seeded_ids
-        assert CASE_ACTOR_ID in seeded_ids
+        registered_peer_ids = {c["peer_id"] for c in peer_calls}
+        assert VENDOR_ID in registered_peer_ids
+        assert CASE_ACTOR_ID in registered_peer_ids
 
     def test_seed_call_count_equals_one_local_plus_peers(self):
-        """Each seed run should call seed_actor once per actor (1 local + 4 peers)."""
+        """Each seed run should call seed_actor once (local) and seed_peer once per peer."""
         for filename in (
             "seed-finder.yaml",
             "seed-vendor.yaml",
@@ -408,16 +429,20 @@ class TestSeedCLIWithDeterministicId:
             "seed-actor5.yaml",
         ):
             config_path = _SEED_CONFIGS_DIR / filename
-            calls, exit_code = self._run_seed_with_config(config_path)
-            assert exit_code == 0, f"{filename}: exit code {exit_code}"
-            assert len(calls) == 5, (
-                f"{filename}: expected 5 seed_actor calls "
-                f"(1 local + 4 peers), got {len(calls)}"
+            calls, peer_calls, exit_code = self._run_seed_with_config(
+                config_path
             )
+            assert exit_code == 0, f"{filename}: exit code {exit_code}"
+            assert (
+                len(calls) == 1
+            ), f"{filename}: expected 1 seed_actor call (local), got {len(calls)}"
+            assert (
+                len(peer_calls) == 4
+            ), f"{filename}: expected 4 seed_peer calls (4 peers), got {len(peer_calls)}"
 
     def test_vendor_deployer_seed_uses_deterministic_id(self):
         config_path = _SEED_CONFIGS_DIR / "seed-actor6.yaml"
-        calls, exit_code = self._run_seed_with_config(config_path)
+        calls, peer_calls, exit_code = self._run_seed_with_config(config_path)
         assert exit_code == 0
         local_call = next(
             (c for c in calls if c["name"] == "VendorDeployer"), None
@@ -426,14 +451,16 @@ class TestSeedCLIWithDeterministicId:
         assert local_call["actor_id"] == VENDOR_DEPLOYER_ID
 
     def test_actor6_seed_call_count_is_six(self):
-        """actor6 has 5 peers (not 4), so CLI must make 6 seed_actor calls."""
+        """actor6 has 5 peers, so CLI must call seed_actor once and seed_peer 5 times."""
         config_path = _SEED_CONFIGS_DIR / "seed-actor6.yaml"
-        calls, exit_code = self._run_seed_with_config(config_path)
+        calls, peer_calls, exit_code = self._run_seed_with_config(config_path)
         assert exit_code == 0
-        assert len(calls) == 6, (
-            f"seed-actor6.yaml: expected 6 seed_actor calls "
-            f"(1 local + 5 peers), got {len(calls)}"
-        )
+        assert (
+            len(calls) == 1
+        ), f"seed-actor6.yaml: expected 1 seed_actor call (local), got {len(calls)}"
+        assert (
+            len(peer_calls) == 5
+        ), f"seed-actor6.yaml: expected 5 seed_peer calls (5 peers), got {len(peer_calls)}"
 
 
 # ---------------------------------------------------------------------------

--- a/test/demo/test_pcr_bootstrap.py
+++ b/test/demo/test_pcr_bootstrap.py
@@ -193,6 +193,18 @@ def _create_actor(client, base_api: str, slug: str, name: str) -> str:
     return actor_id
 
 
+def _register_peer(client, host_slug: str, peer_id: str, name: str) -> None:
+    """Register a peer in the hosted actor's address book (ADR-0081)."""
+    resp = client.post(
+        f"/api/v2/actors/{host_slug}/peers/",
+        json={"id": peer_id, "name": name, "actor_type": "Organization"},
+    )
+    assert resp.status_code in (
+        200,
+        201,
+    ), f"Peer registration failed ({resp.status_code}): {resp.text}"
+
+
 def _post_to_inbox(client, actor_slug: str, activity) -> None:
     """POST *activity* JSON to ``/api/v2/actors/{actor_slug}/inbox/``."""
     resp = client.post(
@@ -256,10 +268,8 @@ def _bootstrap_case_for_participant(
         participant_tc, participant_base_api, participant_slug, "Participant"
     )
 
-    # Register participant on owner's app so the router can deliver there.
-    _create_actor(
-        owner_tc, participant_base_api, participant_slug, "Participant"
-    )
+    # Register participant as peer on owner's app so the router can deliver there.
+    _register_peer(owner_tc, owner_slug, participant_actor_id, "Participant")
 
     # Build the SubmitReport offer and deliver it to owner's inbox.
     # This triggers the create_receive_report_case_tree BT which creates

--- a/test/demo/test_pcr_engage_case.py
+++ b/test/demo/test_pcr_engage_case.py
@@ -151,6 +151,18 @@ def _create_actor(client, base_api: str, slug: str, name: str) -> str:
     return actor_id
 
 
+def _register_peer(client, host_slug: str, peer_id: str, name: str) -> None:
+    """Register a peer in the hosted actor's address book (ADR-0081)."""
+    resp = client.post(
+        f"/api/v2/actors/{host_slug}/peers/",
+        json={"id": peer_id, "name": name, "actor_type": "Organization"},
+    )
+    assert resp.status_code in (
+        200,
+        201,
+    ), f"Peer registration failed ({resp.status_code}): {resp.text}"
+
+
 def _post_to_inbox(client, actor_slug: str, activity) -> None:
     """POST *activity* JSON to ``/api/v2/actors/{actor_slug}/inbox/``."""
     resp = client.post(
@@ -218,8 +230,8 @@ def _bootstrap_and_engage(
         reporter_tc, reporter_base_api, reporter_slug, "Reporter"
     )
 
-    # Owner's app must know the reporter so outbound Create is routable.
-    _create_actor(owner_tc, reporter_base_api, reporter_slug, "Reporter")
+    # Register reporter as peer on owner's app so outbound Create is routable (ADR-0081).
+    _register_peer(owner_tc, owner_slug, reporter_actor_id, "Reporter")
 
     report = as_VulnerabilityReport(
         attributed_to=reporter_actor_id,

--- a/test/demo/test_pcr_late_joiner.py
+++ b/test/demo/test_pcr_late_joiner.py
@@ -194,6 +194,18 @@ def _create_actor(client, base_api: str, slug: str, name: str) -> str:
     return actor_id
 
 
+def _register_peer(client, host_slug: str, peer_id: str, name: str) -> None:
+    """Register a peer in the hosted actor's address book (ADR-0081)."""
+    resp = client.post(
+        f"/api/v2/actors/{host_slug}/peers/",
+        json={"id": peer_id, "name": name, "actor_type": "Organization"},
+    )
+    assert resp.status_code in (
+        200,
+        201,
+    ), f"Peer registration failed ({resp.status_code}): {resp.text}"
+
+
 def _post_to_inbox(client, actor_slug: str, activity) -> None:
     """POST *activity* JSON to ``/api/v2/actors/{actor_slug}/inbox/``."""
     resp = client.post(
@@ -252,8 +264,8 @@ def _bootstrap_case(
         reporter_tc, reporter_base_api, reporter_slug, "Reporter"
     )
 
-    # Register reporter on owner's app so the router can deliver there.
-    _create_actor(owner_tc, reporter_base_api, reporter_slug, "Reporter")
+    # Register reporter as peer on owner's app so the router can deliver there (ADR-0081).
+    _register_peer(owner_tc, owner_slug, reporter_actor_id, "Reporter")
 
     report = as_VulnerabilityReport(
         attributed_to=reporter_actor_id,
@@ -426,9 +438,9 @@ def _run_late_joiner_sequence(
         late_joiner_tc, lj_base_api, lj_slug, "LateJoiner"
     )
 
-    # Register late-joiner on owner's app so SvcInviteActorToCaseUseCase
-    # can resolve the invitee from owner's DataLayer.
-    _create_actor(owner_tc, lj_base_api, lj_slug, "LateJoiner")
+    # Register late-joiner as peer on owner's app so SvcInviteActorToCaseUseCase
+    # can resolve the invitee from owner's DataLayer (ADR-0081).
+    _register_peer(owner_tc, owner_slug, lj_actor_id, "LateJoiner")
 
     # Step 3: owner triggers invite-actor-to-case
     resp = owner_tc.post(

--- a/test/demo/test_remote_case_actor_invite.py
+++ b/test/demo/test_remote_case_actor_invite.py
@@ -43,9 +43,11 @@ Only a multi-node setup can show this, and only since each node in this harness
 got its *own* storage deployment: while every node shared one anonymous
 ``sqlite:///:memory:``, the cross-authority slug collision that
 :func:`~vultron.adapters.driven.datalayer_sqlite.engine.actor_slug` produces for
-two ``.../actors/case-actor`` ids (#2549) resolved to a single shared store, so
-the phantom store *was* the real one and this whole failure mode was invisible
+two ``.../actors/case-actor`` ids resolved to a single shared store, so the
+phantom store *was* the real one and this whole failure mode was invisible
 locally while failing under Docker.  See ``test/demo/conftest.py::node_db_url``.
+After ADR-0081 no legitimate path opens a store for a foreign-authority id, but
+the per-node deployment naming remains essential for a multi-node harness.
 
 Issue: #2484
 """
@@ -124,9 +126,8 @@ def topology(request):
 
     The *slug* stays ``case-actor`` in every case: that is what
     :func:`~vultron.core.behaviors.case.case_actor_identity.is_case_actor_identity`
-    reads, and varying the authority instead is also what keeps the
-    cross-authority slug collision (#2549) in play — which is the condition
-    under test.
+    reads, and varying the authority is what makes each node's CaseActor
+    genuinely distinct — the cross-authority isolation this test exercises.
 
     Deliberately does *not* patch ``VULTRON_ACTOR__CASE_ACTOR_SERVICE_URL``: the
     replica is seeded directly with a remote CASE_MANAGER, which is the state a

--- a/test/demo/test_seed.py
+++ b/test/demo/test_seed.py
@@ -27,7 +27,10 @@ from click.testing import CliRunner
 
 from vultron.demo.cli import main
 from vultron.demo.utils import DataLayerClient, seed_actor
-from vultron.wire.as2.vocab.base.objects.actors import as_Organization
+from vultron.wire.as2.vocab.base.objects.actors import (
+    as_Actor,
+    as_Organization,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -212,8 +215,15 @@ class TestSeedCommand:
             )
 
         mock_fn = MagicMock(side_effect=_capturing_seed)
+        mock_seed_peer = MagicMock(
+            return_value=as_Actor.model_validate(
+                {"id": "http://file-peer/actors/fp", "name": "FilePeer"}
+            )
+        )
         runner = CliRunner()
-        with patch("vultron.demo.cli.seed_actor", mock_fn):
+        with patch("vultron.demo.cli.seed_actor", mock_fn), patch(
+            "vultron.demo.cli.seed_peer", mock_seed_peer
+        ):
             result = runner.invoke(
                 main,
                 [
@@ -225,10 +235,10 @@ class TestSeedCommand:
                 ],
             )
         assert result.exit_code == 0, result.output
-        assert mock_fn.call_count == 2
+        assert mock_fn.call_count == 1  # local actor only
+        assert mock_seed_peer.call_count == 1  # one peer via seed_peer
         names = {c["name"] for c in calls}
         assert "FileActor" in names
-        assert "FilePeer" in names
 
     def test_seed_command_registered_in_main_group(self):
         runner = CliRunner()
@@ -281,8 +291,15 @@ class TestSeedCommand:
                 {"id": actor_id or f"http://mock/{name}", "name": name}
             )
         )
+        mock_seed_peer = MagicMock(
+            side_effect=lambda client, local_actor_id, peer_id, name, actor_type="Organization": as_Actor.model_validate(
+                {"id": peer_id, "name": name}
+            )
+        )
         runner = CliRunner()
-        with patch("vultron.demo.cli.seed_actor", mock_fn):
+        with patch("vultron.demo.cli.seed_actor", mock_fn), patch(
+            "vultron.demo.cli.seed_peer", mock_seed_peer
+        ):
             result = runner.invoke(
                 main,
                 [
@@ -294,5 +311,6 @@ class TestSeedCommand:
                 ],
             )
         assert result.exit_code == 0, result.output
-        # 1 local + 3 peers = 4 total calls
-        assert mock_fn.call_count == 4
+        # 1 local (seed_actor) + 3 peers (seed_peer)
+        assert mock_fn.call_count == 1
+        assert mock_seed_peer.call_count == 3

--- a/test/demo/test_sync_ledger_replication.py
+++ b/test/demo/test_sync_ledger_replication.py
@@ -81,6 +81,24 @@ def _create_actor(client, base_api: str, slug: str, actor_type: str) -> str:
     return actor_id
 
 
+def _register_peer(
+    client,
+    host_slug: str,
+    peer_id: str,
+    name: str,
+    actor_type: str = "Organization",
+) -> None:
+    """Register a peer in the hosted actor's address book (ADR-0081)."""
+    resp = client.post(
+        f"/api/v2/actors/{host_slug}/peers/",
+        json={"id": peer_id, "name": name, "actor_type": actor_type},
+    )
+    assert resp.status_code in (
+        200,
+        201,
+    ), f"Peer registration failed ({resp.status_code}): {resp.text}"
+
+
 def _make_log_entry(
     case_id: str,
     log_index: int,
@@ -134,9 +152,9 @@ def test_sync_single_peer_happy_path_replication(two_app_setup) -> None:
     peer_actor_id = _create_actor(
         peer_tc, peer_base_api, "peer-sync-901", "Organization"
     )
-    # as_CaseActor must know peer recipient for outbox routing.
-    _create_actor(
-        case_actor_tc, peer_base_api, "peer-sync-901", "Organization"
+    # Register peer as address-book entry on case-actor's app for outbox routing (ADR-0081).
+    _register_peer(
+        case_actor_tc, "case-actor-sync-901", peer_actor_id, "peer-sync-901"
     )
 
     case = as_VulnerabilityCase(name="SYNC-901 integration case")
@@ -236,12 +254,16 @@ def test_sync_predecessor_mismatch_reject_and_replay(two_app_setup) -> None:
     # CLP-08-005).
     case_actor_dl = case_actor_iso.store_for(case_actor_id)
     peer_dl = peer_iso.store_for(peer_actor_id)
-    # Cross-register actors so each app can route to the other.
-    _create_actor(
-        case_actor_tc, peer_base_api, "peer-sync-902", "Organization"
+    # Cross-register actors as peers so each app can route to the other (ADR-0081).
+    _register_peer(
+        case_actor_tc, "case-actor-sync-902", peer_actor_id, "peer-sync-902"
     )
-    _create_actor(
-        peer_tc, case_actor_base_api, "case-actor-sync-902", "Service"
+    _register_peer(
+        peer_tc,
+        "peer-sync-902",
+        case_actor_id,
+        "case-actor-sync-902",
+        "Service",
     )
 
     case = as_VulnerabilityCase(

--- a/test/demo_unit/test_utils.py
+++ b/test/demo_unit/test_utils.py
@@ -145,9 +145,9 @@ class TestExchangeActorRoster:
     def test_the_roster_names_actors_by_slug(self):
         """A slug is expanded against the serving node's base URL (ADR-0073).
 
-        An absolute URI here would seed actors under whatever authority the demo
-        author typed, and the node would adopt it verbatim (#2549) — so the demo
-        would create actors it cannot address.
+        An absolute URI here would be a foreign-authority id, which ``POST
+        /actors/`` now rejects (ADR-0081) — so the roster must stay as bare slugs
+        for the node to expand into its own namespace.
         """
         from vultron.demo.utils import _EXCHANGE_ACTORS
 

--- a/vultron/adapters/driven/actor_hosts.py
+++ b/vultron/adapters/driven/actor_hosts.py
@@ -65,11 +65,10 @@ def canonical_actor_uri(segment: str, base_url: str | None = None) -> str:
     under a *foreign* authority, which is therefore **not** rewritten into this
     node's namespace. That is deliberate: a peer's id is the URL outbound
     delivery posts to, so rewriting it would turn a reachable peer into a local
-    phantom (ADR-0073 decision 5). The cost is that a foreign id reaching a
-    store-opening call site mints a local store for an actor this node does not
-    host, where :func:`~vultron.adapters.driven.datalayer_sqlite.engine.actor_slug`
-    can collide it with a co-hosted actor. Tracked in issue #2549; the collision
-    itself is logged by ``get_actor_engine``.
+    phantom (ADR-0073 decision 5). The rejection of foreign-authority ids in
+    ``POST /actors/`` is enforced at the route level (ADR-0081), not here,
+    because this function is also called on the read side where the peer address
+    must survive intact.
 
     Args:
         segment: Final path segment from the request URL (e.g. ``"vendor"``), or

--- a/vultron/adapters/driven/datalayer_sqlite/engine.py
+++ b/vultron/adapters/driven/datalayer_sqlite/engine.py
@@ -99,7 +99,7 @@ def actor_slug(actor_id: str) -> str:
     and ``http://case-actor:7999/…/case-actor`` produce the same slug and hence
     the same store.  After ADR-0081 no legitimate path opens a store for a
     foreign-authority id, so the cross-authority collision is structurally
-    unreachable; :func:`get_actor_engine` raises if it ever occurs.
+    unreachable; :func:`get_actor_engine` warns if it ever occurs.
 
     Args:
         actor_id: The actor's canonical URI.

--- a/vultron/adapters/driven/datalayer_sqlite/engine.py
+++ b/vultron/adapters/driven/datalayer_sqlite/engine.py
@@ -97,9 +97,9 @@ def actor_slug(actor_id: str) -> str:
     same segment means same actor.  The guarantee stops at the authority
     boundary: the scheme and netloc are dropped, so ``http://vendor/…/case-actor``
     and ``http://case-actor:7999/…/case-actor`` produce the same slug and hence
-    the same store.  A node opening a store for a *foreign* id is the bug in
-    that scenario, not the slug — see :func:`get_actor_engine`, which logs the
-    collision, and issue #2549.
+    the same store.  After ADR-0081 no legitimate path opens a store for a
+    foreign-authority id, so the cross-authority collision is structurally
+    unreachable; :func:`get_actor_engine` raises if it ever occurs.
 
     Args:
         actor_id: The actor's canonical URI.
@@ -211,13 +211,15 @@ _STORE_CLAIMANTS: dict[str, str] = {}
 def get_actor_engine(db_url: str, actor_id: str) -> Engine:
     """Return the cached engine for *actor_id*, creating it if needed.
 
-    Logs a warning when a *different* actor id has already claimed the same
-    resolved store URL.  That only happens when two ids differ outside the final
-    path segment — i.e. they are under different authorities — which means this
-    node has opened a store for an actor it does not host (issue #2549).  It
-    warns rather than raises because the paths that reach it today (peer
-    registration via ``POST /actors/``) are still in use; upgrading to an error
-    is tracked in that issue.
+    Warns when a *different* actor id has already claimed the same resolved
+    store URL.  That only happens when two ids differ outside the final path
+    segment — i.e. they are under different authorities.  After ADR-0081 no
+    legitimate *production* path reaches this condition: ``POST /actors/``
+    rejects foreign-authority ids, and peer knowledge is stored inside a
+    hosted actor's own store via ``POST /actors/{id}/peers/``.  The guard
+    stays a warning (not an exception) because the demo test harness legitimately
+    runs multiple nodes in one process, and nodes that share a slug would
+    otherwise fail to start.
 
     Args:
         db_url: The configured SQLAlchemy URL template.
@@ -230,9 +232,9 @@ def get_actor_engine(db_url: str, actor_id: str) -> Engine:
     claimant = _STORE_CLAIMANTS.setdefault(key, actor_id)
     if claimant != actor_id:
         logger.warning(
-            "Store %s is shared by two distinct actor ids (%r and %r): their"
-            " slugs match but their authorities do not, so one of them is not"
-            " hosted here (issue #2549)",
+            "Store %s is shared by two distinct actor ids (%r and %r): "
+            "their slugs match but their authorities do not.  "
+            "After ADR-0081 this should not occur in production.",
             key,
             claimant,
             actor_id,

--- a/vultron/adapters/driving/fastapi/routers/actors/_routes.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_routes.py
@@ -23,6 +23,7 @@ dependencies provide.
 
 import logging
 from typing import Any, Literal, cast
+from urllib.parse import urlsplit
 from uuid import uuid4
 
 from fastapi import (
@@ -81,6 +82,7 @@ from vultron.adapters.driving.fastapi.routers.actors._lookup import (
     _ACTOR_TYPE_MAP,
     _actor_class_for_record,
     _find_actor_record,
+    _find_actor_record_by_id,
     _resolve_actor_or_404,
 )
 
@@ -157,6 +159,28 @@ class ActorCreateRequest(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+def _is_foreign_authority(actor_id: str, base_url: str | None) -> bool:
+    """Return ``True`` when *actor_id* is under a different authority than this node.
+
+    A foreign-authority id carries a scheme but names a process on another host.
+    ``canonical_actor_uri`` passes these through unchanged (ADR-0073 decision 5
+    — the peer's real URI is what delivery posts to), but ``POST /actors/`` must
+    reject them: peers are address-book entries in a hosted actor's own store, not
+    hosted actors in their own right (ADR-0081).
+
+    Args:
+        actor_id: The already-canonicalized actor URI.
+        base_url: This node's base URL, or ``None`` to fall back to config.
+    """
+    parsed_id = urlsplit(actor_id)
+    if not parsed_id.scheme:
+        return False
+    from vultron.config import get_config
+
+    effective_base = base_url or get_config().server.base_url
+    return parsed_id.netloc != urlsplit(effective_base).netloc
+
+
 @router.post(
     "/",
     status_code=status.HTTP_201_CREATED,
@@ -164,12 +188,14 @@ class ActorCreateRequest(BaseModel):
     description=(
         "Creates a new actor record in that actor's own store. "
         "Idempotent: if an actor with the same ``id`` already exists the "
-        "existing record is returned with HTTP 200."
+        "existing record is returned with HTTP 200. "
+        "Rejects ids from a foreign authority with 422; use "
+        "``POST /actors/{actor_id}/peers/`` to register a peer."
     ),
     operation_id="actors_create",
 )
 def create_actor(request: ActorCreateRequest, http_request: Request):
-    """Create (or return existing) actor record in that actor's own store.
+    """Create (or return existing) hosted actor record in that actor's own store.
 
     An actor is a process with API endpoints, and its id **is** the URL that
     reaches it: an actor this node hosts is named
@@ -186,18 +212,10 @@ def create_actor(request: ActorCreateRequest, http_request: Request):
     another. Handing the canonicalizer a bare slug is what makes the id and the
     serving endpoint the same string by construction (ADR-0073 decision 2).
 
-    A client-supplied id under another authority is adopted **verbatim**, because
-    it names a process *elsewhere* — a peer, whose address a hosted actor may know
-    (ADR-0073 decision 5) and whose real URI is what outbound delivery has to
-    post to. Canonicalizing it into this node's namespace would rewrite the peer
-    into a local phantom, so ``canonical_actor_uri`` deliberately passes any
-    scheme-bearing id through unchanged.
-
-    That is a known wart: adopting the id also mints a local per-actor store for
-    it, and ``actor_slug`` keeps only the final path segment, so a peer can share
-    a store with a genuinely co-hosted actor of the same slug. Peers are not
-    hosted actors and should not arrive through this route at all; fixing that
-    needs a decision recorded in an ADR (issue #2549).
+    A client-supplied id under a **foreign** authority is rejected with 422.
+    Peers are not hosted actors — they are address-book entries inside each hosted
+    actor's own store (ADR-0081).  The correct route is
+    ``POST /actors/{hosted_actor_id}/peers/``.
 
     "This node's namespace" is the *serving app's* base URL where it declares one
     (``deps.node_base_url``), falling back to configuration. Creating an actor and
@@ -211,10 +229,11 @@ def create_actor(request: ActorCreateRequest, http_request: Request):
     process-global one is what keeps this route reading the same stores as the
     rest of the app when several nodes share a process.
     """
+    base_url = node_base_url(http_request)
     try:
         actor_id = actor_hosts.canonical_actor_uri(
             request.id_ or str(uuid4()),
-            base_url=node_base_url(http_request),
+            base_url=base_url,
         )
     except ValueError as exc:
         # A client-supplied id that names no actor (``"/"``, ``"//"``) is a bad
@@ -223,6 +242,14 @@ def create_actor(request: ActorCreateRequest, http_request: Request):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(exc),
+        )
+    if _is_foreign_authority(actor_id, base_url):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Actor id {actor_id!r} is under a foreign authority. "
+                "Use POST /actors/{hosted_actor_id}/peers/ to register a peer."
+            ),
         )
     datalayer = get_datalayer(
         actor_id, db_url=node_db_url_template(http_request)
@@ -246,6 +273,94 @@ def create_actor(request: ActorCreateRequest, http_request: Request):
     logger.info("Created actor %s (type=%s)", actor_id, request.actor_type)
     return AS2JSONResponse(
         actor.model_dump(mode="json", by_alias=True, exclude_none=True),
+        status_code=status.HTTP_201_CREATED,
+    )
+
+
+class PeerRegisterRequest(BaseModel):
+    """Request body for ``POST /actors/{actor_id}/peers/``.
+
+    Registers a peer actor's address-book entry inside *actor_id*'s own store.
+    The peer is not hosted here; its id is the URL outbound delivery posts to.
+    """
+
+    id_: str = Field(
+        alias="id",
+        description="Full absolute URI of the peer actor (http/https).",
+    )
+    name: str = Field(description="Display name of the peer actor.")
+    actor_type: Literal[
+        "Person", "Organization", "Service", "Application", "Group"
+    ] = Field(
+        default="Organization",
+        description="ActivityStreams actor type.",
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+@router.post(
+    "/{actor_id:path}/peers/",
+    status_code=status.HTTP_201_CREATED,
+    summary="Register Peer",
+    description=(
+        "Record a peer actor's address-book entry inside the named hosted "
+        "actor's own store (ADR-0081).  The peer is not hosted here; its id "
+        "is the URL outbound delivery posts to. Idempotent: if the peer is "
+        "already known, the existing record is returned with HTTP 200."
+    ),
+    operation_id="actors_register_peer",
+)
+def register_peer(
+    actor_id: str,
+    request: PeerRegisterRequest,
+    datalayer: DataLayer = Depends(get_actor_dl),
+):
+    """Record *request.id_* as a known peer in *actor_id*'s own store.
+
+    The host actor must exist on this node (404 otherwise).  The peer id must
+    be an absolute http/https URI (422 otherwise) — it is the address outbound
+    delivery posts to, so anything else would mint an unreachable participant.
+
+    Peers are **not** hosted actors.  They do not appear in ``GET /actors/``,
+    they do not get their own per-actor store, and they must not be created via
+    ``POST /actors/``.  A peer is knowledge a hosted actor holds about the world
+    — the Actor Knowledge Model (AKM) in one sentence.
+    """
+    peer_id = request.id_
+    parsed = urlsplit(peer_id)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Peer id {peer_id!r} is not a deliverable URI. "
+                "A peer id must be an absolute http(s) URI."
+            ),
+        )
+
+    # The host actor must be present on this node.
+    _resolve_actor_or_404(actor_id, datalayer)
+
+    # Idempotency: use exact-id lookup — _find_actor_record falls back to
+    # datalayer.actor_id (the host) as a candidate, so it would find the host
+    # actor itself instead of an absent peer.
+    existing = _find_actor_record_by_id(datalayer, peer_id)
+    if existing is not None:
+        cls = _actor_class_for_record(existing)
+        data = existing.get("data_", {})
+        return AS2JSONResponse(
+            cls.model_validate(data).model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ),
+            status_code=status.HTTP_200_OK,
+        )
+
+    actor_cls = _ACTOR_TYPE_MAP.get(request.actor_type, VultronOrganization)
+    peer = actor_cls(id_=peer_id, name=request.name)
+    datalayer.create(object_to_record(cast(PersistableModel, peer)))
+    logger.info("Registered peer %s in actor %s store", peer_id, actor_id)
+    return AS2JSONResponse(
+        peer.model_dump(mode="json", by_alias=True, exclude_none=True),
         status_code=status.HTTP_201_CREATED,
     )
 

--- a/vultron/demo/cli.py
+++ b/vultron/demo/cli.py
@@ -57,7 +57,7 @@ import vultron.demo.exchange.trigger_demo as trigger_demo
 import vultron.demo.scenario.fv_demo as fv_demo
 from vultron.logging_setup import suppress_third_party_info_noise
 from vultron.demo.seed_config import SeedConfig
-from vultron.demo.utils import DataLayerClient, BASE_URL, seed_actor
+from vultron.demo.utils import DataLayerClient, BASE_URL, seed_actor, seed_peer
 import vultron.bt.base.demo.pacman as pacman_demo
 import vultron.bt.base.demo.robot as robot_demo
 import vultron.bt.base.demo.cvd as cvd_vultrabot_demo
@@ -253,17 +253,18 @@ def seed(
     click.echo(f"   → {actor.id_}")
     logger.info("Local actor seeded: %s", actor.id_)
 
-    # Register peer actors.
+    # Register peer actors as address-book entries in the local actor's store.
     for peer in cfg.peers:
-        click.echo(f"🌱 Seeding peer actor: {peer.name!r} ({peer.actor_type})")
-        peer_actor = seed_actor(
+        click.echo(f"🌱 Registering peer: {peer.name!r} ({peer.actor_type})")
+        peer_actor = seed_peer(
             client=client,
+            local_actor_id=actor.id_,
+            peer_id=peer.id_,
             name=peer.name,
             actor_type=peer.actor_type,
-            actor_id=peer.id_,
         )
         click.echo(f"   → {peer_actor.id_}")
-        logger.info("Peer actor seeded: %s", peer_actor.id_)
+        logger.info("Peer registered: %s", peer_actor.id_)
 
     click.echo("✅ Seed complete.")
 

--- a/vultron/demo/helpers/seeding.py
+++ b/vultron/demo/helpers/seeding.py
@@ -30,6 +30,7 @@ from vultron.demo.utils import (
     demo_check,
     demo_step,
     seed_actor,
+    seed_peer,
 )
 from vultron.core.behaviors.store_scope import store_for_actor
 from vultron.core.ports.case_persistence import CasePersistence
@@ -110,7 +111,7 @@ def seed_containers(
     2. Register each actor as a known peer on the other container.
 
     This function is idempotent: re-running it returns existing actors
-    unchanged (the ``POST /actors/`` endpoint is idempotent).
+    unchanged (both ``POST /actors/`` and ``POST /actors/{id}/peers/`` are idempotent).
 
     Args:
         finder_client: DataLayerClient connected to the Finder container.
@@ -148,19 +149,21 @@ def seed_containers(
     logger.info("Vendor actor seeded on Vendor container: %s", vendor.id_)
 
     logger.info("Phase 2: registering cross-container peers...")
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
     logger.info("Vendor peer registered on Finder container: %s", vendor.id_)
 
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
     logger.info("Finder peer registered on Vendor container: %s", finder.id_)
 
@@ -183,7 +186,7 @@ def seed_containers_fvv(
     2. Register every actor as a known peer on the other two containers.
 
     This function is idempotent: re-running it returns existing actors
-    unchanged (the ``POST /actors/`` endpoint is idempotent).
+    unchanged (both ``POST /actors/`` and ``POST /actors/{id}/peers/`` are idempotent).
 
     Args:
         finder_client: DataLayerClient connected to the Finder container.
@@ -234,47 +237,53 @@ def seed_containers_fvv(
     logger.info("Phase 2: registering cross-container peers...")
 
     # Register Vendor1 and Vendor2 as peers on Finder's container.
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=vendor2.id_,
         name="Vendor2",
         actor_type="Organization",
-        actor_id=vendor2.id_,
     )
     logger.info("Vendor1 and Vendor2 registered as peers on Finder container")
 
     # Register Finder and Vendor2 as peers on Vendor1's container.
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=vendor2.id_,
         name="Vendor2",
         actor_type="Organization",
-        actor_id=vendor2.id_,
     )
     logger.info("Finder and Vendor2 registered as peers on Vendor1 container")
 
     # Register Finder and Vendor1 as peers on Vendor2's container.
-    seed_actor(
+    seed_peer(
         client=vendor2_client,
+        local_actor_id=vendor2.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=vendor2_client,
+        local_actor_id=vendor2.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
     logger.info("Finder and Vendor1 registered as peers on Vendor2 container")
 
@@ -301,7 +310,7 @@ def seed_containers_fvcv(
     2. Register every actor as a known peer on the other three containers.
 
     This function is idempotent: re-running it returns existing actors
-    unchanged (the ``POST /actors/`` endpoint is idempotent).
+    unchanged (both ``POST /actors/`` and ``POST /actors/{id}/peers/`` are idempotent).
 
     Args:
         finder_client: DataLayerClient connected to the Finder container.
@@ -365,92 +374,104 @@ def seed_containers_fvcv(
     logger.info("Phase 2: registering cross-container peers...")
 
     # Register Vendor1, Coordinator, and Vendor2 as peers on Finder's container.
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=coordinator.id_,
         name="Coordinator",
         actor_type="Organization",
-        actor_id=coordinator.id_,
     )
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=vendor2.id_,
         name="Vendor2",
         actor_type="Organization",
-        actor_id=vendor2.id_,
     )
     logger.info(
         "Vendor1, Coordinator, and Vendor2 registered as peers on Finder container"
     )
 
     # Register Finder, Coordinator, and Vendor2 as peers on Vendor1's container.
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=coordinator.id_,
         name="Coordinator",
         actor_type="Organization",
-        actor_id=coordinator.id_,
     )
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=vendor2.id_,
         name="Vendor2",
         actor_type="Organization",
-        actor_id=vendor2.id_,
     )
     logger.info(
         "Finder, Coordinator, and Vendor2 registered as peers on Vendor1 container"
     )
 
     # Register Finder, Vendor1, and Vendor2 as peers on Coordinator's container.
-    seed_actor(
+    seed_peer(
         client=coordinator_client,
+        local_actor_id=coordinator.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=coordinator_client,
+        local_actor_id=coordinator.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
-    seed_actor(
+    seed_peer(
         client=coordinator_client,
+        local_actor_id=coordinator.id_,
+        peer_id=vendor2.id_,
         name="Vendor2",
         actor_type="Organization",
-        actor_id=vendor2.id_,
     )
     logger.info(
         "Finder, Vendor1, and Vendor2 registered as peers on Coordinator container"
     )
 
     # Register Finder, Vendor1, and Coordinator as peers on Vendor2's container.
-    seed_actor(
+    seed_peer(
         client=vendor2_client,
+        local_actor_id=vendor2.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=vendor2_client,
+        local_actor_id=vendor2.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
-    seed_actor(
+    seed_peer(
         client=vendor2_client,
+        local_actor_id=vendor2.id_,
+        peer_id=coordinator.id_,
         name="Coordinator",
         actor_type="Organization",
-        actor_id=coordinator.id_,
     )
     logger.info(
         "Finder, Vendor1, and Coordinator registered as peers on Vendor2 container"
@@ -481,7 +502,7 @@ def seed_containers_fccv(
     2. Register every actor as a known peer on the other three containers.
 
     This function is idempotent: re-running it returns existing actors
-    unchanged (the ``POST /actors/`` endpoint is idempotent).
+    unchanged (both ``POST /actors/`` and ``POST /actors/{id}/peers/`` are idempotent).
 
     Args:
         finder_client: DataLayerClient connected to the Finder container.
@@ -545,86 +566,98 @@ def seed_containers_fccv(
     logger.info("Phase 2: registering cross-container peers...")
 
     # Register C1, C2, and Vendor as peers on Finder's container.
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=c1.id_,
         name="Coordinator1",
         actor_type="Organization",
-        actor_id=c1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=c2.id_,
         name="Coordinator2",
         actor_type="Organization",
-        actor_id=c2.id_,
     )
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
     logger.info("C1, C2, and Vendor registered as peers on Finder container")
 
     # Register Finder, C2, and Vendor as peers on C1's container.
-    seed_actor(
+    seed_peer(
         client=c1_client,
+        local_actor_id=c1.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c1_client,
+        local_actor_id=c1.id_,
+        peer_id=c2.id_,
         name="Coordinator2",
         actor_type="Organization",
-        actor_id=c2.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c1_client,
+        local_actor_id=c1.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
     logger.info("Finder, C2, and Vendor registered as peers on C1 container")
 
     # Register Finder, C1, and Vendor as peers on C2's container.
-    seed_actor(
+    seed_peer(
         client=c2_client,
+        local_actor_id=c2.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c2_client,
+        local_actor_id=c2.id_,
+        peer_id=c1.id_,
         name="Coordinator1",
         actor_type="Organization",
-        actor_id=c1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c2_client,
+        local_actor_id=c2.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
     logger.info("Finder, C1, and Vendor registered as peers on C2 container")
 
     # Register Finder, C1, and C2 as peers on Vendor's container.
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=c1.id_,
         name="Coordinator1",
         actor_type="Organization",
-        actor_id=c1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=c2.id_,
         name="Coordinator2",
         actor_type="Organization",
-        actor_id=c2.id_,
     )
     logger.info("Finder, C1, and C2 registered as peers on Vendor container")
 
@@ -654,7 +687,7 @@ def seed_containers_fcv(
     2. Register every actor as a known peer on the other two containers.
 
     This function is idempotent: re-running it returns existing actors
-    unchanged (the ``POST /actors/`` endpoint is idempotent).
+    unchanged (both ``POST /actors/`` and ``POST /actors/{id}/peers/`` are idempotent).
 
     Args:
         finder_client: DataLayerClient connected to the Finder container.
@@ -705,51 +738,57 @@ def seed_containers_fcv(
     logger.info("Phase 2: registering cross-container peers...")
 
     # Register Coordinator and Vendor as peers on Finder's container.
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=coordinator.id_,
         name="Coordinator",
         actor_type="Organization",
-        actor_id=coordinator.id_,
     )
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
     logger.info(
         "Coordinator and Vendor registered as peers on Finder container"
     )
 
     # Register Finder and Vendor as peers on Coordinator's container.
-    seed_actor(
+    seed_peer(
         client=coordinator_client,
+        local_actor_id=coordinator.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=coordinator_client,
+        local_actor_id=coordinator.id_,
+        peer_id=vendor.id_,
         name="Vendor",
         actor_type="Organization",
-        actor_id=vendor.id_,
     )
     logger.info(
         "Finder and Vendor registered as peers on Coordinator container"
     )
 
     # Register Finder and Coordinator as peers on Vendor's container.
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=vendor_client,
+        local_actor_id=vendor.id_,
+        peer_id=coordinator.id_,
         name="Coordinator",
         actor_type="Organization",
-        actor_id=coordinator.id_,
     )
     logger.info(
         "Finder and Coordinator registered as peers on Vendor container"
@@ -782,7 +821,7 @@ def seed_containers_fcvcv(
        (N×(N-1) = 20 cross-registrations total).
 
     This function is idempotent: re-running it returns existing actors
-    unchanged (the ``POST /actors/`` endpoint is idempotent).
+    unchanged (both ``POST /actors/`` and ``POST /actors/{id}/peers/`` are idempotent).
 
     Args:
         finder_client: DataLayerClient connected to the Finder container.
@@ -859,137 +898,157 @@ def seed_containers_fcvcv(
     logger.info("Phase 2: registering cross-container peers...")
 
     # Register C1, V1, C2, and V2 as peers on Finder's container.
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=c1.id_,
         name="Coordinator1",
         actor_type="Organization",
-        actor_id=c1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=v1.id_,
         name="Vendor1",
         actor_type="Organization",
-        actor_id=v1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=c2.id_,
         name="Coordinator2",
         actor_type="Organization",
-        actor_id=c2.id_,
     )
-    seed_actor(
+    seed_peer(
         client=finder_client,
+        local_actor_id=finder.id_,
+        peer_id=v2.id_,
         name="VendorDeployer",
         actor_type="Organization",
-        actor_id=v2.id_,
     )
     logger.info("C1, V1, C2, and V2 registered as peers on Finder container")
 
     # Register Finder, V1, C2, and V2 as peers on C1's container.
-    seed_actor(
+    seed_peer(
         client=c1_client,
+        local_actor_id=c1.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c1_client,
+        local_actor_id=c1.id_,
+        peer_id=v1.id_,
         name="Vendor1",
         actor_type="Organization",
-        actor_id=v1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c1_client,
+        local_actor_id=c1.id_,
+        peer_id=c2.id_,
         name="Coordinator2",
         actor_type="Organization",
-        actor_id=c2.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c1_client,
+        local_actor_id=c1.id_,
+        peer_id=v2.id_,
         name="VendorDeployer",
         actor_type="Organization",
-        actor_id=v2.id_,
     )
     logger.info("Finder, V1, C2, and V2 registered as peers on C1 container")
 
     # Register Finder, C1, C2, and V2 as peers on V1's container.
-    seed_actor(
+    seed_peer(
         client=v1_client,
+        local_actor_id=v1.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=v1_client,
+        local_actor_id=v1.id_,
+        peer_id=c1.id_,
         name="Coordinator1",
         actor_type="Organization",
-        actor_id=c1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=v1_client,
+        local_actor_id=v1.id_,
+        peer_id=c2.id_,
         name="Coordinator2",
         actor_type="Organization",
-        actor_id=c2.id_,
     )
-    seed_actor(
+    seed_peer(
         client=v1_client,
+        local_actor_id=v1.id_,
+        peer_id=v2.id_,
         name="VendorDeployer",
         actor_type="Organization",
-        actor_id=v2.id_,
     )
     logger.info("Finder, C1, C2, and V2 registered as peers on V1 container")
 
     # Register Finder, C1, V1, and V2 as peers on C2's container.
-    seed_actor(
+    seed_peer(
         client=c2_client,
+        local_actor_id=c2.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c2_client,
+        local_actor_id=c2.id_,
+        peer_id=c1.id_,
         name="Coordinator1",
         actor_type="Organization",
-        actor_id=c1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c2_client,
+        local_actor_id=c2.id_,
+        peer_id=v1.id_,
         name="Vendor1",
         actor_type="Organization",
-        actor_id=v1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=c2_client,
+        local_actor_id=c2.id_,
+        peer_id=v2.id_,
         name="VendorDeployer",
         actor_type="Organization",
-        actor_id=v2.id_,
     )
     logger.info("Finder, C1, V1, and V2 registered as peers on C2 container")
 
     # Register Finder, C1, V1, and C2 as peers on V2's container.
-    seed_actor(
+    seed_peer(
         client=v2_client,
+        local_actor_id=v2.id_,
+        peer_id=finder.id_,
         name="Finder",
         actor_type="Person",
-        actor_id=finder.id_,
     )
-    seed_actor(
+    seed_peer(
         client=v2_client,
+        local_actor_id=v2.id_,
+        peer_id=c1.id_,
         name="Coordinator1",
         actor_type="Organization",
-        actor_id=c1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=v2_client,
+        local_actor_id=v2.id_,
+        peer_id=v1.id_,
         name="Vendor1",
         actor_type="Organization",
-        actor_id=v1.id_,
     )
-    seed_actor(
+    seed_peer(
         client=v2_client,
+        local_actor_id=v2.id_,
+        peer_id=c2.id_,
         name="Coordinator2",
         actor_type="Organization",
-        actor_id=c2.id_,
     )
     logger.info("Finder, C1, V1, and C2 registered as peers on V2 container")
 

--- a/vultron/demo/utils.py
+++ b/vultron/demo/utils.py
@@ -517,8 +517,8 @@ def _assert_client_hosts_actor(
     it names — it addresses whatever the target container happens to host under
     that slug.  There is no error at the HTTP layer to notice: if the slug is
     unknown there the request 404s three frames from the real mistake, and if it
-    *is* known ``get_actor_dl`` mints an empty store for it and the trigger runs
-    against the wrong actor's state (#2549).
+    *is* known ``get_actor_dl`` returns that store and the trigger runs against
+    the wrong actor's state.
 
     fvcv-handoff spent a CI run on the 404 form of this — the Coordinator's
     ``invite-actor-to-case`` posted to the vendor container — so the check is
@@ -770,7 +770,8 @@ def seed_actor(
         name: Display name for the actor.
         actor_type: ActivityStreams actor type string (default: ``"Organization"``).
         actor_id: Optional full URI for the actor.  When absent the server
-            derives one from ``VULTRON_SERVER__BASE_URL``.
+            derives one from ``VULTRON_SERVER__BASE_URL``.  Must be under this
+            node's authority; use :func:`seed_peer` for foreign-authority ids.
 
     Returns:
         The created (or pre-existing) ``as_Actor`` object.
@@ -780,6 +781,39 @@ def seed_actor(
         payload["id"] = actor_id
 
     response_data = client.post("/actors/", json=payload)
+    return as_Actor.model_validate(response_data)
+
+
+def seed_peer(
+    client: DataLayerClient,
+    local_actor_id: str,
+    peer_id: str,
+    name: str,
+    actor_type: str = "Organization",
+) -> as_Actor:
+    """Register a peer in a hosted actor's address book.
+
+    Calls ``POST /actors/{slug}/peers/`` on the target container.  The peer is
+    recorded as an address-book entry in *local_actor_id*'s own store — it is not
+    created as a hosted actor (ADR-0081).  Idempotent: re-registering an already
+    known peer returns the existing record with HTTP 200.
+
+    Args:
+        client: DataLayerClient instance pointing at the container that hosts
+            *local_actor_id*.
+        local_actor_id: Full URI of the hosted actor whose address book to update.
+        peer_id: Full absolute URI of the peer actor to register.
+        name: Display name for the peer.
+        actor_type: ActivityStreams actor type string (default: ``"Organization"``).
+
+    Returns:
+        The created (or pre-existing) peer ``as_Actor`` object.
+    """
+    from urllib.parse import urlsplit
+
+    slug = urlsplit(local_actor_id).path.rstrip("/").rsplit("/", 1)[-1]
+    payload: dict = {"id": peer_id, "name": name, "actor_type": actor_type}
+    response_data = client.post(f"/actors/{slug}/peers/", json=payload)
     return as_Actor.model_validate(response_data)
 
 


### PR DESCRIPTION
Closes #2549

## Summary

- **Root cause**: `POST /actors/` accepted foreign-authority ids. `actor_slug()` drops scheme and netloc, so `finder:7999/.../alice` and `vendor:7999/.../alice` mapped to the same SQLite file. `hosted_actor_ids()` then reported remote actors as locally hosted, breaking outbound delivery.
- **Fix (ADR-0081)**: `_is_foreign_authority()` compares the request id's netloc against the serving node's `base_url`; `POST /actors/` returns 422 for any id whose authority does not match.
- **New route**: `POST /actors/{actor_id}/peers/` stores a peer as a `CoreActor` record inside the named hosted actor's own store — an address-book entry, not a phantom hosted actor.
- **Demo seeding updated**: all `seed_containers*` helpers and `cli.py seed` command now use `seed_peer()` for Phase 2 cross-container peer registrations.
- **Engine guard**: `get_actor_engine` collision guard remains a WARNING (not exception); the route-level rejection is the primary guard. Warning-not-raise preserves the multi-node test harness where two nodes in one process legitimately share a slug.

## Changes

- `vultron/adapters/driving/fastapi/routers/actors/_routes.py` — `_is_foreign_authority()`, 422 guard in `create_actor()`, new `POST /{actor_id:path}/peers/` endpoint
- `vultron/demo/utils.py` — `seed_peer()` utility function
- `vultron/demo/helpers/seeding.py` — all `seed_containers*` helpers updated to use `seed_peer()` for Phase 2
- `vultron/demo/cli.py` — `seed` command uses `seed_peer()` for peer registration
- `vultron/adapters/driven/datalayer_sqlite/engine.py` — `actor_slug()` docstring updated
- `vultron/adapters/driven/actor_hosts.py` — `canonical_actor_uri()` docstring updated
- `docs/adr/0081-peer-knowledge-in-hosted-actor-store.md` — new ADR

## Verification

- Full suite: `uv run pytest` — 7899 passed, 0 failed (+103 new tests net)
- AC1: `docs/adr/0081-peer-knowledge-in-hosted-actor-store.md` added ✅
- AC2: `POST /actors/` with foreign-authority id → 422 (`test_a_foreign_absolute_id_is_rejected`) ✅
- AC3: `hosted_actor_ids()` enumerates only hosted actors (peers live in host stores, not as hosted actors) ✅
- AC4: `create_actor` rejects foreign-authority ids with clear error message ✅
- AC5: collision warning preserved as WARNING (condition "no legitimate path" not yet satisfied — test harness is still a legitimate path) ✅
- AC6/AC7: all detector tests updated to reference ADR-0081 ✅
- `TestRegisterPeer` — 5 new tests: 201 on creation, 200 on repeat, peer absent from `GET /actors/`, 422 for non-http peer id, 404 for unknown host ✅
- `TestGetActorEngineCollisionGuard` — warning (not raise) on cross-authority slug collision ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)