### PR TITLE
fix: VultronProtocolViolationError subclasses ValueError so Pydantic absorbs it in validators

### DIFF
--- a/docs/reference/codebase/CONVENTIONS.md
+++ b/docs/reference/codebase/CONVENTIONS.md
@@ -55,6 +55,7 @@
   - Wire layer: raises `vultron.wire.errors` types on parse/validation failure
   - Core use cases: raises `vultron.errors.VultronValidationError` or similar domain errors; fail-fast at use-case boundary (ARCH-15)
   - Adapters: catch and translate errors into HTTP responses or log entries
+- **Pydantic validator exceptions**: any custom exception raised from a `model_validator` or `field_validator` MUST inherit from `ValueError` (or `TypeError`/`AssertionError`) so Pydantic wraps it in `ValidationError` rather than letting it escape `model_validate()`. See `VultronProtocolViolationError` in `vultron/errors.py` for the canonical example; its docstring explains the requirement (issue #2905).
 - **Logging**: use `logging.getLogger(__name__)` at module level; `logger.debug(...)` for trace detail, `logger.warning(...)` for recoverable issues
 - **Sensitive data**: no specific redaction rules observed; [ASK USER] whether PII from vulnerability reports requires redaction at log points
 

--- a/plan/incoming/learnings/20260901-inbox-rehydrate-outside-try.md
+++ b/plan/incoming/learnings/20260901-inbox-rehydrate-outside-try.md
@@ -1,0 +1,30 @@
+---
+title: "inbox_handler and inbox_pipeline call rehydrate() outside try/except"
+type: learning
+timestamp: 2026-09-01T00:00:00Z
+source: ISSUE-2905
+signal: concern
+---
+
+In `vultron/adapters/driving/fastapi/inbox_handler.py:418` and
+`vultron/adapters/driving/fastapi/inbox_pipeline.py:80`, `rehydrate()` is
+called **outside** any try/except block.
+
+Issue #2905 was caused by `VultronProtocolViolationError` (a plain
+`VultronError` subclass) escaping Pydantic's `model_validate()` and
+propagating all the way through `rehydrate()` into the bare call site,
+crashing the `while` loop in `inbox_handler` and dropping all subsequent
+inbox items.
+
+The fix (adding `ValueError` to `VultronProtocolViolationError`'s MRO) makes
+Pydantic absorb the exception for the specific validator that triggered it.
+However, the structural fragility remains: any future Pydantic validator that
+raises a new custom exception type **not** in the `(ValueError, TypeError,
+AssertionError)` set would cause the same class of crash.
+
+Recommend either:
+
+1. Wrapping the `rehydrate()` call in `inbox_handler` and `inbox_pipeline`
+   with a broad `except Exception` guard that logs and skips the bad item, or
+2. Documenting a project convention that all exceptions raised from Pydantic
+   validators MUST inherit from `ValueError`.

--- a/test/wire/as2/vocab/test_case_status.py
+++ b/test/wire/as2/vocab/test_case_status.py
@@ -128,5 +128,46 @@ class TestFromCorePreservesPublished(unittest.TestCase):
         self.assertEqual(expected_roles, wire.cvd_role)
 
 
+class TestRetiredVfdKeyRejection(unittest.TestCase):
+    """_reject_retired_vfd_keys must raise ValidationError, not a raw
+    VultronProtocolViolationError that escapes Pydantic (issue #2905).
+
+    Pydantic only absorbs ValueError/TypeError/AssertionError from validators.
+    When the validator raised VultronProtocolViolationError (a plain VultronError
+    subclass) the exception escaped model_validate() entirely, crashing the
+    inbox-processing loop rather than being treated as a validation failure.
+    """
+
+    def test_vfd_state_snake_raises_validation_error(self):
+        """vfd_state in inbound data raises ValidationError, not a raw exception."""
+        with pytest.raises(ValidationError):
+            as_ParticipantStatus.model_validate(
+                {
+                    "context": CASE_ID,
+                    "attributed_to": ACTOR_ID,
+                    "vfd_state": "VFD",
+                }
+            )
+
+    def test_vfd_state_camel_raises_validation_error(self):
+        """vfdState in inbound data raises ValidationError, not a raw exception."""
+        with pytest.raises(ValidationError):
+            as_ParticipantStatus.model_validate(
+                {
+                    "context": CASE_ID,
+                    "attributed_to": ACTOR_ID,
+                    "vfdState": "VFD",
+                }
+            )
+
+    def test_valid_data_without_vfd_state_constructs_normally(self):
+        """Sanity check: valid data without vfd_state still constructs OK."""
+        ps = as_ParticipantStatus(
+            context=CASE_ID,
+            attributed_to=ACTOR_ID,
+        )
+        self.assertEqual(CASE_ID, ps.context)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vultron/errors.py
+++ b/vultron/errors.py
@@ -100,7 +100,7 @@ class VultronOutboxObjectIntegrityError(VultronError):
         super().__init__(message)
 
 
-class VultronProtocolViolationError(VultronError):
+class VultronProtocolViolationError(VultronError, ValueError):
     """Raised when an inbound protocol message violates a mandatory requirement.
 
     The inbound mirror of :exc:`VultronOutboxObjectIntegrityError`.  While
@@ -112,6 +112,13 @@ class VultronProtocolViolationError(VultronError):
     participant as a bare URI string rather than a fully inline typed object.
     Receivers MUST raise this error and reject the bootstrap rather than
     silently synthesising participant state from domain knowledge.
+
+    ``ValueError`` is included in the base classes so that Pydantic absorbs
+    this error when it is raised from a ``model_validator`` or
+    ``field_validator`` and wraps it in a ``ValidationError`` rather than
+    letting it escape the ``model_validate()`` call.  Callers that need to
+    distinguish a protocol violation from an ordinary validation failure can
+    inspect ``ValidationError.errors()[0]['ctx']['error']``.
     """
 
 


### PR DESCRIPTION
- Closes #2905
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

`_reject_retired_vfd_keys` raised `VultronProtocolViolationError` from a Pydantic `model_validator`, but Pydantic only absorbs `ValueError`/`TypeError`/`AssertionError` — so the exception escaped `model_validate()` entirely and crashed the inbox-processing loop. Fix: add `ValueError` as a second base class to `VultronProtocolViolationError`.

## Changes

- **`vultron/errors.py`**: Added `ValueError` to `VultronProtocolViolationError`'s MRO; updated docstring to explain the Pydantic absorption requirement.
- **`test/wire/as2/vocab/test_case_status.py`**: Added `TestRetiredVfdKeyRejection` — three regression tests confirming both retired keys raise `ValidationError` (not a raw exception) and that valid data still constructs normally.
- **`plan/incoming/learnings/`**: Logged structural concern — `inbox_handler.py` and `inbox_pipeline.py` call `rehydrate()` outside any try/except; a future validator raising a non-`ValueError` type would reproduce this crash class.

## Verification

- 7960 unit tests pass (3 new); 1248 integration tests pass
- Black, flake8, mypy, pyright all clean