### PR TITLE
feat(skills): enforce type/epic/milestone on every new issue

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -41,21 +41,27 @@ If this fails, stop and investigate before proceeding.
    ```
 
    If the user selects **"Create a new bug"**: ask for a description,
-   synthesize a title, and create the issue:
+   synthesize a title, then **before creating** determine the required fields:
+
+   1. **Parent epic** — invoke `calve-epics` Mode 1 to find the best-fit open
+      Epic. If it reports no match, present an `AskUserQuestion` with the top 5
+      closest epics plus "Specify other epic number". **A parent epic is
+      required** — do not create the issue until one is confirmed.
+
+   2. **Milestone** — query open milestones and ask the user to confirm the
+      best-fit one (see `shared/issue-creation-requirements.md` for defaults).
+
+   Then create with all three required fields:
 
    ```bash
    BUG_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Bug)
    ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
      --title "${BUG_TITLE}" \
      --body "${BUG_BODY}" \
-     --issue-type-id "${BUG_TYPE_ID}")
+     --issue-type-id "${BUG_TYPE_ID}" \
+     --parent "${EPIC_NUMBER}" \
+     --milestone "${MILESTONE_NUMBER}")
    ```
-
-   Immediately after creation, route the new issue onto the epic forest:
-   invoke `calve-epics` Mode 1 on `${ISSUE_NUMBER}`. If `calve-epics` reports
-   no matching epic, present an `AskUserQuestion` with the top 5 closest open
-   epics plus "Specify other epic number". **A parent epic is required** —
-   do not proceed to Phase 2 until the issue is wired to a parent.
 
 3. Invoke `orient-agent` to load baseline context.
 4. Fetch the issue body and comments.

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -164,14 +164,28 @@ Invoke `deepen-context` with focus hints derived from the issue body
 
 2. Search `vultron/` and `test/` to confirm the current state.
 3. Do not assume missing functionality; verify in code.
-4. If a blocking prerequisite is discovered, create and wire it:
+4. If a blocking prerequisite is discovered, create and wire it. Inherit
+   the current task's milestone; if it has none, pick the best-fit one
+   (see `shared/issue-creation-requirements.md`):
 
    ```bash
+   TASK_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Task)
+   MILESTONE_NUMBER=$(gh issue view "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
+     --json milestone --jq '.milestone.number // ""')
+   # Determine parent epic from the current task's parent
+   EPIC_NUMBER=$(gh api graphql -f query='{
+     repository(owner:"CERTCC", name:"Vultron") {
+       issue(number: '"${ISSUE_NUMBER}"') { parent { number } }
+     }
+   }' --jq '.data.repository.issue.parent.number // ""')
+
    NEW_ISSUE=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
      --title "<prerequisite title>" \
      --body "<description>" \
+     --issue-type-id "${TASK_TYPE_ID}" \
      --label "size:<S|M|L>" \
-     --parent <CURRENT_TASK_NUMBER>)
+     --parent "${EPIC_NUMBER:-${ISSUE_NUMBER}}" \
+     --milestone "${MILESTONE_NUMBER}")
    bash .agents/skills/shared/add-to-project.sh "${NEW_ISSUE}"
    ```
 

--- a/.agents/skills/manage-github-issue/SKILL.md
+++ b/.agents/skills/manage-github-issue/SKILL.md
@@ -22,11 +22,14 @@ structured relationships are wired.
 
 ```bash
 # Create a new issue (prints issue number to stdout)
+TASK_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Task)
 ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
   --title "Implement X" \
   --body "$(cat body.md)" \
+  --issue-type-id "${TASK_TYPE_ID}" \
   --label "size:M" \
   --parent 42 \
+  --milestone 25 \
   --blocked-by 50)
 
 # Update an existing issue — wire relationships
@@ -52,12 +55,17 @@ ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
 | `--body` | — | Body markdown |
 | `--label` | — | Comma-separated label names |
 | `--assignees` | — | Comma-separated GitHub usernames |
-| `--issue-type-id` | — | GraphQL node ID of the issue type |
-| `--parent` | — | Parent issue number |
+| `--issue-type-id` | — | GraphQL node ID of the issue type (**required** on create) |
+| `--parent` | — | Parent epic issue number (**required** on create) |
+| `--milestone` | — | Milestone number (**required** on create) |
 | `--blocked-by` | — | Space-separated issue numbers that block this one |
 | `--blocks` | — | Space-separated issue numbers this one blocks |
 | `--sub-issue` | — | Child issue number (repeatable) |
 | `--clean-body` | — | Strip legacy body-text relationship markers |
+
+> **On create**, `--issue-type-id`, `--parent`, and `--milestone` are all required.
+> The script exits non-zero if any is missing.
+> See `shared/issue-creation-requirements.md` for lookup commands and defaults.
 
 Outputs: issue number on **stdout**; progress messages on **stderr**.
 

