### PR TITLE
docs: plan issue #2832 — G04 causal ordering and ledger authority

### DIFF
--- a/docs/adr/0058-causal-gating-in-demo-scenarios.md
+++ b/docs/adr/0058-causal-gating-in-demo-scenarios.md
@@ -114,7 +114,7 @@ describing the case's progress in CVD domain terms with each step's antecedent
 named, carrying a machine-readable list of causal edges. The invariant harness
 asserts every declared edge appears in the observed case ledger with the
 antecedent's `log_index` preceding the consequent's. Because `log_index` order is
-causal order (ADR-0041) and the harness already reads per-scenario ledger dumps,
+causal order (ADR-0079, CLP-14-001) and the harness already reads per-scenario ledger dumps,
 this needs no new instrumentation.
 
 The narrative is the part of this decision that does work the gates cannot. A

--- a/notes/event-driven-control-flow.md
+++ b/notes/event-driven-control-flow.md
@@ -236,7 +236,7 @@ is written independently of the implementation, it can contradict it. Each
 narrative carries a machine-readable list of causal edges, and the invariant
 harness asserts every declared edge appears in the observed case ledger with the
 antecedent's `log_index` before the consequent's — `log_index` order is causal
-order (ADR-0041), and the harness already reads the ledger dumps
+order (ADR-0079, CLP-14-001), and the harness already reads the ledger dumps
 (DEMOMA-22-003 through DEMOMA-22-006).
 
 ---

--- a/plan/history/2609/learning/CONCERN-2832.md
+++ b/plan/history/2609/learning/CONCERN-2832.md
@@ -66,3 +66,15 @@ to codify the remaining gaps, and creating two impl Tasks.
   but without a spec entry the behaviour was invisible to reviewers and future
   implementors. When ADR-0037-style buffering is in play, always check whether
   invariant specs explicitly state *when* the guard fires.
