### PR TITLE
fix: make VOCABULARY and CORE_VOCABULARY keys disjoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,16 +296,14 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   flow, not raw `git rebase origin/main`.
 - **`as_VulnerabilityCase` (wire) vs `VulnerabilityCase` (core)** — all classes
   in `vultron/wire/as2/vocab/objects/` use `as_` prefix. Bare name = core type.
-  See ARCH-14-001. Note the *registry* keys currently collide even though the
-  class names do not: `VOCABULARY["VulnerabilityCase"]` is the **wire** class,
-  because the key is derived via `cls.__name__.removeprefix("as_")`. ADR-0082
-  makes the keys disjoint (ARCH-23-002); until then, do not infer a class's
-  branch from its registry key. Never resolve a core type's wire counterpart by
-  name coincidence — use the pairing registry (ARCH-23-001). **Until issue #2937
-  lands there is no pairing-registry module to import**, so do not go looking for
-  one and do not add a new name-coincidence lookup in the meantime; the existing
-  `VOCABULARY.get(type(obj).__name__)` call in `As2WireRenderAdapter.render()` is
-  the one site slated to be replaced.
+  See ARCH-14-001. Registry keys are now disjoint (ARCH-23-002, issue #2941):
+  `VOCABULARY` uses full `as_*` class name keys (`"as_VulnerabilityCase"`);
+  `WIRE_TYPE_MAP` uses wire `type_` value keys (`"VulnerabilityCase"`). The
+  render adapter uses `WIRE_TYPE_MAP.get(type(obj).__name__)` to resolve a core
+  class to its wire counterpart. Never resolve a core type's wire counterpart by
+  name coincidence — use `WIRE_TYPE_MAP` (for type_ values) or `VOCABULARY` (for
+  wire class name lookups). The full pairing registry (ARCH-23-001) is tracked
+  by issue #2937.
 - **Never add a new `from vultron.core.models import …` inside `vultron/wire/`** —
   wire code that needs to convert a core object to wire form MUST use the
   `as_Foo.from_core(core_obj)` class method already present on every wire vocab

--- a/test/adapters/driven/test_wire_render_adapter.py
+++ b/test/adapters/driven/test_wire_render_adapter.py
@@ -28,7 +28,7 @@ from datetime import timedelta
 import pytest
 
 from vultron.adapters.driven.wire_render import As2WireRenderAdapter
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.registry import find_in_vocabulary
 from vultron.core.models.actor import VultronPerson
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_actor import CaseActor
@@ -66,10 +66,13 @@ def _assert_wire_dict(result: dict, expected_type: str) -> None:
     # The 'id' field is always emitted by VultronAS2Object
     assert "id" in result, f"Missing 'id' key in wire dict for {expected_type}"
     # AC-5 / CLP-07-001: output must be receiver-reconstitutable
-    wire_cls = VOCABULARY.get(expected_type)
+    try:
+        wire_cls = find_in_vocabulary(expected_type)
+    except KeyError:
+        wire_cls = None
     assert (
         wire_cls is not None
-    ), f"No VOCABULARY entry for {expected_type!r} — cannot verify reconstitutability"
+    ), f"No vocabulary entry for {expected_type!r} — cannot verify reconstitutability"
     wire_cls.model_validate(result)
 
 

--- a/test/architecture/test_normalize_wire_to_core_ratchet.py
+++ b/test/architecture/test_normalize_wire_to_core_ratchet.py
@@ -40,7 +40,7 @@ Related: issue #2232 (the shape duality), issue #2268 (migrating the rest).
 import vultron.adapters.driven.datalayer_sqlite  # noqa: F401
 from vultron.adapters.driven.db_record import _NORMALIZE_WIRE_TO_CORE
 from vultron.core.models.registry import CORE_VOCABULARY
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.registry import VOCABULARY, WIRE_TYPE_MAP
 
 _WIRE_MODULE_PREFIX = "vultron.wire.as2"
 
@@ -69,10 +69,15 @@ _NOT_YET_NORMALIZED: frozenset[str] = frozenset()
 
 
 def _shadowing_types() -> dict[str, type]:
-    """Return wire classes whose bare ``type_`` collides with a core type."""
+    """Return wire classes whose type_ value collides with a core type name.
+
+    After ARCH-23-002 (VOCABULARY/CORE_VOCABULARY keys disjoint), the collision
+    check moves from VOCABULARY to WIRE_TYPE_MAP, which is keyed by wire type_
+    values and contains all 15 formerly-shadowing wire classes.
+    """
     return {
         type_: cls
-        for type_, cls in VOCABULARY.items()
+        for type_, cls in WIRE_TYPE_MAP.items()
         if type_ in CORE_VOCABULARY
         and cls.__module__.startswith(_WIRE_MODULE_PREFIX)
     }
