### PR TITLE
chore(learnings): make all 62 incoming learning files archivable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,14 @@ repos:
         exclude: ^notes/README\.md$
         pass_filenames: false
 
+      - id: validate-incoming-learnings-frontmatter
+        name: Validate incoming learnings frontmatter
+        entry: uv run python -c "from vultron.metadata.history.incoming import validate_incoming_learnings; validate_incoming_learnings()"
+        language: system
+        files: ^plan/incoming/learnings/.*\.md$
+        exclude: ^plan/incoming/learnings/README\.md$
+        pass_filenames: false
+
       - id: validate-adr-frontmatter
         name: Validate ADR frontmatter
         entry: uv run python -c "from vultron.metadata.adr.loader import load_adr_registry; load_adr_registry()"

--- a/plan/incoming/learnings/2026-08-28-2175-is-leader-defer.md
+++ b/plan/incoming/learnings/2026-08-28-2175-is-leader-defer.md
@@ -1,7 +1,9 @@
 ---
-date: 2026-08-28
-issue: "2175"
-type: defer
+title: "DEFER: EmitCaseStatusUpdateNode inner BTBridge ignores is_leader"
+type: learning
+timestamp: "2026-08-28T19:29:30Z"
+source: ISSUE-2175
+signal: concern
 ---
 # DEFER: EmitCaseStatusUpdateNode inner BTBridge ignores is_leader
 

--- a/plan/incoming/learnings/20260826-causal-edge-schema-decision.md
+++ b/plan/incoming/learnings/20260826-causal-edge-schema-decision.md
@@ -1,7 +1,7 @@
 ---
 title: "Causal-edge schema: YAML frontmatter format decided for ISSUE-2204"
 type: learning
-timestamp: 2026-08-26
+timestamp: "2026-08-26T00:00:00Z"
 source: ISSUE-2204
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260826-optional-note-propagates-demo-step-contract.md
+++ b/plan/incoming/learnings/20260826-optional-note-propagates-demo-step-contract.md
@@ -1,7 +1,7 @@
 ---
 title: "Optional[as_Note] return propagates demo_step suppression contract to all callers"
 type: learning
-timestamp: "2026-08-26"
+timestamp: "2026-08-26T00:00:00Z"
 source: ISSUE-2390
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260826-pre-existing-bugs-from-code-review-2204.md
+++ b/plan/incoming/learnings/20260826-pre-existing-bugs-from-code-review-2204.md
@@ -1,7 +1,7 @@
 ---
 title: "5 pre-existing bugs surfaced by code review on PR #2726"
 type: learning
-timestamp: 2026-08-26
+timestamp: "2026-08-26T00:00:00Z"
 source: ISSUE-2204
 signal: concern
 ---

--- a/plan/incoming/learnings/20260826-sibling-demo-async-race-not-fixed.md
+++ b/plan/incoming/learnings/20260826-sibling-demo-async-race-not-fixed.md
@@ -1,7 +1,7 @@
 ---
 title: "6 sibling demo scenarios have same async race window as fcv-reject (#2390)"
 type: learning
-timestamp: "2026-08-26"
+timestamp: "2026-08-26T00:00:00Z"
 source: ISSUE-2390
 signal: concern
 ---

--- a/plan/incoming/learnings/20260827-bugfix-skill-current-task-number-undefined.md
+++ b/plan/incoming/learnings/20260827-bugfix-skill-current-task-number-undefined.md
@@ -1,7 +1,7 @@
 ---
 title: bugfix SKILL.md Phase 5 references CURRENT_TASK_NUMBER which is not defined in that scope
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2604
 signal: process-issue
 ---

--- a/plan/incoming/learnings/20260827-code-review-1314-deferred-preexisting.md
+++ b/plan/incoming/learnings/20260827-code-review-1314-deferred-preexisting.md
@@ -1,9 +1,9 @@
 ---
 title: Code review of PR for #1314 surfaced 5 pre-existing bugs in unrelated files
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-1314
-signal: deferred-bug
+signal: concern
 ---
 
 During the code review for the docs-only PR implementing #1314

--- a/plan/incoming/learnings/20260827-code-review-2109-deferred-preexisting.md
+++ b/plan/incoming/learnings/20260827-code-review-2109-deferred-preexisting.md
@@ -1,9 +1,9 @@
 ---
 title: Code review of PR for #2109 surfaced 5 pre-existing bugs in unrelated files
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2109
-signal: deferred-bug
+signal: concern
 ---
 
 During the code review for PR implementing #2109 (fixname() prefix-map refactor),

