### PR TITLE
fix(bugfix-skill): embed plan in ask_user question field

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -162,8 +162,9 @@ Invoke `deepen-context` with focus hints derived from the investigation
 
 ## Phase 3 — Present Findings (BLOCKING)
 
-Present a single structured briefing via `ask_user`. Include every item
-from Phase 2 with concrete evidence:
+Embed the complete briefing in the `question` field of the `ask_user` call —
+do **not** output it as free text before the tool call. Include every item
+from Phase 2 with concrete evidence directly in the question text:
 
 ```text
 Reproduced at: <file:line>


### PR DESCRIPTION
## Summary

Fixes the bugfix skill silently asking "do you want to proceed with this plan?" without showing the plan. The Phase 3 instruction now requires the full investigation briefing to be embedded in the `question` field of the `ask_user` call rather than output as free text before the tool call.

## Changes

- **`.agents/skills/bugfix/SKILL.md`**: replaced ambiguous "Present a single structured briefing via `ask_user`" with an explicit requirement to embed the briefing in the `question` field, with a note not to output it as pre-tool text