@@ -81,7 +86,8 @@ def _shadowing_types() -> dict[str, type]:
 def test_registries_are_populated():
     """Guard the guard: an empty registry would make every assertion vacuous."""
     assert len(CORE_VOCABULARY) > 10
-    assert len(VOCABULARY) > 50
+    assert len(VOCABULARY) > 20
+    assert len(WIRE_TYPE_MAP) > 20
 
 
 def test_normalize_set_may_only_grow():

--- a/test/core/behaviors/case/test_bug_26040902_regression.py
+++ b/test/core/behaviors/case/test_bug_26040902_regression.py
@@ -120,17 +120,18 @@ def test_receive_report_case_bt_succeeds_without_conftest_imports(
         VultronOffer,
         VultronReport,
     )
-    from vultron.wire.as2.vocab.base.registry import VOCABULARY
+    from vultron.wire.as2.vocab.base.registry import WIRE_TYPE_MAP
 
     dl = _fresh_datalayer
 
-    # Verify key types ARE registered (dynamic discovery must have run)
-    assert "VulnerabilityReport" in VOCABULARY, (
-        "BUG-26040902: VulnerabilityReport not in VOCABULARY — "
+    # Verify key types ARE registered (dynamic discovery must have run).
+    # After ARCH-23-002, collision keys live in WIRE_TYPE_MAP, not VOCABULARY.
+    assert "VulnerabilityReport" in WIRE_TYPE_MAP, (
+        "BUG-26040902: VulnerabilityReport not in WIRE_TYPE_MAP — "
         "dynamic discovery did not run"
     )
-    assert "VulnerabilityCase" in VOCABULARY, (
-        "BUG-26040902: VulnerabilityCase not in VOCABULARY — "
+    assert "VulnerabilityCase" in WIRE_TYPE_MAP, (
+        "BUG-26040902: VulnerabilityCase not in WIRE_TYPE_MAP — "
         "dynamic discovery did not run"
     )
 

--- a/test/core/behaviors/case/test_ledger_snapshots.py
+++ b/test/core/behaviors/case/test_ledger_snapshots.py
@@ -226,27 +226,27 @@ class TestSnapshotObjectWireReconstitutable:
     """AC-7: every payloadSnapshot object dict revalidates through its wire vocabulary class."""
 
     def test_create_case_object_wire_reconstitutable(self, case, port):
-        from vultron.wire.as2.vocab.base.registry import VOCABULARY
+        from vultron.wire.as2.vocab.base.registry import find_in_vocabulary
 
         snap = build_create_case_snapshot(case, CASE_ACTOR_ID, CASE_ID, port)
         obj = snap["object"]
-        wire_cls = VOCABULARY[obj["type"]]
+        wire_cls = find_in_vocabulary(obj["type"])
         wire_cls.model_validate(obj)
 
     def test_add_report_object_wire_reconstitutable(self, report, case, port):
-        from vultron.wire.as2.vocab.base.registry import VOCABULARY
+        from vultron.wire.as2.vocab.base.registry import find_in_vocabulary
 
         snap = build_add_report_to_case_snapshot(
             report, case, CASE_ACTOR_ID, CASE_ID, port
         )
         obj = snap["object"]
-        wire_cls = VOCABULARY[obj["type"]]
+        wire_cls = find_in_vocabulary(obj["type"])
         wire_cls.model_validate(obj)
 
     def test_add_participant_status_object_wire_reconstitutable(
         self, participant, port
     ):
-        from vultron.wire.as2.vocab.base.registry import VOCABULARY
+        from vultron.wire.as2.vocab.base.registry import find_in_vocabulary
 
         snap = build_add_participant_status_snapshot(
             participant.participant_statuses[0],
@@ -256,18 +256,18 @@ class TestSnapshotObjectWireReconstitutable:
             port,
         )
         obj = snap["object"]
-        wire_cls = VOCABULARY[obj["type"]]
+        wire_cls = find_in_vocabulary(obj["type"])
         wire_cls.model_validate(obj)
 
     def test_add_case_status_object_wire_reconstitutable(self, case, port):
-        from vultron.wire.as2.vocab.base.registry import VOCABULARY
+        from vultron.wire.as2.vocab.base.registry import find_in_vocabulary
 
         raw_status = case.case_statuses[0]
         snap = build_add_case_status_snapshot(
             raw_status, case, VENDOR_ID, CASE_ID, port
         )
         obj = snap["object"]
-        wire_cls = VOCABULARY[obj["type"]]
+        wire_cls = find_in_vocabulary(obj["type"])
         wire_cls.model_validate(obj)
 
 

--- a/test/wire/as2/vocab/base/test_registry.py
+++ b/test/wire/as2/vocab/base/test_registry.py
@@ -310,6 +310,73 @@ class TestDisjointKeys:
             ), f"WIRE_TYPE_MAP key {key!r} still has 'as_' prefix"
 
 
+class TestWireTypeValues:
+    """ARCH-23-003: serialized wire `type_` values are independent of registry key changes."""
+
+    def setup_method(self):
+        import vultron.wire.as2.vocab  # noqa: F401
+
+    def test_all_concrete_type_defaults_are_reachable_via_wire_type_map(self):
+        """ARCH-23-003: every wire class with a concrete type_ default is findable by that value.
+
+        The registry key is an internal lookup concern; the `type` field value is an
+        external protocol commitment. For each wire class registered in WIRE_TYPE_MAP
+        with a concrete type_ default, the type_ value must itself be a key in
+        WIRE_TYPE_MAP (either as the primary key, or as an override entry), ensuring
+        the serialized wire output remains reachable after any key restructuring.
+        """
+        from pydantic_core import PydanticUndefinedType
+
+        unreachable = []
+        for key, cls in WIRE_TYPE_MAP.items():
+            field = cls.model_fields.get("type_")
+            if field is None:
+                continue
+            default = field.default
+            if isinstance(default, PydanticUndefinedType) or default is None:
+                continue
+            type_value = str(default)
+            # The class must be reachable via its own type_ value
+            if WIRE_TYPE_MAP.get(type_value) is None:
+                unreachable.append((key, cls.__name__, type_value))
+
+        assert unreachable == [], (
+            f"ARCH-23-003: {len(unreachable)} wire class(es) have type_ values that "
+            f"are not reachable via WIRE_TYPE_MAP — serialized output would be "
+            f"undeserializable: {unreachable}"
+        )
+
+    @pytest.mark.parametrize(
+        "type_value,expected_class_name",
+        [
+            ("VulnerabilityCase", "as_VulnerabilityCase"),
+            ("VulnerabilityReport", "as_VulnerabilityReport"),
+            ("Accept", "as_Accept"),
+            ("Create", "as_Create"),
+            ("Announce", "as_Announce"),
+            ("Person", "as_VultronPerson"),
+            ("Service", "as_VultronService"),
+            ("Actor", "as_Actor"),
+            ("Add", "as_Add"),
+            ("EmbargoEvent", "as_EmbargoEvent"),
+        ],
+    )
+    def test_critical_type_values_resolve_to_expected_wire_class(
+        self, type_value, expected_class_name
+    ):
+        """ARCH-23-003: key wire type_ values resolve to the same wire classes as before.
+
+        Verifies that registry key restructuring did not alter which class handles
+        each wire type_ value, ensuring deserialization is byte-identical to the
+        pre-change behaviour.
+        """
+        cls = find_in_vocabulary(type_value)
+        assert cls.__name__ == expected_class_name, (
+            f"ARCH-23-003: find_in_vocabulary({type_value!r}) returned "
+            f"{cls.__name__!r}, expected {expected_class_name!r}"
+        )
+
+
 class TestSetTypeFromClassName:
     """VM-03-003: set_type_from_class_name must use removeprefix, not lstrip."""
 

--- a/test/wire/as2/vocab/base/test_registry.py
+++ b/test/wire/as2/vocab/base/test_registry.py
@@ -24,7 +24,11 @@ Verifies:
 
 import pytest
 
-from vultron.wire.as2.vocab.base.registry import VOCABULARY, find_in_vocabulary
+from vultron.wire.as2.vocab.base.registry import (
+    VOCABULARY,
+    WIRE_TYPE_MAP,
+    find_in_vocabulary,
+)
 
 
 class TestFindInVocabulary:
@@ -98,21 +102,23 @@ class TestAutoRegistration:
                 serialization_alias="type",
             )
 
