### PR TITLE
feat(wire): implement VM-10-002 — set VultronAS2Object.context_ default to Vultron context URI

### DIFF
--- a/plan/incoming/learnings/20260901-wire-normalize-ratchet-threshold-weakened.md
+++ b/plan/incoming/learnings/20260901-wire-normalize-ratchet-threshold-weakened.md
@@ -1,0 +1,12 @@
+---
+name: wire-normalize-ratchet-threshold-weakened
+description: test_normalize_wire_to_core_ratchet.py threshold was lowered from >50 to >20 entries, creating a 40-entry blind spot for partial-import failures
+metadata:
+  type: project
+---
+
+`test/architecture/test_normalize_wire_to_core_ratchet.py:89` checks `assert len(VOCABULARY) > 20` and `assert len(WIRE_TYPE_MAP) > 20` (split from a previous combined `> 50` check).
+
+**Why:** If a circular-import guard or missing subpackage import leaves ~25 entries in each registry, both `> 20` guards pass while ~40 wire types are absent, making the shadow-collision and normalization ratchets give vacuously correct results.
+
+**How to apply:** Raise each threshold to ≥35 (half the real count ~70) so a partial population fails immediately. Pre-existing issue discovered during code review of PR for #2500.

--- a/plan/incoming/learnings/20260901-wire-type-map-key-naming-agents-md-wrong.md
+++ b/plan/incoming/learnings/20260901-wire-type-map-key-naming-agents-md-wrong.md
@@ -1,0 +1,14 @@
+---
+name: wire-type-map-key-naming-agents-md-wrong
+description: AGENTS.md incorrectly states WIRE_TYPE_MAP uses wire type_ value keys; actual keys are cls.__name__.removeprefix("as_"), which diverges from type_ for actor classes
+metadata:
+  type: project
+---
+
+AGENTS.md line 302 says: "WIRE_TYPE_MAP uses wire `type_` value keys (`'VulnerabilityCase'`)".
+
+**Actual behavior**: `__init_subclass__` in `as_Base` registers `WIRE_TYPE_MAP[cls.__name__.removeprefix("as_")] = cls`.  For `as_VulnerabilityCase` the key happens to equal the `type_` value, but for `as_VultronPerson` the key is `"VultronPerson"` while `type_` is `"Person"`.  The AS2 type_ keys (`Person`, `Application`, etc.) are added by explicit override in `vultron_actor.py` lines 103–107, not by the generic hook.
+
+**Why:** Discovered during code review of PR for issue #2500.
+
+**How to apply:** AGENTS.md needs a correction to say the key is `cls.__name__.removeprefix("as_")` (not the type_field value). Separately, `vultron_actor.py` explicitly registers the AS2 type_ key overrides for actor classes. This is a pre-existing doc error.