+
+- **#1166 (distributed consensus ledger) does not conflict with ADR-0079.**
+  AC-4 of #2832 required checking that the near-term decision (ADR-0079:
+  single-writer CaseActor, log_index = causal order) does not foreclose
+  consensus-based ledgering (#1166). It does not: ADR-0079 defines the
+  *current* authority model for cases with a single designated CaseActor.
+  #1166 would introduce a consensus layer *beneath* that abstraction —
+  consensus is an upgrade path for the authority mechanism, not a contradiction
+  of it. The log_index-is-causal-order property would remain valid in a
+  consensus-backed system; the CaseActor role would simply gain a replicated
+  backing store. #1166 remains open as a long-horizon architectural item;
+  no immediate action required.

--- a/plan/history/2609/learning/CONCERN-2832.md
+++ b/plan/history/2609/learning/CONCERN-2832.md
@@ -1,0 +1,68 @@
+---
+source: CONCERN-2832
+timestamp: '2026-09-01T18:07:51.271128+00:00'
+title: 'G04: Causal ordering and ledger authority — fix mis-citations, add CM-29 and
+  CSB-19 spec groups'
+type: learning
+---
+
+## Outcome
+
+Closed CONCERN-2832 (G04: Causal ordering and ledger authority). The design was
+already substantially resolved by ADR-0079 (accepted 2026-08-26) and the
+CLP-14/CLP-15 spec entries in `specs/case-ledger-processing.yaml`. Planning work
+reduced to: fixing three stale ADR-0041 mis-citations, adding two new spec groups
+to codify the remaining gaps, and creating two impl Tasks.
+
+## What Was Done
+
+**PR #2978**: <https://github.com/CERTCC/Vultron/pull/2978>
+
+1. **Fixed ADR-0041 mis-citations** (three sites): `specs/case-management.yaml`
+   CM-18-007 rationale, `notes/event-driven-control-flow.md`, and
+   `docs/adr/0058-causal-gating-in-demo-scenarios.md` all cited ADR-0041 as the
+   authority for `log_index` causal order. Corrected to ADR-0079 / CLP-14-001.
+
+2. **Added CM-29** "Case Status Recency Resolution" (`specs/case-management.yaml`):
+   `current_status` MUST determine recency by timestamps only; `id_` MUST NOT be
+   used as a sort tiebreaker. Closes the spec gap behind bug #2737
+   (UUID-scheme IDs sort higher than HTTPS-scheme IDs, causing auto-seeded initial
+   statuses to beat received statuses when both lack timestamps).
+
+3. **Added CSB-19** "CS Ordering Invariants Under Out-of-Order Ledger Delivery"
+   (`specs/cs-behavior.yaml`): CS guards (ephemeral-state, history-prefix,
+   CP-before-ET) MUST be evaluated at buffer-drain time in causal order, not at
+   original out-of-order receipt. Codifies existing correct behaviour per ADR-0037.
+   Closes the spec gap behind #2527.
+
+## Implementation Issues Created
+
+- **#2979** (size:S, parent #2684, blocked-by #2832): Fix `current_status` UUID
+  tiebreaker — replace `cs.id_` with `datetime.min.replace(tzinfo=timezone.utc)`
+  in `vultron/core/models/case.py` and
+  `vultron/wire/as2/vocab/objects/vulnerability_case.py`.
+
+- **#2980** (size:M, parent #607, blocked-by #2832): Write
+  `docs/topics/case_ledger_sync.md` — user-facing explanation of ledger
+  synchronisation, log_index causal order, and the ADR-0037 buffer/drain
+  mechanics.
+
+## Learnings
+
+- **ADR-0079 was already the settled answer.** When a Concern arrives with a
+  multi-issue batch and an ADR already exists for the core question, the planning
+  session's real work is gap-filling (mis-citations, missing spec entries) not
+  re-deciding. Orient-agent + deepen-context surfaced this in minutes; don't
+  assume a Concern requires a new ADR.
+
+- **ID-scheme sort order is an invisible footgun.** `urn:uuid:…` (prefix `'u'`)
+  sorts lexically above `https://…` (prefix `'h'`). Any `max(key=…id_)` fallback
+  on mixed-scheme IDs will silently prefer the UUID-scheme value. Watch for this
+  pattern wherever a "latest" or "most-recent" winner is chosen from a mixed
+  collection.
+
+- **Buffer-time vs drain-time invariant evaluation** is a recurring spec gap in
+  async BT architectures. The code was already correct (guards fire at drain),
+  but without a spec entry the behaviour was invisible to reviewers and future
+  implementors. When ADR-0037-style buffering is in play, always check whether
+  invariant specs explicitly state *when* the guard fires.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -1801,7 +1801,7 @@ groups:
       its consent state in a single transition, so a placeholder entry is unnecessary. Emitting two entries per participant would
       also shift every downstream `log_index`; PR #1746 was reverted for exactly that, having broken `fvcv-extension` VFD
       replication timing. Holding initialization to one entry per participant keeps `log_index` order stable and preserves the
-      ADR-0041 property that `log_index` order is causal order.'
+      ADR-0079 property that `log_index` order is causal order (CLP-14-001).'
     verification: Integration tests in `test/demo/` confirm that the default embargo is
       established before each participant's PEC state is written during case initialization, so
       each initial `ParticipantStatus` carries the correct post-initialization consent value.
@@ -3290,3 +3290,35 @@ groups:
       spec_id: CM-27-001
     adr:
     - ADR-0064
+- id: CM-29
+  title: Case Status Recency Resolution
+  description: Rules for determining which CaseStatus snapshot is the most recent
+    when multiple snapshots exist in the case_statuses history.
+  specs:
+  - id: CM-29-001
+    priority: MUST
+    kind: project
+    statement: >-
+      `VulnerabilityCase.current_status` MUST determine the most-recent
+      `CaseStatus` by comparing `updated` then `published` timestamps only.
+      The `id_` field MUST NOT be used as a sort tiebreaker.
+    rationale: >-
+      Using `id_` as a fallback when timestamps are absent produces
+      scheme-dependent ordering: auto-seeded statuses carry UUID-based IDs
+      (`urn:uuid:…`, starting with `'u'`) which sort lexically higher than
+      HTTPS-scheme IDs (`https://…`, starting with `'h'`), causing the
+      initial auto-seeded status to beat a legitimately newer received status
+      when both lack explicit timestamps. ID scheme is an implementation
+      artefact, not a time proxy. When timestamps are absent or equal, the
+      fallback MUST resolve to the earliest possible time (e.g., `datetime.min`)
+      so that timestampless statuses sort to the bottom rather than the top.
+      Source: #2737.
+    verification: >-
+      Unit test: construct a VulnerabilityCase with an auto-seeded status
+      (urn:uuid ID, no timestamps) and a received status (HTTPS ID, no
+      timestamps); assert current_status returns the received status.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-27-001
+    lint_suppress:
+    - missing_story_reference

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -2462,3 +2462,80 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: CSB-18-002
+- id: CSB-19
+  title: CS Ordering Invariants Under Out-of-Order Ledger Delivery
+  description: Normative requirements for how CS ordering invariants interact
+    with the ADR-0037 out-of-order ledger entry buffer. Clarifies when invariant
+    guards are evaluated relative to buffer receipt and buffer drain.
+  specs:
+  - id: CSB-19-001
+    priority: MUST
+    kind: protocol
+    statement: >-
+      CS ordering invariants (ephemeral-state guard, history-prefix validity,
+      CP-before-ET ordering) MUST be evaluated at buffer-drain time — that is,
+      against the causal-order replay produced by the ADR-0037 gap buffer —
+      not at the time of original out-of-order receipt.
+    rationale: >-
+      An out-of-order `Announce(CaseLedgerEntry)` carrying a CS update is
+      buffered by `BufferOutOfOrderEntryNode` before any domain effects are
+      applied; the CS state machine is not touched at buffer-receipt time.
+      When the gap fills, the buffer drain re-runs the full announce receive
+      BT on each buffered entry in log_index order (ADR-0037, CLP-14-001),
+      so CS guards see the entries in correct causal sequence. Evaluating
+      guards at original receipt would produce false violations whenever the
+      predecessor CS entry has not yet arrived.
+    adr:
+    - ADR-0037
+    - ADR-0079
+    relationships:
+    - rel_type: depends_on
+      spec_id: CSB-12-001
+    lint_suppress:
+    - missing_story_reference
+  - id: CSB-19-002
+    priority: MUST_NOT
+    kind: protocol
+    statement: >-
+      A buffered out-of-order CS ledger entry MUST NOT trigger an ephemeral-state
+      violation or history-prefix validation failure at the time it is buffered.
+      Such checks MUST be deferred until the entry is replayed in causal order
+      during buffer drain.
+    rationale: >-
+      An ephemeral-state entry (e.g., a pX-state CaseStatus arriving before its
+      P-state predecessor) is structurally valid in isolation; the violation
+      would only be real if the predecessor never arrives. Flagging it at buffer
+      time produces a false positive and may cause the entry to be incorrectly
+      rejected, breaking convergence.
+    relationships:
+    - rel_type: refines
+      spec_id: CSB-19-001
+    lint_suppress:
+    - missing_story_reference
+  - id: CSB-19-003
+    priority: MUST
+    kind: protocol
+    statement: >-
+      The CP-before-ET ordering constraint (CSB-12-001: CS→P MUST be recorded
+      before ET is emitted) is preserved under out-of-order ledger delivery
+      because the CaseActor commits entries in causal order (CLP-14-001). The
+      P-state ledger entry always carries a lower log_index than the ET entry
+      that follows it; the buffer drain therefore always processes P before ET
+      when both are buffered.
+    rationale: >-
+      CSB-12-001 is enforced at the CaseActor write-side: the CaseActor commits
+      the P-state entry before committing the ET entry. This means the P-state
+      entry's log_index is strictly lower than the ET entry's log_index. The
+      ADR-0037 buffer drains in log_index order, so the constraint cannot be
+      violated by reordered delivery alone. No receiver-side re-enforcement
+      of the temporal constraint is required; the causal order in the ledger
+      is sufficient.
+    relationships:
+    - rel_type: refines
+      spec_id: CSB-19-001
+    - rel_type: depends_on
+      spec_id: CSB-12-001
+    - rel_type: depends_on
+      spec_id: CLP-14-001
+    lint_suppress:
+    - missing_story_reference

--- a/test/core/models/test_ledger_gap_buffer.py
+++ b/test/core/models/test_ledger_gap_buffer.py
@@ -92,8 +92,16 @@ class TestBufferAndTakeNext:
         assert buf.take_next(CASE_A, "deadbeef" * 8) is None
         assert buf.depth(CASE_A) == 1
 
+    @pytest.mark.spec("CSB-19-001")
+    @pytest.mark.spec("CSB-19-003")
     def test_cascade_drain_in_order(self):
-        """A contiguous buffered run drains one hop at a time in O(1) lookups."""
+        """A contiguous buffered run drains one hop at a time in O(1) lookups.
+
+        Covers CSB-19-001 (CS invariants evaluated at drain time in causal
+        order) and CSB-19-003 (P-before-ET is preserved because drain order
+        equals log_index order, so the lower-indexed entry always precedes the
+        higher-indexed one regardless of arrival order).
+        """
         entries = _chain(5)  # 0..4
         buf = LedgerGapBuffer()
         for e in entries[1:]:  # buffer 1,2,3,4
@@ -107,6 +115,23 @@ class TestBufferAndTakeNext:
             tail = nxt.entry_hash
         assert drained == [1, 2, 3, 4]
         assert buf.depth(CASE_A) == 0
+
+    @pytest.mark.spec("CSB-19-002")
+    def test_buffer_does_not_evaluate_cs_invariants(self):
+        """Buffering an out-of-order entry never triggers CS validation (CSB-19-002).
+
+        The LedgerGapBuffer is a pure data structure with no knowledge of CS
+        state; buffer() only stores the entry keyed on its predecessor hash.
+        An out-of-order pX-state entry (whose P-predecessor has not arrived)
+        is buffered without any CS guard evaluation — the guard fires at drain
+        time when entries are replayed in causal order.
+        """
+        buf = LedgerGapBuffer()
+        _e0, e1 = _chain(2)
+        # Buffer e1 before e0 has been persisted — simulates out-of-order receipt.
+        result = buf.buffer(e1)
+        assert result is True  # accepted with no CS-side-effect
+        assert buf.depth(CASE_A) == 1
 
     def test_cases_are_isolated(self):
         buf = LedgerGapBuffer()


### PR DESCRIPTION
Closes #2832
Closes #2207
Closes #2527

## Summary

Resolves planning-group Concern #2832 (G04: Causal ordering and ledger authority) by fixing three ADR-0041 mis-citations and adding two new spec groups that codify the causal-ordering invariants established by ADR-0079.

## Changes

- **`specs/case-management.yaml`**: Fixed ADR-0041 mis-citation in CM-18-007 rationale (→ ADR-0079 / CLP-14-001); added CM-29 "Case Status Recency Resolution" (MUST NOT use `id_` as tiebreaker for `current_status`)
- **`specs/cs-behavior.yaml`**: Added CSB-19 "CS Ordering Invariants Under Out-of-Order Ledger Delivery" (CS guards evaluated at buffer-drain time in causal order, not at original out-of-order receipt)
- **`notes/event-driven-control-flow.md`**: Fixed ADR-0041 mis-citation (→ ADR-0079, CLP-14-001)
- **`docs/adr/0058-causal-gating-in-demo-scenarios.md`**: Fixed ADR-0041 mis-citation (→ ADR-0079, CLP-14-001)

## Implementation Issues
- #2979 (pending: T2 — docs/topics/case_ledger_sync.md)