### PR TITLE
fix(start-dev): persist claude sessions and limit container resources

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -78,12 +78,13 @@ _exec_shell() {
 }
 
 _cleanup() {
-    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    docker stop -t 5 "$CONTAINER_NAME" >/dev/null 2>&1 || true
 }
 
-# Container already running — just attach
-if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
-    echo "Attaching to running container '$CONTAINER_NAME'..."
+# Container exists (running or stopped) — start if needed, then attach
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    docker start "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    echo "Attaching to container '$CONTAINER_NAME'..."
     _exec_shell
     exit 0
 fi
@@ -98,7 +99,9 @@ DOCKER_ARGS=(
     --name "$CONTAINER_NAME"
     --hostname "$CONTAINER_NAME"
     --env-file "$ENV_FILE"
-    --cpus "${SLOT_CPUS:-3}"
+    --cpus "${SLOT_CPUS:-2}"
+    --memory "${SLOT_MEMORY:-6g}"
+    --memory-swap "${SLOT_MEMORY:-6g}"
     -e LANG=C.UTF-8
     -e LC_ALL=C.UTF-8
     -e TERM=xterm-256color
@@ -107,6 +110,7 @@ DOCKER_ARGS=(
     -e WIP_OUTPUTS=/app/wip_outputs
     -e GRAPHIFY_MAX_WORKERS=4
     -v "${MAIN_NAME}-data:/home/vscode/.data"
+    -v "${MAIN_NAME}-${SLOT}-claude:/home/vscode/.claude"
     # NOTE: .devcontainer is NOT mounted. It is baked into the image and belongs
     # to the container's own working tree. Mounting the host copy over it made
     # one host directory the working tree for every slot plus the host repo, so


### PR DESCRIPTION
## Summary

Fixes two issues with slot-based devcontainers: Claude Code session data was
lost on every container exit (blocking `claude --resume`), and unbounded CPU
use could saturate the host.

## Changes

- **`start-dev.sh`**: Mount per-slot named volume `<project>-<slot>-claude` at
  `~/.claude/` so Claude session transcripts survive container restarts and
  rebuilds — `claude --resume` now works after a container is stopped or
  force-killed.
- **`start-dev.sh`**: Change `_cleanup` from `docker rm -f` to `docker stop -t 5`
  and update the re-attach check to use `docker ps -a` (handles stopped
  containers), so the full container filesystem also survives graceful exit.
- **`start-dev.sh`**: Lower default CPU hard limit from 3 → 2 (`SLOT_CPUS`
  override still works), and add 6g memory + memory-swap limits (`SLOT_MEMORY`
  override available) to prevent the Docker VM from consuming all host cores.