### PR TITLE
docs: add case ledger synchronization explanation page

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -146,9 +146,12 @@ Run the appropriate suite based on PR type:
 **Docs PR** (`type: docs`):
 
 ```bash
-# Linters only — no Python changed
+# Linters only — no Python changed. Scope matches run-linters and build
+# Phase 6; bare `uv run flake8` walks the whole repo (including scripts/,
+# which carries pre-existing C901/E741 findings no other gate covers) and
+# fails every docs PR on debt it did not introduce.
 uv run black --check .
-uv run flake8
+uv run flake8 vultron/ test/
 uv run mypy vultron
 uv run pyright
 ```

--- a/docs/howto/activitypub/activities/ledger_replication.md
+++ b/docs/howto/activitypub/activities/ledger_replication.md
@@ -11,13 +11,15 @@ with `Announce(VulnerabilityCase)` (ADR-0059).
 
 See also:
 
+- [Case Ledger Synchronization](../../../topics/case_ledger_sync.md) — why the
+  ledger is ordered this way and what the buffering guarantees
 - [ADR-0037 — Buffer Out-of-Order Ledger
   Entries](../../../adr/0037-buffer-out-of-order-ledger-entries.md)
 - [ADR-0059 — Buffer Pre-Genesis Ledger
   Entries](../../../adr/0059-buffer-pre-genesis-ledger-entries.md)
 - [ADR-0077 — Ledger Replication Companion
   Spec](../../../adr/0077-ledger-replication-companion-spec.md)
-- Spec: `specs/case-event-log-synchronization.yaml` (SYNC-09, SYNC-10, SYNC-15)
+- Spec: `specs/sync-ledger-replication.yaml` (SYNC-09, SYNC-10, SYNC-14, SYNC-15)
 
 ## Announce(CaseLedgerEntry) — Log Replication
 

