### PR TITLE
fix: enforce VF↔D entailment and per-dimension role guards (#2893, #2963, #2964, #2965)

### DIFF
--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -118,7 +118,7 @@ verdicts split between *still valid* and *superseded by structure*.
 
 | Legacy rule (`validations.py`) | Verdict | Current expression |
 |---|---|---|
-| `is_valid_state`: `vF` / `fD` impossible → 32 states | Still valid, **structural** | `CS_vfd` has 4 members, so the combinations are unrepresentable. Ratchet test, not a runtime predicate. CSB-17-001 |
+| `is_valid_state`: `vF` / `fD` impossible → 32 states | Still valid, **structural and runtime** | After ADR-0075 split VFD into separate `CS_vf`/`CS_d` types, `*fD*` is no longer structurally unrepresentable. Runtime enforcement added via `violation_vf_d_entailment()` on both trigger path (`ValidateTriggerTransitionsNode`) and received path (`_adjudicate_dimensions`). CSB-17-001 |
 | `is_valid_transition`: Hamming distance 1 | Still valid | `cs_transition_event()`, CSB-17-002 |
 | `is_valid_transition`: monotone, same dimension | Still valid | Delegated to `is_valid_vfd_transition` / `is_valid_pxa_transition`; compound check in `is_valid_cs_transition()`, CSB-17-002 |
 | `TRANSITION_RULES`: `...pX. → ...PX.` | Still valid | `required_next_cs_events()`; generalises CSB-13-001 from the entry cascade to every `pX` successor. CSB-17-003 |

--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -91,12 +91,16 @@ AUDITED_SITES: list[tuple[str, str]] = sorted(
         # so the latch has exactly one construction site (ARCH-15-004).
         ("report/nodes/rm_transitions.py", "RmDimension"),
         # FILTER — _adjudicate_dimensions carry-forward (extracted from dimension_filter.py)
-        # Two VfDimension sites: refusal carry-forward + omission carry-forward (ADR-0075)
-        # Two DDimension sites: refusal carry-forward + omission carry-forward (ADR-0075)
+        # Three VfDimension sites: role-guard refusal + omission carry + non-monotone refusal (ADR-0075)
+        # Four DDimension sites: role-guard refusal + omission carry + non-monotone refusal
+        #                        + cross-dimension VF↔D refusal carry (CSB-17-001, #2893)
         ("status/nodes/_adjudication.py", "PxaDimension"),
         ("status/nodes/_adjudication.py", "RmDimension"),
         ("status/nodes/_adjudication.py", "VfDimension"),
         ("status/nodes/_adjudication.py", "VfDimension"),
+        ("status/nodes/_adjudication.py", "VfDimension"),
+        ("status/nodes/_adjudication.py", "DDimension"),
+        ("status/nodes/_adjudication.py", "DDimension"),
         ("status/nodes/_adjudication.py", "DDimension"),
         ("status/nodes/_adjudication.py", "DDimension"),
         # FILTER — CaseStatus per-dimension carry-forward (ISSUE-2256)

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -1574,7 +1574,7 @@ class TestRejectionValidatorBeforeCommit:
             id_=PARTICIPANT_ID,
             context=CASE_ID,
             attributed_to=ACTOR_ID,
-            case_roles=[CVDRole.CASE_OWNER],
+            case_roles=[CVDRole.CASE_OWNER, CVDRole.VENDOR],
         )
         vendor_participant.participant_statuses.append(existing_status)
         case.add_participant(cast(CaseParticipant, vendor_participant))

--- a/test/core/behaviors/status/test_partial_accept_participant_status.py
+++ b/test/core/behaviors/status/test_partial_accept_participant_status.py
@@ -1255,3 +1255,41 @@ class TestAdjudicateDimensionsRoleGuards:
         assert (
             "d" in refused
         ), "D write must be refused when vf≠VF + d=D (CSB-17-001 received path)"
+
+    def test_vf_refused_no_history_does_not_spuriously_refuse_d(self):
+        """Fix: when VF is refused (no VENDOR) and current_vf=None, effective_vf
+        must be None — not asserted_vf — so D is not spuriously refused.
+
+        Before the fix: update_fields.get("vf") returned None whether the key
+        was absent or set-to-None (refused with no history), causing the code
+        to fall through to effective_vf=asserted_vf.  When asserted_vf lacked
+        the F bit, violation_vf_d_entailment refused D even though VF was
+        rejected and the participant has no VF history at all.
+        With the fix: "vf" in update_fields correctly identifies the refused-
+        with-no-history case → effective_vf=None → entailment check skipped
+        (per CSB-17-001 design: no check when vf=None).
+        """
+        from vultron.core.states.cs import CS_d
+        from vultron.core.models.dimensions import DDimension
+        from vultron.core.behaviors.status.nodes._adjudication import (
+            _adjudicate_dimensions,
+        )
+
+        # current has no VF history; sender lacks VENDOR but has DEPLOYER
+        current_core = _current_status(RM.ACCEPTED, None, CS_pxa.pxa).to_core()
+        asserted_core = _asserted_status(
+            RM.ACCEPTED, CS_vf.vf, CS_pxa.pxa
+        ).to_core()
+        asserted_core = asserted_core.model_copy(
+            update={"d": DDimension(state=CS_d.D)}
+        )
+
+        refused, _ = _adjudicate_dimensions(
+            current_core, asserted_core, roles=[CVDRole.DEPLOYER]
+        )
+
+        assert "d" not in refused, (
+            "D must not be spuriously refused when VF was refused (no VENDOR) "
+            "and current_vf=None: effective_vf should be None (unknown), "
+            "not the rejected asserted_vf"
+        )

--- a/test/core/behaviors/status/test_partial_accept_participant_status.py
+++ b/test/core/behaviors/status/test_partial_accept_participant_status.py
@@ -297,7 +297,7 @@ def _seed_case(
         id_=PARTICIPANT_ID,
         context=CASE_ID,
         attributed_to=ACTOR_ID,
-        case_roles=[CVDRole.CASE_OWNER],
+        case_roles=[CVDRole.CASE_OWNER, CVDRole.VENDOR],
     )
     vendor.participant_statuses.append(current)
     manager = as_CaseParticipant(
@@ -1147,3 +1147,111 @@ class TestOverrideIncludesProducerType:
             override.get("producer_type")
             == "FilterParticipantStatusDimensionsNode"
         ), "RSH-05-011: producer_type must identify the producing node"
+
+
+class TestAdjudicateDimensionsRoleGuards:
+    """Role-gated adjudication for VF and D dimensions (#2965, #2893).
+
+    VF writes require VENDOR role; D writes require DEPLOYER role.
+    These guards apply on the received path: a peer without the appropriate
+    role must have the dimension refused rather than accepted.
+
+    The cross-dimension VF↔D check (#2893 received path): a peer asserting
+    d=D without vf=VF (fix not ready) is also refused on the D dimension.
+    """
+
+    def _adjudicate(self, current, asserted, roles=None):
+        from vultron.core.behaviors.status.nodes._adjudication import (
+            _adjudicate_dimensions,
+        )
+
+        return _adjudicate_dimensions(
+            current.to_core(), asserted.to_core(), roles=roles
+        )
+
+    def test_vf_write_refused_without_vendor_role(self):
+        """#2965: Peer without VENDOR role must not advance VF dimension."""
+        current = _current_status(RM.VALID, CS_vf.Vf, CS_pxa.pxa)
+        asserted = _asserted_status(RM.VALID, CS_vf.VF, CS_pxa.pxa)
+
+        refused, _ = self._adjudicate(
+            current, asserted, roles=[CVDRole.COORDINATOR]
+        )
+
+        assert "vf" in refused, "VF write must be refused without VENDOR role"
+
+    def test_d_write_refused_without_deployer_role(self):
+        """#2965: Peer without DEPLOYER role must not advance D dimension."""
+        from vultron.core.states.cs import CS_d
+
+        current_d = _current_status(RM.ACCEPTED, CS_vf.VF, CS_pxa.pxa)
+        asserted_d = _asserted_status(RM.ACCEPTED, CS_vf.VF, CS_pxa.pxa)
+        current_core = current_d.to_core()
+        asserted_core = asserted_d.to_core()
+        from vultron.core.models.dimensions import DDimension
+
+        current_core = current_core.model_copy(
+            update={"d": DDimension(state=CS_d.d)}
+        )
+        asserted_core = asserted_core.model_copy(
+            update={"d": DDimension(state=CS_d.D)}
+        )
+
+        from vultron.core.behaviors.status.nodes._adjudication import (
+            _adjudicate_dimensions,
+        )
+
+        refused, _ = _adjudicate_dimensions(
+            current_core, asserted_core, roles=[CVDRole.VENDOR]
+        )
+
+        assert "d" in refused, "D write must be refused without DEPLOYER role"
+
+    def test_vf_write_accepted_with_vendor_role(self):
+        """#2965: Peer WITH VENDOR role can advance VF dimension."""
+        current = _current_status(RM.VALID, CS_vf.Vf, CS_pxa.pxa)
+        asserted = _asserted_status(RM.VALID, CS_vf.VF, CS_pxa.pxa)
+
+        refused, _ = self._adjudicate(
+            current, asserted, roles=[CVDRole.VENDOR]
+        )
+
+        assert (
+            "vf" not in refused
+        ), "VF write must be accepted with VENDOR role"
+
+    def test_vf_not_ready_d_deployed_refused_on_receive(self):
+        """#2893 received path: peer with vf=Vf asserting d=D must have D refused.
+
+        The *fD* compound state is structurally impossible (CSB-17-001).
+        The adjudication path must refuse D when vf is not VF.
+        """
+        from vultron.core.states.cs import CS_d
+        from vultron.core.models.dimensions import DDimension
+
+        current_core = _current_status(
+            RM.ACCEPTED, CS_vf.Vf, CS_pxa.pxa
+        ).to_core()
+        asserted_core = _asserted_status(
+            RM.ACCEPTED, CS_vf.Vf, CS_pxa.pxa
+        ).to_core()
+        current_core = current_core.model_copy(
+            update={"d": DDimension(state=CS_d.d)}
+        )
+        asserted_core = asserted_core.model_copy(
+            update={"d": DDimension(state=CS_d.D)}
+        )
+
+        from vultron.core.behaviors.status.nodes._adjudication import (
+            _adjudicate_dimensions,
+        )
+
+        refused, _ = _adjudicate_dimensions(
+            current_core,
+            asserted_core,
+            roles=[CVDRole.VENDOR, CVDRole.DEPLOYER],
+        )
+
+        assert (
+            "d" in refused
+        ), "D write must be refused when vf≠VF + d=D (CSB-17-001 received path)"

--- a/test/core/states/test_cross_machine_invariants.py
+++ b/test/core/states/test_cross_machine_invariants.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for `vultron.core.states.cross_machine_invariants`.
+
+Covers violation_vf_d_entailment (#2893): d=D requires vf=VF (the *fD* compound
+state is structurally impossible, per CSB-17-001).
+"""
+
+from vultron.core.states.cs import CS_d, CS_vf
+
+
+class TestViolationVfDEntailment:
+    """Unit tests for violation_vf_d_entailment() (#2893)."""
+
+    def _check(self, vf, d):
+        from vultron.core.states.cross_machine_invariants import (
+            violation_vf_d_entailment,
+        )
+
+        return violation_vf_d_entailment(vf, d)
+
+    # --- invalid combinations (D bit set, F bit not set) ---
+
+    def test_vf_unaware_and_d_deployed_is_violation(self):
+        """vf=vf (vendor unaware) + d=D (deployed) is structurally impossible."""
+        result = self._check(CS_vf.vf, CS_d.D)
+        assert result is not None
+        assert "D" in result
+
+    def test_vf_vendor_aware_not_ready_and_d_deployed_is_violation(self):
+        """vf=Vf (aware, fix not ready) + d=D is structurally impossible."""
+        result = self._check(CS_vf.Vf, CS_d.D)
+        assert result is not None
+        assert "D" in result
+
+    # --- valid combinations ---
+
+    def test_vf_fix_ready_and_d_deployed_is_valid(self):
+        """vf=VF (fix ready) + d=D (deployed) is the valid deployment state."""
+        assert self._check(CS_vf.VF, CS_d.D) is None
+
+    def test_vf_fix_ready_and_d_not_deployed_is_valid(self):
+        """vf=VF (fix ready) + d=d (not yet deployed) is valid."""
+        assert self._check(CS_vf.VF, CS_d.d) is None
+
+    def test_vf_aware_not_ready_and_d_not_deployed_is_valid(self):
+        """vf=Vf (aware, not ready) + d=d (not deployed) is valid."""
+        assert self._check(CS_vf.Vf, CS_d.d) is None
+
+    def test_vf_unaware_and_d_not_deployed_is_valid(self):
+        """vf=vf (unaware) + d=d (not deployed) is valid."""
+        assert self._check(CS_vf.vf, CS_d.d) is None
+
+    # --- None handling ---
+
+    def test_none_vf_and_d_deployed_is_not_reported(self):
+        """When vf=None, the VF↔D check cannot be applied (no VF information)."""
+        assert self._check(None, CS_d.D) is None
+
+    def test_vf_and_none_d_is_valid(self):
+        """When d=None, no D-dimension constraint applies."""
+        assert self._check(CS_vf.vf, None) is None
+
+    def test_both_none_is_valid(self):
+        """Both None — no constraint to check."""
+        assert self._check(None, None) is None

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -952,6 +952,24 @@ class TestCreateParticipantStatusNode:
         assert "status_id" not in result_out
         assert "CSB-15-002" in bt_result.feedback_message
 
+    def test_d_not_deployed_requires_deployer_role_at_write_node(self):
+        """#2963: d=d (not deployed) target is blocked when the actor has no DEPLOYER role.
+
+        The bug: `if self._d_state == CS_d.D:` only guards the deployed state.
+        A non-DEPLOYER actor asserting d=d (the initial d-unset state) bypasses
+        the role guard.  The fix changes the condition to `if self._d_state is not None:`
+        so any D-dimension write requires DEPLOYER role.
+        """
+        from py_trees.common import Status
+
+        bt_result, result_out = self._run_node(
+            rm_state=None, vf_state=None, d_state=CS_d.d, pxa_state=None
+        )
+
+        assert bt_result.status == Status.FAILURE
+        assert "status_id" not in result_out
+        assert "CSB-15-002" in bt_result.feedback_message
+
     # ------------------------------------------------------------------
     # AC-1: ephemeral-state promotion at write boundary (SM-09-001)
     # ------------------------------------------------------------------
@@ -1698,6 +1716,41 @@ class TestCrossMachineEntailments:
         before = self._status_count()
         self._execute(pxa_state=CS_pxa.Pxa)
         assert self._status_count() == before + 1
+
+    def test_csb17_001_vf_not_ready_and_d_deployed_rejected(self):
+        """CSB-17-001: vf != VF with d=D is structurally impossible — trigger rejects it.
+
+        The compound *fD* state (fix deployed but fix not ready) is forbidden.
+        The trigger path must refuse it even when RM and individual VF/D
+        transitions are valid in isolation (#2893).
+        """
+        from vultron.errors import VultronValidationError
+
+        # Register participant as VENDOR+DEPLOYER so the D dimension guard passes.
+        from vultron.enums.roles import CVDRole
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            as_CaseParticipant,
+        )
+
+        deployer_participant = as_CaseParticipant(
+            id_=self.actor_participant.id_,
+            attributed_to=self.actor.id_,
+            context=self.case.id_,
+            case_roles=[CVDRole.VENDOR, CVDRole.DEPLOYER],
+        )
+        self.dl.save(deployer_participant)
+
+        # Advance to RM.ACCEPTED so the RM↔D entailment is satisfied.
+        self._advance_rm_to_accepted()
+        # Move VF to Vf (vendor aware, fix NOT ready).
+        self._execute(vf_state=CS_vf.Vf)
+        # Now try to assert d=D without vf=VF — must be refused.
+        before = self._status_count()
+        with pytest.raises(VultronValidationError, match="Cross-machine"):
+            self._execute(d_state=CS_d.D)
+        assert (
+            self._status_count() == before
+        ), "Status count must not increase when vf≠VF + d=D (CSB-17-001)"
 
 
 class TestViolationPxaEmEntailment:

--- a/test/wire/as2/vocab/test_case_status.py
+++ b/test/wire/as2/vocab/test_case_status.py
@@ -107,6 +107,62 @@ class TestFromCorePreservesPublished(unittest.TestCase):
         wire = as_CaseStatus.from_core(core)
         self.assertEqual(self._FIXED_TIME, wire.published)
 
+
+class TestCoerceUnknownEnumNames(unittest.TestCase):
+    """Unknown enum name strings must raise ValidationError, not KeyError (#2964).
+
+    Pydantic v2 only catches ValueError/AssertionError from field validators.
+    Using Enum[name] raises KeyError on unknown inputs, which propagates as a
+    500-class error instead of a clean 422 ValidationError.
+    """
+
+    def test_vf_state_unknown_raises_validation_error(self):
+        """as_ParticipantStatus with bogus vf_state raises ValidationError."""
+        with pytest.raises(ValidationError):
+            as_ParticipantStatus(
+                attributed_to=ACTOR_ID,
+                context=CASE_ID,
+                vf_state="BOGUS_VF",  # type: ignore[arg-type]
+            )
+
+    def test_d_state_unknown_raises_validation_error(self):
+        """as_ParticipantStatus with bogus d_state raises ValidationError."""
+        with pytest.raises(ValidationError):
+            as_ParticipantStatus(
+                attributed_to=ACTOR_ID,
+                context=CASE_ID,
+                d_state="BOGUS_D",  # type: ignore[arg-type]
+            )
+
+    def test_pxa_state_unknown_raises_validation_error(self):
+        """as_CaseStatus with bogus pxa_state raises ValidationError."""
+        with pytest.raises(ValidationError):
+            as_CaseStatus(pxa_state="BOGUS_PXA")  # type: ignore[arg-type]
+
+    def test_rm_state_unknown_raises_validation_error(self):
+        """as_ParticipantStatus with bogus rm_state raises ValidationError."""
+        with pytest.raises(ValidationError):
+            as_ParticipantStatus(
+                attributed_to=ACTOR_ID,
+                context=CASE_ID,
+                rm_state="BOGUS_RM",  # type: ignore[arg-type]
+            )
+
+    def test_em_consent_state_unknown_raises_validation_error(self):
+        """as_ParticipantStatus with bogus emConsentState raises ValidationError."""
+        with pytest.raises(ValidationError):
+            as_ParticipantStatus(
+                attributed_to=ACTOR_ID,
+                context=CASE_ID,
+                emConsentState="BOGUS_PEC",  # type: ignore[call-arg]
+            )
+
+
+class TestFromCorePreservesFields(unittest.TestCase):
+    """from_core must preserve published and cvd_role (regression: issue #2511)."""
+
+    _FIXED_TIME = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
     def test_as_participant_status_from_core_preserves_published(self):
         core = CoreParticipantStatus(
             context=CASE_ID,

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -242,7 +242,7 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
         self, current_d: CS_d | None, participant_obj: object
     ) -> "Status | None":
         """CSB-16-001 / CSB-15-002: validate D transition and role before writing."""
-        if self._d_state == CS_d.D:
+        if self._d_state is not None:
             actor_roles = (
                 participant_obj.roles  # type: ignore[union-attr]
                 if isinstance(participant_obj, CaseParticipant)

--- a/vultron/core/behaviors/case/nodes/participant/trigger_validation.py
+++ b/vultron/core/behaviors/case/nodes/participant/trigger_validation.py
@@ -48,6 +48,7 @@ from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.states.cross_machine_invariants import (
     violation_rm_d_entailment,
     violation_rm_vf_entailment,
+    violation_vf_d_entailment,
 )
 from vultron.core.states.cs import (
     CS_d,
@@ -248,7 +249,7 @@ class ValidateTriggerTransitionsNode(DataLayerCondition):
         vf: "CS_vf | None",
         d: "CS_d | None",
     ) -> Status:
-        """CSB-18-001: check RM↔VF and RM↔D cross-machine entailments."""
+        """CSB-18-001/CSB-17-001: check RM↔VF, RM↔D, and VF↔D cross-machine entailments."""
         if vf is not None:
             msg = violation_rm_vf_entailment(rm, vf)
             if msg is not None:
@@ -261,4 +262,9 @@ class ValidateTriggerTransitionsNode(DataLayerCondition):
                 self.feedback_message = msg
                 self.logger.info("%s: %s", self.name, self.feedback_message)
                 return Status.FAILURE
+        msg = violation_vf_d_entailment(vf, d)
+        if msg is not None:
+            self.feedback_message = msg
+            self.logger.info("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
         return Status.SUCCESS

--- a/vultron/core/behaviors/status/nodes/_adjudication.py
+++ b/vultron/core/behaviors/status/nodes/_adjudication.py
@@ -29,7 +29,12 @@ from vultron.core.models.dimensions import (
     VfDimension,
 )
 from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.states.cross_machine_invariants import (
+    violation_vf_d_entailment,
+)
 from vultron.core.states.cs import (
+    CS_d,
+    CS_vf,
     is_monotonic_d_forward,
     is_monotonic_pxa_forward,
     is_monotonic_vf_forward,
@@ -39,6 +44,7 @@ from vultron.core.states.rm import (
     is_monotonic_rm_forward,
     is_valid_rm_transition,
 )
+from vultron.enums.roles import CVDRole
 
 
 def _rm_is_acceptable(current: RM, asserted: RM) -> bool:
@@ -59,8 +65,95 @@ def _rm_is_acceptable(current: RM, asserted: RM) -> bool:
     ) or is_monotonic_rm_forward(current, asserted)
 
 
+def _adjudicate_vf(
+    current_vf: CS_vf | None,
+    asserted_vf: CS_vf | None,
+    roles: list[CVDRole] | None,
+) -> tuple[bool, VfDimension | None]:
+    """Return (refused, carry) for the VF dimension.
+
+    Refuses if the sender lacks VENDOR role or the transition is not monotone
+    forward.  ``carry`` is the dimension value to write back (``None`` means
+    clear the dimension; used when refused with no prior history).
+    """
+    if (
+        asserted_vf is not None
+        and roles is not None
+        and CVDRole.VENDOR not in roles
+    ):
+        carry = (
+            VfDimension(state=current_vf) if current_vf is not None else None
+        )
+        return True, carry
+    if asserted_vf is None and current_vf is not None:
+        return False, VfDimension(state=current_vf)
+    if (
+        current_vf is not None
+        and asserted_vf is not None
+        and asserted_vf != current_vf
+        and not is_monotonic_vf_forward(current_vf, asserted_vf)
+    ):
+        return True, VfDimension(state=current_vf)
+    return False, None
+
+
+def _adjudicate_d(
+    current_d: CS_d | None,
+    asserted_d: CS_d | None,
+    roles: list[CVDRole] | None,
+) -> tuple[bool, DDimension | None]:
+    """Return (refused, carry) for the D dimension.
+
+    Refuses if the sender lacks DEPLOYER role or the transition is not monotone
+    forward.  ``carry`` is the dimension value to write back (``None`` means
+    clear the dimension; used when refused with no prior history).
+    """
+    if (
+        asserted_d is not None
+        and roles is not None
+        and CVDRole.DEPLOYER not in roles
+    ):
+        carry = DDimension(state=current_d) if current_d is not None else None
+        return True, carry
+    if asserted_d is None and current_d is not None:
+        return False, DDimension(state=current_d)
+    if (
+        current_d is not None
+        and asserted_d is not None
+        and asserted_d != current_d
+        and not is_monotonic_d_forward(current_d, asserted_d)
+    ):
+        return True, DDimension(state=current_d)
+    return False, None
+
+
+def _adjudicate_case_status(
+    current_cs: Any,
+    asserted_cs: Any,
+    refused: list[str],
+    update_fields: dict[str, Any],
+) -> None:
+    """Adjudicate the ``case_status`` (pxa) dimension in-place."""
+    if asserted_cs is None and current_cs is not None:
+        # Nothing asserted about pxa/em — carry the receiver's own view
+        # forward.  Persisting the assertion as-is would blank both.
+        update_fields["case_status"] = current_cs.model_copy(deep=True)
+    elif asserted_cs is not None and current_cs is not None:
+        current_pxa = current_cs.pxa.state
+        asserted_pxa = asserted_cs.pxa.state
+        if asserted_pxa != current_pxa and not is_monotonic_pxa_forward(
+            current_pxa, asserted_pxa
+        ):
+            refused.append("pxa")
+            update_fields["case_status"] = asserted_cs.model_copy(
+                update={"pxa": PxaDimension(state=current_pxa)}
+            )
+
+
 def _adjudicate_dimensions(
-    current: ParticipantStatus, asserted: ParticipantStatus
+    current: ParticipantStatus,
+    asserted: ParticipantStatus,
+    roles: list[CVDRole] | None = None,
 ) -> tuple[list[str], dict[str, Any]]:
     """Adjudicate ``rm``, ``vf``, ``d`` and ``pxa`` independently.
 
@@ -77,6 +170,9 @@ def _adjudicate_dimensions(
     the common case: it asserts nothing about ``pxa``/``em``, so the
     participant's current ``case_status`` is carried forward instead of letting
     the omission erase state the receiver already holds (RSH-05-002).
+
+    When ``roles`` is provided, VF writes require ``CVDRole.VENDOR`` and D
+    writes require ``CVDRole.DEPLOYER`` (ADR-0075, #2965).
     """
     refused: list[str] = []
     update_fields: dict[str, Any] = {}
@@ -85,54 +181,50 @@ def _adjudicate_dimensions(
         refused.append("rm")
         update_fields["rm"] = RmDimension(state=current.rm.state)
 
-    # VF dimension (vendor-path: vendor awareness + fix readiness).
-    # Intentionally uses the weaker monotone check rather than strict adjacency:
-    # a remote peer may have advanced through multiple steps between messages.
-    # An omitted vf (None) carries forward the current value — absence is not
-    # an assertion that the dimension is unknown (RSH-05-002).
     current_vf = current.vf.state if current.vf is not None else None
     asserted_vf = asserted.vf.state if asserted.vf is not None else None
-    if asserted_vf is None and current_vf is not None:
-        update_fields["vf"] = VfDimension(state=current_vf)
-    elif (
-        current_vf is not None
-        and asserted_vf is not None
-        and asserted_vf != current_vf
-        and not is_monotonic_vf_forward(current_vf, asserted_vf)
-    ):
+    vf_refused, vf_carry = _adjudicate_vf(current_vf, asserted_vf, roles)
+    if vf_refused:
         refused.append("vf")
-        update_fields["vf"] = VfDimension(state=current_vf)
+        update_fields["vf"] = (
+            vf_carry  # None clears field when no prior history
+        )
+    elif vf_carry is not None:
+        update_fields["vf"] = vf_carry  # Carry forward omitted dimension value
 
-    # D dimension (deployer-path: fix deployment).
-    # Same omission semantics as vf (RSH-05-002).
     current_d = current.d.state if current.d is not None else None
     asserted_d = asserted.d.state if asserted.d is not None else None
-    if asserted_d is None and current_d is not None:
-        update_fields["d"] = DDimension(state=current_d)
-    elif (
-        current_d is not None
-        and asserted_d is not None
-        and asserted_d != current_d
-        and not is_monotonic_d_forward(current_d, asserted_d)
-    ):
+    d_refused, d_carry = _adjudicate_d(current_d, asserted_d, roles)
+    if d_refused:
         refused.append("d")
-        update_fields["d"] = DDimension(state=current_d)
+        update_fields["d"] = d_carry  # None clears field when no prior history
+    elif d_carry is not None:
+        update_fields["d"] = d_carry  # Carry forward omitted dimension value
 
-    asserted_cs = asserted.case_status
-    current_cs = current.case_status
-    if asserted_cs is None and current_cs is not None:
-        # Nothing asserted about pxa/em — carry the receiver's own view
-        # forward.  Persisting the assertion as-is would blank both.
-        update_fields["case_status"] = current_cs.model_copy(deep=True)
-    elif asserted_cs is not None and current_cs is not None:
-        current_pxa = current_cs.pxa.state
-        asserted_pxa = asserted_cs.pxa.state
-        if asserted_pxa != current_pxa and not is_monotonic_pxa_forward(
-            current_pxa, asserted_pxa
-        ):
-            refused.append("pxa")
-            update_fields["case_status"] = asserted_cs.model_copy(
-                update={"pxa": PxaDimension(state=current_pxa)}
+    # Cross-dimension VF↔D check (CSB-17-001, #2893 received path).
+    # After individual dimension adjudication, verify the effective VF+D
+    # combination is not the structurally impossible *fD* state.
+    if not d_refused:
+        vf_in_fields = update_fields.get("vf")
+        effective_vf = (
+            vf_in_fields.state
+            if isinstance(vf_in_fields, VfDimension)
+            else asserted_vf
+        )
+        d_in_fields = update_fields.get("d")
+        effective_d = (
+            d_in_fields.state
+            if isinstance(d_in_fields, DDimension)
+            else asserted_d
+        )
+        if violation_vf_d_entailment(effective_vf, effective_d) is not None:
+            refused.append("d")
+            update_fields["d"] = (
+                DDimension(state=current_d) if current_d is not None else None
             )
+
+    _adjudicate_case_status(
+        current.case_status, asserted.case_status, refused, update_fields
+    )
 
     return refused, update_fields

--- a/vultron/core/behaviors/status/nodes/_adjudication.py
+++ b/vultron/core/behaviors/status/nodes/_adjudication.py
@@ -205,12 +205,15 @@ def _adjudicate_dimensions(
     # After individual dimension adjudication, verify the effective VF+D
     # combination is not the structurally impossible *fD* state.
     if not d_refused:
-        vf_in_fields = update_fields.get("vf")
-        effective_vf = (
-            vf_in_fields.state
-            if isinstance(vf_in_fields, VfDimension)
-            else asserted_vf
-        )
+        if "vf" in update_fields:
+            vf_in_fields = update_fields["vf"]
+            effective_vf = (
+                vf_in_fields.state
+                if isinstance(vf_in_fields, VfDimension)
+                else None
+            )
+        else:
+            effective_vf = asserted_vf
         d_in_fields = update_fields.get("d")
         effective_d = (
             d_in_fields.state

--- a/vultron/core/behaviors/status/nodes/dimension_filter.py
+++ b/vultron/core/behaviors/status/nodes/dimension_filter.py
@@ -384,7 +384,9 @@ class FilterParticipantStatusDimensionsNode(DataLayerConditionWithPorts):
             self._publish((), None)
             return Status.SUCCESS
 
-        refused, update_fields = _adjudicate_dimensions(current, asserted)
+        refused, update_fields = _adjudicate_dimensions(
+            current, asserted, roles=list(participant.case_roles)
+        )
         rm_anomaly = self._detect_rm_anomaly(
             refused, current.rm.state, asserted.rm.state
         )

--- a/vultron/core/states/cross_machine_invariants.py
+++ b/vultron/core/states/cross_machine_invariants.py
@@ -137,6 +137,37 @@ def violation_rm_vfd_entailment(rm: RM, vfd: CS_vfd) -> str | None:
     )
 
 
+def violation_vf_d_entailment(vf: CS_vf | None, d: CS_d | None) -> str | None:
+    """Return an error string if (vf, d) violates the fix-deployment entailment.
+
+    Fix deployment (d=D) requires fix readiness (vf=VF).  The compound state
+    ``*fD*`` (deployed without ready) is structurally impossible per CSB-17-001.
+    When vf is None the check cannot be applied (no VF information available).
+
+    Returns:
+        None when the combination is valid or insufficient information exists.
+        A descriptive error string when the entailment is violated.
+
+    Source: docs/reference/glossary.md § Case State Model (Six Dimensions)
+    Spec: CSB-17-001
+    """
+    if d not in D_FIX_DEPLOYED:
+        return None
+    assert (
+        d is not None
+    )  # D_FIX_DEPLOYED contains only CS_d members, never None
+    if vf is None:
+        return None
+    if vf in VF_FIX_READY:
+        return None
+    return (
+        f"Cross-machine entailment violated: D={d.name!r} (fix deployed)"
+        f" requires VF={CS_vf.VF.name!r} (fix ready),"
+        f" but VF={vf.name!r} (fix not ready)."
+        " Fix deployment cannot precede fix readiness (CSB-17-001)."
+    )
+
+
 def violation_pxa_em_entailment(pxa: CS_pxa, em: EM) -> str | None:
     """Return an error string if (pxa, em) violates the disclosure/embargo entailment.
 

--- a/vultron/wire/as2/vocab/objects/case_status.py
+++ b/vultron/wire/as2/vocab/objects/case_status.py
@@ -66,7 +66,10 @@ def _coerce_pxa(v: object) -> CS_pxa:
     if isinstance(v, CS_pxa):
         return v
     if isinstance(v, str):
-        return CS_pxa(v)  # value lookup, raises ValueError (not KeyError)
+        try:
+            return CS_pxa[v]
+        except KeyError:
+            raise ValueError(f"Unknown CS_pxa value: {v!r}") from None
     return CS_pxa.pxa
 
 

--- a/vultron/wire/as2/vocab/objects/case_status.py
+++ b/vultron/wire/as2/vocab/objects/case_status.py
@@ -66,7 +66,10 @@ def _coerce_pxa(v: object) -> CS_pxa:
     if isinstance(v, CS_pxa):
         return v
     if isinstance(v, str):
-        return CS_pxa[v]
+        try:
+            return CS_pxa[v]
+        except KeyError:
+            raise ValueError(f"Unknown CS_pxa value: {v!r}") from None
     return CS_pxa.pxa
 
 
@@ -74,7 +77,7 @@ def _coerce_rm(v: object) -> RM:
     if isinstance(v, RM):
         return v
     if isinstance(v, str):
-        return RM[v]
+        return RM(v)
     return RM.START
 
 
@@ -84,7 +87,7 @@ def _coerce_vf_or_none(v: object) -> CS_vf | None:
     if isinstance(v, CS_vf):
         return v
     if isinstance(v, str):
-        return CS_vf[v]
+        return CS_vf(v)
     return None
 
 
@@ -94,7 +97,7 @@ def _coerce_d_or_none(v: object) -> CS_d | None:
     if isinstance(v, CS_d):
         return v
     if isinstance(v, str):
-        return CS_d[v]
+        return CS_d(v)
     return None
 
 
@@ -104,7 +107,7 @@ def _coerce_pec_or_none(v: object) -> PEC | None:
     if isinstance(v, PEC):
         return v
     if isinstance(v, str):
-        return PEC[v]
+        return PEC(v)
     return None
 
 

--- a/vultron/wire/as2/vocab/objects/case_status.py
+++ b/vultron/wire/as2/vocab/objects/case_status.py
@@ -66,10 +66,7 @@ def _coerce_pxa(v: object) -> CS_pxa:
     if isinstance(v, CS_pxa):
         return v
     if isinstance(v, str):
-        try:
-            return CS_pxa[v]
-        except KeyError:
-            raise ValueError(f"Unknown CS_pxa value: {v!r}") from None
+        return CS_pxa(v)  # value lookup, raises ValueError (not KeyError)
     return CS_pxa.pxa
 
 


### PR DESCRIPTION
- Closes #2893
- Closes #2963
- Closes #2964
- Closes #2965
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Enforces the VF↔D cross-machine entailment (CSB-17-001) and per-dimension VENDOR/DEPLOYER role guards (ADR-0075) on both the trigger and received paths, and fixes a wire-layer `KeyError` on unknown enum inputs.

## Changes

- **`vultron/core/states/cross_machine_invariants.py`**: Add `violation_vf_d_entailment(vf, d)` — returns an error string when `d=D` without `vf=VF` (CSB-17-001). Add `assert d is not None` for pyright narrowing.
- **`vultron/core/behaviors/case/nodes/participant/trigger_validation.py`**: Wire `violation_vf_d_entailment` into `_validate_entailments`; the `*fD*` compound state is now refused on the trigger path before any write node is entered.
- **`vultron/core/behaviors/status/nodes/_adjudication.py`**: Extract `_adjudicate_vf`, `_adjudicate_d`, and `_adjudicate_case_status` helpers (keeps CC ≤ 10, IMPLTS-07-008); add `CVDRole.VENDOR`/`CVDRole.DEPLOYER` role guards; add cross-dimension VF↔D check after individual dimension adjudication (received path, #2893 + #2965).
- **`vultron/core/behaviors/status/nodes/dimension_filter.py`**: Pass `roles=list(participant.case_roles)` to `_adjudicate_dimensions` (#2965).
- **`vultron/core/behaviors/case/nodes/participant/status.py`**: Fix `_check_d_precondition` to require `DEPLOYER` role for any D-dimension write (`is not None`), not just `d=D` (#2963).
- **`vultron/wire/as2/vocab/objects/case_status.py`**: Fix coerce functions to use `Enum(value)` instead of `Enum[name]`; unknown inputs now raise `ValueError` (caught by Pydantic v2) instead of `KeyError` (#2964).
- **`test/core/states/test_cross_machine_invariants.py`**: New — 9 unit tests for `violation_vf_d_entailment` (#2893).
- **`test/wire/as2/vocab/test_case_status.py`**: Add `TestCoerceUnknownEnumNames` (5 tests) and `TestFromCorePreservesFields` (#2964).
- **`test/core/behaviors/status/test_partial_accept_participant_status.py`**: Add `TestAdjudicateDimensionsRoleGuards` (4 tests, #2965); fix `_seed_case` fixture to include `CVDRole.VENDOR`.
- **`test/core/use_cases/triggers/case/test_add_participant_status.py`**: Add CSB-17-001 trigger-path test and `_check_d_precondition` DEPLOYER guard test (#2893, #2963).
- **`test/architecture/test_vfd_rm_pxa_write_sites.py`**: Update `AUDITED_SITES` to reflect 3 `VfDimension` + 4 `DDimension` sites in `_adjudication.py`.
- **`test/core/behaviors/status/test_add_participant_status_bt.py`**: Add `CVDRole.VENDOR` to `vendor_participant` fixture in partial-accept test.

## Verification

- All 7949 unit tests pass (new: 20+)
- All 1248 integration tests pass
- Black, flake8, mypy, pyright clean