### PR TITLE
docs: plan issue #2793 — Actor Knowledge Model explanation page

### DIFF
--- a/docs/topics/actor-knowledge-model.md
+++ b/docs/topics/actor-knowledge-model.md
@@ -51,7 +51,8 @@ recipient cannot resolve it. The recipient has no access to the sender's
 data store, so it cannot fetch the object from there. If it has never
 received that object before, the URI is meaningless.
 
-This is why the protocol requires full inline objects in outbound activities:
+This is why the protocol requires full inline objects in outbound activities
+(AKM-02-001, AKM-02-002):
 
 > **Every outbound activity must carry its `object` field as a fully
 > inline typed object, not as a bare URI.**

--- a/docs/topics/actor-knowledge-model.md
+++ b/docs/topics/actor-knowledge-model.md
@@ -1,0 +1,145 @@
+# Actor Knowledge Model
+
+This page explains a foundational invariant of the Vultron protocol: an
+actor's knowledge of the world is bounded entirely by what it has received
+via ActivityStreams Activities. Understanding this invariant is essential for
+anyone implementing the protocol, in any language or framework.
+
+---
+
+## The invariant
+
+Every actor in Vultron maintains its own private data store. That store is
+not accessible to any other actor — not even an actor running on the same
+server or in the same process. There is no shared memory. There is no back
+channel. There is no way for one actor to look something up in another
+actor's store.
+
+This means that what an actor knows about the world is determined entirely
+by what it has received:
+
+> **An actor's knowledge is bounded by the AS2 Activities it has received.**
+
+That is the Actor Knowledge Model (AKM). It is not a performance preference.
+It is not an optimization to avoid network round-trips. It is the
+architectural invariant on which the protocol is built.
+
+---
+
+## Why it follows from the actor model
+
+The [Protocol Event Flow](protocol_flow.md) page describes how each actor
+has an inbox and an outbox: messages arrive, the actor processes them, and
+results go out. No actor reaches into another actor's state directly.
+
+The AKM is the knowledge-layer consequence of that model. If an actor cannot
+reach another's state, then the only way to learn something about the world
+outside itself is to receive a message that contains it. Receiving an
+activity is the only way to learn that something exists.
+
+This has a concrete corollary for activity construction.
+
+---
+
+## The full-inline-object rule
+
+When an actor sends an activity, the recipient will try to understand it.
+To understand it, the recipient needs the objects the activity refers to.
+
+If the sender puts only a URI in the activity's `object` field, the
+recipient cannot resolve it. The recipient has no access to the sender's
+data store, so it cannot fetch the object from there. If it has never
+received that object before, the URI is meaningless.
+
+This is why the protocol requires full inline objects in outbound activities:
+
+> **Every outbound activity must carry its `object` field as a fully
+> inline typed object, not as a bare URI.**
+
+The recipient receives the full object alongside the activity that references
+it, so no external lookup is needed.
+
+### The one approved exception
+
+The `target` field of an `Invite` activity in selective-disclosure scenarios
+is permitted to carry an object reference rather than a fully inline object.
+This is the only approved exception to the full-inline-object rule (AKM-02-003).
+
+All other outbound initiating activities — `Create`, `Offer`, `Invite`,
+`Announce`, `Add`, `Remove`, `Update`, `Join`, `Ignore`, `Leave` — must carry
+a fully inline typed object (AKM-03-001).
+
+---
+
+## Co-located actors still use the wire
+
+The AKM applies even when two actors are running in the same process or on
+the same server. Co-located actors MUST communicate via the wire protocol
+and MUST NOT exchange information through direct data-store access or
+in-process calls that bypass the inbox and outbox (AKM-01-002).
+
+This is easy to get wrong when building a prototype: it is tempting to let
+two actors share a data structure when they are in the same process.
+Doing so violates the AKM. It couples the actors in a way that breaks as
+soon as they are separated, and it means the system's behavior in a
+distributed deployment cannot be inferred from its behavior in a single
+process.
+
+The isolation is architectural. Keep it, even when co-location makes
+shortcutting it convenient.
+
+---
+
+## What this means for implementers
+
+The practical test for any outbound activity is:
+
+> *Can the recipient understand this activity using only what it has already
+> received from me, plus what is inline in this message?*
+
+If the answer is no — because the activity contains a bare URI that the
+recipient has never seen — the activity will fail at the recipient.
+The recipient will not be able to pattern-match it, will not be able to
+extract meaningful state, and will likely treat it as an unknown or
+malformed message.
+
+Building an implementation that passes this test requires constructing
+activities with full objects at the point of creation, not after the fact.
+The failure mode — a bare URI where an object is expected — is silent in
+many frameworks: the activity serialises, is transmitted, and arrives
+looking syntactically valid. The failure only appears when the recipient
+tries to act on it.
+
+---
+
+## Actor addressing and knowledge
+
+A related implication: knowing a peer's URI is sufficient to address a
+message to that peer. You do not need a local record of the peer actor's
+profile to send them an activity (AKM-05-001).
+
+An actor that has never interacted with a peer before may still invite that
+peer to a case, send them a message, or transfer ownership to them — as long
+as it has a valid deliverable URI. Fetching or storing the peer's actor
+profile is an enrichment step, not a precondition for protocol participation.
+
+---
+
+## Summary
+
+| Principle | Statement |
+|---|---|
+| Private data store | Each actor's data store is private. No other actor can access it. |
+| Bounded knowledge | What an actor knows is limited to what it has received. |
+| Full inline objects | Outbound activities must carry fully inline objects, not bare URIs. |
+| One exception | The `target` field of `Invite` may carry a reference in selective-disclosure scenarios. |
+| Co-located actors | Co-location does not relax the isolation rule. Use the wire protocol. |
+| Addressing | A URI is sufficient to address a peer. A local actor record is enrichment only. |
+
+---
+
+## Further reading
+
+- [Protocol Event Flow](protocol_flow.md) — the actor model that the AKM extends
+- [Formal Protocol](../reference/formal_protocol/index.md) — normative protocol requirements
+- [Actor Knowledge Model spec](../reference/specs/protocol.md#akm) — the normative AKM requirements (AKM-01 through AKM-05)

--- a/docs/topics/actor-knowledge-model.md
+++ b/docs/topics/actor-knowledge-model.md
@@ -63,7 +63,8 @@ it, so no external lookup is needed.
 ### The one approved exception
 
 The `target` field of an `Invite` activity in selective-disclosure scenarios
-is permitted to carry an object reference rather than a fully inline object.
+is permitted to carry a case stub — a typed object with `id`, `type`, and
+minimal fields for informed consent — rather than the full case object.
 This is the only approved exception to the full-inline-object rule (AKM-02-003).
 
 All other outbound initiating activities — `Create`, `Offer`, `Invite`,
@@ -133,7 +134,7 @@ profile is an enrichment step, not a precondition for protocol participation.
 | Private data store | Each actor's data store is private. No other actor can access it. |
 | Bounded knowledge | What an actor knows is limited to what it has received. |
 | Full inline objects | Outbound activities must carry fully inline objects, not bare URIs. |
-| One exception | The `target` field of `Invite` may carry a reference in selective-disclosure scenarios. |
+| One exception | The `target` field of `Invite` may carry a case stub in selective-disclosure scenarios. |
 | Co-located actors | Co-location does not relax the isolation rule. Use the wire protocol. |
 | Addressing | A URI is sufficient to address a peer. A local actor record is enrichment only. |
 

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -22,6 +22,7 @@ This section provides an overview of the Vultron Protocol, including:
 - :material-shape-outline: [Process Models](process_models/index.md)
 - :material-cube-unfolded: [Formal Protocol overview](../reference/formal_protocol/index.md) — in [Reference](../reference/index.md)
 - :material-arrow-decision-auto-outline: [Behavior Logic](behavior_logic/index.md)
+- :material-database-lock-outline: [Actor Knowledge Model](actor-knowledge-model.md)
 - :material-book: [User Stories](../reference/user_stories/index.md) — in [Reference](../reference/index.md)
 - :material-altimeter: [Measuring CVD](../reference/measuring_cvd/index.md) — in [Reference](../reference/index.md)
 - :material-source-branch: [Other Uses](other_uses/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - The Case Model: 'topics/case_model.md'
     - Protocol Event Flow: 'topics/protocol_flow.md'
     - Message Semantics: 'topics/message_semantics.md'
+    - Actor Knowledge Model: 'topics/actor-knowledge-model.md'
     - Process Models:
       - 'topics/process_models/index.md'
       - Report Management:

--- a/plan/history/2609/idea/IDEA-2793.md
+++ b/plan/history/2609/idea/IDEA-2793.md
@@ -1,0 +1,11 @@
+---
+source: IDEA-2793
+timestamp: '2026-09-01T18:28:53.098482+00:00'
+title: Add Actor Knowledge Model explanation to public docs
+type: idea
+---
+
+Add an Explanation page to docs/topics/ documenting the Actor Knowledge Model — the protocol invariant that an actor's knowledge of the world is bounded entirely by what it has received via ActivityStreams Activities. This has significant implications for protocol design and is essential for external implementers to understand.
+
+**Processed**: 2026-09-01 — implementation tracked in #2985.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/2984>.


### PR DESCRIPTION
- Closes #2793
- Closes #2985

## Summary

Adds a new public Explanation page documenting the Actor Knowledge Model (AKM) — the protocol invariant that an actor's knowledge is bounded entirely by what it has received via AS2 Activities. This fills a gap in the public docs where the full-inline-object requirement and DataLayer isolation rule were present as normative specs but had no accessible explanation for external implementers.

## Changes

- **`docs/topics/actor-knowledge-model.md`**: New Explanation page covering the core invariant, the full-inline-object rule and its one approved exception, the co-located-actor isolation rule, and what the AKM means for implementers in any language
- **`docs/topics/index.md`**: Add Actor Knowledge Model entry to the grid cards
- **`mkdocs.yml`**: Register the new page in the nav alongside Protocol Event Flow and Message Semantics