--- a/docs/howto/activitypub/activities/ledger_replication.md
+++ b/docs/howto/activitypub/activities/ledger_replication.md
@@ -124,5 +124,5 @@ activity = announce_vulnerability_case_activity(
   `announce_log_entry_activity`, `reject_log_entry_activity`
 - Factory: `vultron/wire/as2/factories/case.py` —
   `announce_vulnerability_case_activity`
-- Spec: `specs/case-event-log-synchronization.yaml` (SYNC-03, SYNC-09, SYNC-10,
+- Spec: `specs/sync-ledger-replication.yaml` (SYNC-03, SYNC-09, SYNC-10,
   SYNC-15)

--- a/docs/topics/case_ledger_sync.md
+++ b/docs/topics/case_ledger_sync.md
@@ -1,0 +1,349 @@
+# Case Ledger Synchronization
+
+A vulnerability case is coordinated by organizations that do not share a
+database. Each one keeps its own copy of the case. This page explains how
+those copies stay in agreement, and it answers two questions:
+
+- Who decides the order in which things happened?
+- What happens when messages arrive in the wrong order?
+
+Vultron answers the first question with a single writer. It answers the second
+by holding an early message until the message it depends on arrives.
+
+---
+
+## One writer, many copies
+
+Every participant in a case keeps a local copy of the case, called a
+**replica**. No participant can read or write another participant's replica.
+Knowledge travels only in messages — see the
+[Actor Knowledge Model](actor-knowledge-model.md).
+
+One peer is different. The **Case Actor** is the service peer that holds the
+`CASE_MANAGER` role for the case. It keeps the **case ledger**: the
+append-only history that is authoritative for the case. The Case Actor is the
+only peer that appends to that history
+([CLP-01-003](../reference/specs/protocol.md#clp-01)).
+
+The flow of a change is always the same:
+
+1. A participant sends the Case Actor an assertion — *I accept the embargo*,
+   *my report is now validated*, *here is a note*.
+2. The Case Actor judges the assertion and appends one entry recording the
+   outcome. An entry's `disposition` says whether the assertion was
+   `recorded` (accepted) or `rejected`, so a refusal is part of the history
+   rather than a silence.
+3. The Case Actor sends the new entry to every participant as
+   `Announce(CaseLedgerEntry)`.
+4. Each participant applies the entry to its own replica.
+
+Because there is exactly one writer, no participant ever has to reconcile two
+competing versions of the case history. There is only one version. A
+participant's replica is a projection of the ledger, not an independent record.
+
+The same rule applies in reverse: a participant accepts a case update only
+from the Case Actor for that case, and rejects an update from any other sender
+([PCR-03-001](../reference/specs/protocol.md#pcr-03)). Nobody else can write
+to a replica, and the replica's owner does not edit it directly either — even
+when that owner is the organization that opened the case.
+
+---
+
+## What a ledger entry carries
+
+Each entry is a small, immutable record. These are the fields that carry the
+ordering and integrity guarantees this page is about.
+
+| Field | Meaning |
+|---|---|
+| `case_id` | The case this entry belongs to |
+| `log_index` | Position in the case history; starts at 0 and counts up |
+| `published` | When the Case Actor stamped the entry, by its own clock |
+| `prevLogHash` | Hash of the entry immediately before this one |
+| `entryHash` | Hash of this entry's own content |
+| `payloadSnapshot` | A copy of the assertion the entry records |
+
+`prevLogHash` and `entryHash` link the entries into a chain, like the teeth of
+a zipper. Each entry names its predecessor, so a receiver can tell whether an
+entry belongs at the end of the history it already holds. The first entry in a
+case names the **genesis hash**, a value derived from the case object itself,
+so the chain is anchored to the case it describes.
+
+---
+
+## Log index is the causal order
+
+The `log_index` sequence *is* the causal order of the case. If the Case Actor
+observed event A before event B, then A has the lower `log_index`
+([CLP-14-001](../reference/specs/protocol.md#clp-14), ADR-0079). Anything
+that needs to know what happened first compares log indexes. It does not
+compare clocks.
+
+This matters because clocks disagree. Two organizations on different
+continents, running different software, will not agree on the millisecond at
+which an event occurred. Sorting a shared history by wall-clock time would make
+the order depend on whose clock was fast. Sorting by `log_index` does not.
+
+Timestamps are still recorded, and they are still useful — as corroborating
+evidence, and for spotting a participant whose clock is wrong. They are not
+the order.
+
+### What the ledger claims, and what it does not
+
+The ledger is authoritative **from the Case Actor's point of view**. It is a
+postmark, not a forensic reconstruction. It records the sequence in which the
+Case Actor observed and processed events, and it makes no claim about when
+those events happened inside another organization
+([CLP-15-005](../reference/specs/protocol.md#clp-15)).
+
+- For events the Case Actor generates itself, causal order is known by
+  construction: the entries are written one after another on a single path.
+- For events reported by participants, the Case Actor's own receive-and-commit
+  order is the order. The Case Actor cannot verify a causal claim about
+  something it did not see.
+
+The Case Actor never reorders entries to match timestamps supplied by someone
+else. Doing so would let external data override the one thing the Case Actor
+knows first-hand.
+
+### Rules the Case Actor follows
+
+| Rule | Requirement |
+|---|---|
+| Order is never reversed: an event observed earlier never gets a higher `log_index` | [CLP-14-001](../reference/specs/protocol.md#clp-14) |
+| Every entry carries a timestamp; none may be empty | [CLP-14-002](../reference/specs/protocol.md#clp-14) |
+| Timestamps on consecutive recorded entries never move backwards as `log_index` increases | [CLP-14-003](../reference/specs/protocol.md#clp-14) |
+| Every entry in a ledger belongs to the same case | [CLP-14-004](../reference/specs/protocol.md#clp-14) |
+| No two entries in a case share a `log_index` | [CLP-14-005](../reference/specs/protocol.md#clp-14) |
+| No entry predates the case it belongs to | [CLP-14-006](../reference/specs/protocol.md#clp-14) |
+
+A ledger is also expected to be complete: the conformance checks require a
+contiguous run of indexes from the genesis entry through the newest one, with
+no holes. A receiver that finds a hole knows an entry is missing, not that the
+Case Actor skipped a number.
+
+The Case Actor should also refuse an assertion whose own timestamp is far in
+the future or far in the past compared to its clock — by default, more than
+five minutes ahead or more than seven days old
+([CLP-14-007](../reference/specs/protocol.md#clp-14),
+[CLP-14-008](../reference/specs/protocol.md#clp-14)). These are sanity
+checks, not proof of honesty; a participant with a badly wrong clock can still
+produce a well-formed but misleading assertion.
+
+---
+
+## What participants must do
+
+The Case Actor can only record the order it sees. That places an obligation on
+each participant: send events in the order they happened.
+
+- If A caused B, send A first
+  ([CLP-15-001](../reference/specs/protocol.md#clp-15)).
+- Do not collect several related events and send them in an arbitrary order
+  ([CLP-15-002](../reference/specs/protocol.md#clp-15)).
+- Give B a timestamp no earlier than A's
+  ([CLP-15-003](../reference/specs/protocol.md#clp-15)).
+- Timestamp an event with when it happened, not when the batch went out or a
+  retry was attempted
+  ([CLP-15-004](../reference/specs/protocol.md#clp-15)).
+
+A participant that breaks these rules produces a malformed assertion. That is
+a fault on the sending side, not a Case Actor failure.
+
+---
+
+## When entries arrive out of order
+
+Ledger entries travel over ordinary message transport, which gives no ordering
+guarantee. Vultron may also not be the only implementation on the wire. So a
+replica can receive entry 7 before entry 6.
+
+The naive response is to reject entry 7, on the grounds that it does not extend
+the chain, and wait for the Case Actor to send it again. That does not work.
+The replay travels the same unordered transport and can arrive out of order
+again, so under repeated reordering an entry can be lost indefinitely. In an
+earlier version of this implementation, that is what stalled a late-joining
+vendor at case closure.
+
+Instead, a replica **keeps** an early entry
+([ADR-0037](../adr/0037-buffer-out-of-order-ledger-entries.md),
+[SYNC-14-001](../reference/specs/protocol.md#sync-14)). It puts the entry
+in a holding area and waits for the predecessor. Convergence then no longer
+depends on delivery order at all.
+
+### What gets held, and what does not
+
+A replica holds an entry when the entry does not extend its chain but clearly
+belongs *later* in the history — its `log_index` is more than one past the end
+of what the replica holds. That is a forward gap: the predecessor has not
+arrived yet.
+
+Two kinds of entry are not held:
+
+- An entry at or behind the end of the chain. That is a duplicate or a stale
+  replay, not a gap.
+- An entry exactly one past the end of the chain whose `prevLogHash` still
+  does not match. Nothing is missing in front of it, so it is not a gap — it
+  is a fork, a claim about a history the replica does not share.
+
+Both go to the ordinary duplicate and divergence handling instead.
+
+Even when it does hold an entry, the replica still sends
+`Reject(CaseLedgerEntry)` naming the last entry it accepted
+([SYNC-14-002](../reference/specs/protocol.md#sync-14)). Holding solves
+reordering; it cannot solve loss. If the missing entry was never delivered at
+all, the reject is what prompts the Case Actor to send it again.
+
+The Case Actor does not replay on demand without limit. If a peer keeps
+rejecting from the same position, the Case Actor waits out a short cooldown
+before replaying to it again
+([SYNC-15-003](../reference/specs/protocol.md#sync-15)). Without that bound, a
+peer that cannot anchor its chain rejects every entry it is sent, each reject
+triggers another full replay, and the two feed each other into a storm. A
+reject from a position that *has* advanced always triggers a replay, so a peer
+making progress is never held back.
+
+The holding area is bounded. When it is full, the replica discards the entry
+farthest ahead of the gap and logs a warning
+([SYNC-14-006](../reference/specs/protocol.md#sync-14)). A discarded entry is
+recoverable through the reject-and-replay path, though the cooldown above may
+delay it, so a hostile or broken peer streaming far-future entries cannot
+exhaust memory.
+
+The holding area is deliberately **not** the ledger
+([SYNC-14-005](../reference/specs/protocol.md#sync-14)). Across Vultron,
+the presence of an entry in an actor's own store means *this entry is committed
+and its effects are applied*
+([SYNC-13-001](../reference/specs/protocol.md#sync-13)). A held entry is
+neither, so storing it would break that meaning.
+
+### Entries that arrive before the case
+
+The same holding area covers a related race: an entry can arrive before the
+participant has the case object at all. Without the case, the replica cannot
+compute the genesis hash and so cannot anchor the chain.
+
+A replica holds these entries too
+([SYNC-15-004](../reference/specs/protocol.md#sync-15)), with no gap
+comparison — there is no chain yet to compare against, so every entry for the
+unknown case is held, including entry 0. When the case is later delivered, the
+replica drains the holding area for that case
+([SYNC-15-005](../reference/specs/protocol.md#sync-15)). Seeding the case
+is enough, because the genesis hash is derived from the case object; the
+genesis ledger entry does not have to be re-sent
+([ADR-0059](../adr/0059-buffer-pre-genesis-ledger-entries.md)).
+
+### Draining the held entries
+
+Each held entry is filed under the hash of the predecessor it is waiting for.
+So after the replica commits a new last entry, finding the successor is a
+single lookup: the held entry whose `prevLogHash` equals the hash of the entry
+just committed.
+
+The drain then repeats. Commit the successor, look up *its* successor, and
+continue until no held entry extends the chain
+([SYNC-14-003](../reference/specs/protocol.md#sync-14)). A run of ten
+entries that arrived in reverse order clicks into place in one cascade, in
+`log_index` order.
+
+Three properties make the drain safe:
+
+- **Same path.** A drained entry goes through the same processing as an entry
+  that arrived in order — no separate code path with its own behavior
+  ([SYNC-14-008](../reference/specs/protocol.md#sync-14)). In this
+  implementation that means the drain re-runs the announce receive behavior
+  tree on each held entry, in `log_index` order.
+- **Effects before storage.** The entry's consequences — an embargo ending, a
+  participant joining, a status changing — are applied first, and the entry is
+  stored only if they all succeed
+  ([SYNC-12-001](../reference/specs/protocol.md#sync-12),
+  [SYNC-14-004](../reference/specs/protocol.md#sync-14)).
+- **Applied once.** An entry already in the local ledger is skipped entirely,
+  so a replay or a duplicate cannot apply the same effects twice
+  ([SYNC-12-003](../reference/specs/protocol.md#sync-12),
+  [SYNC-14-007](../reference/specs/protocol.md#sync-14)).
+
+Because held entries are replayed through the ordinary path, the
+reject-and-replay recovery becomes order-tolerant as well, at no extra cost.
+
+---
+
+## Why state checks wait for the drain
+
+Holding an entry has a consequence that is easy to get wrong. Case State (CS)
+has ordering rules of its own: an **ephemeral** state cannot be a resting
+place, so it has exactly one permitted successor and must be followed by it;
+the recorded history must remain a valid sequence throughout; and a move to
+public awareness must be recorded before the embargo termination that it
+triggers.
+
+If a replica checked those rules at the moment an entry *arrived*, an
+out-of-order entry would look like a violation. An entry naming a state that is
+only reachable from its predecessor would appear to arrive from nowhere.
+
+That is why the checks run at drain time instead
+([CSB-19-001](../reference/specs/protocol.md#csb-19)). A held entry is
+parked before any case-state effect is applied, so the state machine is never
+touched at arrival time. When the gap closes, the entries replay in
+`log_index` order — which is causal order — and the guards see them in the
+sequence they were meant to be seen in.
+
+An entry waiting in the holding area therefore raises no state violation at
+all ([CSB-19-002](../reference/specs/protocol.md#csb-19)). An entry naming an
+ephemeral state is perfectly well-formed on its own; it would only be a real
+violation if the entry that resolves it never arrived. Flagging it on arrival
+would be a false alarm, and rejecting it would prevent the replica from ever
+converging.
+
+The public-awareness-before-embargo-termination ordering survives reordering
+for free ([CSB-19-003](../reference/specs/protocol.md#csb-19)). The Case Actor
+commits the public-awareness entry first, so it holds the lower `log_index`.
+The drain works in `log_index` order, so it can never present the termination
+entry first. No receiver-side re-check of the timing is needed; the order in
+the ledger is sufficient.
+
+---
+
+## What a replica guarantees
+
+Taken together, the ledger rules and the holding area give each participant
+these properties:
+
+| Property | Meaning |
+|---|---|
+| Append-only | A committed entry is immutable and identified by its content hash |
+| Deterministic projection | The same run of entries produces the same state in every conforming implementation |
+| Idempotent replay | Re-processing entries already seen changes nothing |
+| Monotonic progress | A replica never regresses the position it has acknowledged |
+| Reject on divergence | An entry that does not extend the chain is not silently accepted |
+| Order-independent convergence | Delivery order does not affect the final state |
+
+The result is eventual consistency with a strong bound: given the same
+entries, every replica reaches the same state as the Case Actor, no matter what
+order those entries arrived in.
+
+The holding area itself is in memory only, and is lost on restart. That is
+deliberate. Nothing in it is committed, so nothing is lost that the catch-up
+check cannot recover by re-synchronizing from the Case Actor.
+
+---
+
+## Further reading
+
+- [The Case Model](case_model.md) — the case, its participants, and the
+  Case Actor's role
+- [Actor Knowledge Model](actor-knowledge-model.md) — why nothing can be
+  learned except by receiving a message
+- [CS Process Model](process_models/cs/index.md) — the case-state rules the
+  drain-time checks enforce
+- [Protocol specifications](../reference/specs/protocol.md) — the normative
+  requirements behind this page, including CLP-14, CLP-15, CSB-19, PCR-03, and
+  SYNC-12 through SYNC-15
+- [Glossary](../reference/glossary.md) — definitions for case ledger, replica,
+  genesis hash, and the replication phases
+- [ADR-0079](../adr/0079-case-ledger-causal-ordering.md) — Case Actor
+  observation order is the canonical causal order
+- [ADR-0037](../adr/0037-buffer-out-of-order-ledger-entries.md) — hold
+  out-of-order entries instead of discarding them
+- [ADR-0059](../adr/0059-buffer-pre-genesis-ledger-entries.md) — hold entries
+  that arrive before the case

--- a/docs/topics/case_ledger_sync.md
+++ b/docs/topics/case_ledger_sync.md
@@ -31,21 +31,45 @@ The flow of a change is always the same:
    *my report is now validated*, *here is a note*.
 2. The Case Actor judges the assertion and appends one entry recording the
    outcome. An entry's `disposition` says whether the assertion was
-   `recorded` (accepted) or `rejected`, so a refusal is part of the history
-   rather than a silence.
+   `recorded` (accepted) or `rejected`, so a refusal leaves a trace rather
+   than a silence.
 3. The Case Actor sends the new entry to every participant as
    `Announce(CaseLedgerEntry)`.
-4. Each participant applies the entry to its own replica.
+4. Each participant records the entry, and applies its effects to its own
+   replica if the entry was `recorded`.
 
 Because there is exactly one writer, no participant ever has to reconcile two
 competing versions of the case history. There is only one version. A
-participant's replica is a projection of the ledger, not an independent record.
+participant's replica is a projection of that history, not an independent
+record.
 
 The same rule applies in reverse: a participant accepts a case update only
 from the Case Actor for that case, and rejects an update from any other sender
 ([PCR-03-001](../reference/specs/protocol.md#pcr-03)). Nobody else can write
 to a replica, and the replica's owner does not edit it directly either — even
 when that owner is the organization that opened the case.
+
+### Two views of the ledger
+
+The ledger can be read two ways, and most of this page is about the second one.
+
+- The **audit log** is every entry the Case Actor appended, in the order it
+  appended them — rejections included.
+- The **recorded projection** is the subset whose `disposition` is `recorded`.
+  That projection is the authoritative history of the case
+  ([CLP-04-001](../reference/specs/protocol.md#clp-04)).
+
+Case state is reconstructed from the recorded projection alone; a replica
+ignores rejected entries when working out what is true of the case
+([CLP-04-002](../reference/specs/protocol.md#clp-04)). The hash chain is
+computed over that projection too
+([CLP-04-003](../reference/specs/protocol.md#clp-04)), so a rejection does not
+advance the chain: the next recorded entry names the previous *recorded* entry
+as its predecessor, not a rejection appended in between.
+
+A rejection is therefore evidence — *the Case Actor saw this assertion and
+refused it* — rather than a fact about the case. Where the rest of this page
+says "the chain" or "the history", it means the recorded projection.
 
 ---
 
@@ -59,13 +83,14 @@ ordering and integrity guarantees this page is about.
 | `case_id` | The case this entry belongs to |
 | `log_index` | Position in the case history; starts at 0 and counts up |
 | `published` | When the Case Actor stamped the entry, by its own clock |
-| `prevLogHash` | Hash of the entry immediately before this one |
+| `prevLogHash` | Hash of the previous `recorded` entry |
 | `entryHash` | Hash of this entry's own content |
 | `payloadSnapshot` | A copy of the assertion the entry records |
 
 `prevLogHash` and `entryHash` link the entries into a chain, like the teeth of
-a zipper. Each entry names its predecessor, so a receiver can tell whether an
-entry belongs at the end of the history it already holds. The first entry in a
+a zipper. Each entry names its predecessor in the recorded projection, so a
+receiver can tell whether an entry belongs at the end of the history it already
+holds. The first entry in a
 case names the **genesis hash**, a value derived from the case object itself,
 so the chain is anchored to the case it describes.
 
@@ -117,10 +142,16 @@ knows first-hand.
 | No two entries in a case share a `log_index` | [CLP-14-005](../reference/specs/protocol.md#clp-14) |
 | No entry predates the case it belongs to | [CLP-14-006](../reference/specs/protocol.md#clp-14) |
 
-A ledger is also expected to be complete: the conformance checks require a
-contiguous run of indexes from the genesis entry through the newest one, with
-no holes. A receiver that finds a hole knows an entry is missing, not that the
-Case Actor skipped a number.
+Whether the index run may contain holes is not settled. A replica must hold a
+contiguous run from the genesis entry through the position it has acknowledged
+before it may take new protocol-significant actions on the case
+([SYNC-10-004](../reference/specs/protocol.md#sync-10)), and in practice a
+receiver treats a hole as a missing entry. But `log_index` is consumed by every
+appended entry, rejections included, and rejections are not part of the recorded
+projection — so a hole in that projection is not by itself proof of loss.
+ADR-0079 states the rule both ways in different sections; the contradiction is
+tracked in [#2752](https://github.com/CERTCC/Vultron/issues/2752) and is not
+resolved here.
 
 The Case Actor should also refuse an assertion whose own timestamp is far in
 the future or far in the past compared to its clock — by default, more than
@@ -182,9 +213,10 @@ Two kinds of entry are not held:
 
 - An entry at or behind the end of the chain. That is a duplicate or a stale
   replay, not a gap.
-- An entry exactly one past the end of the chain whose `prevLogHash` still
-  does not match. Nothing is missing in front of it, so it is not a gap — it
-  is a fork, a claim about a history the replica does not share.
+- An entry exactly one past the end of the chain whose `prevLogHash` does not
+  match the hash of the replica's last recorded entry. Nothing is missing in
+  front of it, so it is not a gap — it is a fork, a claim about a history the
+  replica does not share.
 
 Both go to the ordinary duplicate and divergence handling instead.
 
@@ -203,12 +235,13 @@ triggers another full replay, and the two feed each other into a storm. A
 reject from a position that *has* advanced always triggers a replay, so a peer
 making progress is never held back.
 
-The holding area is bounded. When it is full, the replica discards the entry
-farthest ahead of the gap and logs a warning
-([SYNC-14-006](../reference/specs/protocol.md#sync-14)). A discarded entry is
-recoverable through the reject-and-replay path, though the cooldown above may
-delay it, so a hostile or broken peer streaming far-future entries cannot
-exhaust memory.
+The holding area should also be bounded, so that a hostile or broken peer
+streaming far-future entries cannot exhaust memory. When it is full, the replica
+discards the entry farthest ahead of the gap and logs a warning
+([SYNC-14-006](../reference/specs/protocol.md#sync-14)). Discarding is safe
+because the reject for that gap has already been sent — but the eviction itself
+sends nothing, so recovery waits on the replay that reject triggers, or on the
+next entry that fails to match the tail. The cooldown above may delay either.
 
 The holding area is deliberately **not** the ledger
 ([SYNC-14-005](../reference/specs/protocol.md#sync-14)). Across Vultron,
@@ -323,8 +356,11 @@ entries, every replica reaches the same state as the Case Actor, no matter what
 order those entries arrived in.
 
 The holding area itself is in memory only, and is lost on restart. That is
-deliberate. Nothing in it is committed, so nothing is lost that the catch-up
-check cannot recover by re-synchronizing from the Case Actor.
+deliberate: nothing in it is committed, so a restart cannot cost the replica
+anything it had already accepted. The dropped entries themselves come back the
+same way an evicted one does — the next entry that does not match the replica's
+tail produces a `Reject`, and the Case Actor replays from the position that
+reject names.
 
 ---
 
@@ -337,8 +373,8 @@ check cannot recover by re-synchronizing from the Case Actor.
 - [CS Process Model](process_models/cs/index.md) — the case-state rules the
   drain-time checks enforce
 - [Protocol specifications](../reference/specs/protocol.md) — the normative
-  requirements behind this page, including CLP-14, CLP-15, CSB-19, PCR-03, and
-  SYNC-12 through SYNC-15
+  requirements behind this page, including CLP-01, CLP-04, CLP-14, CLP-15,
+  CSB-19, PCR-03, SYNC-10, and SYNC-12 through SYNC-15
 - [Glossary](../reference/glossary.md) — definitions for case ledger, replica,
   genesis hash, and the replication phases
 - [ADR-0079](../adr/0079-case-ledger-causal-ordering.md) — Case Actor

--- a/docs/topics/case_model.md
+++ b/docs/topics/case_model.md
@@ -253,6 +253,8 @@ brokers all inter-participant messages. It participates as a
 
 ## See also
 
+- [Case Ledger Synchronization](case_ledger_sync.md) — how the canonical
+  ledger orders events and how replicas catch up to it
 - [Process Models](process_models/index.md) — RM, EM, and CS state machines
   that drive status transitions
 - [Demo Scenarios](scenarios/index.md) — how the objects evolve end-to-end

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -18,6 +18,7 @@ This section provides an overview of the Vultron Protocol, including:
 
 - :material-information-outline: [Background](background/index.md)
 - :material-file-tree-outline: [The Case Model](case_model.md)
+- :material-sync: [Case Ledger Synchronization](case_ledger_sync.md)
 - :material-message-text-outline: [Message Semantics](message_semantics.md)
 - :material-shape-outline: [Process Models](process_models/index.md)
 - :material-cube-unfolded: [Formal Protocol overview](../reference/formal_protocol/index.md) — in [Reference](../reference/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -353,10 +353,12 @@ validation:
   links:
     # Fail --strict on a link to a #fragment that does not exist on the target
     # page. Default is `info`, which is silent in the warning count: a page can
-    # ship dozens of dead in-page links and still look clean. Note that only
-    # heading anchors count as targets — the per-requirement `<a id="clp-14-001">`
-    # anchors in the generated spec tables do NOT. Cite the requirement ID in the
-    # link text and point the href at its group anchor (`#clp-14`).
+    # ship dozens of dead in-page links and still look clean. Note that this
+    # check only knows about heading anchors: the per-requirement
+    # `<a id="clp-14-001">` anchors in the generated spec tables are real and
+    # work in a browser, but linking to one still warns here. Cite the
+    # requirement ID in the link text and point the href at its group anchor
+    # (`#clp-14`).
     anchors: warn
 draft_docs: |
   draft-*.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -350,6 +350,14 @@ validation:
     # declared in not_in_nav above. Surfaces future un-navved pages (e.g. new
     # ADRs) and fails any --strict build (see mkdocs-build-strict.sh). #1304.
     omitted_files: warn
+  links:
+    # Fail --strict on a link to a #fragment that does not exist on the target
+    # page. Default is `info`, which is silent in the warning count: a page can
+    # ship dozens of dead in-page links and still look clean. Note that only
+    # heading anchors count as targets — the per-requirement `<a id="clp-14-001">`
+    # anchors in the generated spec tables do NOT. Cite the requirement ID in the
+    # link text and point the href at its group anchor (`#clp-14`).
+    anchors: warn
 draft_docs: |
   draft-*.md
   !reference/draft-vultron-spec.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Interoperability: 'topics/background/interoperability.md'
       - Defining CVD Success: 'topics/background/cvd_success.md'
     - The Case Model: 'topics/case_model.md'
+    - Case Ledger Synchronization: 'topics/case_ledger_sync.md'
     - Protocol Event Flow: 'topics/protocol_flow.md'
     - Message Semantics: 'topics/message_semantics.md'
     - Actor Knowledge Model: 'topics/actor-knowledge-model.md'

--- a/plan/incoming/learnings/20260901-2789-ac2-wrong-path-in-issue.md
+++ b/plan/incoming/learnings/20260901-2789-ac2-wrong-path-in-issue.md
@@ -1,7 +1,7 @@
 ---
 title: "ISSUE-2789 AC-2 named a path that would have duplicated an existing scenario"
 type: learning
-timestamp: 2026-09-01
+timestamp: "2026-09-01T00:00:00Z"
 source: ISSUE-2789
 signal: process-issue
 ---

--- a/plan/incoming/learnings/20260901-2789-catchup-merge-reverted-2882.md
+++ b/plan/incoming/learnings/20260901-2789-catchup-merge-reverted-2882.md
@@ -1,7 +1,7 @@
 ---
 title: "A catch-up merge silently reverted PR #2882's BT wiring, and no test noticed"
 type: learning
-timestamp: 2026-09-01
+timestamp: "2026-09-01T00:00:00Z"
 source: ISSUE-2789
 signal: process-issue
 ---

--- a/plan/incoming/learnings/20260901-2789-delegated-author-lost-at-extraction.md
+++ b/plan/incoming/learnings/20260901-2789-delegated-author-lost-at-extraction.md
@@ -1,7 +1,7 @@
 ---
 title: "CM-24-002's attributed_to was dropped at extraction, so no core code could use it"
 type: learning
-timestamp: 2026-09-01
+timestamp: "2026-09-01T00:00:00Z"
 source: ISSUE-2789
 signal: concern
 ---

--- a/plan/incoming/learnings/20260901-2789-reject-ownership-transfer-routing-unspecified.md
+++ b/plan/incoming/learnings/20260901-2789-reject-ownership-transfer-routing-unspecified.md
@@ -1,7 +1,7 @@
 ---
 title: "CM-21 specifies Offer and Accept routing for ownership transfer but not Reject"
 type: learning
-timestamp: 2026-09-01
+timestamp: "2026-09-01T00:00:00Z"
 source: ISSUE-2789
 signal: spec-gap
 ---

--- a/vultron/wire/as2/factories/sync.py
+++ b/vultron/wire/as2/factories/sync.py
@@ -20,7 +20,7 @@ replication activities. Internal activity subclasses are imported here
 and MUST NOT be imported by callers.
 
 Spec: ``specs/activity-factories.yaml`` AF-01-001 through AF-04-003.
-Spec: ``specs/case-event-log-synchronization.yaml`` SYNC-09-002,
+Spec: ``specs/sync-ledger-replication.yaml`` SYNC-09-002,
 SYNC-03-001, SYNC-03-002.
 """
 


### PR DESCRIPTION
- Closes #2980

## Summary

Adds `docs/topics/case_ledger_sync.md`, an Explanation page covering how a case
keeps one authoritative history and how participant replicas catch up to it.
Written in plain technical language using CVD domain vocabulary rather than
implementation identifiers.

## Changes

- **`docs/topics/case_ledger_sync.md`** (new):
  - Single-writer Case Actor authority, and the fact that no peer — including
    the case owner — writes a replica directly (CLP-01-003, PCR-03-001)
  - The two readings of the ledger: the full audit log versus the **recorded
    projection** that is the authoritative history. A rejection does not advance
    the hash chain and does not contribute to case state
    (CLP-04-001 through CLP-04-003)
  - Ledger entry structure and the `prevLogHash`/`entryHash` chain anchored at
    the genesis hash
  - `log_index` as the canonical causal order, what the ledger claims and what
    it does not, and the Case Actor's ordering and timestamp rules (ADR-0079,
    CLP-14-001 through CLP-14-008)
  - Participant emission obligations (CLP-15-001 through CLP-15-005)
  - The out-of-order holding area: what is held, the fork and stale-entry cases
    that are not, the reject backstop and its replay cooldown, and bounded
    eviction (ADR-0037, SYNC-14, SYNC-15-003)
  - Entries that arrive before the case, and drain on case seed (ADR-0059,
    SYNC-15-004, SYNC-15-005)
  - The cascading drain and the three invariants it preserves — same path,
    effects before storage, applied once (SYNC-12, SYNC-14)
  - Why case-state ordering checks run at drain time rather than at arrival
    (CSB-19-001, CSB-19-002, CSB-19-003)
- **`mkdocs.yml`**: nav entry under Explanation, after The Case Model; and
  `validation.links.anchors: warn` — see Guardrails below
- **`docs/topics/index.md`**: card link in the Explanation index
- **`docs/topics/case_model.md`**: two-way cross-reference from See also
- **`docs/howto/activitypub/activities/ledger_replication.md`**: link to the new
  explanation page (DF-01-004, how-to → explanation), and corrected both stale
  references to `specs/case-event-log-synchronization.yaml`, retired in #934
  (now `specs/sync-ledger-replication.yaml`)
- **`vultron/wire/as2/factories/sync.py`**: same retired spec filename in a
  module docstring — these two files were the full remaining set
- **`.agents/skills/create-pr/SKILL.md`**: scope the docs-PR flake8 run to
  `vultron/ test/`, matching `run-linters` and `build` Phase 6

## Guardrails added

Writing this page surfaced a silent failure mode: MkDocs' link validator only
knows about **heading** anchors, so the per-requirement `<a id="clp-14-001">`
anchors in the generated spec tables — which are real and work in a browser —
are not recognised as targets. MkDocs reports those links at `info`, which is
invisible in the strict-build warning count: the first draft of this page shipped
31 dead in-page links and looked clean.

`validation.links.anchors` is now `warn`, which makes them visible. Verified zero
fallout: the warning count is unchanged at 101, all of them pre-existing
`markdown_exec` failures (#2904). The convention — cite the requirement ID in the
link text, point the href at its group anchor (`#clp-14`) — is documented inline
in `mkdocs.yml` and is what the existing `docs/topics/behavior_logic/*.md` pages
already do.

One caveat, found in review: this does not yet **gate** anything. No workflow
runs `mkdocs build --strict` — `docs-build-check` and `deploy_site` both run a
plain build — so the warnings are printed and the job stays green. The same has
been true of the `validation.nav.omitted_files` guardrail from #1304. Filed as
#3051, blocked on #2904.

## Verification

- `mdlint.sh`: 0 issues
- `mkdocs build --strict`: 101 warnings, all pre-existing `markdown_exec`
  failures in the AS2 howto pages; nothing attributable to this branch, and no
  anchor warnings after enabling the check
- Unit and integration suites both pass (no Python behavior changed)
- `black`, `mypy`, `pyright`, `flake8 vultron/ test/` clean

## Review findings

Pre-PR code review raised five accuracy findings, all fixed in this branch: the
permitted-gaps claim, the unclassified fork case at `tail_index + 1`, the
omitted replay cooldown, the ephemeral-state paraphrase, and
rejected-disposition entries being part of the replicated history.

`/pr-ship` triage then raised ten more. Seven are fixed here — see
`848ec9b2c`; the largest was that the page never distinguished the recorded
projection from the full audit log, which made three separate statements wrong.
The remaining three are out of this PR's family and filed separately:

- **#3051** — no workflow runs `mkdocs --strict`, so the new anchor validation
  (and the older nav validation) never gates CI. Blocked on #2904.
- **#3052** — ADR-0037, ADR-0059 and `notes/sync-ledger-replication.md` all
  claim the SYNC-10 catch-up gate re-syncs the gap buffer after a restart. It
  cannot: `is_ledger_fresh_for_case()` is a purely local predicate that contacts
  nobody. The page's own copy of this claim is corrected here; amending two ADR
  Consequences sections is not.
- **#3053** — `_reconstruct_tail_hash` and `is_ledger_fresh_for_case` ignore
  `disposition`, contradicting `CaseLedger.tail_hash` and CLP-04-003. Latent
  today, but reachable via the documented emit-side correlation-marker pattern.

The permitted-gaps finding traces to a contradiction inside ADR-0079 itself,
already tracked as #2752 — evidence added there rather than duplicated here, and
the page now names the question as open rather than picking a side.