### PR TITLE
spec(RSH-05): add RSH-05-018/019 validation predicates for Add(CaseStatus) per-dimension adjudication

### DIFF
--- a/docs/adr/0061-per-dimension-partial-accept.md
+++ b/docs/adr/0061-per-dimension-partial-accept.md
@@ -165,4 +165,6 @@ RM ratchet.
   reject-on-divergence invariants.
 
 Generated spec requirements: `received-status-handling.yaml` RSH-05-001 through
-RSH-05-008.
+RSH-05-008. The same per-dimension adjudication decision was subsequently
+extended to `Add(CaseStatus)` (EM and PXA dimensions only): RSH-05-015 through
+RSH-05-019 (ISSUE-2256, ISSUE-2671).

--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -249,8 +249,8 @@ Extends the same liberal-accept pattern that ADR-0061 / ISSUE-2235 applied to
 ```text
 AddCaseStatusToCaseBT (Sequence)
 ├─ CheckCaseStatusIdempotencyNode       ← precondition guard (CLP-10-009)
-├─ FilterCsEmDimensionNode              ← per-dim EM adjudication; always SUCCESS
-├─ FilterCsPxaDimensionNode             ← per-dim PXA adjudication; always SUCCESS
+├─ FilterCsEmDimensionNode              ← per-dim EM adjudication (RSH-05-018); always SUCCESS
+├─ FilterCsPxaDimensionNode             ← per-dim PXA adjudication (RSH-05-019); always SUCCESS
 ├─ FinalizeCsFilterNode                 ← FAILURE on whole-refusal; publishes filter
 ├─ GuardedCommitOrSkip                  ← canonical ledger commit (CLP-10-006)
 ├─ AppendCaseStatusToCaseNode           ← records accepted portion
@@ -265,11 +265,13 @@ removed; per-dimension filter nodes are its replacement.
 
 `FilterCsEmDimensionNode` runs first: it clears both `BB_CASE_STATUS_DIM_FILTER`
 and `BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE` unconditionally (RSH-05-010, BT-17-003),
-evaluates the EM transition, and writes a per-tick accumulator dict to the
+evaluates the EM transition per the acceptance predicate in RSH-05-018
+(`is_valid_em_transition()`), and writes a per-tick accumulator dict to the
 blackboard.
 
 `FilterCsPxaDimensionNode` runs second: it reads the accumulator via the
-`_BB_CS_FILTER_ACC` input port, evaluates the PXA transition, and writes the
+`_BB_CS_FILTER_ACC` input port, evaluates the PXA transition per the acceptance
+predicate in RSH-05-019 (`is_monotonic_pxa_forward()`), and writes the
 updated accumulator back via `_set_output(_BB_CS_FILTER_ACC_WRITE, acc)` — an
 explicit write-back using a dual-alias output port (`_BB_CS_FILTER_ACC_WRITE`)
 mapped to the same physical blackboard key (`/{_BB_CS_FILTER_ACC}`). This

--- a/plan/incoming/learnings/20260901-code-review-2671-preexisting-findings.md
+++ b/plan/incoming/learnings/20260901-code-review-2671-preexisting-findings.md
@@ -1,0 +1,39 @@
+---
+title: Pre-existing code review findings deferred from ISSUE-2671
+type: learning
+timestamp: 2026-09-01
+source: ISSUE-2671
+signal: pre-existing-finding
+---
+
+Code review during ISSUE-2671 build session surfaced three findings in files
+NOT part of the PR diff (`add_case_status_tree.py`, `test_case_status.py`).
+All are pre-existing relative to this branch.
+
+## Findings
+
+**Finding 1 (Bug — deferred as #2983)**
+`add_case_status_tree.py:113`: `status_id = request.status_id or ""`
+(empty-string fallback) while `case_id` was hardened to `or None`.
+Use-case guard at `status.py:69` only rejects `None`, so an empty-string
+`status_id` slips through. `CheckCaseStatusIdempotencyNode` then fails to
+find `""` in existing statuses and returns SUCCESS — idempotency guard
+silently bypassed.
+
+**Finding 2 (IMPROVE — pre-existing, no bug)**
+`add_case_status_tree.py:119`: redundant `case_id or None` — `case_id` was
+already normalized to `or None` on line 114. No runtime impact but could
+mislead future readers.
+
+**Finding 3 (IMPROVE — pre-existing, test quality)**
+`test/core/behaviors/status/nodes/test_case_status.py:148`: assertion uses
+`or` over two string-presence checks, making it weaker than intended.
+A refactor that drops either word would silently pass the assertion.
+
+## Disposition
+
+- Finding 1 → Bug #2983 (parent: #2694, milestone 24, size:S)
+- Finding 2 → can be fixed in same PR as Finding 1
+- Finding 3 → can be fixed in same PR as Finding 1
+
+Parent issue for ISSUE-2671 is #2694 (Persistence-boundary state enforcement).

--- a/specs/received-status-handling.yaml
+++ b/specs/received-status-handling.yaml
@@ -571,9 +571,10 @@ groups:
       value does not discard an accepted PXA value from the same CaseStatus
       snapshot, and vice versa.
     note: >
-      Implemented by `FilterCsEmDimensionNode` and `FilterCsPxaDimensionNode`
-      in `vultron/core/behaviors/status/nodes/cs_dimension_filter.py`, wired
-      as precondition guards of `add_case_status_tree`. See ISSUE-2256.
+      Implemented by the three-node sequence `FilterCsEmDimensionNode`,
+      `FilterCsPxaDimensionNode`, and `FinalizeCsFilterNode` in
+      `vultron/core/behaviors/status/nodes/cs_dimension_filter.py`, wired as
+      precondition guards of `add_case_status_tree`. See ISSUE-2256.
     lint_suppress:
     - missing_story_reference
   - id: RSH-05-016
@@ -619,6 +620,70 @@ groups:
       Implemented by `FinalizeCsFilterNode.update()` returning `Status.FAILURE`
       when `(filtered.em.state, filtered.pxa.state) == (current.em.state,
       current.pxa.state)`.
+    lint_suppress:
+    - missing_story_reference
+  - id: RSH-05-018
+    priority: MUST
+    kind: protocol
+    statement: >
+      When adjudicating the EM dimension of a received `Add(CaseStatus)`, the
+      receiver MUST accept the asserted EM state if and only if it is identical
+      to the current EM state or it is a valid EM state-machine transition from
+      the current EM state, as determined by `is_valid_em_transition()`. Any
+      other asserted EM value MUST be refused and the current EM value carried
+      forward (RSH-05-016).
+    rationale: >
+      EM follows a directed state machine
+      (NO_EMBARGO → PROPOSED ↔ ACTIVE ↔ REVISE → EXITED). Out-of-order or
+      backward EM assertions do not correspond to legal protocol events; applying
+      them would corrupt the canonical EM state shared by all participants.
+      Using `is_valid_em_transition()` as the acceptance predicate ensures only
+      structurally valid EM transitions are applied.
+    verification: >
+      Unit tests in `test/core/behaviors/status/test_add_case_status_bt.py`
+      confirm that `FilterCsEmDimensionNode` accepts EM states that satisfy
+      `is_valid_em_transition()` or are identical to the current EM state, and
+      refuses all other asserted EM values by carrying the current value forward.
+    note: >
+      Implemented by `FilterCsEmDimensionNode.update()` in
+      `vultron/core/behaviors/status/nodes/cs_dimension_filter.py`. The predicate
+      is applied as `asserted_em != current_em and not is_valid_em_transition(current_em, asserted_em)`;
+      an identity assertion (`asserted == current`) is always accepted without
+      invoking `is_valid_em_transition()`.
+    lint_suppress:
+    - missing_story_reference
+  - id: RSH-05-019
+    priority: MUST
+    kind: protocol
+    statement: >
+      When adjudicating the PXA dimension of a received `Add(CaseStatus)`, the
+      receiver MUST accept the asserted PXA state if and only if it is identical
+      to the current PXA state or it is a monotone forward move from the current
+      PXA state, as determined by `is_monotonic_pxa_forward()`. Any other
+      asserted PXA value MUST be refused and the current PXA value carried
+      forward (RSH-05-016).
+    rationale: >
+      PXA state is monotone: bits only advance from unaware to aware (p→P,
+      x→X, a→A) and never reverse. The received-side filter uses the weaker
+      `is_monotonic_pxa_forward()` check — not the strict single-step adjacency
+      `is_valid_pxa_transition()` that applies to local write nodes
+      (CSB-16-002) — because a remote peer may have observed multiple PXA
+      events between messages and report a combined advance that skips
+      intermediate steps. Applying the strict check would refuse a valid
+      multi-step advance from a peer that simply missed delivering earlier
+      messages.
+    verification: >
+      Unit tests in `test/core/behaviors/status/test_add_case_status_bt.py`
+      confirm that `FilterCsPxaDimensionNode` accepts PXA states that satisfy
+      `is_monotonic_pxa_forward()` or are identical to the current PXA state,
+      and refuses non-monotone-forward assertions by carrying the current value
+      forward.
+    note: >
+      Implemented by `FilterCsPxaDimensionNode.update()` in
+      `vultron/core/behaviors/status/nodes/cs_dimension_filter.py`. The predicate
+      is `asserted_pxa != current_pxa and not is_monotonic_pxa_forward(current_pxa, asserted_pxa)`;
+      CSB-16-002 strict single-step adjacency applies only to local write nodes,
+      not to the received-side filter.
     lint_suppress:
     - missing_story_reference
 

--- a/test/core/behaviors/status/test_add_case_status_bt.py
+++ b/test/core/behaviors/status/test_add_case_status_bt.py
@@ -564,6 +564,7 @@ class TestAddCaseStatusTree:
         assert BTBridge.get_failure_reason(tree) == CASE_STATUS_ALREADY_PRESENT
 
     @pytest.mark.spec("RSH-05-017")
+    @pytest.mark.spec("RSH-05-018")
     def test_invalid_em_transition_fails(self, dl, make_payload):
         """Invalid EM transition → BT FAILURE; status not appended."""
         case = as_VulnerabilityCase(id_=CASE_ID, name="EM Guard")
@@ -637,6 +638,8 @@ class TestAddCaseStatusTree:
 
     @pytest.mark.spec("RSH-05-015")
     @pytest.mark.spec("RSH-05-016")
+    @pytest.mark.spec("RSH-05-018")
+    @pytest.mark.spec("RSH-05-019")
     def test_valid_em_advance_with_pxa_regression_applies_em_and_refuses_pxa(
         self, dl, make_payload
     ):


### PR DESCRIPTION
- Closes #2671
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Extends `specs/received-status-handling.yaml` RSH-05 to fully specify `Add(CaseStatus)` per-dimension adjudication, closing the scope gap identified in ISSUE-2671. Adds RSH-05-018 (EM acceptance predicate) and RSH-05-019 (PXA acceptance predicate), updates RSH-05-015's note to reference all three implementation nodes, and adds spec markers to two existing tests.

## Changes

- **`specs/received-status-handling.yaml`**: RSH-05-015 note updated to reference all three nodes (`FilterCsEmDimensionNode`, `FilterCsPxaDimensionNode`, `FinalizeCsFilterNode`). RSH-05-018 added: EM MUST be accepted iff identical to current or valid per `is_valid_em_transition()`. RSH-05-019 added: PXA MUST be accepted iff identical to current or a monotone forward move per `is_monotonic_pxa_forward()`; strict adjacency (CSB-16-002) applies only to local write nodes.
- **`test/core/behaviors/status/test_add_case_status_bt.py`**: `@pytest.mark.spec("RSH-05-018")` and `@pytest.mark.spec("RSH-05-019")` added to two existing tests that exercise the acceptance predicates; spec coverage ratchet ceiling unchanged at 937.

## Why the weaker predicate for PXA (RSH-05-019)

The received-side filter uses `is_monotonic_pxa_forward()` — not the strict single-step adjacency `is_valid_pxa_transition()` required by CSB-16-002 for local write nodes — because a remote peer may have observed multiple PXA events between messages and reports a combined advance that skips intermediate steps. Applying the strict check would refuse a valid multi-step advance from a peer that simply missed delivering earlier messages. This rationale was present in code comments but absent from the spec.

## Pre-existing findings (deferred — #2983)

Code review surfaced three pre-existing issues in files not in this PR diff (`add_case_status_tree.py`, `test_case_status.py`):
- `status_id` normalized as `or ""` while `case_id` uses `or None`; idempotency guard can silently pass an empty key → Bug #2983
- Redundant `case_id or None` double-normalization (no runtime impact)
- Weak `or`-conjunction assertion in `test_case_status.py`

## Verification

- 7957 unit tests pass (7956 before + 0 new tests, 0 regressions)
- Spec coverage ratchet: 937 uncovered (unchanged — 2 new specs, 2 new markers)
- Black, flake8, mypy, pyright all clean
- Integration suite timeout is a known pre-existing environment issue (learning `20260901-pytest-sigkill-repeated-runs.md`); spec-only + annotation changes cannot cause integration failures