--- a/plan/incoming/learnings/20260827-code-review-2520-deferred-preexisting.md
+++ b/plan/incoming/learnings/20260827-code-review-2520-deferred-preexisting.md
@@ -1,9 +1,9 @@
 ---
 title: Code review of docs PR for #2520 surfaced 7 pre-existing bugs in unrelated files
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2520
-signal: deferred-bug
+signal: concern
 ---
 
 During code review for PR implementing #2520 (case model explanation docs), the

--- a/plan/incoming/learnings/20260827-glossary-acs-pre-satisfied.md
+++ b/plan/incoming/learnings/20260827-glossary-acs-pre-satisfied.md
@@ -1,8 +1,9 @@
 ---
-name: glossary-acs-pre-satisfied-issue-2523
-description: Issue #2523 listed three glossary terms as missing that were already present — only the FINDER deprecation was genuinely absent
-metadata:
-  type: project
+title: "Issue #2523 listed three glossary terms as missing that were already present"
+type: learning
+timestamp: "2026-08-27T19:45:15Z"
+source: ISSUE-2523
+signal: process-issue
 ---
 
 Issue #2523 ([Docs] Glossary: align reference/glossary.md) listed these

--- a/plan/incoming/learnings/20260827-issue-1760-adr-already-done.md
+++ b/plan/incoming/learnings/20260827-issue-1760-adr-already-done.md
@@ -1,7 +1,7 @@
 ---
 title: Issue 1760 — ADR section already present; only spec entry was missing
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-1760
 signal: process-issue
 ---

--- a/plan/incoming/learnings/20260827-manage-github-issue-no-type-flag.md
+++ b/plan/incoming/learnings/20260827-manage-github-issue-no-type-flag.md
@@ -1,7 +1,7 @@
 ---
 title: manage_github_issue.sh does not support --type flag for setting issue type
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2520
 signal: tooling-issue
 ---

--- a/plan/incoming/learnings/20260827-mermaid-prefix-map-rendering-scope.md
+++ b/plan/incoming/learnings/20260827-mermaid-prefix-map-rendering-scope.md
@@ -1,7 +1,7 @@
 ---
 title: BtNode._mermaid_prefix_map is scoped to the rendering node, not the named node
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2109
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260827-mkdocs-build-strict-arithmetic-bug.md
+++ b/plan/incoming/learnings/20260827-mkdocs-build-strict-arithmetic-bug.md
@@ -1,7 +1,7 @@
 ---
 title: mkdocs-build-strict.sh bash arithmetic bug causes false exit-code failures
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2520
 signal: tooling-issue
 ---

--- a/plan/incoming/learnings/20260827-mkdocs-build-strict-false-negative.md
+++ b/plan/incoming/learnings/20260827-mkdocs-build-strict-false-negative.md
@@ -1,7 +1,7 @@
 ---
 title: mkdocs-build-strict.sh warning counter has bash syntax error that prints misleading failure message
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2523
 signal: tooling-issue
 ---

--- a/plan/incoming/learnings/20260827-not-implemented-from-property-is-programming-error.md
+++ b/plan/incoming/learnings/20260827-not-implemented-from-property-is-programming-error.md
@@ -1,7 +1,7 @@
 ---
 title: "NotImplementedError from a port property is a programming error, not a data condition"
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2668
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2757.md
+++ b/plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2757.md
@@ -1,7 +1,7 @@
 ---
 title: 3 pre-existing bugs surfaced by code review on PR #2775
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2757
 signal: concern
 ---

--- a/plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2780.md
+++ b/plan/incoming/learnings/20260827-pre-existing-bugs-from-code-review-2780.md
@@ -1,7 +1,7 @@
 ---
 title: 2 pre-existing bugs surfaced by code review on PR for #2780
 type: learning
-timestamp: 2026-08-27
+timestamp: "2026-08-27T00:00:00Z"
 source: ISSUE-2780
 signal: concern
 ---

--- a/plan/incoming/learnings/20260828-clp14-chain-callsite-unwired.md
+++ b/plan/incoming/learnings/20260828-clp14-chain-callsite-unwired.md
@@ -1,7 +1,7 @@
 ---
 title: CLP-14 runtime checks unwired at chain.py call site
 type: learning
