### PR TITLE
feat(skills): add write-docs and lint-docs with a documentation style guide

### DIFF
--- a/.agents/skills/check-docs-sync/SKILL.md
+++ b/.agents/skills/check-docs-sync/SKILL.md
@@ -3,7 +3,8 @@ name: check-docs-sync
 description: >
   Three-question docs-sync check: identifies docs/ pages that need updating
   after an implementation or bug-fix change, applies small updates inline
-  (PD-03-007), and files a type:Concern issue for large multi-page rewrites.
+  (PD-03-007) behind a blocking lint-docs gate, offers write-docs for large
+  multi-page rewrites, and files a type:Concern issue when those are deferred.
   Invoked after the PR is pushed (while CI runs), by build (Phase 8), bugfix
   (Phase 4 finalize), and learn (Phase 8).
 ---
@@ -19,6 +20,11 @@ After the PR is pushed (CI starts in the cloud), while CI runs in parallel
 locally. Apply any small docs updates and commit them before the finalize steps
 (archive-history, learnings). Invoked by `build` (Phase 8), `bugfix` (Phase 4
 finalize), and `learn` (Phase 8) for consistency.
+
+Prose rules for every page this skill touches live in
+[`../shared/docs-style-guide.md`](../shared/docs-style-guide.md), made normative
+by `specs/diataxis-requirements.yaml` DF-09-001. This skill does not restate
+them — it enforces them via the `lint-docs` gate in Step 3.
 
 ## Procedure
 
@@ -77,8 +83,12 @@ genuine multi-page rewrites that would bloat the PR beyond its original scope.
 For each small update:
 
 1. Write the change to the target `docs/` file.
-2. Invoke `format-markdown` to lint the updated file before building.
-3. Invoke `build-docs` to validate the build passes, tee-ing output to a temp
+2. Invoke `lint-docs` on the changed pages. This is a **blocking gate**: it
+   fixes mechanical style findings in place, and any finding it reports must be
+   resolved before proceeding. If it escalates a quadrant misclassification,
+   act on the recommendation it gives or hand the page to `write-docs`.
+3. Invoke `format-markdown` to lint the updated file before building.
+4. Invoke `build-docs` to validate the build passes, tee-ing output to a temp
    file so full context is available on failure:
 
    ```bash
@@ -86,12 +96,29 @@ For each small update:
    # On failure with insufficient tail output: grep /tmp/mkdocs-build.log
    ```
 
-4. Fix any linting or build errors before proceeding.
+5. Fix any linting or build errors before proceeding.
 
-### Step 4 — File Concern for large updates
+For a new page, or a full rewrite of an existing one, invoke `write-docs` with
+`mode: inline` instead of writing the page directly. It handles quadrant
+classification, concept ordering, nav wiring, and term registration, and leaves
+the result in this branch for the caller to commit.
 
-For each large update (multi-page rewrite needed), invoke the `new-item` skill
-to file a `type:Concern` issue. Provide these details as context:
+### Step 4 — Offer write-docs, then file a Concern
+
+For each large update (multi-page rewrite needed), **offer `write-docs` before
+deferring**. PD-03-007 prefers an inline update, so the Concern is the fallback,
+not the default. Recommend one course and ask for confirmation:
+
+> "`docs/topics/process_models/em/` needs three pages rewritten after this
+> embargo-consent change. I recommend invoking `write-docs` now with
+> `mode: inline` — the pages are adjacent and the change is mechanical, so it
+> adds roughly 200 lines to this PR rather than a week of context reconstruction.
+> Alternatively I file a Concern and defer. Proceed with `write-docs`?"
+
+If the user accepts, invoke `write-docs` with `mode: inline` and skip the rest
+of this step. If the user declines, or the scope genuinely exceeds this PR,
+invoke the `new-item` skill to file a `type:Concern` issue. Provide these
+details as context:
 
 - **Type**: Concern
 - **Title**: `docs: update <area> pages after <change>`
@@ -119,7 +146,11 @@ Return a summary of what was done:
 ## Constraints
 
 - Only update `docs/` — do not modify code, tests, or `specs/`.
-- Always invoke `build-docs` after each inline `docs/` update; do not skip.
+- Always invoke `lint-docs` and then `build-docs` after each inline `docs/`
+  update; do not skip either. `lint-docs` is a blocking gate (DF-09-001).
 - Small updates MUST be applied in the same PR, not deferred (PD-03-007).
-- File a Concern issue for every large update; never silently skip.
+- Offer `write-docs` before filing a Concern for a large update. Deferring
+  without offering the inline path first inverts PD-03-007's preference.
+- File a Concern issue for every large update that is not done inline; never
+  silently skip.
 - Cite PD-03-007 in every Concern issue body.

--- a/.agents/skills/lint-docs/SKILL.md
+++ b/.agents/skills/lint-docs/SKILL.md
@@ -65,7 +65,7 @@ Apply these directly, unless the auto-fix guard tripped:
 | British spelling in prose | SG-37 | Replace. Skip filenames and ADR titles. |
 | Banned glossary alias | SG-02 | Replace with the canonical term where unambiguous. |
 | Acronym unexpanded at first use on the page | SG-07 | Insert the expansion. |
-| Acronym missing from `_acronyms/index.md` | SG-08 | Add it, alphabetized, longer strings first. |
+| Acronym missing from `_acronyms/index.md` | SG-08 | Add it in strict alphabetical order, case-insensitive. |
 | Filler and hedging | SG-24 | Delete where the sentence survives it. |
 | Legacy `graph` mermaid syntax | SG-35 | Rewrite as `flowchart`. |
 | Isolated out-of-quadrant pronoun | SG-17–SG-19 | Rewrite that sentence for the quadrant's voice. |

--- a/.agents/skills/lint-docs/SKILL.md
+++ b/.agents/skills/lint-docs/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: lint-docs
+description: >
+  Audit pages under docs/ against the Vultron documentation style guide. Fixes
+  mechanical findings (spelling, acronym registration, filler, legacy mermaid
+  syntax, isolated voice slips) and reports judgment findings (concept order,
+  list discipline, quadrant misclassification) with a recommendation. Use after
+  writing docs, as check-docs-sync's gate, or to audit an existing tree.
+---
+
+# Skill: Lint Docs
+
+Semantic linter for hand-written `docs/` prose. Complements `format-markdown`
+(mechanical markdown) and `build-docs` (link and nav validity) — this skill
+checks what neither can see.
+
+Rules and IDs: [`../shared/docs-style-guide.md`](../shared/docs-style-guide.md).
+Normative anchor: `specs/diataxis-requirements.yaml` DF-09-001.
+
+## Interface
+
+| Invocation | Targets |
+|---|---|
+| no argument | Pages changed on this branch: `git diff origin/main...HEAD --name-only -- docs/` |
+| explicit paths | Named files or directories, e.g. `lint-docs docs/howto/` |
+| `--quadrant <name>` | The tree for one quadrant: `tutorial`, `howto`, `reference`, `explanation` |
+
+**Returns**: the list of fixes applied and the findings reported.
+
+### Auto-fix guard
+
+Count the resolved target set before touching anything. **Above 20 files,
+switch to report-only** and say so in the output. A large target set means an
+audit, not an edit, and a 400-file prose diff is never the right output.
+
+---
+
+## Phase 1 — Resolve targets
+
+Expand the invocation to a file list, then drop the exempt paths:
+
+- `docs/adr/**` — MADR template, own conventions
+- `docs/reference/code/**` — mkdocstrings-generated
+- `docs/reference/case_states/**` — generated state pages
+- `docs/includes/**`, `docs/_acronyms/**`, `docs/ns/**` — snippets and namespace files
+- anything matching `not_in_nav`'s generated patterns (`*diagram*.md`, `*table*.md`,
+  `_*.md`, `reference/user_stories/story_*.md`)
+
+Report the target count and whether the auto-fix guard tripped.
+
+## Phase 2 — Classify each page
+
+Determine each page's Diátaxis quadrant from its tree and its content. The
+quadrant selects the voice rules (SG-17 through SG-19) and the list exemption
+(SG-31), so classification precedes every other check.
+
+Where tree and content disagree, that is itself a Phase 4 finding.
+
+## Phase 3 — Mechanical pass (fix)
+
+Apply these directly, unless the auto-fix guard tripped:
+
+| Check | Rule | Action |
+|---|---|---|
+| British spelling in prose | SG-37 | Replace. Skip filenames and ADR titles. |
+| Banned glossary alias | SG-02 | Replace with the canonical term where unambiguous. |
+| Acronym unexpanded at first use on the page | SG-07 | Insert the expansion. |
+| Acronym missing from `_acronyms/index.md` | SG-08 | Add it, alphabetized, longer strings first. |
+| Filler and hedging | SG-24 | Delete where the sentence survives it. |
+| Legacy `graph` mermaid syntax | SG-35 | Rewrite as `flowchart`. |
+| Isolated out-of-quadrant pronoun | SG-17–SG-19 | Rewrite that sentence for the quadrant's voice. |
+
+"Isolated" means a small number of occurrences confined to one or two
+sections. Pervasive drift is Phase 4, not Phase 3 — see SG-20.
+
+## Phase 4 — Judgment pass (report)
+
+Report these with the file, the line, the rule ID, and a recommended fix. Do
+not apply them.
+
+- **Concept order** (SG-10) — a section using a concept the page has not
+  introduced. Name the forward reference and the section order that fixes it.
+- **Unlinked first use** (SG-11) — a glossary or taxonomy term used without a
+  link to its canonical introduction.
+- **Unregistered term** (SG-04, SG-05) — domain vocabulary absent from both the
+  glossary and the taxonomy.
+- **Synonym drift** (SG-06) — two names for one concept on one page.
+- **Sentence and paragraph shape** (SG-13–SG-16) — sentences well past 28 words
+  carrying two claims; paragraphs past five sentences.
+- **List discipline** (SG-28–SG-30) — bullets carrying argument rather than
+  parallel members; unordered sets numbered; term/definition pairs as bullets
+  where a table belongs. Skip how-to and tutorial bodies (SG-31).
+- **Diagram warrant and standalone prose** (SG-32, SG-33) — a diagram with no
+  adjacent sentence saying what it shows, or a decorative diagram.
+- **Uncited normative claim** (SG-25) — "must" in explanation prose with no
+  spec ID or ADR number.
+- **Register** (SG-21–SG-23, SG-26, SG-27) — non-declarative opening, inflated
+  `warning` admonitions, emphasis sprawl.
+- **Grandfathered ASCII diagrams** (SG-36) — low priority; never auto-convert.
+
+### Quadrant misclassification
+
+Pervasive out-of-quadrant voice means the page may be the wrong Diátaxis type
+(SG-20, DF-01-002). A how-to full of "we'll now explore" is a tutorial or an
+explanation in the wrong tree; a tutorial full of "you should understand that"
+is drifting into explanation.
+
+Escalate with a recommendation: state which type the page actually is, whether
+it should be relocated, split, or rewritten in place, and which you would
+choose and why. Then ask for confirmation. Never swap the pronouns to hide it,
+and never ask an open "what should I do with this page?".
+
+## Phase 5 — Revalidate
+
+If Phase 3 changed any file:
+
+1. `format-markdown`
+2. `build-docs` — `mkdocs build --strict`
+
+Skip both when nothing was fixed.
+
+## Phase 6 — Report
+
+Output, in this order:
+
+1. Target count, and whether the auto-fix guard tripped.
+2. Fixes applied, grouped by rule ID, with file and line.
+3. Findings reported, most consequential first, each with a recommended fix.
+4. Any escalation awaiting a decision.
+5. An explicit "no findings" statement when a page is clean.
+
+---
+
+## Constraints
+
+- Never edit outside the resolved target set, except `docs/_acronyms/index.md`
+  for SG-08 registration.
+- Never apply a Phase 4 finding without confirmation. Those are judgment calls
+  by construction.
+- Above 20 target files, report only.
+- Do not duplicate `format-markdown` or `build-docs` checks. Line length, list
+  markers, emphasis style, and link validity belong to those tools; MD013 is
+  disabled repo-wide and no line-length rule applies here (SG-38).
+- Escalate with a recommendation, not an open question.