-        assert "TestAutoRegType" in VOCABULARY
-        assert VOCABULARY["TestAutoRegType"] is as_TestAutoRegType
+        # VOCABULARY is keyed by full class name (ARCH-23-002)
+        assert "as_TestAutoRegType" in VOCABULARY
+        assert VOCABULARY["as_TestAutoRegType"] is as_TestAutoRegType
 
-        # Cleanup to avoid polluting VOCABULARY across tests
-        del VOCABULARY["TestAutoRegType"]
+        # WIRE_TYPE_MAP is keyed by wire type_ value (for parser lookups)
+        assert "TestAutoRegType" in WIRE_TYPE_MAP
+        assert WIRE_TYPE_MAP["TestAutoRegType"] is as_TestAutoRegType
+
+        # Cleanup to avoid polluting registries across tests
+        del VOCABULARY["as_TestAutoRegType"]
+        del WIRE_TYPE_MAP["TestAutoRegType"]
 
     def test_abstract_base_without_type_not_registered(self):
         """Classes with no type_ override in own annotations are not registered."""
-        from vultron.wire.as2.vocab.base.objects.base import as_Object
-
-        # as_Object itself has no concrete type_ annotation
-        assert (
-            "Object" not in VOCABULARY
-            or VOCABULARY.get("Object") is not as_Object
-        )
+        # as_Object itself has no concrete type_ annotation — neither registry
+        assert "as_Object" not in VOCABULARY
+        assert "Object" not in WIRE_TYPE_MAP
 
     def test_union_type_annotation_not_registered(self):
         """Classes with type_: str | None are skipped (abstract bases)."""
