### PR TITLE
Treat an unset PXA dimension as no threat present

### DIFF
--- a/test/core/behaviors/status/nodes/test_threat_termination.py
+++ b/test/core/behaviors/status/nodes/test_threat_termination.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+from types import SimpleNamespace
+
+import pytest
+
+from vultron.core.states.cs import CS_pxa
+from vultron.core.behaviors.status.nodes.threat_termination import (
+    _ThreatTerminationSkipConditionNode,
+)
+
+
+def _node(case_status: object) -> _ThreatTerminationSkipConditionNode:
+    return _ThreatTerminationSkipConditionNode(
+        status_obj=SimpleNamespace(case_status=case_status),
+        case_id="case-1",
+    )
+
+
+def test_threat_present_handles_unset_pxa():
+    """A participant with no PXA dimension has asserted no threat."""
+    assert _node(SimpleNamespace(pxa=None))._threat_present() is False
+
+
+def test_threat_present_false_for_empty_pxa_state():
+    assert (
+        _node(
+            SimpleNamespace(pxa=SimpleNamespace(state=CS_pxa.pxa))
+        )._threat_present()
+        is False
+    )
+
+
+@pytest.mark.parametrize("state", [CS_pxa.Pxa, CS_pxa.pXa, CS_pxa.pxA])
+def test_threat_present_true_when_a_dimension_is_set(state):
+    assert (
+        _node(
+            SimpleNamespace(pxa=SimpleNamespace(state=state))
+        )._threat_present()
+        is True
+    )

--- a/vultron/core/behaviors/status/nodes/threat_termination.py
+++ b/vultron/core/behaviors/status/nodes/threat_termination.py
@@ -97,7 +97,12 @@ class _ThreatTerminationSkipConditionNode(DataLayerConditionWithPorts):
         if case_status is None:
             return False
         if hasattr(case_status, "pxa"):
-            pxa_state = getattr(case_status, "pxa").state
+            pxa = getattr(case_status, "pxa")
+            # A participant that has not set its PXA dimension has asserted no
+            # public exploit or attack, so there is no threat to react to.
+            if pxa is None:
+                return False
+            pxa_state = pxa.state
         elif hasattr(case_status, "pxa_state"):
             pxa_state = getattr(case_status, "pxa_state")
         else:


### PR DESCRIPTION
Fixes #2877.

`_threat_present()` reads `getattr(case_status, "pxa").state` without checking whether `pxa` is set, so a participant whose PXA dimension is still `None` blows up on the attribute access. The guard is the one the issue proposes: an unset PXA dimension is an assertion of nothing, which is not a threat, so it returns `False`.

One correction to the report, since it changes what an operator sees. There is no broad `except Exception` around that access; the only `try` in the function wraps the `pxa_state != CS_pxa.pxa` comparison further down. So this does not silently skip embargo termination, it raises:

```
>>> node = _ThreatTerminationSkipConditionNode(status_obj=SimpleNamespace(case_status=SimpleNamespace(pxa=None)), case_id="case-1")
>>> node._threat_present()
AttributeError: 'NoneType' object has no attribute 'state'
>>> node.update()
AttributeError: 'NoneType' object has no attribute 'state'
```

The fix is the same either way, and the outcome afterwards is the skip the issue describes, this time deliberately.

`test/core/behaviors/status/nodes/test_threat_termination.py` covers the unset dimension, the all-lowercase `pxa` state, and each of P, X and A being set. The first case fails on main with the `AttributeError` above.

`pytest test/core/behaviors/status/nodes/test_threat_termination.py` passes. Three tests in `test/core/behaviors/status/test_partial_accept_participant_status.py` fail in my checkout both with and without this change, so they look unrelated.