--- a/.agents/skills/shared/docs-style-guide.md
+++ b/.agents/skills/shared/docs-style-guide.md
@@ -66,9 +66,14 @@ and from deep links, not by reading in nav order. Implements DF-09-003.
 **SG-08 — Register in the acronyms snippet.** Every acronym used in `docs/`
 must appear in `docs/_acronyms/index.md`, which `pymdownx.snippets` appends to
 every page to produce hover tooltips. If an acronym is missing, add it as part
-of the change. Keep the file alphabetized, and where one acronym is a prefix of
-another, list the longer string first — matching stops at the first hit.
-Auto-fixable.
+of the change. Keep the file in strict alphabetical order, case-insensitive.
+Ordering is a maintainability concern only — the `abbr` extension sorts its own
+list by length descending before matching, so position in the file does not
+affect which abbreviation wins. Auto-fixable.
+
+**SG-08a — One definition per acronym.** `abbr` allows a single expansion per
+token site-wide. Where a token is ambiguous, define it in the sense the docs
+actually use, and check what a redefinition displaces before making it.
 
 **SG-09 — Do not expand in headings.** Use the short form in headings and the
 expansion in the first body paragraph that follows.
@@ -284,7 +289,7 @@ a recommendation.
 | SG-02 | Banned aliases | yes |
 | SG-04, SG-05, SG-06 | Jargon, term registration, one name per concept | |
 | SG-07, SG-09 | Acronym expansion on first use | yes |
-| SG-08 | Acronym registered in `_acronyms/index.md` | yes |
+| SG-08, SG-08a | Acronym registered in `_acronyms/index.md`; one definition per token | yes |
 | SG-10, SG-12 | Concept order, stated prerequisites | |
 | SG-11 | First use links to canonical introduction | |
 | SG-13, SG-14, SG-15, SG-16 | Sentence and paragraph shape | |

--- a/.agents/skills/shared/docs-style-guide.md
+++ b/.agents/skills/shared/docs-style-guide.md
@@ -118,7 +118,7 @@ entry", not "the entry is committed". Passive voice is acceptable when the
 actor is genuinely unknown or irrelevant.
 
 **SG-16 — Paragraphs run two to five sentences.** A paragraph that passes five
-sentences is usually two paragraphs, or a list that failed SG-25.
+sentences is usually two paragraphs, or a list that failed SG-28.
 
 ---
 