@@ -122,8 +128,9 @@ class TestAutoRegistration:
         class as_AbstractLike(as_Base):
             type_: str | None = Field(default=None)
 
-        # Should NOT be registered
-        assert "AbstractLike" not in VOCABULARY
+        # Should NOT be registered in either registry
+        assert "as_AbstractLike" not in VOCABULARY
+        assert "AbstractLike" not in WIRE_TYPE_MAP
 
 
 class TestDynamicDiscovery:
@@ -138,7 +145,7 @@ class TestDynamicDiscovery:
         )
 
     def test_core_as2_types_present(self):
-        """Core ActivityStreams 2.0 types are present after discovery."""
+        """Core ActivityStreams 2.0 types are findable after discovery."""
         import vultron.wire.as2.vocab  # noqa: F401
 
         expected = [
@@ -156,12 +163,11 @@ class TestDynamicDiscovery:
             "Note",
         ]
         for type_name in expected:
-            assert (
-                type_name in VOCABULARY
-            ), f"Expected AS2 type '{type_name}' in vocabulary"
+            cls = find_in_vocabulary(type_name)
+            assert cls is not None, f"Expected AS2 type '{type_name}' findable"
 
     def test_vocab_bug_26040902_regression(self):
-        """as_VulnerabilityReport and VulnerabilityCase are in the vocab.
+        """as_VulnerabilityReport and VulnerabilityCase are findable via vocabulary.
 
         Regression test for BUG-26040902: empty vocab registry caused
         ReceiveReportCaseBT to silently fail in Docker (where no test
@@ -174,13 +180,6 @@ class TestDynamicDiscovery:
         # or as_VulnerabilityReport import is needed.
         import vultron.wire.as2.vocab  # noqa: F401
 
-        assert (
-            "VulnerabilityReport" in VOCABULARY
-        ), "BUG-26040902: as_VulnerabilityReport missing from vocabulary"
-        assert (
-            "VulnerabilityCase" in VOCABULARY
-        ), "BUG-26040902: VulnerabilityCase missing from vocabulary"
-        # Verify the classes are actually correct
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
             as_VulnerabilityReport,
         )
@@ -188,8 +187,21 @@ class TestDynamicDiscovery:
             as_VulnerabilityCase,
         )
 
-        assert VOCABULARY["VulnerabilityReport"] is as_VulnerabilityReport
-        assert VOCABULARY["VulnerabilityCase"] is as_VulnerabilityCase
+        # WIRE_TYPE_MAP is keyed by wire type_ value (ARCH-23-002: disjoint from CORE_VOCABULARY)
+        assert (
+            "VulnerabilityReport" in WIRE_TYPE_MAP
+        ), "BUG-26040902: as_VulnerabilityReport missing from WIRE_TYPE_MAP"
+        assert (
+            "VulnerabilityCase" in WIRE_TYPE_MAP
+        ), "BUG-26040902: VulnerabilityCase missing from WIRE_TYPE_MAP"
+        assert WIRE_TYPE_MAP["VulnerabilityReport"] is as_VulnerabilityReport
+        assert WIRE_TYPE_MAP["VulnerabilityCase"] is as_VulnerabilityCase
+
+        # VOCABULARY is keyed by full wire class name
+        assert "as_VulnerabilityReport" in VOCABULARY
+        assert "as_VulnerabilityCase" in VOCABULARY
+        assert VOCABULARY["as_VulnerabilityReport"] is as_VulnerabilityReport
+        assert VOCABULARY["as_VulnerabilityCase"] is as_VulnerabilityCase
 
 
 class TestCoreTypeMapFallback:
@@ -222,13 +234,13 @@ class TestCoreTypeMapFallback:
             ), f"ARCH-12-003 violation: {name!r} must not be in wire VOCABULARY"
 
     def test_actor_key_is_wire_type(self):
-        """VOCABULARY['Actor'] must be the wire as_Actor, not CoreActor."""
+        """WIRE_TYPE_MAP['Actor'] must be the wire as_Actor, not CoreActor."""
         from vultron.wire.as2.vocab.base.objects.actors import as_Actor
         from vultron.core.models.actor import CoreActor
 
-        assert "Actor" in VOCABULARY
-        assert VOCABULARY["Actor"] is as_Actor
-        assert VOCABULARY["Actor"] is not CoreActor
+        assert "Actor" in WIRE_TYPE_MAP
+        assert WIRE_TYPE_MAP["Actor"] is as_Actor
+        assert WIRE_TYPE_MAP["Actor"] is not CoreActor
 
     def test_core_types_findable_via_fallback(self):
         """find_in_vocabulary must resolve each formerly-misregistered core type."""