--- a/test/wire/as2/vocab/base/test_vultron_context_uri.py
+++ b/test/wire/as2/vocab/base/test_vultron_context_uri.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+"""Tests for VM-10-001 and VM-10-002: VultronAS2Object context_ defaults to the
+Vultron namespace URI, and every wire type whose type_ value is not an AS2
+vocabulary term carries VocabNamespace.VULTRON.
+
+AC-1: VultronAS2Object.context_ defaults to VULTRON_CONTEXT_URI.
+AC-2: as_Base.context_ retains ACTIVITY_STREAMS_NS (tested in test_wire_base_hierarchy.py).
+AC-3: Serialization emits the Vultron URI in @context for VultronAS2Object subclasses.
+AC-4: Round-trip from_json(obj.to_json()) preserves the Vultron @context.
+AC-5: test_as_base_context_is_as2_namespace passes unmodified (in test_wire_base_hierarchy.py).
+AC-6: Every wire type with a non-AS2 type_ value annotates _vocab_ns=VULTRON.
+AC-7: Tests carry @pytest.mark.spec("VM-10-001") / @pytest.mark.spec("VM-10-002").
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import importlib
+import json
+import pkgutil
+
+import pytest
+
+import vultron.wire.as2.vocab.activities as _act_pkg
+import vultron.wire.as2.vocab.objects as _obj_pkg
+from vultron.wire.as2.enums import as_AllObjectTypes
+from vultron.wire.as2.vocab.base.base import (
+    ACTIVITY_STREAMS_NS,
+    VULTRON_CONTEXT_URI,
+)
+from vultron.wire.as2.vocab.base.enums import VocabNamespace
+from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.objects.base import VultronAS2Object
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+
+# Ensure all registered vocab types are loaded for AC-6.
+for _mi in list(pkgutil.iter_modules(_obj_pkg.__path__)):
+    importlib.import_module(f"vultron.wire.as2.vocab.objects.{_mi.name}")
+for _mi in list(pkgutil.iter_modules(_act_pkg.__path__)):
+    importlib.import_module(f"vultron.wire.as2.vocab.activities.{_mi.name}")
+
+# Complete set of standard ActivityStreams 2.0 type_ values.
+_AS2_VOCAB_TERMS = frozenset({m.value for m in as_AllObjectTypes}) | {
+    "Object",
+    "Collection",
+    "OrderedCollection",
+    "CollectionPage",
+    "OrderedCollectionPage",
+    "Link",
+    "Mention",
+    "Base",
+}
+
+
+# --- AC-1: VultronAS2Object default context_ -----------------------------------
+
+
+@pytest.mark.spec("VM-10-002")
+def test_vultron_as2_object_context_defaults_to_vultron_uri():
+    """AC-1: VultronAS2Object.context_ defaults to the Vultron context URI."""
+    obj = VultronAS2Object()
+    assert obj.context_ == VULTRON_CONTEXT_URI
+
+
+@pytest.mark.spec("VM-10-002")
+def test_vultron_as2_object_context_is_not_as2_namespace():
+    """AC-1: VultronAS2Object.context_ does NOT default to the AS2 namespace."""
+    obj = VultronAS2Object()
+    assert obj.context_ != ACTIVITY_STREAMS_NS
+
+
+# --- AC-3: Serialization emits correct @context --------------------------------
+
+
+@pytest.mark.spec("VM-10-001")
+@pytest.mark.spec("VM-10-002")
+def test_vultron_subclass_serializes_vultron_context():
+    """AC-3: A VultronAS2Object subclass serializes @context as the Vultron URI."""
+    obj = VultronAS2Object()
+    data = json.loads(obj.to_json())
+    assert data["@context"] == VULTRON_CONTEXT_URI
+
+
+@pytest.mark.spec("VM-10-001")
+def test_embargo_event_serializes_vultron_context():
+    """AC-3: as_EmbargoEvent (Vultron type extending as_Event) serializes Vultron @context."""
+    obj = as_EmbargoEvent()
+    data = json.loads(obj.to_json())
+    assert data["@context"] == VULTRON_CONTEXT_URI
+
+
+@pytest.mark.spec("VM-10-002")
+def test_as_base_subclass_without_override_retains_as2_context():
+    """AC-3: A plain as_Base subclass (not VultronAS2Object) still uses the AS2 namespace."""
+    from vultron.wire.as2.vocab.base.base import as_Base
+
+    obj = as_Base()
+    data = json.loads(obj.to_json())
+    assert data["@context"] == ACTIVITY_STREAMS_NS
+
+
+# --- AC-4: Round-trip preserves Vultron @context -------------------------------
+
+
+@pytest.mark.spec("VM-10-001")
+@pytest.mark.spec("VM-10-002")
+def test_vultron_as2_object_roundtrip_preserves_context():
+    """AC-4: from_json(obj.to_json()) preserves the Vultron @context."""
+    obj = VultronAS2Object()
+    restored = VultronAS2Object.from_json(obj.to_json())
+    assert restored.context_ == VULTRON_CONTEXT_URI
+
+
+@pytest.mark.spec("VM-10-001")
+def test_embargo_event_roundtrip_preserves_context():
+    """AC-4: as_EmbargoEvent round-trip preserves the Vultron @context."""
+    obj = as_EmbargoEvent()
+    restored = as_EmbargoEvent.from_json(obj.to_json())
+    assert restored.context_ == VULTRON_CONTEXT_URI
+
+
+# --- as_EmbargoEvent namespace annotation -------------------------------------
+
+
+@pytest.mark.spec("VM-10-002")
+def test_embargo_event_vocab_namespace_is_vultron():
+    """as_EmbargoEvent._vocab_ns must be VULTRON (EmbargoEvent is a Vultron term)."""
+    assert as_EmbargoEvent._vocab_ns == VocabNamespace.VULTRON
+
+
+# --- AC-6: Structural check — every non-AS2 type must be annotated VULTRON ----
+
+
+@pytest.mark.spec("VM-10-002")
+def test_all_non_as2_registered_types_are_vultron_namespaced():
+    """AC-6: Every concrete wire type whose type_ value is not an AS2 vocab term
+    must have _vocab_ns == VocabNamespace.VULTRON.
+
+    This catches classes like as_EmbargoEvent that inherit _vocab_ns from an
+    AS2 base (e.g. as_Event) but carry a Vultron-specific type_ value that AS2
+    receivers cannot resolve without the Vultron context URI.
+    """
+    violations = []
+    for class_name, cls in VOCABULARY.items():
+        type_field = cls.model_fields.get("type_")
+        if type_field is None:
+            continue
+        type_default = type_field.default
+        if not isinstance(type_default, str):
+            continue
+        if type_default in _AS2_VOCAB_TERMS:
+            continue
+        ns = getattr(cls, "_vocab_ns", None)
+        if ns != VocabNamespace.VULTRON:
+            violations.append((class_name, type_default, ns))
+
+    assert not violations, (
+        "Wire types with non-AS2 type_ values that are NOT annotated "
+        "VocabNamespace.VULTRON:\n"
+        + "\n".join(
+            f"  {name!r} (type_={t!r}): {ns}" for name, t, ns in violations
+        )
+    )

--- a/vultron/wire/as2/vocab/base/base.py
+++ b/vultron/wire/as2/vocab/base/base.py
@@ -27,6 +27,7 @@ from vultron.wire.as2.vocab.base.registry import VOCABULARY, WIRE_TYPE_MAP
 from vultron.wire.as2.vocab.base.utils import generate_new_id
 
 ACTIVITY_STREAMS_NS = "https://www.w3.org/ns/activitystreams"
+VULTRON_CONTEXT_URI = "https://certcc.github.io/Vultron/ns/context.jsonld"
 
 
 class as_Base(VultronBase):

--- a/vultron/wire/as2/vocab/objects/base.py
+++ b/vultron/wire/as2/vocab/objects/base.py
@@ -18,6 +18,9 @@ Provides a base class for all Vultron ActivityStreams Objects.
 
 from typing import Any, ClassVar, TypeAlias
 
+from pydantic import Field
+
+from vultron.wire.as2.vocab.base.base import VULTRON_CONTEXT_URI
 from vultron.wire.as2.vocab.base.enums import VocabNamespace
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.objects.base import as_Object
@@ -99,6 +102,11 @@ class VultronAS2Object(as_Object):
     """
 
     _vocab_ns: ClassVar[VocabNamespace] = VocabNamespace.VULTRON
