### PR TITLE
fix(cs-filter): FilterCsEmDimensionNode guard hardening + CS invariant guard DRY refactor

### DIFF
--- a/notes/received-status-authorization.md
+++ b/notes/received-status-authorization.md
@@ -326,7 +326,9 @@ Extends the same liberal-accept pattern that ADR-0061 / ISSUE-2235 applied to
 ```text
 AddCaseStatusToCaseBT (Sequence)
 ├─ CheckCaseStatusIdempotencyNode       ← precondition guard (CLP-10-009)
-├─ FilterCsEmDimensionNode              ← per-dim EM adjudication (RSH-05-018); always SUCCESS
+├─ CheckCsEphemeralStateNode            ← pX ephemeral guard (CSB-17-012, #2524)
+├─ CheckCsHistoryPrefixNode             ← history prefix guard (CSB-17-005, #2524)
+├─ FilterCsEmDimensionNode              ← per-dim EM adjudication (RSH-05-018); FAILURE when case absent (CLP-10-009, #2957), SUCCESS otherwise
 ├─ FilterCsPxaDimensionNode             ← per-dim PXA adjudication (RSH-05-019); always SUCCESS
 ├─ FinalizeCsFilterNode                 ← FAILURE on whole-refusal; publishes filter
 ├─ GuardedCommitOrSkip                  ← canonical ledger commit (CLP-10-006)
@@ -340,11 +342,13 @@ removed; per-dimension filter nodes are its replacement.
 
 ### Three-node design
 
-`FilterCsEmDimensionNode` runs first: it clears both `BB_CASE_STATUS_DIM_FILTER`
-and `BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE` unconditionally (RSH-05-010, BT-17-003),
-evaluates the EM transition per the acceptance predicate in RSH-05-018
+`FilterCsEmDimensionNode` runs first: it clears `BB_CASE_STATUS_DIM_FILTER` and
+the per-tick accumulator unconditionally (RSH-05-010, BT-17-003), returns FAILURE
+when the case is not found in the DataLayer (CLP-10-009, #2957 AC-1), evaluates
+the EM transition per the acceptance predicate in RSH-05-018
 (`is_valid_em_transition()`), and writes a per-tick accumulator dict to the
-blackboard.
+blackboard. `BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE` is **not** touched here; its
+sole owner is `FinalizeCsFilterNode` (CONCERN-2711, #2957 AC-2).
 
 `FilterCsPxaDimensionNode` runs second: it reads the accumulator via the
 `_BB_CS_FILTER_ACC` input port, evaluates the PXA transition per the acceptance
@@ -371,7 +375,7 @@ no new state is carried (RSH-05-005).
 |---|---|---|
 | `cs_dim_filter_accumulator` | `FilterCsEmDimensionNode` (write+clear) | `FilterCsPxaDimensionNode`, `FinalizeCsFilterNode` (read) |
 | `append_case_status_dim_filter` | `FilterCsEmDimensionNode` (clear), `FinalizeCsFilterNode` (write) | `AppendCaseStatusToCaseNode` |
-| `ledger_payload_object_override` | `FilterCsEmDimensionNode` (clear), `FinalizeCsFilterNode` (write) | `CommitCaseLedgerEntryNode` |
+| `ledger_payload_object_override` | `FinalizeCsFilterNode` (sole owner: write+clear) | `CommitCaseLedgerEntryNode` |
 
 The `ledger_payload_object_override` override fields use camelCase wire aliases
 (`emState`, `pxaState`) per RSH-05-012. `FinalizeCsFilterNode` is registered

--- a/test/core/behaviors/status/nodes/test_cs_invariant_guards.py
+++ b/test/core/behaviors/status/nodes/test_cs_invariant_guards.py
@@ -317,3 +317,43 @@ class TestCheckCsHistoryPrefixNode:
         """Empty-string case_id → SUCCESS (absent case; nothing to guard)."""
         node = CheckCsHistoryPrefixNode(case_id="", status_id=STATUS_ID)
         assert _run(bridge, node) == Status.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# AC-6: DRY refactor regression — guards still block invalid CS transitions
+# after _resolve_case() replaces inline dl.read() + isinstance (#2957, AC-3)
+# ---------------------------------------------------------------------------
+
+
+class TestCsGuardDryRefactorRegression:
+    """AC-6 regression: _resolve_case() refactor must not change guard outcomes.
+
+    Both guards previously used ``dl.read() + isinstance(VulnerabilityCase)``.
+    AC-3 of #2957 replaced that inline pattern with ``_resolve_case()`` (which
+    wraps ``datalayer.read_case()``).  These tests confirm the blocking
+    behaviour is preserved after that refactor.
+    """
+
+    def test_ephemeral_guard_still_blocks_a_from_pXa(self, dl, bridge):
+        """CheckCsEphemeralStateNode: A-event from pXa → FAILURE via _resolve_case()."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.pXA
+        )
+        dl.create(asserted)
+
+        node = CheckCsEphemeralStateNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.FAILURE
+
+    def test_history_prefix_guard_still_blocks_a_from_pXa(self, dl, bridge):
+        """CheckCsHistoryPrefixNode: A-event from pXa → FAILURE via _resolve_case()."""
+        case = _make_case_with_pxa(CS_pxa.pXa)
+        dl.create(case)
+        asserted = as_CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.pXA
+        )
+        dl.create(asserted)
+
+        node = CheckCsHistoryPrefixNode(case_id=CASE_ID, status_id=STATUS_ID)
+        assert _run(bridge, node) == Status.FAILURE

--- a/test/core/behaviors/status/test_add_case_status_bt.py
+++ b/test/core/behaviors/status/test_add_case_status_bt.py
@@ -1498,3 +1498,63 @@ class TestEmitCaseStatusUpdateNodePromotion:
             last = dl.read(last)
         assert isinstance(last, CaseStatus)
         assert last.pxa.state is CS_pxa.PXa
+
+
+# ---------------------------------------------------------------------------
+# AC-4: FilterCsEmDimensionNode returns FAILURE on missing case (#2957)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterCsEmDimensionNodeMissingCase:
+    """AC-4 regression: FAILURE (not SUCCESS) when case absent from DataLayer.
+
+    CLP-10-009: the guard must abort before GuardedCommit when the case
+    cannot be resolved.  Prior to #2957 the node returned SUCCESS, allowing
+    a ledger write for an unresolvable case.
+    """
+
+    def test_missing_case_returns_failure(self, bridge):
+        """case_id set but case not in DataLayer → FAILURE."""
+        node = FilterCsEmDimensionNode(case_id=CASE_ID, status_id=STATUS_ID)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_missing_case_feedback_message_names_case(self, bridge):
+        """FAILURE feedback_message includes the missing case_id."""
+        node = FilterCsEmDimensionNode(case_id=CASE_ID, status_id=STATUS_ID)
+        bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert node.feedback_message
+        assert CASE_ID in node.feedback_message
+
+
+# ---------------------------------------------------------------------------
+# AC-5: FilterCsEmDimensionNode._clear() does not own BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE (#2957)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterCsEmDimensionNodeClearBehavior:
+    """AC-5 regression: _clear() must not zero BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE.
+
+    That key is solely owned by FinalizeCsFilterNode (CONCERN-2711, BT-17-003).
+    Prior to #2957 FilterCsEmDimensionNode zeroed it in _clear(), potentially
+    wiping a value set by FinalizeCsFilterNode in the same tick.
+    """
+
+    def test_clear_preserves_ledger_override_sentinel(self, bridge):
+        """Pre-seeded BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE survives _clear()."""
+        sentinel = {"test": "sentinel_2957"}
+        py_trees.blackboard.Blackboard.storage[
+            "/ledger_payload_object_override"
+        ] = sentinel
+
+        # Empty DL → FAILURE after _clear(); _clear() must not touch the key.
+        node = FilterCsEmDimensionNode(case_id=CASE_ID, status_id=STATUS_ID)
+        bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        stored = py_trees.blackboard.Blackboard.storage.get(
+            "/ledger_payload_object_override"
+        )
+        assert stored is sentinel, (
+            "FilterCsEmDimensionNode._clear() must not zero"
+            " BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE (CONCERN-2711, #2957)"
+        )

--- a/vultron/core/behaviors/status/add_case_status_tree.py
+++ b/vultron/core/behaviors/status/add_case_status_tree.py
@@ -88,7 +88,8 @@ def add_case_status_tree(
     3. History-prefix guard — rejects single-step PXA transitions that would
        produce an invalid CS history prefix (CSB-17-005, ISSUE-2524).
     4. Per-dimension EM adjudication — accept valid advances, carry forward
-       refused EM; always returns SUCCESS (RSH-05, ISSUE-2256).
+       refused EM; returns FAILURE when the case is not found in the DataLayer
+       (CLP-10-009), otherwise SUCCESS (RSH-05, ISSUE-2256).
     5. Per-dimension PXA adjudication — accepts monotone-forward PXA moves,
        carries forward refused PXA; always returns SUCCESS (RSH-05, ISSUE-2256).
     6. Whole-refusal gate — returns FAILURE if no dimension carries new state;

--- a/vultron/core/behaviors/status/nodes/cs_dimension_filter.py
+++ b/vultron/core/behaviors/status/nodes/cs_dimension_filter.py
@@ -100,7 +100,11 @@ class _CsStatusGuardBase(DataLayerConditionWithPorts):
         assert self.datalayer is not None
         if not self.case_id:
             return None
-        return self.datalayer.read_case(self.case_id)
+        result = self.datalayer.read_case(self.case_id)
+        # Defensive isinstance: guards against misbehaving adapter stubs that
+        # bypass read_case()'s internal type check (the annotation is not
+        # enforced at runtime).
+        return result if isinstance(result, VulnerabilityCase) else None
 
     def _resolve_asserted(self) -> CaseStatus | None:
         assert self.datalayer is not None
@@ -118,16 +122,21 @@ class FilterCsEmDimensionNode(_CsStatusGuardBase):
     accumulator and evaluates whether the asserted EM transition is acceptable.
     Refused EM is carried forward (current value); accepted EM passes through.
 
-    Also clears ``BB_CASE_STATUS_DIM_FILTER`` and
-    ``BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE`` unconditionally at tick start so
-    that no prior execution's values leak into this tick (BT-17-003).
+    Also clears ``BB_CASE_STATUS_DIM_FILTER`` unconditionally at tick start
+    so that no prior execution's value leaks into this tick (BT-17-003).
+    ``BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE`` is solely owned by
+    :class:`FinalizeCsFilterNode`, which clears it on every exit path.
 
     Returns SUCCESS when the status can be resolved and EM adjudication runs.
-    Returns FAILURE when the asserted status cannot be resolved from the
-    DataLayer or the fallback — the tree must not commit a ledger entry for a
-    status that cannot be applied (CLP-10-009, #2704).  Individual EM
-    dimension refusal is not a tree failure; ``FinalizeCsFilterNode`` decides
-    whole-refusal.
+    Returns FAILURE when:
+
+    - The case is not found in the DataLayer — the tree must not commit a
+      ledger entry for an unresolvable case (CLP-10-009, #2710).
+    - The asserted status cannot be resolved from the DataLayer or the
+      fallback (CLP-10-009, #2704).
+
+    Individual EM dimension refusal is not a tree failure; ``FinalizeCsFilterNode``
+    decides whole-refusal.
 
     Must run before ``FilterCsPxaDimensionNode`` and ``FinalizeCsFilterNode``
     in the precondition_guards sequence.
@@ -166,7 +175,7 @@ class FilterCsEmDimensionNode(_CsStatusGuardBase):
             return f
         assert self.datalayer is not None
 
-        case = self.datalayer.read_case(self.case_id)
+        case = self._resolve_case()
         if case is None:
             self.feedback_message = (
                 f"Case '{self.case_id}' not found in DataLayer;"
@@ -379,6 +388,9 @@ class FinalizeCsFilterNode(DataLayerConditionWithPorts):
                 " and no other dimension carries new state"
             )
             self.logger.info("%s: %s", self.name, self.feedback_message)
+            # Sole-owner clear: no stale override must survive this tick
+            # (BT-17-003, CONCERN-2711).
+            self._set_output(BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE, None)
             return Status.FAILURE
 
         self._set_output(

--- a/vultron/core/behaviors/status/nodes/cs_dimension_filter.py
+++ b/vultron/core/behaviors/status/nodes/cs_dimension_filter.py
@@ -104,7 +104,16 @@ class _CsStatusGuardBase(DataLayerConditionWithPorts):
         # Defensive isinstance: guards against misbehaving adapter stubs that
         # bypass read_case()'s internal type check (the annotation is not
         # enforced at runtime).
-        return result if isinstance(result, VulnerabilityCase) else None
+        if isinstance(result, VulnerabilityCase):
+            return result
+        if result is not None:
+            logger.warning(
+                "%s: read_case(%r) returned unexpected type %s; treating as not found",
+                self.__class__.__name__,
+                self.case_id,
+                type(result).__name__,
+            )
+        return None
 
     def _resolve_asserted(self) -> CaseStatus | None:
         assert self.datalayer is not None

--- a/vultron/core/behaviors/status/nodes/cs_dimension_filter.py
+++ b/vultron/core/behaviors/status/nodes/cs_dimension_filter.py
@@ -44,6 +44,7 @@ from vultron.core.behaviors.helpers import (
     DataLayerConditionWithPorts,
     PortInformation,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.dimensions import EmDimension, PxaDimension
 from vultron.core.models.protocols import PersistableModel
@@ -90,6 +91,17 @@ class _CsStatusGuardBase(DataLayerConditionWithPorts):
         self.status_id = status_id
         self.status_obj_fallback = status_obj_fallback
 
+    def _resolve_case(self) -> VulnerabilityCase | None:
+        """Resolve the VulnerabilityCase from the DataLayer (AC-3, #2701).
+
+        Returns None when case_id is absent or the case is not found.
+        Callers must invoke _require_datalayer() before calling this.
+        """
+        assert self.datalayer is not None
+        if not self.case_id:
+            return None
+        return self.datalayer.read_case(self.case_id)
+
     def _resolve_asserted(self) -> CaseStatus | None:
         assert self.datalayer is not None
         obj = self.datalayer.read(self.status_id)
@@ -130,9 +142,6 @@ class FilterCsEmDimensionNode(_CsStatusGuardBase):
             BB_CASE_STATUS_DIM_FILTER: PortInformation(
                 data_type=object, required=False
             ),
-            BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE: PortInformation(
-                data_type=object, required=False
-            ),
         }
 
     @classmethod
@@ -140,13 +149,13 @@ class FilterCsEmDimensionNode(_CsStatusGuardBase):
         return {
             _BB_CS_FILTER_ACC: f"/{_BB_CS_FILTER_ACC}",
             BB_CASE_STATUS_DIM_FILTER: f"/{BB_CASE_STATUS_DIM_FILTER}",
-            BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE: f"/{BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE}",
         }
 
     def _clear(self) -> None:
         self._set_output(_BB_CS_FILTER_ACC, None)
         self._set_output(BB_CASE_STATUS_DIM_FILTER, None)
-        self._set_output(BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE, None)
+        # BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE is FinalizeCsFilterNode's key —
+        # do not zero it here (CONCERN-2711, #2711).
 
     def update(self) -> Status:
         self._clear()  # BT-17-003
@@ -159,7 +168,12 @@ class FilterCsEmDimensionNode(_CsStatusGuardBase):
 
         case = self.datalayer.read_case(self.case_id)
         if case is None:
-            return Status.SUCCESS
+            self.feedback_message = (
+                f"Case '{self.case_id}' not found in DataLayer;"
+                " aborting before GuardedCommit (CLP-10-009, #2710)"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
 
         try:
             current = case.current_status
@@ -334,13 +348,17 @@ class FinalizeCsFilterNode(DataLayerConditionWithPorts):
     def update(self) -> Status:
         acc = self._try_get_input(_BB_CS_FILTER_ACC)
         if not isinstance(acc, dict):
-            return Status.SUCCESS  # no filtering in progress
+            # No filtering in progress — clear stale override from a prior tick
+            # (sole-owner clear, BT-17-003, CONCERN-2711).
+            self._set_output(BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE, None)
+            return Status.SUCCESS
 
         refused: list[str] = acc["refused"]
         if not refused:
-            return (
-                Status.SUCCESS
-            )  # all dimensions accepted — no override needed
+            # All dimensions accepted — no override needed; clear stale value
+            # (sole-owner clear, BT-17-003, CONCERN-2711).
+            self._set_output(BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE, None)
+            return Status.SUCCESS
 
         current: CaseStatus = acc["current"]
         asserted: CaseStatus = acc["asserted"]

--- a/vultron/core/behaviors/status/nodes/cs_invariant_guards.py
+++ b/vultron/core/behaviors/status/nodes/cs_invariant_guards.py
@@ -41,7 +41,6 @@ from py_trees.common import Status
 from vultron.core.behaviors.status.nodes.cs_dimension_filter import (
     _CsStatusGuardBase,
 )
-from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.cs import (
     CS_vfd,
     is_monotonic_pxa_forward,
@@ -92,10 +91,11 @@ class CheckCsEphemeralStateNode(_CsStatusGuardBase):
             return Status.SUCCESS
         if (f := self._require_datalayer()) is not None:
             return f
-        assert self.datalayer is not None
 
-        case = self.datalayer.read(self.case_id)
-        if not isinstance(case, VulnerabilityCase):
+        case = (
+            self._resolve_case()
+        )  # uses read_case() via _CsStatusGuardBase (AC-3, #2701)
+        if case is None:
             return Status.SUCCESS
 
         try:
@@ -163,10 +163,11 @@ class CheckCsHistoryPrefixNode(_CsStatusGuardBase):
             return Status.SUCCESS
         if (f := self._require_datalayer()) is not None:
             return f
-        assert self.datalayer is not None
 
-        case = self.datalayer.read(self.case_id)
-        if not isinstance(case, VulnerabilityCase):
+        case = (
+            self._resolve_case()
+        )  # uses read_case() via _CsStatusGuardBase (AC-3, #2701)
+        if case is None:
             return Status.SUCCESS
 
         try:


### PR DESCRIPTION
- Closes #2957
<!-- ⚠️  MUST BE FIRST — before any ## header -->

## Summary

Hardens `FilterCsEmDimensionNode` to return FAILURE (not SUCCESS) when the case is absent from the DataLayer (AC-1), fixes blackboard key ownership so `FilterCsEmDimensionNode._clear()` no longer zeroes `BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE` (AC-2), and DRY-refactors both CS invariant guard nodes to share `_resolve_case()` from `_CsStatusGuardBase` (AC-3).

## Changes

- **`vultron/core/behaviors/status/nodes/cs_dimension_filter.py`**: AC-1 — return `Status.FAILURE` with diagnostic message when `read_case()` returns `None`; AC-2 — remove `BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE` from `FilterCsEmDimensionNode.output_ports()`, `_domain_port_remappings()`, and `_clear()`; add sole-owner clears to both no-op paths in `FinalizeCsFilterNode.update()`; add `_resolve_case()` to `_CsStatusGuardBase` wrapping `datalayer.read_case()`.
- **`vultron/core/behaviors/status/nodes/cs_invariant_guards.py`**: AC-3 — replace `dl.read() + isinstance(VulnerabilityCase)` inline pattern with `self._resolve_case()` in both `CheckCsEphemeralStateNode.update()` and `CheckCsHistoryPrefixNode.update()`; remove now-unused `VulnerabilityCase` import.
- **`test/core/behaviors/status/test_add_case_status_bt.py`**: AC-4 — `TestFilterCsEmDimensionNodeMissingCase`: FAILURE on missing case; AC-5 — `TestFilterCsEmDimensionNodeClearBehavior`: `_clear()` preserves pre-seeded `BB_LEDGER_PAYLOAD_OBJECT_OVERRIDE` sentinel.
- **`test/core/behaviors/status/nodes/test_cs_invariant_guards.py`**: AC-6 — `TestCsGuardDryRefactorRegression`: both guards still block invalid CS transitions after the `_resolve_case()` refactor.

## Verification

- 8202 unit tests pass (5 new regression tests added)
- 1254 integration tests pass
- Black, flake8, mypy, pyright all clean