### PR TITLE
docs: retire 'coordination agent' from Python docstrings (closes #2458)

### DIFF
--- a/plan/incoming/learnings/20260901-code-review-2458-preexisting-findings.md
+++ b/plan/incoming/learnings/20260901-code-review-2458-preexisting-findings.md
@@ -1,0 +1,34 @@
+---
+title: Pre-existing findings surfaced by code review for PR #2928 (ISSUE-2458)
+type: learning
+timestamp: 2026-09-01
+source: ISSUE-2458
+signal: concern
+---
+
+Code review agent for PR #2928 (ISSUE-2458) used stale local `main` as the diff
+base instead of `origin/main`, surfacing 4 findings in files not touched by this
+PR. These are pre-existing issues that should be tracked:
+
+1. `vultron/wire/as2/vocab/objects/case_status.py:87` — `_coerce_vf_or_none`
+   raises uncaught `KeyError` for unrecognised `vf_state` strings; Pydantic v2
+   only catches `ValueError/TypeError/AssertionError` in validators, so `KeyError`
+   propagates and crashes the inbox pipeline. `_coerce_vf` in `dimensions.py`
+   already has the correct `try/except KeyError → ValueError` wrapping.
+
+2. `vultron/wire/as2/vocab/objects/case_status.py:97` — Same class of bug in
+   `_coerce_d_or_none`: uncaught `KeyError` for unrecognised `d_state` strings.
+
+3. `vultron/core/behaviors/status/nodes/_adjudication.py:95` — When a participant
+   currently has `vf=None` but a peer asserts a non-None VF state, neither branch
+   fires and the peer's claimed VF value is silently accepted, even when the
+   participant has no VENDOR role.
+
+4. `vultron/core/behaviors/status/add_participant_status_tree.py:206` —
+   `EmitCaseStatusUpdateNode` constructed with `case_id=''` when `tree_case_id`
+   is `None`, producing an opaque FAILURE instead of a structural guard failure.
+   Inconsistency: same `tree_case_id` passed as `None` to `ThreatTerminationBranchNode`
+   at line 227.
+
+All four are in files not modified by PR #2928. They require investigation and
+dedicated bug issues before fixing.

--- a/plan/incoming/learnings/20260901-pytest-sigkill-repeated-runs.md
+++ b/plan/incoming/learnings/20260901-pytest-sigkill-repeated-runs.md
@@ -1,0 +1,25 @@
+---
+title: pytest killed by SIGKILL (exit 137) when run multiple times in same session
+type: learning
+timestamp: 2026-09-01
+source: ISSUE-2458
+signal: tooling-issue
+---
+
+During ISSUE-2458 build session, running `uv run pytest --tb=short` three times
+in sequence resulted in the third run being killed with exit code 137 (SIGKILL).
+The first two runs completed normally (7915 passed in ~119s each). The SIGKILL
+occurred at ~27% completion on the third run.
+
+Likely cause: container memory exhaustion from repeated full-suite runs in the
+same session. The `pytest-timeout` thread method kills the *whole process* rather
+than just the offending test, which can also produce exit 137.
+
+Mitigations already documented:
+
+- Always redirect to a file and check pytest's own exit code (`echo $?`)
+- The absence of a summary line from `tail -5` is the signal that the run was killed
+- Known pre-existing: `notes/flaky-tests.md` documents this class of issue
+
+No new action needed beyond awareness: run pytest once before freshen, confirm
+the suite passes, and trust that result for docstring-only changes.

--- a/vultron/adapters/driving/mcp_server.py
+++ b/vultron/adapters/driving/mcp_server.py
@@ -17,8 +17,8 @@
 
 Nothing here works, and nothing imports it. The intent is only the
 placeholder ambition "someday the Vultron service should speak MCP (Model
-Context Protocol) so that coordination agents can drive trigger use cases as
-tools". No design work has been done: no transport, no tool schemas, no
+Context Protocol) so that capability implementations can drive trigger use cases
+as tools". No design work has been done: no transport, no tool schemas, no
 authentication, and no answer to the question below.
 
 Per OX-10-004 / OX-11-004 this raises :class:`NotImplementedError` rather than

--- a/vultron/core/behaviors/call_out/nodes.py
+++ b/vultron/core/behaviors/call_out/nodes.py
@@ -19,7 +19,7 @@ the ``<DOMAIN>_DETERMINISTIC`` bundles: :class:`AlwaysSucceed` (always returns
 
 These are core-owned, production-usable backends: the DETERMINISTIC bundle is
 the happy-path default a real actor uses when a call-out point has no wired-in
-coordination agent yet (ADR-0025). They deliberately carry **no** probabilistic
+capability implementation yet (ADR-0025). They deliberately carry **no** probabilistic
 behaviour — that belongs exclusively to the simulation layer
 (``vultron/demo/fuzzer/base.py``'s ``WeightedBehavior`` family, kept out of core
 per BT-16-001).


### PR DESCRIPTION
- Closes #2458

## Summary

Retire two substantive uses of the deprecated "coordination agent" term
from Python docstrings, replacing them with canonical capability-taxonomy
vocabulary per ADR-0024. Three ADR file-path references are intentionally
left unchanged (the ADR file was not renamed, per AC-2).

## Changes

- **`vultron/core/behaviors/call_out/nodes.py`**: "no wired-in **coordination agent** yet" → "no wired-in **capability implementation** yet"
- **`vultron/adapters/driving/mcp_server.py`**: "coordination agents can drive trigger use cases" → "capability implementations can drive trigger use cases"

## Verification

- All 7915 unit tests pass, 33 xfailed (pre-existing)
- All 1248 integration tests pass, 2 xfailed (pre-existing)
- Black, flake8, mypy, pyright clean