-timestamp: 2026-08-28
+timestamp: "2026-08-28T00:00:00Z"
 source: ISSUE-2679
 signal: concern
 ---

--- a/plan/incoming/learnings/20260828-clp14-gating-design.md
+++ b/plan/incoming/learnings/20260828-clp14-gating-design.md
@@ -1,7 +1,7 @@
 ---
 title: CLP-14 timestamp checks gated on case_published to preserve backward compat
 type: learning
-timestamp: 2026-08-28
+timestamp: "2026-08-28T00:00:00Z"
 source: ISSUE-2679
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260828-cs-vf-cd-strenum-leaf-consistency.md
+++ b/plan/incoming/learnings/20260828-cs-vf-cd-strenum-leaf-consistency.md
@@ -1,7 +1,7 @@
 ---
 title: "CS_vf and CS_d should be StrEnum to match their leaf component enums"
 type: learning
-timestamp: "2026-08-28"
+timestamp: "2026-08-28T00:00:00Z"
 source: ISSUE-2662
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260828-mkdocs-strict-grep-bug.md
+++ b/plan/incoming/learnings/20260828-mkdocs-strict-grep-bug.md
@@ -1,7 +1,7 @@
 ---
 title: mkdocs-build-strict.sh exits with arithmetic error when there are zero warnings
 type: learning
-timestamp: "2026-08-28"
+timestamp: "2026-08-28T00:00:00Z"
 source: ISSUE-2785
 signal: tooling-issue
 ---

--- a/plan/incoming/learnings/20260828-pydantic-v2-before-validator-reverse-order.md
+++ b/plan/incoming/learnings/20260828-pydantic-v2-before-validator-reverse-order.md
@@ -1,7 +1,7 @@
 ---
 title: "Pydantic v2 runs mode='before' validators in reverse definition order"
 type: learning
-timestamp: "2026-08-28"
+timestamp: "2026-08-28T00:00:00Z"
 source: ISSUE-2662
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260831-2067-pr2882-code-review-deferred-findings.md
+++ b/plan/incoming/learnings/20260831-2067-pr2882-code-review-deferred-findings.md
@@ -1,7 +1,9 @@
 ---
 title: "PR #2882 code-review findings — all pre-existing, out of scope"
-date: 2026-08-31
+type: learning
+timestamp: "2026-08-31T17:27:04Z"
 source: ISSUE-2067
+signal: concern
 ---
 
 ## Context

--- a/plan/incoming/learnings/20260831-actionlint-no-go-devcontainer.md
+++ b/plan/incoming/learnings/20260831-actionlint-no-go-devcontainer.md
@@ -1,7 +1,7 @@
 ---
 title: actionlint pre-commit hook hangs in devcontainer — Go not installed
 type: learning
-timestamp: 2026-08-31
+timestamp: "2026-08-31T00:00:00Z"
 source: ISSUE-2627
 signal: tooling-issue
 ---

--- a/plan/incoming/learnings/20260831-extract-event-always-72h-floor-concern.md
+++ b/plan/incoming/learnings/20260831-extract-event-always-72h-floor-concern.md
@@ -1,7 +1,7 @@
 ---
 title: "extract_event() always uses 72h RSVP floor; per-actor floor not enforced"
 type: learning
-timestamp: "2026-08-31"
+timestamp: "2026-08-31T00:00:00Z"
 source: ISSUE-2850
 signal: concern
 ---

--- a/plan/incoming/learnings/20260831-extract-intent-min-rsvp-window-design.md
+++ b/plan/incoming/learnings/20260831-extract-intent-min-rsvp-window-design.md
@@ -1,7 +1,7 @@
 ---
 title: "extract_intent: min_rsvp_window passed as parameter, not read from ActorConfig"
 type: learning
-timestamp: "2026-08-31"
+timestamp: "2026-08-31T00:00:00Z"
 source: ISSUE-2850
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260831-spec-corpus-marker-design.md
+++ b/plan/incoming/learnings/20260831-spec-corpus-marker-design.md
@@ -1,7 +1,7 @@
 ---
 title: "spec_corpus marker + architecture ratchet preferred over path enumeration for CI coverage of spec-reading tests"
 type: learning
