### PR TITLE
docs: plan issue #2831 — G03 BT node defect sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1019,6 +1019,16 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   lands and the `reason=` links the test back to the implementation issue.
   *Source: ISSUE-2606*
 
+- **BT Nodes Must Not Clear Blackboard Keys They Do Not Own** — a node's `_clear()`
+  or tick-start zero-write MUST only target keys that node is the sole producer of.
+  Clearing a shared global key (e.g. `BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE`) in a node
+  that is not its producer silently destroys a value written by an earlier node in the
+  same Sequence, even when the clear runs for BT-17-003 compliance.  Ownership rule:
+  the node that writes the key on its active path is the sole node that clears it on
+  its no-op path.  See the complementary pitfall above ("ledger_payload_object_override
+  Producers MUST Clear the Key on Every No-Op Tick").
+  *Source: CONCERN-2711*
+
 ---
 
 See each subsystem AGENTS.md for additional pitfalls:


### PR DESCRIPTION
- Closes #2831

## Summary

Plans G03: sweeps six BT node defect concerns against HEAD, closes two as resolved (#2699, #2701) and two as stale (#2702, closed via #2702 comment), confirms two as still open (#2710, #2711), and adds an `AGENTS.md` pitfall for blackboard key-ownership (BT-17-003 complement). Implementation tasks created separately.

## Changes

- **`AGENTS.md`**: adds "BT Nodes Must Not Clear Blackboard Keys They Do Not Own" pitfall (G03 AC-4 — blackboard-contract bug class confirmed as recurring across #2699, #2702, #2711).

## Implementation Issues

- #2957 — fix(cs-filter): FilterCsEmDimensionNode guard hardening + DRY refactor (covers #2710, #2711, DRY gap from #2701)
- #2958 — fix(participant-status): collect all dimension errors in _validate_transitions (covers #2112)