+    context_: str = Field(
+        default=VULTRON_CONTEXT_URI,
+        validation_alias="@context",
+        serialization_alias="@context",
+    )
     _field_map: ClassVar[dict[str, str]] = {}
     #: Ref fields that MUST stay inline through persistence. Public (no leading
     #: underscore) because the storage adapter reads it; see the class docstring.

--- a/vultron/wire/as2/vocab/objects/embargo_event.py
+++ b/vultron/wire/as2/vocab/objects/embargo_event.py
@@ -17,14 +17,16 @@ Provides an EmbargoEvent object for the Vultron ActivityStreams Vocabulary.
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 from datetime import datetime, timedelta
-from typing import Literal, TypeAlias, cast
+from typing import ClassVar, Literal, TypeAlias, cast
 
 from pydantic import Field, model_validator
 
 from vultron.core.models.embargo_event import EmbargoEvent as CoreEmbargoEvent
+from vultron.wire.as2.vocab.base.base import VULTRON_CONTEXT_URI
 from vultron.wire.as2.vocab.base.dt_utils import (
     now_utc,
 )
+from vultron.wire.as2.vocab.base.enums import VocabNamespace
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.objects.object_types import as_Event
 from vultron.wire.as2.vocab.base.utils import name_of
@@ -46,6 +48,12 @@ class as_EmbargoEvent(as_Event):
     Domain logic lives in :class:`vultron.core.models.embargo_event.EmbargoEvent`.
     """
 
+    _vocab_ns: ClassVar[VocabNamespace] = VocabNamespace.VULTRON
+    context_: str = Field(
+        default=VULTRON_CONTEXT_URI,
+        validation_alias="@context",
+        serialization_alias="@context",
+    )
     type_: Literal["EmbargoEvent"] = Field(  # type: ignore[assignment]
         default="EmbargoEvent",
         validation_alias="type",


### PR DESCRIPTION
- Closes #2500

## Summary

Implements VM-10-001 and VM-10-002: all Vultron-specific wire objects now emit the Vultron JSON-LD context URI (`https://certcc.github.io/Vultron/ns/context.jsonld`) in `@context` instead of the bare AS2 namespace URI.

## Changes

- **`vultron/wire/as2/vocab/base/base.py`**: Added `VULTRON_CONTEXT_URI` constant alongside `ACTIVITY_STREAMS_NS`.
- **`vultron/wire/as2/vocab/objects/base.py`**: Overrides `context_` on `VultronAS2Object` to default to `VULTRON_CONTEXT_URI`. All `VultronAS2Object` subclasses (`VulnerabilityCase`, `VulnerabilityReport`, `CaseParticipant`, etc.) inherit this automatically.
- **`vultron/wire/as2/vocab/objects/embargo_event.py`**: Fixes the `_vocab_ns` gap — `as_EmbargoEvent` inherited `_vocab_ns = AS` from `as_Event` even though `EmbargoEvent` is a Vultron term. Now sets `_vocab_ns = VocabNamespace.VULTRON` and overrides `context_` directly.
- **`test/wire/as2/vocab/base/test_vultron_context_uri.py`** (new): 9 tests covering AC-1 through AC-7 with `@pytest.mark.spec("VM-10-001")` / `@pytest.mark.spec("VM-10-002")` markers.
- **`plan/incoming/learnings/`**: Two learning files recording pre-existing findings discovered during review.

## Pre-existing findings (DEFER)

Code review surfaced two confirmed pre-existing issues not touched by this PR:
- `AGENTS.md:302` incorrectly states `WIRE_TYPE_MAP` uses wire `type_` value keys; actual keys are `cls.__name__.removeprefix("as_")` — recorded as learning file.
- `test/architecture/test_normalize_wire_to_core_ratchet.py:89` threshold lowered to `>20` (was `>50`), leaving a blind spot — recorded as learning file.

## Verification

- All 7,967 unit tests pass (9 new); 1,248 integration tests pass
- Black, flake8, mypy, pyright clean