--- a/.agents/skills/manage-github-issue/manage_github_issue.sh
+++ b/.agents/skills/manage-github-issue/manage_github_issue.sh
@@ -12,21 +12,27 @@
 #   --body TEXT             Issue body markdown
 #   --label LABEL           Label to apply (repeatable)
 #   --issue-type-id ID      GraphQL node ID for the issue type
-#   --parent N              Set this issue as sub-issue of parent #N
+#   --parent N              Set this issue as sub-issue of parent #N (required on create)
+#   --milestone N           Milestone number to assign (required on create)
 #   --blocked-by N          This issue is blocked by #N (repeatable, idempotent)
 #   --blocks N              This issue blocks #N (repeatable, idempotent)
 #   --sub-issue N           Add #N as sub-issue of this issue (repeatable, idempotent)
 #   --clean-body            Strip legacy relationship markers from the issue body
 #
+# On CREATE (no --issue-number), the following three fields are REQUIRED:
+#   --issue-type-id, --parent, --milestone
+# Missing any one exits non-zero. See shared/issue-creation-requirements.md.
+#
 # Outputs:
 #   Issue number on stdout. Progress and status on stderr.
 #
 # Examples:
-#   # Create with parent and blocker:
+#   # Create with parent, milestone, and blocker:
 #   NUM=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
 #     --title "Implement X" --body "..." \
-#     --label "group:unscheduled,size:M" \
-#     --parent 42 --blocked-by 50)
+#     --issue-type-id "${TASK_TYPE_ID}" \
+#     --label "size:M" \
+#     --parent 42 --milestone 25 --blocked-by 50)
 #
 #   # Wire relationships on an existing issue:
 #   .agents/skills/manage-github-issue/manage_github_issue.sh \
@@ -45,6 +51,7 @@ BODY=""
 LABELS=()
 ISSUE_TYPE_ID=""
 PARENT_ISSUE=""
+MILESTONE=""
 BLOCKED_BY=()
 BLOCKS=()
 SUB_ISSUES=()
@@ -60,6 +67,7 @@ while [[ $# -gt 0 ]]; do
     --label)         LABELS+=("$2");     shift 2 ;;
     --issue-type-id) ISSUE_TYPE_ID="$2"; shift 2 ;;
     --parent)        PARENT_ISSUE="$2";  shift 2 ;;
+    --milestone)     MILESTONE="$2";     shift 2 ;;
     --blocked-by)    BLOCKED_BY+=($2);   shift 2 ;;
     --blocks)        BLOCKS+=($2);       shift 2 ;;
     --sub-issue)     SUB_ISSUES+=("$2"); shift 2 ;;