-timestamp: "2026-08-31"
+timestamp: "2026-08-31T00:00:00Z"
 source: ISSUE-2903
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260901-2491-any-received-event-spec-gap.md
+++ b/plan/incoming/learnings/20260901-2491-any-received-event-spec-gap.md
@@ -1,7 +1,7 @@
 ---
 title: "spec-gap: AnyReceivedEvent union type has no SE spec requirement"
 type: learning
-timestamp: 2026-09-01
+timestamp: "2026-09-01T00:00:00Z"
 source: ISSUE-2491
 signal: spec-gap
 ---

--- a/plan/incoming/learnings/20260901-2491-extract-intent-cast-design.md
+++ b/plan/incoming/learnings/20260901-2491-extract-intent-cast-design.md
@@ -1,7 +1,7 @@
 ---
 title: "design: cast() used to bridge extract_intent return type to AnyReceivedEvent"
 type: learning
-timestamp: 2026-09-01
+timestamp: "2026-09-01T00:00:00Z"
 source: ISSUE-2491
 signal: design-question
 ---

--- a/plan/incoming/learnings/20260901-code-review-2458-preexisting-findings.md
+++ b/plan/incoming/learnings/20260901-code-review-2458-preexisting-findings.md
@@ -1,7 +1,7 @@
 ---
 title: Pre-existing findings surfaced by code review for PR #2928 (ISSUE-2458)
 type: learning
-timestamp: 2026-09-01
+timestamp: "2026-09-01T00:00:00Z"
 source: ISSUE-2458
 signal: concern
 ---

--- a/plan/incoming/learnings/20260901-code-review-2671-preexisting-findings.md
+++ b/plan/incoming/learnings/20260901-code-review-2671-preexisting-findings.md
@@ -1,9 +1,9 @@
 ---
 title: Pre-existing code review findings deferred from ISSUE-2671
 type: learning
-timestamp: 2026-09-01
+timestamp: "2026-09-01T00:00:00Z"
 source: ISSUE-2671
-signal: pre-existing-finding
+signal: concern
 ---
 
 Code review during ISSUE-2671 build session surfaced three findings in files

--- a/plan/incoming/learnings/20260901-pytest-sigkill-repeated-runs.md
+++ b/plan/incoming/learnings/20260901-pytest-sigkill-repeated-runs.md
@@ -1,7 +1,7 @@
 ---
 title: pytest killed by SIGKILL (exit 137) when run multiple times in same session
 type: learning
-timestamp: 2026-09-01
+timestamp: "2026-09-01T00:00:00Z"
 source: ISSUE-2458
 signal: tooling-issue
 ---

--- a/plan/incoming/learnings/20260901-wire-normalize-ratchet-threshold-weakened.md
+++ b/plan/incoming/learnings/20260901-wire-normalize-ratchet-threshold-weakened.md
@@ -1,8 +1,9 @@
 ---
-name: wire-normalize-ratchet-threshold-weakened
-description: test_normalize_wire_to_core_ratchet.py threshold was lowered from >50 to >20 entries, creating a 40-entry blind spot for partial-import failures
-metadata:
-  type: project
+title: "normalize-wire-to-core ratchet threshold lowered to >20, leaving a 40-entry blind spot"
+type: learning
+timestamp: "2026-09-01T18:49:21Z"
+source: ISSUE-2500
+signal: tooling-issue
 ---
 
 `test/architecture/test_normalize_wire_to_core_ratchet.py:89` checks `assert len(VOCABULARY) > 20` and `assert len(WIRE_TYPE_MAP) > 20` (split from a previous combined `> 50` check).

--- a/plan/incoming/learnings/20260901-wire-type-map-key-naming-agents-md-wrong.md
+++ b/plan/incoming/learnings/20260901-wire-type-map-key-naming-agents-md-wrong.md
@@ -1,8 +1,9 @@
 ---
-name: wire-type-map-key-naming-agents-md-wrong
-description: AGENTS.md incorrectly states WIRE_TYPE_MAP uses wire type_ value keys; actual keys are cls.__name__.removeprefix("as_"), which diverges from type_ for actor classes
-metadata:
-  type: project
+title: "AGENTS.md misstates WIRE_TYPE_MAP key derivation; keys are cls.__name__, not type_"
+type: learning
+timestamp: "2026-09-01T18:49:21Z"
+source: ISSUE-2500
+signal: concern
 ---
 
 AGENTS.md line 302 says: "WIRE_TYPE_MAP uses wire `type_` value keys (`'VulnerabilityCase'`)".