--- a/.agents/skills/shared/docs-style-guide.md
+++ b/.agents/skills/shared/docs-style-guide.md
@@ -1,0 +1,311 @@
+# Vultron Documentation Style Guide
+
+Prose rules for hand-written pages under `docs/`. Consumed by `write-docs`
+(when authoring) and `lint-docs` (when auditing), and referenced by
+`check-docs-sync`.
+
+Normative anchor: `specs/diataxis-requirements.yaml` **DF-09-001** requires
+`docs/` prose to follow this file. Rule IDs below (`SG-nn`) are style-guide
+rule identifiers, not spec IDs; each cites the spec entry it implements where
+one exists.
+
+## Scope
+
+| In scope | Out of scope |
+|---|---|
+| `docs/topics/`, `docs/howto/`, `docs/tutorials/`, hand-written `docs/reference/` | `docs/adr/` — MADR template, own skill |
+| `docs/developer/`, `docs/agents/` — same rules, maintainer audience | `docs/reference/code/` — mkdocstrings-generated |
+| | `docs/reference/case_states/` — generated state pages |
+| | `notes/`, `specs/` — own conventions (PD-01, MS) |
+
+Generated pages are exempt. Fix the generator, not the output.
+
+---
+
+## 1. Terminology
+
+**SG-01 — `glossary.md` is the arbiter.** `docs/reference/glossary.md` is the
+canonical source for domain terms. Where a glossary term exists, use it.
+Implements DF-09-002.
+
+**SG-02 — Banned aliases.** The glossary's *Aliases to avoid* column is a
+banned-synonym list. Do not write "responsible disclosure" for **CVD**,
+"researcher" for **Reporter**, "supplier" for **Vendor**, or "stakeholder" for
+**Participant**. Auto-fixable when the replacement is unambiguous.
+
+**SG-03 — Concept names come from the taxonomy.**
+`docs/reference/vultron-taxonomy.md` governs the concept names:
+`vultron-core`, `vultron-wire`, `vultron-transport`, capability sets, capability
+shapes, Vultron roles, Vultron-enabled applications. Write `vultron-core` for
+the abstract protocol; write `vultron/core/` only when referring to the Python
+package.
+
+**SG-04 — Jargon that is not a domain term.** Field jargon absent from both the
+glossary and the taxonomy must be expanded on first use, replaced with plain
+language, or registered as a new glossary term. "Avoid jargon" and "use domain
+language" are the same rule: the glossary decides which is which.
+
+**SG-05 — Register new terms.** A page that introduces a durable domain term
+adds it to `glossary.md` in the same change. Do not coin a term that nothing
+checks. For a term that needs discussion rather than a definition, invoke
+`ubiquitous-language`.
+
+**SG-06 — One name per concept.** Within a page, and across pages covering the
+same concept, use one name throughout. Synonym variation for stylistic relief
+is a defect, not a flourish.
+
+---
+
+## 2. Acronyms
+
+**SG-07 — Expand on first use, per page.** Write the expansion followed by the
+acronym in parentheses at first use on each page: "Coordinated Vulnerability
+Disclosure (CVD)". First use resets per page, because readers arrive from search
+and from deep links, not by reading in nav order. Implements DF-09-003.
+
+**SG-08 — Register in the acronyms snippet.** Every acronym used in `docs/`
+must appear in `docs/_acronyms/index.md`, which `pymdownx.snippets` appends to
+every page to produce hover tooltips. If an acronym is missing, add it as part
+of the change. Keep the file alphabetized, and where one acronym is a prefix of
+another, list the longer string first — matching stops at the first hit.
+Auto-fixable.
+
+**SG-09 — Do not expand in headings.** Use the short form in headings and the
+expansion in the first body paragraph that follows.
+
+---
+
+## 3. Concept order
+
+Writing is a directed acyclic graph of topics: introduce an idea before the
+ideas that depend on it.
+
+**SG-10 — Within a page, no forward references.** No section may use a concept
+the page has not yet introduced, defined, or linked out for. Ordering sections
+so that each depends only on what precedes it is the page's primary structural
+obligation.
+
+**SG-11 — Across pages, the edge is a hyperlink.** First use of a glossary or
+taxonomy term on a page links to its canonical introduction — the glossary
+entry, the taxonomy section, or the explanation page that develops it. The
+glossary and the taxonomy are the concept registry; there is no separate
+dependency file to maintain.
+
+**SG-12 — Prerequisites are stated, not assumed.** A page that requires prior
+reading says so in its opening paragraph and links to it. Tutorials and how-to
+guides use an explicit `## Prerequisites` section (DF-04-008).
+
+---
+
+## 4. Sentence and paragraph shape
+
+Simplified technical English in spirit, not ASD-STE100 compliance. The domain
+vocabulary stays; the sentence complexity goes.
+
+**SG-13 — One idea per sentence.** A sentence carrying two independent claims
+becomes two sentences.
+
+**SG-14 — Sentence length.** Target the corpus band: median 12–15 words, and
+few sentences over 28. A sentence past 28 words is usually doing two jobs.
+
+**SG-15 — Active voice with a named subject.** "The CaseActor commits the
+entry", not "the entry is committed". Passive voice is acceptable when the
+actor is genuinely unknown or irrelevant.
+
+**SG-16 — Paragraphs run two to five sentences.** A paragraph that passes five
+sentences is usually two paragraphs, or a list that failed SG-25.
+
+---
+
+## 5. Voice by agency
+
+Voice follows the relationship between writer and reader, not a pronoun table.
+Ask who has agency.
+
+| Quadrant | Relationship | Pronouns | Spec |
+|---|---|---|---|
+| Tutorial | Tutor accompanying a learner | **we** for the shared journey; **you** for the learner's actions and state | DF-03-004, DF-03-011 |
+| How-to | Practitioner owns the task | **you** and the imperative; author stays out of the way | DF-04-004 |
+| Reference | Description of machinery | Neither. The system is the grammatical subject | DF-05-001, DF-05-007 |
+| Explanation | Author discussing a subject | **we** for the author reasoning; **you** for inviting the reader to consider | DF-06-007 |
+
+**SG-17 — Tutorial split.** "In this tutorial, we will run the demo" for the
+journey; "You should now have three containers running" for what the learner
+has and does. Do not write "We need Docker installed" — the learner needs
+Docker, so it is "You need Docker installed".
+
+**SG-18 — How-to imperative.** "Set `AUTH_MODE` to `oidc`. Run the service."
+Not "We will configure authentication" and not "Let's set `AUTH_MODE`". The
+latter changes the relationship from *here is the procedure you need* to *come
+along while I teach you*.
+
+**SG-19 — Reference describes, never instructs.** "A value of `0` disables the
+timeout", not "Set `timeout` to `0` to disable it". Crossing from describing the
+machinery into instructing the reader is the characteristic reference defect.
+
+**SG-20 — Pronoun drift is a classification signal.** Out-of-quadrant pronouns
+in isolation are a wording defect. Pervasive out-of-quadrant pronouns mean the
+page is probably the wrong Diátaxis type: a how-to full of "we'll now explore"
+is a tutorial or an explanation in the wrong tree, and a tutorial full of "you
+should understand that" is drifting into explanation. Report these as
+misclassification against DF-01-002; do not paper over them by swapping
+pronouns.
+
+---
+
+## 6. Register
+
+Practitioner to practitioner. Explains itself without teaching down; never
+performs expertise. These rules are abstracted from the corpus, with
+`docs/topics/actor-knowledge-model.md`, `docs/topics/background/what-is-vultron.md`,
+and `docs/developer/how-to/run-tests.md` as the closest exemplars.
+
+**SG-21 — Open declaratively.** The first line after the H1 states what the
+thing is or does: "The protocol does not…", "Any Participant can…", "This page
+explains…". No hooks, no rhetorical questions, no history first.
+
+**SG-22 — Assertion, then consequence.** State the rule flat, then say what
+follows from it. Short flat sentences in series carry the emphasis:
+
+> There is no shared memory. There is no back channel. There is no way for one
+> actor to look something up in another actor's store.
+
+**SG-23 — Define by exclusion where it sharpens.** Saying what a thing is not
+is a corpus habit worth keeping: "It is not a performance preference. It is not
+an optimization. It is the architectural invariant on which the protocol is
+built." Reference pages for concepts carry an explicit *What is out of scope*.
+
+**SG-24 — No filler, hedging, or enthusiasm.** Banned: `simply`, `just`,
+`obviously`, `of course`, `note that`, `it should be noted`, `basically`,
+`clearly`, exclamation points, and rhetorical questions outside a
+`!!! question` admonition. Confidence comes from flat declaratives, not
+adverbs. Auto-fixable by deletion where the sentence survives it.
+
+**SG-25 — Cite instead of asserting.** A normative claim carries its identifier
+inline: `(AKM-02-001, AKM-02-002)`, `(ADR-0048, CM-18-003)`. Unattributed
+"must" in explanation prose is a finding — either it is normative and has an ID,
+or it is advice and should not say "must".
+
+**SG-26 — Emphasis discipline.** Bold marks the term being defined, sparingly.
+A blockquote carries the one load-bearing invariant of the page, not general
+quotation. Italics for the first mention of a work or for genuine contrast.
+
+**SG-27 — Admonitions in proportion.** The corpus runs `note` ≫ `tip` > `info` >
+`example` > `question` > `warning`. Reserve `warning` for real hazards — data
+loss, embargo breach, protocol violation. Do not inflate it for emphasis.
+
+---
+
+## 7. Lists and tables
+
+**SG-28 — A bulleted list requires parallel membership.** Items must be
+parallel members of one set: roles, fields, options, states. Reasoning,
+cause and effect, and comparison go in prose. Bullets that each carry a
+sentence of argument are a paragraph that lost its connectives.
+
+**SG-29 — Ordered lists mean ordered.** Numbered lists are for steps executed
+in sequence, or for enumerated items referenced by number elsewhere on the
+page. Do not number an unordered set.
+
+**SG-30 — Tables beat bullets for pairs.** Term and definition, property and
+value, state and meaning: use a table. The corpus does this consistently and
+the result is scannable.
+
+**SG-31 — Quadrant exemption.** How-to and tutorial bodies are exempt from the
+sparing rule. Their steps are inherently sequences and their prerequisites are
+inherently sets.
+
+---
+
+## 8. Diagrams
+
+**SG-32 — A diagram earns its place.** Add one when it shows a relationship
+that prose would need three or more cross-references to convey: a state
+machine, an inter-actor sequence, containment or composition, a lifecycle. No
+page is owed a diagram, and no cap applies — a process-model page legitimately
+carries eight.
+
+**SG-33 — Prose must stand alone.** Every diagram has an adjacent sentence
+stating what it shows, before or immediately after it. The page must remain
+comprehensible when the render fails, in print output, and to a screen reader.
+
+**SG-34 — Mermaid, with a title.** Diagrams use fenced `mermaid` blocks with a
+`---` / `title:` header, which supplies the rendered caption.
+
+**SG-35 — Sanctioned diagram types.** `stateDiagram-v2`, `sequenceDiagram`,
+`flowchart`, `classDiagram`, `erDiagram`. Legacy `graph` is `flowchart` and is
+auto-fixable. Anything outside this list needs a reason.
+
+**SG-36 — Prefer Mermaid to ASCII art.** New structural diagrams use Mermaid.
+Existing ASCII diagrams in `text` fences are grandfathered and reported as
+low-priority findings; do not auto-convert them.
+
+---
+
+## 9. Mechanics
+
+**SG-37 — American spelling.** `organize`, `behavior`, `normalize`,
+`serialize`. Auto-fixable in prose. Existing filenames and ADR titles are
+grandfathered — do not rename `adr/0062-normalise-wire-to-core-*`.
+
+**SG-38 — One sentence per line.** On pages that `write-docs` creates or
+rewrites, each sentence starts on its own line with no mid-sentence hard wrap.
+Prose diffs then show which sentence changed. Pages not touched by a change are
+left as they are; the corpus is mixed by design, and no line-length rule
+applies.
+
+**SG-39 — Headings.** One H1 matching the nav label in substance. H2 and below
+in sentence case. Sections separated by `---` where the page has more than
+three of them, following the corpus.
+
+**SG-40 — No frontmatter requirement.** YAML frontmatter is optional on `docs/`
+pages. Where present, keep `title` and `description` accurate. Do not add
+frontmatter to a page that lacks it just to carry metadata nothing reads.
+
+**SG-41 — Page furniture.** H1, then a two-to-four sentence orientation
+paragraph saying what the page covers and who it is for, then the body. Where a
+page closes with a recap, use a `## Summary` table of principle and statement,
+a `## Further reading` link list with em-dash annotations, or both.
+
+**SG-42 — No page length rule.** Pages are split by quadrant and topic, never
+by length. A long reference page is correct; a three-paragraph explanation page
+is correct.
+
+---
+
+## 10. Rule index
+
+`Fix` marks rules `lint-docs` applies automatically. The rest are reported with
+a recommendation.
+
+| Rule | Subject | Fix |
+|---|---|:---:|
+| SG-01, SG-03 | Glossary and taxonomy are canonical | |
+| SG-02 | Banned aliases | yes |
+| SG-04, SG-05, SG-06 | Jargon, term registration, one name per concept | |
+| SG-07, SG-09 | Acronym expansion on first use | yes |
+| SG-08 | Acronym registered in `_acronyms/index.md` | yes |
+| SG-10, SG-12 | Concept order, stated prerequisites | |
+| SG-11 | First use links to canonical introduction | |
+| SG-13, SG-14, SG-15, SG-16 | Sentence and paragraph shape | |
+| SG-17, SG-18, SG-19 | Voice by quadrant — isolated cases | yes |
+| SG-20 | Pervasive drift as misclassification | |
+| SG-21, SG-22, SG-23 | Opening, assertion order, exclusion | |
+| SG-24 | Filler and hedging | yes |
+| SG-25, SG-26, SG-27 | Citation, emphasis, admonitions | |
+| SG-28, SG-29, SG-30, SG-31 | Lists and tables | |
+| SG-32, SG-33 | Diagram warrant and prose-standalone | |
+| SG-34, SG-35 | Mermaid title, `graph` → `flowchart` | yes |
+| SG-36 | ASCII art grandfathered | |
+| SG-37 | American spelling | yes |
+| SG-38, SG-39, SG-40, SG-41, SG-42 | Line breaks, headings, furniture | |
+
+---
+
+## Escalation
+
+Both skills fix mechanical findings silently and escalate judgment calls with a
+recommendation, never as an open question. State the finding, state what you
+would do about it and why, and ask for confirmation. This applies to quadrant
+misclassification (SG-20), cross-quadrant page splits (DF-01-003), and nav
+placement alike.