@@ -67,6 +75,19 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
+
+# Completeness guard — required on every new issue
+if [[ -z "${ISSUE_NUMBER}" ]]; then
+  MISSING=()
+  [[ -z "${ISSUE_TYPE_ID}" ]] && MISSING+=("--issue-type-id")
+  [[ -z "${PARENT_ISSUE}"  ]] && MISSING+=("--parent (epic parent required)")
+  [[ -z "${MILESTONE}"     ]] && MISSING+=("--milestone")
+  if [[ ${#MISSING[@]} -gt 0 ]]; then
+    echo "ERROR: missing required field(s) for new issue: ${MISSING[*]}" >&2
+    echo "  See .agents/skills/shared/issue-creation-requirements.md" >&2
+    exit 1
+  fi
+fi
 
 REPO_OWNER="${REPO%%/*}"
 REPO_NAME="${REPO##*/}"
@@ -154,6 +175,13 @@ if [[ -z "${ISSUE_NUMBER}" ]]; then
     echo "  Applied labels: ${LABEL_STR}" >&2
   fi
 
+  # Apply milestone
+  if [[ -n "${MILESTONE}" ]]; then
+    gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" \
+      -X PATCH -f "milestone=${MILESTONE}" > /dev/null
+    echo "  Applied milestone: #${MILESTONE}" >&2
+  fi
+
   # Parent was set at create time; clear PARENT_ISSUE to skip Step 2
   PARENT_ISSUE=""
 
@@ -190,6 +218,12 @@ else
       --repo "${REPO}" \
       --add-label "${LABEL_STR}" >&2
     echo "  Applied labels: ${LABEL_STR}" >&2
+  fi
+
+  if [[ -n "${MILESTONE}" ]]; then
+    gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" \
+      -X PATCH -f "milestone=${MILESTONE}" > /dev/null
+    echo "  Applied milestone: #${MILESTONE}" >&2
   fi
 fi
 

--- a/.agents/skills/new-item/SKILL.md
+++ b/.agents/skills/new-item/SKILL.md
@@ -77,6 +77,21 @@ issue yet: invoke `calve-epics` Mode 2 to propose a new epic, confirm it with
 the user, and then proceed with that new epic as the parent. Allow at most one
 parent epic.
 
+### Phase 4b — Milestone Selection
+
+**A milestone is required.** Query open milestones and present as a list:
+
+```bash
+gh api repos/CERTCC/Vultron/milestones \
+  --jq '.[] | "\(.number): \(.title)"'
+```
+
+Present the top candidates ranked by relevance to the issue description.
+Ask the user to confirm or pick a different one. Do **not** offer a "None / skip"
+option — an issue without a milestone is invisible to release planning.
+
+See `shared/issue-creation-requirements.md` for defaults by issue type.
+
 ### Phase 5 — Build Title + Body
 
 Generate a clean title (no `[Idea]` / `[Concern]` prefix) and body matching
@@ -87,7 +102,7 @@ the corresponding GitHub template sections.
 Use `.agents/skills/manage-github-issue/manage_github_issue.sh`.
 
 - **Create**: set issue type ID (`Idea` or `Concern`), apply exactly one label
-  (`idea` or `concern`), and wire parent epic if chosen.
+  (`idea` or `concern`), wire parent epic, and pass `--milestone ${MILESTONE_NUMBER}`.
 - **Update**: update title/body and optionally parent epic; do not change issue
   type. Post a refresh comment after updating.
 

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -62,14 +62,18 @@ selection before continuing.
 #### Creating a new Idea (if selected)
 
 Ask the user to describe the idea (`ask_user`, freeform). Synthesize a
-short title, then create the issue via the `manage-github-issue` helper:
+short title. Then select a parent epic (query open Epics and ask the user to
+confirm — see `new-item` Phase 4 for the pattern) and a milestone (see
+`shared/issue-creation-requirements.md`). Then create:
 
 ```bash
 IDEA_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Idea)
 ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
   --title "${TITLE}" \
   --body "${BODY}" \
-  --issue-type-id "${IDEA_TYPE_ID}")
+  --issue-type-id "${IDEA_TYPE_ID}" \
+  --parent "${EPIC_NUMBER}" \
+  --milestone "${MILESTONE_NUMBER}")
 ```
 
 ### Phase 0b — Sync
@@ -254,12 +258,23 @@ returns the PR URL. Use the returned URL in the `archive-history` call (Phase 9)
 
 Create one Task sub-issue per distinct AC cluster from Phase 4.
 
+Before creating, resolve the milestone to carry forward:
+
+```bash
+MILESTONE_NUMBER=$(gh issue view "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
+  --json milestone --jq '.milestone.number // ""')
+# If the source issue has no milestone, query open milestones and ask the user
+# to pick one (see shared/issue-creation-requirements.md for defaults).
+```
+
 For Ideas and Concerns, wire the impl issue as **blocked-by the source
 issue** and as **child of the parent epic** (if `EPIC_NUMBER` is non-empty):
 
 ```bash
 PARENT_ARG=""
 [ -n "${EPIC_NUMBER}" ] && PARENT_ARG="--parent ${EPIC_NUMBER}"
+
+TASK_TYPE_ID=$(bash .agents/skills/shared/board-id.sh issue-type Task)
 
 # Body template. Include the "## Prior Art" section only when Phase 4
 # found relevant helpers, use cases, or base classes; omit it entirely
@@ -280,8 +295,10 @@ Source: #${ISSUE_NUMBER}
 $([ -n "${PR_URL}" ] && echo "Docs PR: ${PR_URL}")
 $([ -n "${SPEC_FILE}" ] && echo "Spec: \`specs/${SPEC_FILE}\`")
 $([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`")" \
+  --issue-type-id "${TASK_TYPE_ID}" \
   --label "size:<S|M|L>" \
   ${PARENT_ARG} \
+  --milestone "${MILESTONE_NUMBER}" \
   --blocked-by "${ISSUE_NUMBER}")
 ```
 
@@ -363,7 +380,7 @@ See the loaded companion file for the type-specific completion step:
 - [ ] Docs updated — optional for all types (or consciously skipped with a note)
 - [ ] Markdown lint clean (if docs changed)
 - [ ] PR opened with `specs-notes` label — always
-- [ ] Implementation issue(s) created via `manage-github-issue` + `add-to-project.sh`
+- [ ] Implementation issue(s) created via `manage-github-issue` + `add-to-project.sh` (with type, parent epic, and milestone set)
 - [ ] Impl issues wired per type (blocked-by for Ideas/Concerns; sub-issue for Epics)
 - [ ] Impl issues reference docs PR URL in their body (Ideas/Concerns only — Phase 8)
 - [ ] Docs PR body updated with Implementation Issues section (Ideas/Concerns only — Phase 8b)

--- a/.agents/skills/shared/README.md
+++ b/.agents/skills/shared/README.md
@@ -7,6 +7,7 @@ Shared scripts and reference documents referenced by multiple skills.
 | File | Purpose | Loaded by |
 |---|---|---|
 | `completeness-doctrine.md` | Project quality standard: what "done" means, finding severity taxonomy (FAIL/IMPROVE/DEFER), scope expansion rules | `orient-agent` Step 3 — in context for every workflow |
+| `issue-creation-requirements.md` | Three required fields (type, parent epic, milestone) for every new issue; lookup commands and defaults | `manage-github-issue`, `new-item`, `plan-issue`, `bugfix`, `build` |
 | `pr-body-guide.md` | PR body templates and formatting rules | `build`, `bugfix`, `plan-issue` |
 | `upward-reflection.md` | Mandatory end-of-session signal checklist (spec-gap, spec-ambiguity, etc.) and learning-file format | `build` Phase 8, `bugfix` Phase 3 |
 

--- a/.agents/skills/shared/issue-creation-requirements.md
+++ b/.agents/skills/shared/issue-creation-requirements.md
@@ -1,0 +1,43 @@
+# Issue Creation Requirements
+
+Every new issue created via `manage_github_issue.sh` **must** supply three fields.
+Missing any one causes the script to exit non-zero.
+
+## Required fields
+
+| Field | Flag | Why |
+|---|---|---|
+| **Issue type** | `--issue-type-id ID` | Determines the issue's workflow lane (Task, Bug, Idea, Concern). Without it the issue has no type and is invisible to type-filtered views. |
+| **Parent epic** | `--parent N` | Routes the issue into the epic forest so it appears in sprint planning and prioritisation. An orphaned issue is invisible to capacity planning. |
+| **Milestone** | `--milestone N` | Anchors the issue to a delivery target. Without it the issue floats outside every milestone filter. |
+
+## Lookup commands
+
+```bash
+# Issue type IDs (Task, Bug, Idea, Concern, Epic)
+bash .agents/skills/shared/board-id.sh issue-type Task
+
+# Open epics (pick the best-fit parent)
+gh issue list --repo CERTCC/Vultron --state open --limit 200 \
+  --json number,title,issueType \
+  --jq '.[] | select(.issueType.name == "Epic") | "#\(.number): \(.title)"'
+
+# Open milestones with numbers
+gh api repos/CERTCC/Vultron/milestones \
+  --jq '.[] | "\(.number): \(.title)"'
+```
+
+## Determining the right values
+
+- **Issue type**: infer from the work — implementation tasks → `Task`, regressions → `Bug`,
+  exploratory captures → `Idea` or `Concern`.
+- **Parent epic**: use `calve-epics` Mode 1 to find the best-fit open Epic; if none
+  matches, run Mode 2 to propose a new one. Never leave an issue without a parent.
+- **Milestone**: inherit from the source issue (the Idea/Concern/Bug being planned or fixed)
+  when one exists; otherwise pick the milestone whose scope best matches the work.
+  "Project Health" (milestone 25) is the default for tooling and process improvements.
+
+## Exemptions
+
+Epics are created via `create_epic.sh`, which bypasses this guard (Epics are
+legitimately root-level and do not have a parent issue). No other exemptions exist.


### PR DESCRIPTION
- Closes #2922
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Adds a completeness guard to `manage_github_issue.sh` so every new issue
is required to carry a type, a parent epic, and a milestone. Adds a shared
reference doc and updates all four caller skills to supply the three fields.

## Changes

- **`.agents/skills/manage-github-issue/manage_github_issue.sh`**: add
  `--milestone N` flag (applied via REST after create/update); add
  completeness guard that exits non-zero on create when `--issue-type-id`,
  `--parent`, or `--milestone` is absent
- **`.agents/skills/shared/issue-creation-requirements.md`**: new canonical
  reference doc for the three required fields, with lookup commands and defaults
- **`.agents/skills/shared/README.md`**: index entry for the new doc
- **`.agents/skills/manage-github-issue/SKILL.md`**: mark three params as
  required; update quick-start example to include `--milestone`
- **`.agents/skills/new-item/SKILL.md`**: add Phase 4b milestone selection
  before issue creation
- **`.agents/skills/plan-issue/SKILL.md`**: resolve milestone from source
  issue before creating impl issues; pass `--issue-type-id` and `--milestone`
- **`.agents/skills/bugfix/SKILL.md`**: determine epic + milestone before
  creating the bug issue (not after)
- **`.agents/skills/build/SKILL.md`**: pass `--issue-type-id`, `--parent`
  (from current task's epic), and `--milestone` when creating prerequisite issues