--- a/plan/incoming/learnings/2627-deferred-bugs-dl-read-case.md
+++ b/plan/incoming/learnings/2627-deferred-bugs-dl-read-case.md
@@ -1,8 +1,9 @@
 ---
-name: 2627-deferred-bugs-dl-read-case
-description: Three pre-existing bugs found during code review of #2627 — test mocks stub dl.read when production calls dl.read_case
-metadata:
-  type: project
+title: "Three pre-existing dl.read/dl.read_case mock mismatches found reviewing #2627"
+type: learning
+timestamp: "2026-08-31T20:46:24Z"
+source: ISSUE-2627
+signal: concern
 ---
 
 Three bugs discovered (not introduced) during code review of Issue #2627 PR.

--- a/plan/incoming/learnings/concern-inbox-handler-protocol-violation-requeue.md
+++ b/plan/incoming/learnings/concern-inbox-handler-protocol-violation-requeue.md
@@ -1,8 +1,9 @@
 ---
-name: concern-inbox-handler-protocol-violation-requeue
-description: inbox_handler._process_inbox_item re-queues VultronProtocolViolationError indefinitely (sibling of InboxPipeline fix #2861)
-metadata:
-  type: project
+title: "inbox_handler._process_inbox_item re-queues VultronProtocolViolationError indefinitely"
+type: learning
+timestamp: "2026-08-31T14:28:32Z"
+source: ISSUE-2861
+signal: concern
 ---
 
 `vultron/adapters/driving/fastapi/inbox_handler.py` `_process_inbox_item` (line ~347) uses

--- a/specs/build-workflow.yaml
+++ b/specs/build-workflow.yaml
@@ -198,6 +198,33 @@ groups:
             spec_id: HM-06-005
         lint_suppress:
         - missing_story_reference
+      - id: BW-02-005
+        priority: MUST
+        kind: process
+        statement: >-
+          Conformance to BW-02-001 through BW-02-004 MUST be checked at commit
+          time by validating every file in `plan/incoming/learnings/` through
+          `HistoryEntryFrontmatter` — the same model
+          `append-history --from-file` uses — so the check and the archiver
+          cannot drift. A validator that reimplements the rules
+          independently does not satisfy this.
+        rationale: >-
+          Between the spec being written and ISSUE-2762, 37 of 62 entries
+          accumulated frontmatter that no check rejected and the archiver
+          could not accept. The defect was invisible precisely because the
+          only enforcement lived in the last step of a workflow that runs
+          weeks after the file is written. Validating at commit time against
+          the archiver's own model is what makes the queue stay drainable.
+        verification: >-
+          The `validate-incoming-learnings-frontmatter` pre-commit hook calls
+          `vultron.metadata.history.incoming.validate_incoming_learnings()`,
+          and `test/metadata/test_incoming_learnings.py::TestRealCorpus`
+          asserts the committed corpus validates.
+        relationships:
+          - rel_type: depends_on
+            spec_id: BW-02-001
+        lint_suppress:
+        - missing_story_reference
   - id: BW-03
     title: learn Skill Processing
     specs:

--- a/test/metadata/test_incoming_learnings.py
+++ b/test/metadata/test_incoming_learnings.py
@@ -1,0 +1,128 @@
+"""Tests for the incoming-learnings frontmatter validator.
+
+Covers: BW-02-001, BW-02-002, BW-02-004.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vultron.metadata.history.incoming import (
+    LEARNINGS_DIR,
+    validate_incoming_learnings,
+)
+
+_GOOD = """---
+title: "A thing was learned"
+type: learning
+timestamp: "2026-09-01T00:00:00Z"
+source: ISSUE-2762
+signal: concern
+---
+
+Body text.
+"""
+
+
+def _repo(tmp_path: Path, **files: str) -> Path:
+    """Build a throwaway repo root containing the given learning files."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    directory = tmp_path / LEARNINGS_DIR
+    directory.mkdir(parents=True)
+    for name, text in files.items():
+        (directory / name).write_text(text, encoding="utf-8")
+    return tmp_path
+
+
+class TestValidateIncomingLearnings:
+    def test_accepts_conformant_file(self, tmp_path: Path) -> None:
+        root = _repo(tmp_path, **{"20260901-good.md": _GOOD})
+        result = validate_incoming_learnings(root)
+        assert set(result) == {"20260901-good.md"}
+        assert result["20260901-good.md"].source == "ISSUE-2762"
+
+    def test_missing_directory_is_not_an_error(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        assert validate_incoming_learnings(tmp_path) == {}
+
+    def test_skips_readme(self, tmp_path: Path) -> None:
+        root = _repo(
+            tmp_path,
+            **{"20260901-good.md": _GOOD, "README.md": "# not an entry\n"},
+        )
+        assert set(validate_incoming_learnings(root)) == {"20260901-good.md"}
+
+    @pytest.mark.spec("BW-02-004")
+    def test_rejects_bare_date_timestamp(self, tmp_path: Path) -> None:
+        """The defect that silently accumulated across 37 files."""
+        bad = _GOOD.replace(
+            'timestamp: "2026-09-01T00:00:00Z"', "timestamp: 2026-09-01"
+        )
+        root = _repo(tmp_path, **{"20260901-bare.md": bad})
+        with pytest.raises(ValueError) as exc:
+            validate_incoming_learnings(root)
+        assert "20260901-bare.md" in str(exc.value)
+        assert "timestamp" in str(exc.value)
+
+    @pytest.mark.spec("BW-02-001")
+    def test_rejects_unquoted_title_ending_in_colon(
+        self, tmp_path: Path
+    ) -> None:
+        """An unquoted trailing colon makes the whole block invalid YAML."""
+        bad = _GOOD.replace(
+            'title: "A thing was learned"',
+            "title: Chose degrade over fail-fast for an invite with no to:",
+        )
+        root = _repo(tmp_path, **{"20260901-colon.md": bad})
+        with pytest.raises(ValueError) as exc:
+            validate_incoming_learnings(root)
+        assert "20260901-colon.md" in str(exc.value)
+
+    @pytest.mark.spec("BW-02-001")
+    def test_rejects_missing_required_field(self, tmp_path: Path) -> None:
+        bad = _GOOD.replace("source: ISSUE-2762\n", "")
+        root = _repo(tmp_path, **{"20260901-nosource.md": bad})
+        with pytest.raises(ValueError) as exc:
+            validate_incoming_learnings(root)
+        assert "source" in str(exc.value)
+
+    def test_rejects_signal_outside_the_enum(self, tmp_path: Path) -> None:
+        """BW-07-002 defines the signal set; invented values must not pass."""
+        bad = _GOOD.replace("signal: concern", "signal: deferred-bug")
+        root = _repo(tmp_path, **{"20260901-signal.md": bad})
+        with pytest.raises(ValueError) as exc:
+            validate_incoming_learnings(root)
+        assert "signal" in str(exc.value)
+
+    def test_reports_every_offender_at_once(self, tmp_path: Path) -> None:
+        """One pass should surface the whole backlog, not just the first file."""
+        root = _repo(
+            tmp_path,
+            **{
+                "20260901-a.md": _GOOD.replace(
+                    'timestamp: "2026-09-01T00:00:00Z"',
+                    "timestamp: 2026-09-01",
+                ),
+                "20260901-b.md": _GOOD.replace("type: learning\n", ""),
+                "20260901-ok.md": _GOOD,
+            },
+        )
+        with pytest.raises(ValueError) as exc:
+            validate_incoming_learnings(root)
+        message = str(exc.value)
+        assert "20260901-a.md" in message
+        assert "20260901-b.md" in message
+        assert "2 file(s)" in message
+
+
+class TestRealCorpus:
+    @pytest.mark.spec("BW-02-001")
+    def test_every_committed_learning_file_is_archivable(self) -> None:
+        """The repo's own queue must stay drainable by `learn`.
+
+        This is the ratchet: it is what stops the 37-file backlog from
+        re-accumulating between releases.
+        """
+        assert validate_incoming_learnings()

--- a/vultron/metadata/history/incoming.py
+++ b/vultron/metadata/history/incoming.py
@@ -1,0 +1,115 @@
+"""Validator for ``plan/incoming/learnings/*.md`` frontmatter.
+
+Incoming learning files are staged in the same frontmatter format as history
+entries so that archiving is a content-free move (BW-02-001).  The archiver
+(``append-history --from-file``) validates each file through
+:class:`~vultron.metadata.history.models.HistoryEntryFrontmatter` before it
+writes anything, so a file that fails that model cannot be archived at all.
+
+Nothing else in the pipeline used to check this.  A malformed entry looked fine
+in review and in CI, and only failed months later when ``learn`` tried to drain
+the queue — by which time 37 of 62 files had accumulated the same defect
+(ISSUE-2762).  This module exists so the check runs at commit time against the
+*same* model the archiver uses, which is what keeps the two from drifting.
+
+Requirements: BW-02-001 through BW-02-004.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import frontmatter
+from pydantic import ValidationError
+
+from vultron.metadata.history.models import HistoryEntryFrontmatter
+
+LEARNINGS_DIR = Path("plan") / "incoming" / "learnings"
+
+SKIP_FILES = {"README.md"}
+
+
+def _find_repo_root(start: Path | None = None) -> Path:
+    """Return the repository root by searching upward for ``pyproject.toml``."""
+    origin = start or Path.cwd()
+    for parent in [origin, *origin.parents]:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise FileNotFoundError(
+        "Could not locate repository root (pyproject.toml) starting from"
+        f" {origin}"
+    )
+
+
+def _describe(exc: Exception) -> str:
+    """Render a validation failure as a single compact line."""
+    if isinstance(exc, ValidationError):
+        parts = []
+        for err in exc.errors():
+            field = ".".join(str(p) for p in err.get("loc", ())) or "<root>"
+            parts.append(f"{field}: {err.get('msg', 'invalid')}")
+        return "; ".join(parts)
+    return f"{type(exc).__name__}: {exc}"
+
+
+def validate_incoming_learnings(
+    repo_root: Path | None = None,
+) -> dict[str, HistoryEntryFrontmatter]:
+    """Validate every incoming learning file's frontmatter.
+
+    Args:
+        repo_root: Repository root.  Resolved automatically when ``None``.
+
+    Returns:
+        Mapping of filename to its parsed frontmatter, for the files that
+        validated.
+
+    Raises:
+        ValueError: If any file fails to parse or validate.  The message lists
+            every offending file so a contributor fixes them in one pass
+            rather than one commit at a time.
+    """
+    root = repo_root or _find_repo_root()
+    directory = root / LEARNINGS_DIR
+
+    if not directory.is_dir():
+        return {}
+
+    validated: dict[str, HistoryEntryFrontmatter] = {}
+    failures: list[str] = []
+
+    for path in sorted(directory.glob("*.md")):
+        if path.name in SKIP_FILES:
+            continue
+        try:
+            post = frontmatter.load(path)
+        except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+            # A `title:` whose text contains or ends with a colon and is left
+            # unquoted makes the whole block invalid YAML, so parse failures
+            # are a real and recurring mode here rather than a theoretical one.
+            failures.append(f"  {path.name}: unparseable frontmatter — {exc}")
+            continue
+
+        try:
+            validated[path.name] = HistoryEntryFrontmatter.model_validate(
+                post.metadata
+            )
+        except ValidationError as exc:
+            failures.append(f"  {path.name}: {_describe(exc)}")
+
+    if failures:
+        raise ValueError(
+            f"{len(failures)} file(s) in {LEARNINGS_DIR} cannot be archived by"
+            " `append-history --from-file` (BW-02-001):\n"
+            + "\n".join(failures)
+            + "\n\nCommon fixes:\n"
+            '  - timestamp MUST be tz-aware and quoted: "YYYY-MM-DDTHH:MM:SSZ"'
+            " (BW-02-004);\n"
+            "    a bare YYYY-MM-DD parses to a naive datetime and is rejected.\n"
+            "  - source MUST be the originating work item, e.g. ISSUE-1234"
+            " (BW-02-002).\n"
+            "  - type MUST be `learning`.\n"
+            "  - quote any title containing or ending with a colon."
+        )
+
+    return validated


### PR DESCRIPTION
- Depends on #3007 (this PR targets its branch, not `main`)

## Summary

Clears the BW-02 conformance backlog that #3007 discovered and documented but
deliberately did not sweep, and adds the commit-time guard that stops it
re-accumulating.

**Before: 25 of 62 incoming learning files could be archived by
`append-history --from-file`. After: 62 of 62.** Verified against
`HistoryEntryFrontmatter` itself — the model the archiver validates through — not
a reimplementation of its rules.

The practical effect is that `learn` can drain its own input queue again. Every
rejected file was a learning that could be written and reviewed but never
promoted into specs or notes.

## Three causes, not the two originally identified

| Cause | Files | Fix |
|---|---|---|
| Bare-date `timestamp` | 30 | `timestamp: 2026-08-27` → `timestamp: "2026-08-27T00:00:00Z"` |
| Missing / wrong-template frontmatter | 7 | Rewritten to `title`/`type`/`timestamp`/`source`/`signal` |
| Invented `signal` values | 4 | `deferred-bug`, `pre-existing-finding` → `concern` |

The third was not in #3007's write-up — it only surfaced once the bare-date
failures stopped masking it. `deferred-bug` (3 files) and `pre-existing-finding`
(1 file) are not members of `LearningSignalType`. All four are deferred
code-review findings, and `20260901-code-review-2458-preexisting-findings.md` is
the same kind of entry already using `signal: concern`, so that is the in-corpus
precedent rather than a judgement call.

Five of the seven in the middle row carried `name:`/`description:`/`metadata:`
frontmatter — the **agent memory-file format**, not the learning-entry format.
They were written from the wrong template entirely, which is why they were
missing every required field rather than just one.

## `source` was traced, not guessed

#3007's write-up said these "need a human to supply the originating `source`".
Each one turned out to be recoverable from the file or its provenance:

| File | `source` | Evidence |
|---|---|---|
| `2026-08-28-2175-is-leader-defer.md` | `ISSUE-2175` | legacy `issue: "2175"` field |
| `20260827-glossary-acs-pre-satisfied.md` | `ISSUE-2523` | body: "Issue #2523 … listed these" |
| `20260901-wire-normalize-ratchet-threshold-weakened.md` | `ISSUE-2500` | body: "discovered during code review of PR for #2500"; added by the #2500 commit |
| `20260901-wire-type-map-key-naming-agents-md-wrong.md` | `ISSUE-2500` | same |
| `2627-deferred-bugs-dl-read-case.md` | `ISSUE-2627` | body: "code review of Issue #2627 PR" |
| `concern-inbox-handler-protocol-violation-requeue.md` | `ISSUE-2861` | body: "identified during sibling scan for PR fixing #2861" |
| `20260831-2067-pr2882-code-review-deferred-findings.md` | `ISSUE-2067` | already present |

For the last one, note `source` is the **originating** work item (#2861), not the
tracking issue the concern was later filed as (#2865) — where it came from, not
where it went.

Timestamps come from `git log --diff-filter=A` per file, which is a truer answer
for BW-02-003 ("MUST reflect the actual creation time of the observation") than
filename-derived midnight.

## The guard — BW-02-005 (new)

Fixing 37 files is worthless if the 38th lands next week, so:

- **`vultron/metadata/history/incoming.py`** — `validate_incoming_learnings()`
  validates the directory through `HistoryEntryFrontmatter`. The spec states the
  reuse as a MUST: a validator that reimplements the rules independently does not
  satisfy BW-02-005, because the failure mode being prevented is exactly the
  check and the archiver drifting apart. Reports every offender in one message
  rather than failing on the first, so the next backlog is cleared in one pass.
- **`validate-incoming-learnings-frontmatter` pre-commit hook.** The existing
  `validate-notes-frontmatter` hook is scoped to `notes/` and printed
  `no files to check` while seven learning files were staged in #3007 — that is
  the root cause of the accumulation, and this closes it.
- **`test/metadata/test_incoming_learnings.py`** — 9 tests, including a ratchet
  (`TestRealCorpus`) asserting the committed corpus stays archivable, and
  coverage for the unquoted-trailing-colon case that makes frontmatter
  unparseable outright.

## Verification

- `validate_incoming_learnings()` → 62 validated, 0 failures.
- **Hook verified in both directions**: fails on a deliberately reverted
  timestamp (naming the file and the reason), passes on the fixed tree, and ran
  clean in the real commit path.
- Unit tier: all passing, 0 F/E. `test/metadata/` and `test/metadata/specs/`
  green.
- black, flake8, mypy, pyright, markdownlint clean. No new xfails.

## Review note

This is 37 near-identical frontmatter edits plus 4 substantive files. The two
worth actually reading are `vultron/metadata/history/incoming.py` and the seven
rewritten frontmatter blocks in the table above; the other 30 are one-line
timestamp quoting. No file body content was changed anywhere — only frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