--- a/.agents/skills/write-docs/SKILL.md
+++ b/.agents/skills/write-docs/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: write-docs
+description: >
+  Author or rewrite a page under docs/ — classify its Diátaxis quadrant, plan
+  concept order, draft it against the Vultron documentation style guide,
+  register new terms and acronyms, wire mkdocs.yml nav, and validate. Use when
+  asked to write, add, or rewrite documentation, or when check-docs-sync
+  identifies a docs change too large for an inline edit.
+---
+
+# Skill: Write Docs
+
+Authors hand-written pages under `docs/` — the published Diátaxis quadrants
+plus the maintainer-facing `docs/developer/` and `docs/agents/` trees.
+
+Rules live in [`../shared/docs-style-guide.md`](../shared/docs-style-guide.md)
+(`SG-nn` rule IDs). Normative anchors: `specs/diataxis-requirements.yaml`
+DF-01 through DF-09.
+
+Out of scope: `docs/adr/` (use `create-architectural-decision-record`),
+generated trees (`docs/reference/code/`, `docs/reference/case_states/`),
+`notes/`, and `specs/`.
+
+## Interface
+
+| Parameter | Description |
+|---|---|
+| `topic` | What the page must cover. Required. |
+| `quadrant` | `tutorial`, `howto`, `reference`, or `explanation`. Inferred if omitted. |
+| `target` | Existing page to rewrite. Omit to create a new page. |
+| `mode` | `pr` (default when invoked conversationally) or `inline` (leave changes in the caller's branch) |
+
+**Returns**: the list of pages written, plus the PR URL in `pr` mode.
+
+---
+
+## Phase 1 — Load context
+
+Read, in order:
+
+1. `.claude/skills/shared/docs-style-guide.md` — the rules.
+2. `docs/reference/glossary.md` — canonical terms and banned aliases (SG-01, SG-02).
+3. `docs/reference/vultron-taxonomy.md` — concept names (SG-03). Skim the Quick
+   Reference table unless the page is about a taxonomy concept.
+4. `docs/_acronyms/index.md` — which acronyms are already registered (SG-08).
+
+Load the DF requirements via `load-specs` if not already in context.
+
+Do not read exemplar pages wholesale. The style guide's section 6 carries the
+register; read a specific page only when this page must align closely with it.
+
+## Phase 2 — Classify the quadrant
+
+Apply the Diátaxis compass (`notes/diataxis-framework.md` §6):
+
+- Action + acquisition → **tutorial**
+- Action + application → **how-to**
+- Cognition + application → **reference**
+- Cognition + acquisition → **explanation**
+
+The classification decides voice (SG-17 through SG-19), list discipline
+(SG-31), and which tree the page lands in. Get it right before drafting.
+
+### Cross-quadrant requests
+
+DF-01-003 forbids mixing content types on one page. A request like "document
+the embargo lifecycle" often spans quadrants: an explanation of why embargoes
+work the way they do, a how-to for negotiating one, and a reference table of EM
+states.
+
+When the topic spans quadrants, **recommend a split and ask for confirmation**:
+name each page, its quadrant, its path, and the cross-links between them. Do
+not silently write one blended page, and do not ask an open "how should I
+structure this?".
+
+## Phase 3 — Plan concept order
+
+Before writing prose, list the concepts the page must introduce and order them
+so each depends only on what precedes it (SG-10). Concepts the page will not
+introduce get a link to their canonical introduction instead (SG-11).
+
+Write the section outline from that order. If the outline requires a forward
+reference, the outline is wrong — reorder, or link out.
+
+## Phase 4 — Draft
+
+Write against the style guide. The rules that most often get missed:
+
+- Voice by agency for the quadrant (SG-17, SG-18, SG-19) — a reference page
+  makes the system the grammatical subject and never instructs.
+- Expand each acronym at first use on this page (SG-07).
+- Link each glossary or taxonomy term at first use (SG-11).
+- One sentence per line (SG-38).
+- Bullets only for parallel members of a set; tables for pairs (SG-28, SG-30).
+- A diagram only where it earns its place, with a prose sentence stating what
+  it shows (SG-32, SG-33).
+- Cite spec IDs and ADR numbers for normative claims (SG-25).
+- American spelling (SG-37), sentence-case H2s (SG-39).
+
+Page furniture per SG-41: H1, a two-to-four sentence orientation paragraph,
+`---`-separated sections, and a `## Summary` table and/or `## Further reading`
+list where a recap helps.
+
+## Phase 5 — Register terms and acronyms
+
+1. Any acronym used and not present in `docs/_acronyms/index.md` gets added
+   there, alphabetized, longer strings before their prefixes (SG-08).
+2. Any durable domain term the page introduces gets a `glossary.md` entry with
+   a definition and its aliases to avoid (SG-05). For a term that needs
+   discussion rather than a definition, invoke `ubiquitous-language`.
+
+Never coin a term without registering it.
+
+## Phase 6 — Wire the nav
+
+`mkdocs.yml` sets `validation.nav.omitted_files: warn`, and `build-docs` runs
+`--strict`, so a page absent from the nav fails the build. Every new page must
+be navved or explicitly listed under `not_in_nav`.
+
+Nav order carries reading order, so **propose the slot and confirm it**: name
+the section, the position within it, and the label, with one sentence of
+reasoning. Maintainer-facing pages (`docs/developer/`, `docs/agents/`) are
+covered by existing `not_in_nav` patterns and need no nav entry.
+
+## Phase 7 — Validate
+
+In this order:
+
+1. `lint-docs` on the pages written — fixes mechanical findings, reports the rest.
+   Resolve every reported finding before proceeding.
+2. `format-markdown` — markdownlint-cli2 via `./mdlint.sh`.
+3. `build-docs` — `mkdocs build --strict`, which must pass with no warnings
+   (PD-04-001).
+
+## Phase 8 — Deliver
+
+- `mode: pr` — commit via `commit`, then invoke `create-pr` with
+  `type: docs` and the `specs-notes` label where specs changed.
+- `mode: inline` — leave the changes staged in the caller's branch and return
+  the list of pages written. The caller owns the commit and the PR.
+
+---
+
+## Constraints
+
+- Only write under `docs/`, plus `docs/_acronyms/index.md`, `glossary.md`, and
+  `mkdocs.yml`. Do not modify code, tests, or `specs/`.
+- One page, one quadrant (DF-01-002, DF-01-003). Split rather than blend.
+- Never leave a new page out of the nav without a `not_in_nav` match.
+- Escalate judgment calls with a recommendation, not an open question. This
+  applies to quadrant splits (Phase 2) and nav placement (Phase 6).
+- Do not rewrite a page outside the requested scope. A page that needs work you
+  were not asked for is a finding to report, not a change to make.

--- a/.agents/skills/write-docs/SKILL.md
+++ b/.agents/skills/write-docs/SKILL.md
@@ -104,7 +104,9 @@ list where a recap helps.
 ## Phase 5 — Register terms and acronyms
 
 1. Any acronym used and not present in `docs/_acronyms/index.md` gets added
-   there, alphabetized, longer strings before their prefixes (SG-08).
+   there, in strict alphabetical order, case-insensitive (SG-08). Do not order
+   by length — the `abbr` extension sorts its own list, so file position does
+   not affect which abbreviation matches.
 2. Any durable domain term the page introduces gets a `glossary.md` entry with
    a definition and its aliases to avoid (SG-05). For a term that needs
    discussion rather than a definition, invoke `ubiquitous-language`.

--- a/docs/_acronyms/index.md
+++ b/docs/_acronyms/index.md
@@ -5,11 +5,15 @@ add the longer string first. (E.g., CERT/CC before CERT.) The matching
 stops after the first match is found.
 -->
 *[ACM]: Association for Computing Machinery
+*[ADRs]: Architectural Decision Records
+*[ADR]: Architectural Decision Record
 *[AFB]: Air Force Base
 *[AFLCMC]: Air Force Life Cycle Management Center
 *[AI]: Artificial Intelligence
+*[AKM]: Actor Knowledge Model
 *[AMA]: Ask Me Anything
 *[API]: Application Programming Interface
+*[AS2]: ActivityStreams 2.0
 *[ASCII]: American Standard Code for Information Interchange
 *[ATMs]: Automated Teller Machines
 *[ATM]: Automated Teller Machine
@@ -19,19 +23,26 @@ stops after the first match is found.
 *[BGP]: Border Gateway Protocol
 *[BIND]: Berkeley Internet Name Domain
 *[BOD]: Binding Operational Directive
+*[BTs]: Behavior Trees
+*[BT]: Behavior Tree
 
 *[CAPEC]: Common Attack Pattern Enumeration and Classification
-*[CA]: Certificate Authority
+*[CA]: Attacks Observed (CS message)
 *[CERT/CC]: CERT Coordination Center, a part of the Software Engineering Institute at Carnegie Mellon University
 *[CERT]: The CERT Division of the Software Engineering Institute
+*[CE]: CS Error (CS message)
+*[CF]: Fix Readiness (CS message)
 *[CISA]: Cybersecurity and Infrastructure Security Agency, a part of the U.S. Department of Homeland Security
 *[CI]: Continuous Integration
-*[CD]: Continuous Deployment
+*[CD]: Fix Deployed (CS message)
+*[CK]: CS Acknowledgement (CS message)
+*[CLI]: Command Line Interface
 *[CMU]: Carnegie Mellon University
 *[CNAs]: CVE Numbering Authorities
 *[CNA]: CVE Numbering Authority
 *[COPPA]: Children's Online Privacy Protection Act
 *[CPE]: Common Platform Enumeration
+*[CP]: Public Awareness (CS message)
 *[CSAF]: Common Security Advisory Framework
 *[CSIRTs]: Computer Security Incident Response Teams
 *[CSIRT]: Computer Security Incident Response Team
@@ -41,8 +52,10 @@ stops after the first match is found.
 *[CVE]: Common Vulnerabilities and Exposures
 *[CVRF]: Common Vulnerability Reporting Format, superseded by the Common Security Advisory Framework (CSAF)
 *[CVSS]: Common Vulnerability Scoring System
+*[CV]: Vendor Awareness (CS message)
 *[CWE]: Common Weakness Enumeration
 *[CWSS]: Common Weakness Scoring System
+*[CX]: Exploit Public (CS message)
 
 *[DFAs]: Deterministic Finite Automata
 *[DFA]: Deterministic Finite Automaton
@@ -54,13 +67,22 @@ stops after the first match is found.
 *[DDoS]: Distributed Denial of Service
 *[DoS]: Denial of Service
 
+*[EA]: Embargo Proposal Acceptance (EM message)
+*[EC]: Embargo Revision Acceptance (EM message)
+*[EE]: Embargo Error (EM message)
 *[EFF]: Electronic Frontier Foundation
+*[EJ]: Embargo Revision Rejection (EM message)
+*[EK]: Embargo Acknowledgement (EM message)
 *[EM]: Embargo Management
 *[ENISA]: European Union Agency for Cybersecurity
 *[EoL]: End of Life
 *[EOL]: End of Life
 *[EO]: Executive Order
+*[EP]: Embargo Proposal (EM message)
+*[ER]: Embargo Proposal Rejection (EM message)
+*[ET]: Embargo Termination (EM message)
 *[EU]: European Union
+*[EV]: Embargo Revision Proposal (EM message)
 
 *[FAQ]: Frequently Asked Questions
 *[FCC]: U.S. Federal Communications Commission
@@ -72,6 +94,9 @@ stops after the first match is found.
 *[FTC]: U.S. Federal Trade Commission
 *[FTP]: File Transfer Protocol
 
+*[GE]: General Error (general message)
+*[GI]: General Inquiry (general message)
+*[GK]: General Acknowledgement (general message)
 *[GnuPG]: GNU Privacy Guard, an implementation of the OpenPGP standard
 *[GPG]: GNU Privacy Guard, an implementation of the OpenPGP standard
 
@@ -99,6 +124,7 @@ stops after the first match is found.
 *[JTAG]: Joint Test Action Group
 *[JVN]: Japan Vulnerability Notes
 
+*[MADR]: Markdown Any Decision Records
 *[ML]: Machine Learning
 *[MON]: The Monitoring Process Area of the CERT Resilience Management Model
 *[MPLS]: Multiprotocol Label Switching
@@ -121,18 +147,27 @@ stops after the first match is found.
 *[OUSPG]: Oulu University Secure Programming Group
 
 *[PCI DSS]: Payment Card Industry Data Security Standard
+*[PEC]: Participant Embargo Consent
 *[PGP]: Pretty Good Privacy
 *[PoC]: Proof of Concept Exploit
 *[PSIRTs]: Product Security Incident Response Teams
 *[PSIRT]: Product Security Incident Response Team
+*[PXA]: Public aware, eXploit public, Attacks observed — the public-path case state dimensions
 
+*[RA]: Report Accepted (RM message)
+*[RC]: Report Closed (RM message)
+*[RD]: Report Deferred (RM message)
 *[REST]: Representational State Transfer
-*[RE]: Reverse Engineering
+*[RE]: Report Error (RM message)
 *[RFCs]: Requests for Comments
 *[RFC]: Request for Comments
 *[RFID]: Radio Frequency Identification
+*[RI]: Report Invalid (RM message)
+*[RK]: Report Acknowledgement (RM message)
 *[RMM]: The CERT Resilience Management Model
 *[RM]: Report Management
+*[RS]: Report Submission (RM message)
+*[RV]: Report Valid (RM message)
 
 *[SAAS]: Software as a Service
 *[SaaS]: Software as a Service
@@ -172,6 +207,8 @@ stops after the first match is found.
 *[TV]: Television
 
 *[UK]: United Kingdom
+*[URIs]: Uniform Resource Identifiers
+*[URI]: Uniform Resource Identifier
 *[URLs]: Uniform Resource Locators
 *[URL]: Uniform Resource Locator
 *[US]: United States
@@ -182,6 +219,7 @@ stops after the first match is found.
 *[VDPs]: Vulnerability Disclosure Programs
 *[VDP]: Vulnerability Disclosure Program
 *[VEP]: Vulnerability Equities Process
+*[VFD]: Vendor aware, Fix ready, fix Deployed — the vendor-path case state dimensions
 *[VINCE]: Vulnerability Information and Coordination Environment
 *[VMs]: Virtual Machines
 *[VM]: Vulnerability Management

--- a/docs/_acronyms/index.md
+++ b/docs/_acronyms/index.md
@@ -1,12 +1,18 @@
-<!-- 
-Try to keep these alphabetized.
-However, if you add an acronym that is a subset of another acronym,
-add the longer string first. (E.g., CERT/CC before CERT.) The matching
-stops after the first match is found.
+<!--
+Keep this list in strict alphabetical order (case-insensitive by acronym).
+
+Ordering is purely for human maintainability: the `abbr` extension sorts
+the list by length descending before building its match regex
+(markdown/extensions/abbr.py), so the position of an entry in this file has
+no effect on which abbreviation matches. An earlier version of this comment
+asked for longer strings before their prefixes; that is no longer required.
+
+One definition per acronym. Where a token is ambiguous, define it in the
+sense the docs actually use.
 -->
 *[ACM]: Association for Computing Machinery
-*[ADRs]: Architectural Decision Records
 *[ADR]: Architectural Decision Record
+*[ADRs]: Architectural Decision Records
 *[AFB]: Air Force Base
 *[AFLCMC]: Air Force Life Cycle Management Center
 *[AI]: Artificial Intelligence
@@ -15,56 +21,55 @@ stops after the first match is found.
 *[API]: Application Programming Interface
 *[AS2]: ActivityStreams 2.0
 *[ASCII]: American Standard Code for Information Interchange
-*[ATMs]: Automated Teller Machines
 *[ATM]: Automated Teller Machine
+*[ATMs]: Automated Teller Machines
 
 *[BCP]: Best Current Practice
 *[BFF]: CERT Basic Fuzzing Framework
 *[BGP]: Border Gateway Protocol
 *[BIND]: Berkeley Internet Name Domain
 *[BOD]: Binding Operational Directive
-*[BTs]: Behavior Trees
 *[BT]: Behavior Tree
+*[BTs]: Behavior Trees
 
-*[CAPEC]: Common Attack Pattern Enumeration and Classification
 *[CA]: Attacks Observed (CS message)
-*[CERT/CC]: CERT Coordination Center, a part of the Software Engineering Institute at Carnegie Mellon University
-*[CERT]: The CERT Division of the Software Engineering Institute
-*[CE]: CS Error (CS message)
-*[CF]: Fix Readiness (CS message)
-*[CISA]: Cybersecurity and Infrastructure Security Agency, a part of the U.S. Department of Homeland Security
-*[CI]: Continuous Integration
+*[CAPEC]: Common Attack Pattern Enumeration and Classification
 *[CD]: Fix Deployed (CS message)
+*[CE]: CS Error (CS message)
+*[CERT]: The CERT Division of the Software Engineering Institute
+*[CERT/CC]: CERT Coordination Center, a part of the Software Engineering Institute at Carnegie Mellon University
+*[CF]: Fix Readiness (CS message)
+*[CI]: Continuous Integration
+*[CISA]: Cybersecurity and Infrastructure Security Agency, a part of the U.S. Department of Homeland Security
 *[CK]: CS Acknowledgement (CS message)
 *[CLI]: Command Line Interface
 *[CMU]: Carnegie Mellon University
-*[CNAs]: CVE Numbering Authorities
 *[CNA]: CVE Numbering Authority
+*[CNAs]: CVE Numbering Authorities
 *[COPPA]: Children's Online Privacy Protection Act
-*[CPE]: Common Platform Enumeration
 *[CP]: Public Awareness (CS message)
-*[CSAF]: Common Security Advisory Framework
-*[CSIRTs]: Computer Security Incident Response Teams
-*[CSIRT]: Computer Security Incident Response Team
+*[CPE]: Common Platform Enumeration
 *[CS]: Case State
-*[MPCVD]: Multi-Party Coordinated Vulnerability Disclosure
+*[CSAF]: Common Security Advisory Framework
+*[CSIRT]: Computer Security Incident Response Team
+*[CSIRTs]: Computer Security Incident Response Teams
+*[CV]: Vendor Awareness (CS message)
 *[CVD]: Coordinated Vulnerability Disclosure
 *[CVE]: Common Vulnerabilities and Exposures
 *[CVRF]: Common Vulnerability Reporting Format, superseded by the Common Security Advisory Framework (CSAF)
 *[CVSS]: Common Vulnerability Scoring System
-*[CV]: Vendor Awareness (CS message)
 *[CWE]: Common Weakness Enumeration
 *[CWSS]: Common Weakness Scoring System
 *[CX]: Exploit Public (CS message)
 
-*[DFAs]: Deterministic Finite Automata
+*[DDoS]: Distributed Denial of Service
 *[DFA]: Deterministic Finite Automaton
+*[DFAs]: Deterministic Finite Automata
 *[DFIR]: Digital Forensics and Incident Response
 *[DHS]: U.S. Department of Homeland Security
 *[DNS]: Domain Name System
 *[DoD]: U.S. Department of Defense
 *[DoJ]: U.S. Department of Justice
-*[DDoS]: Distributed Denial of Service
 *[DoS]: Denial of Service
 
 *[EA]: Embargo Proposal Acceptance (EM message)
@@ -75,9 +80,9 @@ stops after the first match is found.
 *[EK]: Embargo Acknowledgement (EM message)
 *[EM]: Embargo Management
 *[ENISA]: European Union Agency for Cybersecurity
-*[EoL]: End of Life
-*[EOL]: End of Life
 *[EO]: Executive Order
+*[EOL]: End of Life
+*[EoL]: End of Life
 *[EP]: Embargo Proposal (EM message)
 *[ER]: Embargo Proposal Rejection (EM message)
 *[ET]: Embargo Termination (EM message)
@@ -85,12 +90,12 @@ stops after the first match is found.
 *[EV]: Embargo Revision Proposal (EM message)
 
 *[FAQ]: Frequently Asked Questions
-*[FCC]: U.S. Federal Communications Commission
 *[FBI]: U.S. Federal Bureau of Investigation
+*[FCC]: U.S. Federal Communications Commission
 *[FDA]: U.S. Food and Drug Administration
 *[FERPA]: Family Educational Rights and Privacy Act
-*[FIRST]: Forum of Incident Response and Security Teams
 *[FI]: Finland
+*[FIRST]: Forum of Incident Response and Security Teams
 *[FTC]: U.S. Federal Trade Commission
 *[FTP]: File Transfer Protocol
 
@@ -111,13 +116,13 @@ stops after the first match is found.
 *[IETF]: Internet Engineering Task Force
 *[IoT]: Internet of Things
 *[IP]: Internet Protocol
-*[ISACs]: Information Sharing and Analysis Centers
 *[ISAC]: Information Sharing and Analysis Center
-*[ISAOs]: Information Sharing and Analysis Organizations
+*[ISACs]: Information Sharing and Analysis Centers
 *[ISAO]: Information Sharing and Analysis Organization
+*[ISAOs]: Information Sharing and Analysis Organizations
 *[ISO]: International Organization for Standardization
-*[ISPs]: Internet Service Providers
 *[ISP]: Internet Service Provider
+*[ISPs]: Internet Service Providers
 
 *[JPCERT/CC]: Japan Computer Emergency Response Team Coordination Center
 *[JSON]: JavaScript Object Notation
@@ -127,11 +132,12 @@ stops after the first match is found.
 *[MADR]: Markdown Any Decision Records
 *[ML]: Machine Learning
 *[MON]: The Monitoring Process Area of the CERT Resilience Management Model
+*[MPCVD]: Multi-Party Coordinated Vulnerability Disclosure
 *[MPLS]: Multiprotocol Label Switching
 
 *[NCSC]: National Cyber Security Centre
-*[NDAs]: Non-Disclosure Agreements
 *[NDA]: Non-Disclosure Agreement
+*[NDAs]: Non-Disclosure Agreements
 *[NHTSA]: National Highway Traffic Safety Administration
 *[NIAC]: National Infrastructure Advisory Council
 *[NIST]: National Institute of Standards and Technology
@@ -150,22 +156,22 @@ stops after the first match is found.
 *[PEC]: Participant Embargo Consent
 *[PGP]: Pretty Good Privacy
 *[PoC]: Proof of Concept Exploit
-*[PSIRTs]: Product Security Incident Response Teams
 *[PSIRT]: Product Security Incident Response Team
+*[PSIRTs]: Product Security Incident Response Teams
 *[PXA]: Public aware, eXploit public, Attacks observed — the public-path case state dimensions
 
 *[RA]: Report Accepted (RM message)
 *[RC]: Report Closed (RM message)
 *[RD]: Report Deferred (RM message)
-*[REST]: Representational State Transfer
 *[RE]: Report Error (RM message)
-*[RFCs]: Requests for Comments
+*[REST]: Representational State Transfer
 *[RFC]: Request for Comments
+*[RFCs]: Requests for Comments
 *[RFID]: Radio Frequency Identification
 *[RI]: Report Invalid (RM message)
 *[RK]: Report Acknowledgement (RM message)
-*[RMM]: The CERT Resilience Management Model
 *[RM]: Report Management
+*[RMM]: The CERT Resilience Management Model
 *[RS]: Report Submission (RM message)
 *[RV]: Report Valid (RM message)
 
@@ -173,23 +179,23 @@ stops after the first match is found.
 *[SaaS]: Software as a Service
 *[SBOM]: Software Bill of Materials
 *[SCAP]: Security Content Automation Protocol
-*[SDLC]: Secure Development Lifecycle
 *[SDL]: Software Development Lifecycle
+*[SDLC]: Secure Development Lifecycle
 *[SDR]: Software Defined Radio
 *[SEC]: U.S. Securities and Exchange Commission
 *[SEI]: Software Engineering Institute
 *[SERA]: Security Engineering Risk Analysis
 *[SIG]: Special Interest Group
-*[SLAs]: Service Level Agreements
 *[SLA]: Service Level Agreement
-*[SLEs]: Service Level Expectations
+*[SLAs]: Service Level Agreements
 *[SLE]: Service Level Expectation
-*[SMEs]: Subject Matter Experts
+*[SLEs]: Service Level Expectations
 *[SME]: Subject Matter Expert
+*[SMEs]: Subject Matter Experts
 *[SMTP]: Simple Mail Transfer Protocol
 *[SNMP]: Simple Network Management Protocol
-*[SPDX]: Software Package Data Exchange
 *[SP]: Special Publication
+*[SPDX]: Software Package Data Exchange
 *[SR]: Special Report
 *[SSL]: Secure Sockets Layer
 *[SSVC]: Stakeholder-Specific Vulnerability Categorization
@@ -199,32 +205,32 @@ stops after the first match is found.
 *[TCP]: Transmission Control Protocol
 *[TF-IDF]: Term Frequency-Inverse Document Frequency
 *[TLP]: Traffic Light Protocol
-*[TTPs]: Tactics, Techniques, and Procedures
-*[TTP]: Tactics, Techniques, and Procedures
 *[TLS]: Transport Layer Security
 *[TSIG]: Transaction Signature
-*[TVs]: Televisions
+*[TTP]: Tactics, Techniques, and Procedures
+*[TTPs]: Tactics, Techniques, and Procedures
 *[TV]: Television
+*[TVs]: Televisions
 
 *[UK]: United Kingdom
-*[URIs]: Uniform Resource Identifiers
 *[URI]: Uniform Resource Identifier
-*[URLs]: Uniform Resource Locators
+*[URIs]: Uniform Resource Identifiers
 *[URL]: Uniform Resource Locator
+*[URLs]: Uniform Resource Locators
 *[US]: United States
 
 *[VAR]: Vulnerability Analysis and Resolution, a process area of the CERT RMM
-*[VDBs]: Vulnerability Databases
 *[VDB]: Vulnerability Database
-*[VDPs]: Vulnerability Disclosure Programs
+*[VDBs]: Vulnerability Databases
 *[VDP]: Vulnerability Disclosure Program
+*[VDPs]: Vulnerability Disclosure Programs
 *[VEP]: Vulnerability Equities Process
 *[VFD]: Vendor aware, Fix ready, fix Deployed — the vendor-path case state dimensions
 *[VINCE]: Vulnerability Information and Coordination Environment
-*[VMs]: Virtual Machines
 *[VM]: Vulnerability Management
-*[VRF]: Vulnerability Reporting Form
+*[VMs]: Virtual Machines
 *[VR]: Vulnerability Response
+*[VRF]: Vulnerability Reporting Form
 *[VU#]: CERT Vulnerability Note
 *[VXREF]: Vulnerability Cross-Reference
 

--- a/docs/reference/terms.md
+++ b/docs/reference/terms.md
@@ -1,24 +1,35 @@
 # Terms and Definitions
 
-Throughout this documentation, we refer to CVD Roles from the [*CERT Guide to Coordinated
-Vulnerability Disclosure*](https://certcc.github.io/CERT-Guide-to-CVD){:target="_blank"}:
+This page defines the Coordinated Vulnerability Disclosure (CVD) stakeholder roles and case terms used throughout this documentation.
+The canonical source for Vultron domain terminology is the [Glossary](glossary.md).
+This page covers the subset of terms that map onto the [*CERT Guide to Coordinated Vulnerability Disclosure*](https://certcc.github.io/CERT-Guide-to-CVD){:target="_blank"} and the relevant ISO standards, together with the synonyms those sources use.
 
-!!! info "Finder"
+## CVD Roles
 
-    The individual or organization that identifies the vulnerability
+The role names below follow the *CERT Guide to Coordinated Vulnerability Disclosure*.
+Each corresponds to a `CVDRole` value in the protocol, except where noted.
 
 !!! info "Reporter"
 
     The individual or organization that notifies the vendor of the
     vulnerability
 
+*Reporter* is the protocol-salient role for vulnerability discovery: the protocol is concerned with who reported a vulnerability, not with who found it.
+
+!!! info "Finder"
+
+    The individual or organization that identifies the vulnerability
+
+*Finder* is not a distinct protocol role (ADR-0078).
+An actor that discovers a vulnerability and reports it holds the *Reporter* role.
+An actor that discovers a vulnerability without reporting it is recorded in the report content or in case notes, as metadata rather than as a role.
+
 !!! info "Vendor (Supplier)"
 
     The individual or organization that created or maintains the
     vulnerable product
 
-The *Vendor* role is synonymous with the *Supplier* role as it appears
-in [SSVC](https://github.com/CERTCC/SSVC){:target="_blank"} Version 2 and above.
+The *Vendor* role is synonymous with the *Supplier* role as it appears in [Stakeholder-Specific Vulnerability Categorization (SSVC)](https://github.com/CERTCC/SSVC){:target="_blank"} Version 2 and above.
 
 !!! info "Deployer (User)"
 
@@ -28,27 +39,37 @@ in [SSVC](https://github.com/CERTCC/SSVC){:target="_blank"} Version 2 and above.
 The *Deployer* role is synonymous with the *User* role in
 [ISO/IEC 29147:2018](https://www.iso.org/standard/72311.html){:target="_blank"}
 and
-[ISO/IEC 30111:2019](https://www.iso.org/standard/69725.html){:target="_blank"},
-while the other roles are named consistent with those standards.
+[ISO/IEC 30111:2019](https://www.iso.org/standard/69725.html){:target="_blank"}.
+The other roles are named consistent with those standards.
 
 !!! info "Coordinator"
 
     An individual or organization that facilitates the coordinated
     response process
 
-We also add a new role in this documentation, which we expect to incorporate
-into a future version of the *CVD Guide*:
+!!! info "Observer"
+
+    A case participant with no vendor fix-and-deployment obligations
+
+*Observer* is the base role — the lowest non-null privilege set — and is admitted through the standard invitation and acceptance flow (ADR-0057).
+
+## Exploit Publisher
+
+This documentation adds one stakeholder role that the *CVD Guide* does not define, and that is expected in a future version of that guide.
 
 !!! info "Exploit Publisher"
 
     An individual or organization that publishes exploits
 
-Exploit Publishers might be the same as Finders, Reporters, Coordinators, or
-Vendors, but this is not guaranteed.
-For example, Vendors that produce tools for Cybersecurity Red Teams might play a combination
-of roles: Finder, Reporter, Vendor, Coordinator, and/or Exploit Publisher.
+*Exploit Publisher* has no corresponding `CVDRole` value.
+It describes a behavior the protocol constrains rather than a role a participant holds: an Exploit Publisher participating in a pre-public case is expected to comply with the protocol, and to withhold exploit code while an embargo is active.
 
-Finally, we have a few additional terms to define:
+An Exploit Publisher may also be a Finder, Reporter, Coordinator, or Vendor, and often is.
+A vendor that produces tools for cybersecurity red teams can hold several roles at once: Reporter, Vendor, Coordinator, and Exploit Publisher.
+
+## Units of Work
+
+Three further terms name the units of work in the CVD process.
 
 !!! info "CVD Case (Case)"
 
@@ -57,11 +78,10 @@ Finally, we have a few additional terms to define:
 
 !!! info "CVD Case Participant (Participant)"
 
-    Finder, Vendor, Coordinator, Deployer, etc., as defined above
+    An actor holding one or more CVD Roles in a Case
 
 !!! info "Vulnerability Report (Report)"
 
     The unit of work for an individual Case Participant's [Report Management (RM) process](../topics/process_models/rm/index.md)
 
-A diagram showing the relationship between CVD Cases, Participants, and Reports can be
-found in [Case Object](../howto/case_object.md).
+[Case Object](../howto/case_object.md) contains a diagram of the relationships between CVD Cases, Participants, and Reports.

--- a/notes/diataxis-framework.md
+++ b/notes/diataxis-framework.md
@@ -4,6 +4,8 @@ status: active
 description: >
   Implementation standards for Vultron technical documentation using the
   Diátaxis framework.
+related_specs:
+  - specs/diataxis-requirements.yaml
 related_notes:
   - notes/message-type-reference.md
 ---
@@ -200,3 +202,22 @@ is the catalyst for attaining Deep Quality.
 Following these standards produces documentation that is logical, user-centric,
 and architecturally sound—a professional interface that truly serves the
 practitioner's craft.
+
+### Authoring and linting tooling
+
+The prose-level rules that operationalize this framework are maintained as a
+normative style guide, `.claude/skills/shared/docs-style-guide.md`, made
+binding by `specs/diataxis-requirements.yaml` DF-09-001. Its `SG-nn` rules cover
+terminology, acronym expansion, concept order, sentence shape, voice by agency
+per quadrant, lists, and diagrams.
+
+Two skills consume that guide:
+
+- `write-docs` authors or rewrites a page — classify the quadrant, plan concept
+  order, draft against the style guide, register terms and acronyms, and wire the
+  nav.
+- `lint-docs` audits existing pages, fixing mechanical findings and reporting
+  judgment findings with a recommendation.
+
+`check-docs-sync` runs `lint-docs` as a blocking gate whenever a change touches
+`docs/`.

--- a/specs/diataxis-requirements.yaml
+++ b/specs/diataxis-requirements.yaml
@@ -2,7 +2,7 @@ id: DF
 title: Diátaxis documentation requirements
 description: >-
   Brief requirements for organizing project documentation according to the Diátaxis framework.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -111,6 +111,18 @@ groups:
     statement: >-
       provide explicit links to the related Reference and Explanation pages (prerequisites,
       background, deeper rationale). Keep these resources out of the tutorial body.
+  - id: DF-03-011
+    priority: MUST
+    kind: process
+    statement: >-
+      Tutorials MUST reserve first-person plural ("we") for the shared journey and use second
+      person ("you") for the learner's own actions, possessions, and state.
+    rationale: >-
+      DF-03-004 establishes "we" as the tutorial voice but does not say what it covers. The
+      division of labor is what makes the voice work: "we" affirms the tutor/learner
+      relationship, while "you" identifies who is acting and what they now have. Writing "we
+      need Docker installed" misattributes the learner's prerequisite to the tutor, and
+      pervasive "you should understand that" signals a tutorial drifting into Explanation.
 - id: DF-04
   title: How-to guides
   specs:
@@ -190,6 +202,18 @@ groups:
     statement: >-
       Allow brief code examples in reference material only to illustrate usage, not to provide
       step-by-step instruction.
+  - id: DF-05-007
+    priority: MUST
+    kind: process
+    statement: >-
+      Reference material MUST make the system, not the reader, the grammatical subject of its
+      descriptive sentences.
+    rationale: >-
+      DF-05-001 and DF-05-003 require neutral, instruction-free description without saying how to
+      achieve it. Naming the grammatical subject is the operational test: "A value of `0`
+      disables the timeout" describes the machinery, while "Set `timeout` to `0` to disable it"
+      has crossed into instruction and belongs in a How-to guide. The subject test catches the
+      drift that "be neutral" alone does not.
 - id: DF-06
   title: Explanation
   specs:
@@ -222,6 +246,18 @@ groups:
     priority: MUST
     kind: process
     statement: Weave connections to related topics to build a web of understanding.
+  - id: DF-06-007
+    priority: MAY
+    kind: process
+    statement: >-
+      Explanation MAY use first-person plural ("we") for the author's reasoning and second person
+      ("you") to invite the reader to consider a point.
+    rationale: >-
+      DF was silent on Explanation voice, which left the most-used voice in the corpus formally
+      unaddressed. Explanation is discursive and DF-06-003 already permits opinion and
+      perspective, so both pronouns are legitimate here — "we chose a state-machine model
+      because…" and "you might expect this to behave like a queue; it does not" each do work that
+      impersonal prose cannot.
 - id: DF-08
   title: File metadata
   specs:
@@ -236,3 +272,73 @@ groups:
     statement: >-
       Place cross-reference sources only in the header metadata and use inline links for cross-spec
       references.
+- id: DF-09
+  title: Prose style
+  description: >-
+    Requirements governing the prose itself, as distinct from the architecture of the
+    documentation set. The detailed rules, their `SG-nn` identifiers, and their worked examples
+    live in `.claude/skills/shared/docs-style-guide.md`; these entries make that file normative
+    and give reviewers citable IDs.
+  specs:
+  - id: DF-09-001
+    priority: MUST
+    kind: process
+    statement: >-
+      Hand-written prose under `docs/` MUST follow the documentation style guide at
+      `.claude/skills/shared/docs-style-guide.md`.
+    rationale: >-
+      Style rules are numerous, example-heavy, and change more often than requirements do, so
+      they are maintained as a guide rather than as several dozen spec entries. This entry is the
+      anchor that gives the guide normative force and lets `lint-docs` findings cite a spec ID.
+      Generated trees (`docs/reference/code/`, `docs/reference/case_states/`) and `docs/adr/` are
+      outside the guide's scope; fix the generator or the template instead.
+  - id: DF-09-002
+    priority: MUST
+    kind: process
+    statement: >-
+      Domain terminology in `docs/` MUST match the canonical term in `docs/reference/glossary.md`,
+      with `docs/reference/vultron-taxonomy.md` canonical for Vultron concept names.
+    rationale: >-
+      "Avoid jargon" and "use domain language" are the same rule with the glossary as arbiter: a
+      term in the glossary is domain language and should be used, and a term in neither the
+      glossary nor the taxonomy is jargon that must be expanded, replaced, or registered. Naming
+      one arbiter also prevents the three overlapping term sources from drifting further apart.
+  - id: DF-09-003
+    priority: MUST
+    kind: process
+    statement: >-
+      Acronyms MUST be expanded on first use on each `docs/` page.
+    rationale: >-
+      First use resets per page because readers arrive from search results and deep links rather
+      than by reading in nav order. Site-wide `abbr` tooltips are not sufficient on their own:
+      they do not survive print output, and they are invisible to anyone reading the raw Markdown
+      on GitHub.
+  - id: DF-09-004
+    priority: MUST
+    kind: process
+    statement: >-
+      Every acronym used in `docs/` MUST be registered in `docs/_acronyms/index.md`.
+    rationale: >-
+      `pymdownx.snippets` auto-appends that file to every page, so a registered acronym gets a
+      hover definition everywhere it appears. An unregistered one silently gets nothing.
+  - id: DF-09-005
+    priority: SHOULD
+    kind: process
+    statement: >-
+      A `docs/` page SHOULD introduce, define, or link out for each concept before the sections
+      that depend on it.
+    rationale: >-
+      Prose is a directed acyclic graph of topics. A forward reference forces the reader to hold
+      an undefined term until the page explains it, or to leave the page to find out. Across
+      pages the dependency edge is a hyperlink from first use to the concept's canonical
+      introduction, so the glossary and the taxonomy serve as the concept registry and no
+      separate dependency file is required.
+  - id: DF-09-006
+    priority: SHOULD
+    kind: process
+    statement: >-
+      Every diagram in `docs/` SHOULD be accompanied by prose stating what the diagram shows.
+    rationale: >-
+      The page must stay comprehensible when the Mermaid render fails, in print-site output, and
+      to a screen reader. The accompanying sentence also disciplines the author: a diagram whose
+      point cannot be stated in a sentence usually has not earned its place.


### PR DESCRIPTION
## Summary

Adds a documentation authoring skill (`write-docs`), a semantic prose linter
(`lint-docs`), and the shared style guide both consume. Anchors the prose rules
in a new `DF-09` spec group, adds the three voice rules DF was missing, and
reconciles `docs/reference/terms.md` to the glossary and ADR-0078.

Designed in a `grill-me` session. The gap it fills: `DF` already covered the
Diátaxis architecture and per-quadrant voice, but nothing covered the prose —
no terminology rule, no acronym rule, no concept-ordering rule, no list or
diagram guidance.

## Changes

- **`.agents/skills/shared/docs-style-guide.md`** (new): 42 `SG-nn` rules —
  `glossary.md` as terminology arbiter with its "Aliases to avoid" column as a
  banned-synonym list, acronym expansion plus registration in
  `docs/_acronyms/index.md`, concept order as a DAG (no forward references
  within a page; first use links to the canonical introduction across pages),
  STE-flavored sentence shape, voice by agency, register, list discipline,
  diagram warrant, and mechanics. Includes a rule index marking which rules are
  auto-fixable.
- **`.agents/skills/write-docs/SKILL.md`** (new): classify quadrant → plan
  concept order → draft → register terms and acronyms → wire `mkdocs.yml` nav →
  validate. Splits cross-quadrant requests into multiple cross-linked pages per
  DF-01-003. `pr` and `inline` modes so both conversational and
  skill-invoked callers work.
- **`.agents/skills/lint-docs/SKILL.md`** (new): fixes mechanical findings
  (spelling, banned aliases, acronyms, filler, legacy `graph` syntax, isolated
  voice slips) and reports judgment findings with a recommendation. Auto-fix
  guard switches to report-only above 20 target files, so a corpus-wide run can
  never produce a 400-file prose diff.
- **`.agents/skills/check-docs-sync/SKILL.md`**: `lint-docs` becomes a blocking
  gate in Step 3. Step 4 now offers `write-docs` before falling back to a
  deferred Concern, matching PD-03-007's stated preference for inline updates.
- **`specs/diataxis-requirements.yaml`** (1.0.0 → 1.1.0): `DF-03-011` (tutorial
  reserves "we" for the shared journey, "you" for the learner's actions and
  state), `DF-05-007` (reference makes the system the grammatical subject),
  `DF-06-007` (explanation may use either), and a new `DF-09 Prose style` group
  making the style guide normative and giving `lint-docs` citable IDs. All
  additive — no existing entry weakened.
- **`docs/reference/terms.md`**: reconciled to `glossary.md` and ADR-0078.
  Finder is no longer presented as a protocol role; `Observer` added (ADR-0057);
  `Exploit Publisher` marked as having no `CVDRole` value, with its VP-14
  behavioral expectations stated; reference voice fixed so the system is the
  subject rather than "we"; acronyms expanded at first use.

- **`docs/_acronyms/index.md`**: registers 41 acronyms, applying DF-09-004 to the
  corpus in the same PR that introduces it — Vultron terms (ADR, AKM, AS2, BT,
  MADR, PEC), `VFD`/`PXA` expanded as their dimension initials rather than the
  backformed gloss specs use, `CLI`/`URI`, and all 28 formal protocol message
  symbols with their authoritative names from `formal_protocol/messages.md`.
  Three entries are redefined to their protocol sense (`RE` Report Error,
  `CD` Fix Deployed, `CA` Attacks Observed); the displaced meanings had no live
  use in published docs while the protocol senses have ~200 occurrences.
  The file is also now in strict alphabetical order: `markdown` 3.10.2's `abbr`
  extension sorts by length descending before matching
  (`markdown/extensions/abbr.py:125`), so the old
  longer-string-before-prefix convention was unnecessary. Verified by rendering
  that `CERT/CC` and `MPCVD` still resolve correctly, and that all 206
  definitions are byte-identical across the sort. `SG-08` is corrected
  accordingly, and `SG-08a` added for the one-definition-per-token constraint.

## Design notes

Voice is treated as an agency rule, not a pronoun table: who owns the task
decides the pronouns. That reframing means the corpus's 287 uses of "we" in
`docs/topics/` were never violations — `DF-06` was simply silent on Explanation
voice — while `docs/howto/` and `docs/reference/` have real problems.

Per `SG-20`, pervasive out-of-quadrant pronouns are reported as *quadrant
misclassification* against DF-01-002 rather than as a wording defect, because a
how-to full of "we'll now explore" is usually a tutorial in the wrong tree.
Swapping the pronouns would hide that.

Both skills fix mechanical findings silently and escalate judgment calls with a
recommendation rather than an open question.

## Verification

- `markdownlint-cli2`: clean on all 5 changed/new markdown files (also via
  pre-commit hook).
- Spec corpus: `test/metadata/` and the spec ratchet tests pass (505 tests). New
  entries are `kind: process`, so the protocol-coverage ratchet is unaffected.
- `black --check .`: clean, 1334 files.
- Spec registry linter and `flake8`: pass via pre-commit hook on the commit.
- `mypy` and `pyright` were **not** run locally. This PR changes no Python, so
  `python-app.yml` (which runs them) is correctly skipped by its path filter.
- `mkdocs build --strict`: **fails with 101 pre-existing `markdown_exec`
  warnings**, identical on `origin/main` — verified by stashing this branch's
  changes and rebuilding. This is #2904 (frozen-model assignment in
  `_strip_published_udpated`); CI's `docs-build-check` omits `--strict`, which
  is why main is green. None of the warnings reference files in this PR, and
  this PR adds no `markdown_exec` blocks.

## Follow-on

- #3028 — read-only `lint-docs` inventory of the existing corpus, wired under
  Epic #607. Sized from the design scan: 63 "we" vs 7 "you" in `docs/howto/`,
  36 "we" in `docs/reference/formal_protocol/`, 4 legacy `graph` blocks. The
  acronym-registration finding is resolved in this PR and struck from that issue.
- #2904 blocks `PD-04-001` from being satisfiable at all today. Worth fixing
  before `write-docs` Phase 7 and `lint-docs` Phase 5 depend on a clean strict
  build in anger.