@@ -263,3 +275,79 @@ class TestCoreTypeMapFallback:
 
         cls = find_in_vocabulary("ReplicationState")
         assert cls is VultronReplicationState
+
+
+class TestDisjointKeys:
+    """ARCH-23-002: set(VOCABULARY) & set(CORE_VOCABULARY) must be empty."""
+
+    def setup_method(self):
+        import vultron.wire.as2.vocab.objects  # noqa: F401
+
+    def test_vocabulary_and_core_vocabulary_keys_are_disjoint(self):
+        """ARCH-23-002: VOCABULARY and CORE_VOCABULARY key sets are disjoint."""
+        from vultron.core.models.registry import CORE_VOCABULARY
+
+        collision = set(VOCABULARY) & set(CORE_VOCABULARY)
+        assert collision == set(), (
+            f"ARCH-23-002 violation: {len(collision)} key(s) shared between "
+            f"VOCABULARY and CORE_VOCABULARY: {sorted(collision)}"
+        )
+
+    def test_vocabulary_keys_use_wire_class_prefix(self):
+        """VOCABULARY keys use the full 'as_*' wire class name."""
+        import vultron.wire.as2.vocab.objects  # noqa: F401
+
+        for key in VOCABULARY:
+            assert key.startswith(
+                "as_"
+            ), f"VOCABULARY key {key!r} does not start with 'as_'"
+
+    def test_wire_type_map_keys_are_stripped(self):
+        """WIRE_TYPE_MAP keys are wire type_ values (no 'as_' prefix)."""
+        for key in WIRE_TYPE_MAP:
+            assert not key.startswith(
+                "as_"
+            ), f"WIRE_TYPE_MAP key {key!r} still has 'as_' prefix"
+
+
+class TestSetTypeFromClassName:
+    """VM-03-003: set_type_from_class_name must use removeprefix, not lstrip."""
+
+    def test_removeprefix_not_lstrip_for_normal_class(self):
+        """set_type_from_class_name strips 'as_' prefix exactly once."""
+        from pydantic import Field
+        from typing import Literal
+        from vultron.wire.as2.vocab.base.objects.base import as_Object
+
+        class as_Widget(as_Object):
+            type_: Literal["Widget"] = Field(
+                default="Widget",
+                validation_alias="type",
+                serialization_alias="type",
+            )
+
+        obj = as_Widget()
+        assert obj.type_ == "Widget"
+
+        del VOCABULARY["as_Widget"]
+        del WIRE_TYPE_MAP["Widget"]
+
+    def test_removeprefix_not_lstrip_for_ambiguous_class(self):
+        """set_type_from_class_name does NOT strip extra leading 'a'/'s'/'_' chars.
+
+        lstrip('as_') would incorrectly strip leading 'a', 's', or '_' chars
+        from the post-prefix remainder (e.g. 'as_SomeThing' via lstrip would
+        strip 'S'... actually 'a','s','_' are lowercase, so this demonstrates
+        the boundary). The key risk is a class like as_assign (stripped name
+        'assign' starts with 'a'/'s'); lstrip would give 'ign'.
+        """
+        from vultron.wire.as2.vocab.base.base import as_Base
+
+        class as_satellite(as_Base):
+            pass
+
+        obj = as_satellite()
+        # removeprefix gives 'satellite'; lstrip would give 'tellite'
+        assert (
+            obj.type_ == "satellite"
+        ), f"Expected 'satellite', got {obj.type_!r} — lstrip bug not fixed?"

--- a/test/wire/as2/vocab/base/test_registry_completeness.py
+++ b/test/wire/as2/vocab/base/test_registry_completeness.py
@@ -44,7 +44,11 @@ import sys
 import pytest
 
 import vultron.wire.as2.vocab  # noqa: F401 — triggers dynamic discovery
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.registry import (
+    VOCABULARY,
+    WIRE_TYPE_MAP,
+    find_in_vocabulary,
+)
 
 # ---------------------------------------------------------------------------
 # Module-level discovery helpers
@@ -130,15 +134,16 @@ def _module_defines_own_type_annotation(module_name: str) -> bool:
 
 
 def _module_contributes_registered_type(module_name: str) -> bool:
-    """Return True if any class defined in this module is in VOCABULARY."""
+    """Return True if any class defined in this module is in VOCABULARY or WIRE_TYPE_MAP."""
     mod = importlib.import_module(module_name)
+    all_registered = set(VOCABULARY.values()) | set(WIRE_TYPE_MAP.values())
     for name in dir(mod):
         obj = getattr(mod, name, None)
         if obj is None or not isinstance(obj, type):
             continue
         if getattr(obj, "__module__", None) != module_name:
             continue
-        if any(vocab_cls is obj for vocab_cls in VOCABULARY.values()):
+        if obj in all_registered:
             return True
     return False
 
@@ -211,8 +216,12 @@ _EXPECTED_TYPES = [
 
 @pytest.mark.parametrize("type_name", _EXPECTED_TYPES)
 def test_expected_type_is_registered(type_name):
-    """Each expected type name is present in the vocabulary."""
-    assert type_name in VOCABULARY, (
-        f"Expected type '{type_name}' not found in VOCABULARY. "
-        f"Available keys: {sorted(VOCABULARY.keys())}"
+    """Each expected type name is findable via the vocabulary."""
+    try:
+        cls = find_in_vocabulary(type_name)
+    except KeyError:
+        cls = None
+    assert cls is not None, (
+        f"Expected type '{type_name}' not findable in vocabulary. "
+        f"VOCABULARY keys: {sorted(VOCABULARY.keys())}"
     )

--- a/test/wire/as2/vocab/base/test_wire_base_hierarchy.py
+++ b/test/wire/as2/vocab/base/test_wire_base_hierarchy.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field
 from vultron.core.models.base import VultronBase, VultronObject
 from vultron.wire.as2.vocab.base.base import as_Base
 from vultron.wire.as2.vocab.base.objects.base import as_Object
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.registry import VOCABULARY, WIRE_TYPE_MAP
 from vultron.wire.as2.vocab.base.utils import URN_UUID_PREFIX
 
 # --- AC-1/AC-2: Inheritance chain (ARCH-12-001) ----------------------------
@@ -149,8 +149,8 @@ def test_as_object_id_uses_wire_default():
 def test_concrete_wire_subclass_still_registers():
     """A concrete as_Object subclass with Literal type_ is still auto-registered.
 
-    Regression: the inheritance change must not break VOCABULARY registration
-    via as_Base.__init_subclass__.
+    Regression: the inheritance change must not break VOCABULARY/WIRE_TYPE_MAP
+    registration via as_Base.__init_subclass__.
     """
 
     class as_HierarchyTestProbe(as_Object):
@@ -160,8 +160,14 @@ def test_concrete_wire_subclass_still_registers():
             serialization_alias="type",
         )
 
-    assert "HierarchyTestProbe" in VOCABULARY
-    assert VOCABULARY["HierarchyTestProbe"] is as_HierarchyTestProbe
+    # VOCABULARY keyed by full class name (ARCH-23-002)
+    assert "as_HierarchyTestProbe" in VOCABULARY
+    assert VOCABULARY["as_HierarchyTestProbe"] is as_HierarchyTestProbe
 
-    # Cleanup to avoid polluting VOCABULARY across tests
-    del VOCABULARY["HierarchyTestProbe"]
+    # WIRE_TYPE_MAP keyed by type_ value (for parser lookups)
+    assert "HierarchyTestProbe" in WIRE_TYPE_MAP
+    assert WIRE_TYPE_MAP["HierarchyTestProbe"] is as_HierarchyTestProbe
+
+    # Cleanup to avoid polluting registries across tests
+    del VOCABULARY["as_HierarchyTestProbe"]
+    del WIRE_TYPE_MAP["HierarchyTestProbe"]

--- a/test/wire/as2/vocab/test_vultron_actor.py
+++ b/test/wire/as2/vocab/test_vultron_actor.py
@@ -29,7 +29,7 @@ from vultron.core.models.actor import (
 )
 from vultron.wire.as2.enums import as_ActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.registry import WIRE_TYPE_MAP
 from vultron.wire.as2.vocab.objects.embargo_policy import as_EmbargoPolicy
 from vultron.wire.as2.vocab.objects.vultron_actor import (
     VultronActorMixin,
@@ -172,14 +172,15 @@ class TestVultronActorTypePreservation(unittest.TestCase):
 
 class TestWireActorVocabularyAndRoundTrip(unittest.TestCase):
     def test_vocabulary_points_to_wire_actor_types(self):
-        # ARCH-12-003: VOCABULARY["Actor"] must be the wire as_Actor, not CoreActor.
+        # ARCH-12-003: WIRE_TYPE_MAP["Actor"] must be the wire as_Actor, not CoreActor.
         # CoreActor was removed from VOCABULARY in issue #1992.
-        self.assertIs(VOCABULARY["Actor"], as_Actor)
-        self.assertIs(VOCABULARY["Person"], as_VultronPerson)
-        self.assertIs(VOCABULARY["Organization"], as_VultronOrganization)
-        self.assertIs(VOCABULARY["Service"], as_VultronService)
-        self.assertIs(VOCABULARY["Application"], as_VultronApplication)
-        self.assertIs(VOCABULARY["Group"], as_VultronGroup)
+        # ARCH-23-002: actor type_ value keys live in WIRE_TYPE_MAP, not VOCABULARY.
+        self.assertIs(WIRE_TYPE_MAP["Actor"], as_Actor)
+        self.assertIs(WIRE_TYPE_MAP["Person"], as_VultronPerson)
+        self.assertIs(WIRE_TYPE_MAP["Organization"], as_VultronOrganization)
+        self.assertIs(WIRE_TYPE_MAP["Service"], as_VultronService)
+        self.assertIs(WIRE_TYPE_MAP["Application"], as_VultronApplication)
+        self.assertIs(WIRE_TYPE_MAP["Group"], as_VultronGroup)
 
     def test_core_person_to_wire_person_model_validate_round_trip(self):
         core_actor = CoreVultronPerson(

--- a/vultron/adapters/driven/wire_render/as2.py
+++ b/vultron/adapters/driven/wire_render/as2.py
@@ -18,7 +18,7 @@
 
 Translates a core domain object to its wire-layer counterpart via:
 
-1. Vocabulary lookup — ``VOCABULARY.get(type(obj).__name__)``
+1. Vocabulary lookup — ``WIRE_TYPE_MAP.get(type(obj).__name__)``
 2. Wire-counterpart guard — ``issubclass(wire_cls, VultronAS2Object)``
 3. ``wire_cls.from_core(obj)``
 4. ``model_dump(by_alias=True, exclude_none=True, mode="json")``
@@ -42,7 +42,7 @@ Per ``specs/architecture.yaml`` ARCH-20-001 through ARCH-20-004.
 from typing import Any
 
 from vultron.errors import VultronValidationError
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.registry import WIRE_TYPE_MAP
 from vultron.wire.as2.vocab.objects.base import VultronAS2Object
 
 
@@ -58,7 +58,7 @@ class As2WireRenderAdapter:
     def render(self, obj: Any) -> dict[str, Any]:
         """Render a core domain object as wire-shaped JSON.
 
-        Looks up the wire counterpart in the AS2 vocabulary registry by
+        Looks up the wire counterpart in ``WIRE_TYPE_MAP`` by
         ``type(obj).__name__``, verifies it is a
         :class:`~vultron.wire.as2.vocab.objects.base.VultronAS2Object`
         (the only class with ``from_core()``), then returns the camelCase
@@ -79,7 +79,7 @@ class As2WireRenderAdapter:
                 does not extend ``VultronAS2Object`` (ARCH-20-003).
         """
         type_name = type(obj).__name__
-        wire_cls = VOCABULARY.get(type_name)
+        wire_cls = WIRE_TYPE_MAP.get(type_name)
 
         if wire_cls is None or not issubclass(wire_cls, VultronAS2Object):
             raise VultronValidationError(

--- a/vultron/wire/as2/vocab/base/base.py
+++ b/vultron/wire/as2/vocab/base/base.py
@@ -23,7 +23,7 @@ from pydantic.alias_generators import to_camel
 
 from vultron.core.models.base import VultronBase
 from vultron.wire.as2.vocab.base.enums import VocabNamespace
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.registry import VOCABULARY, WIRE_TYPE_MAP
 from vultron.wire.as2.vocab.base.utils import generate_new_id
 
 ACTIVITY_STREAMS_NS = "https://www.w3.org/ns/activitystreams"
@@ -49,8 +49,9 @@ class as_Base(VultronBase):
             return
         if _typing.get_origin(annotation) is _typing.Union:
             return
-        key = cls.__name__.removeprefix("as_")
-        VOCABULARY[key] = cls
+        if cls.__name__.startswith("as_"):
+            VOCABULARY[cls.__name__] = cls
+        WIRE_TYPE_MAP[cls.__name__.removeprefix("as_")] = cls
 
     context_: str = Field(
         default=ACTIVITY_STREAMS_NS,
@@ -75,7 +76,7 @@ class as_Base(VultronBase):
     def set_type_from_class_name(self):
         if self.type_ is None:
             object.__setattr__(
-                self, "type_", self.__class__.__name__.lstrip("as_")
+                self, "type_", self.__class__.__name__.removeprefix("as_")
             )
         return self
 

--- a/vultron/wire/as2/vocab/base/objects/actors.py
+++ b/vultron/wire/as2/vocab/base/objects/actors.py
@@ -25,7 +25,7 @@ from vultron.wire.as2.vocab.base.objects.collections import (
     as_Collection,
     as_OrderedCollection,
 )
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.registry import WIRE_TYPE_MAP
 
 
 class as_Actor(as_Object):
@@ -172,7 +172,7 @@ as_PersonRef: TypeAlias = ActivityStreamRef[as_Person]
 
 # as_Actor has no concrete type_ annotation of its own but is used as a
 # concrete stored type with type_='Actor' via set_type_from_class_name().
-VOCABULARY["Actor"] = as_Actor
+WIRE_TYPE_MAP["Actor"] = as_Actor
 
 
 def main():

--- a/vultron/wire/as2/vocab/base/registry.py
+++ b/vultron/wire/as2/vocab/base/registry.py
@@ -22,14 +22,16 @@ from vultron.core.models.registry import find_in_core_type_map
 
 VOCABULARY: dict[str, type[BaseModel]] = {}
 
+WIRE_TYPE_MAP: dict[str, type[BaseModel]] = {}
+
 
 def find_in_vocabulary(item_name: str) -> type[BaseModel]:
     """Find a class in the vocabulary by type name.
 
-    Checks the wire ``VOCABULARY`` first, then falls back to the core
-    ``CORE_TYPE_MAP`` (via :func:`find_in_core_type_map`) for types that
-    belong to the core domain layer and must not be registered as wire
-    vocabulary entries (ARCH-12-003).
+    Checks ``WIRE_TYPE_MAP`` (keyed by wire ``type_`` value) first, then
+    ``VOCABULARY`` (keyed by full wire class name), then falls back to the
+    core ``CORE_TYPE_MAP`` (via :func:`find_in_core_type_map`) for types
+    that belong to the core domain layer (ARCH-12-003).
 
     Args:
         item_name: The name of the type to find.
@@ -38,6 +40,8 @@ def find_in_vocabulary(item_name: str) -> type[BaseModel]:
     Raises:
         KeyError: If the type name is not registered in either vocabulary.
     """
+    if item_name in WIRE_TYPE_MAP:
+        return WIRE_TYPE_MAP[item_name]
     if item_name in VOCABULARY:
         return VOCABULARY[item_name]
     try:

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -29,7 +29,7 @@ from vultron.core.models.actor import (
 from vultron.wire.as2.enums import as_ActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
-from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.registry import WIRE_TYPE_MAP
 
 _WIRE_ACTOR_TO_CORE: dict[str, Type[CoreActor]] = {
     as_ActorType.PERSON: VultronPerson,
@@ -100,11 +100,11 @@ class as_VultronGroup(VultronActorMixin):
     )
 
 
-VOCABULARY["Person"] = as_VultronPerson
-VOCABULARY["Organization"] = as_VultronOrganization
-VOCABULARY["Service"] = as_VultronService
-VOCABULARY["Application"] = as_VultronApplication
-VOCABULARY["Group"] = as_VultronGroup
+WIRE_TYPE_MAP["Person"] = as_VultronPerson
+WIRE_TYPE_MAP["Organization"] = as_VultronOrganization
+WIRE_TYPE_MAP["Service"] = as_VultronService
+WIRE_TYPE_MAP["Application"] = as_VultronApplication
+WIRE_TYPE_MAP["Group"] = as_VultronGroup
 
 
 as_VultronPersonRef: TypeAlias = ActivityStreamRef[as_VultronPerson]


### PR DESCRIPTION
- Closes #2941

## Summary

Fixes two defects: 15-key collision between `VOCABULARY` and `CORE_VOCABULARY` (ARCH-23-002), and `lstrip("as_")` used instead of `removeprefix("as_")` in `set_type_from_class_name` (VM-03-003).

## Changes

- **`vultron/wire/as2/vocab/base/registry.py`** — add `WIRE_TYPE_MAP` (keyed by wire `type_` value, e.g. `"VulnerabilityCase"`); update `find_in_vocabulary()` to check `WIRE_TYPE_MAP` before `VOCABULARY` and the core fallback
- **`vultron/wire/as2/vocab/base/base.py`** — `__init_subclass__`: VOCABULARY now keyed by full `as_*` class name (`"as_VulnerabilityCase"`); WIRE_TYPE_MAP keyed by stripped name (`"VulnerabilityCase"` = core class name = wire type_ value for non-actor types). Fix `lstrip("as_")` → `removeprefix("as_")`
- **`vultron/wire/as2/vocab/base/objects/actors.py`** — `VOCABULARY["Actor"]` → `WIRE_TYPE_MAP["Actor"]`
- **`vultron/wire/as2/vocab/objects/vultron_actor.py`** — five actor `VOCABULARY[type_]` overrides → `WIRE_TYPE_MAP[type_]`
- **`vultron/adapters/driven/wire_render/as2.py`** — `VOCABULARY.get(type_name)` → `WIRE_TYPE_MAP.get(type_name)` (render adapter looks up by core class name)
- **7 test files** updated to use the new keying scheme; 2 new test classes added (`TestDisjointKeys` asserting ARCH-23-002, `TestSetTypeFromClassName` asserting VM-03-003)

## Verification

- `set(VOCABULARY) & set(CORE_VOCABULARY) == set()` confirmed by new `TestDisjointKeys` test
- All 7934 unit tests pass (2 new test classes, ~15 new test methods)
- All 1248 integration tests pass
- Black, flake8, mypy, pyright all clean