### PR TITLE
Audit call-out gate security-significant defaults (#2676)

### DIFF
--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -117,6 +117,24 @@ inbox adapter wires it for the two inbound status semantics
 (`vultron/adapters/driving/fastapi/inbox_port_factories.py`), making the
 trusted-deployment posture visible in code (RSH-07-003).
 
+> **Mechanism vs. posture (ADR-0080 / RSH-07-004).** The tables and guard in
+> this audit classify the conservative-default *posture* — which of these gates
+> must default to the floor rather than to a p-driven permissive backend. That
+> posture is settled and unchanged. The *mechanism* that currently implements it
+> for the two status gates — `RequireCaseOwnerApprovalNode`, an interim blocking
+> stub that returns `FAILURE` unconditionally (`nodes.py`, self-described as
+> such) — is **superseded** by RSH-07-004 (ADR-0080, CONCERN-2812), which found
+> the ADR-0046/ADR-0076 Evaluator model unreachable at the moment authorization
+> is first needed and mandates a conversation-state *routing subtree* instead.
+> RSH-07-004's verification explicitly requires that "no `CallOutBackendFactory`
+> returns an unconditional `FAILURE` node as the conservative default." So when
+> the routing subtree lands, the qualifying-gate rows above stay in this table
+> (they remain security-significant), but the `Default` mechanism changes and
+> the guard's `test_status_gates_conservative_default_blocks` assertion must be
+> revised to check the security *property* rather than the `FAILURE` tick. This
+> audit deliberately did not implement RSH-07-004 (a separate, larger change);
+> it only pins the current interim reality.
+
 ### Look-alike gates that do NOT qualify (default stays permissive)
 
 Two embargo gates share surface structure with the qualifying set but fail the
@@ -162,7 +180,10 @@ generalized rule **BT-23-012** (so the criterion binds future gate authors);
 its durable analysis is this section; its regression guard is
 `test/core/behaviors/call_out/test_security_significant_defaults.py`. ADR-0025's
 security-significant exception (and ADR-0076) already stand and needed no change
-(#2676 AC-5's "if additional gates are found" condition was not triggered).
+(#2676 AC-5's "if additional gates are found" condition was not triggered). The
+conservative-default *posture* recorded here is unaffected by ADR-0080 —
+RSH-07-004 amends only the *mechanism* for the two status gates (see the
+mechanism-vs-posture note above).
 
 ---
 

--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -8,10 +8,14 @@ description: >
   planning session for issue #1631.
 related_specs:
   - specs/behavior-tree-integration.yaml
+  - specs/received-status-handling.yaml
+  - specs/em-behavior.yaml
 related_notes:
   - notes/coordination-agents.md
   - notes/bt-fuzzer-nodes.md
   - notes/configuration.md
+  - notes/received-status-authorization.md
+  - notes/embargo-lifecycle.md
 relevant_packages:
   - vultron/core/behaviors
   - vultron/demo/fuzzer
@@ -82,6 +86,83 @@ Currently there are four `p=0.5` nodes (all default to `AlwaysSucceed`):
 | `WantToProposeEmbargo` | Embargo | Happy path = want to propose |
 | `AllPartiesKnown` | Reporting to others | Happy path = all parties identified |
 | `NotificationsComplete` | Reporting to others | Happy path = notifications done |
+
+---
+
+## Security-Significant Gate Audit (#2676)
+
+ADR-0076 flipped the two named status gates to a conservative default and
+declared a project-wide exception to the ceiling/floor rule (now generalized
+as a normative rule in **BT-23-012**). Issue #2676 audited **every**
+`CallOutBackendFactory` field across all bundles under
+`vultron/core/behaviors/call_out/bundles/` against that exception's criterion:
+
+> A gate qualifies as **security-significant** when its permissive backend
+> would let a party **other than the Case Owner** *unilaterally* cause
+> **canonical case-state adoption** or **embargo teardown** on the **received
+> side** — not merely operational inconvenience.
+
+### Qualifying gates (default conservative)
+
+Exactly two, both received-side, both already flipped under ADR-0076
+(delivered by #2092) — no further change:
+
+| Gate | Bundle field | Default |
+|---|---|---|
+| `StatusAdoptionGate` (`CaseOwnerApprovesStatusUpdate`) | `status_adoption_gate_factory` | `RequireCaseOwnerApprovalNode` (RSH-07-001) |
+| `EmbargoTeardownAuthorizationGate` | `embargo_teardown_authorization_gate_factory` | `RequireCaseOwnerApprovalNode` (RSH-07-002) |
+
+`STATUS_AUTHORIZATION_PERMISSIVE` is the explicit opt-in override; the FastAPI
+inbox adapter wires it for the two inbound status semantics
+(`vultron/adapters/driving/fastapi/inbox_port_factories.py`), making the
+trusted-deployment posture visible in code (RSH-07-003).
+
+### Look-alike gates that do NOT qualify (default stays permissive)
+
+Two embargo gates share surface structure with the qualifying set but fail the
+criterion. They are called out here because a future reader auditing for
+`AlwaysSucceed` on an authorization-flavored gate will find them and must not
+"harden" them:
+
+- **`CaseOwnerApprovesEmbargoResponse`** (`case_owner_approves_embargo_response_factory`,
+  `embargo/response_decision_tree.py`) — received-side, and carries the same
+  `CheckIsCaseOwner` gospel-bypass as `StatusAdoptionGate`. But its permissive
+  default is *accept-by-default*, which **EMB-15-001 (MUST) requires**, and
+  entering/maintaining an embargo is the **protective** direction — the
+  opposite of the teardown/premature-disclosure threat ADR-0076 addresses.
+  Flipping it to a blocking default would both violate EMB-15-001 and route
+  non-owners to the reject arm, *reducing* embargo protection. Not
+  security-significant.
+- **`EmbargoExitPolicyGuard`** (`embargo_exit_policy_guard_factory`,
+  `embargo/terminate_active_embargo_tree.py`) — its permissive default does
+  authorize embargo *exit* (the teardown direction), but this is a
+  **trigger-side** seam: the actor's own voluntary exit of an embargo it is a
+  party to (self-authorized), not a channel a remote non-owner controls. It is
+  gated behind a fail-closed reason Selector (all three
+  `exit_embargo_*` reason factories default `AlwaysFail`), so the tree makes no
+  forward progress by default, and EMB-14-002 frames the guard as an optional
+  policy veto ("MAY veto"). Flipping it to a blocking default would kill EMB-14's
+  legitimate voluntary-exit path. Not security-significant. (The received-side
+  teardown path *is* covered — by `EmbargoTeardownAuthorizationGate`, above.)
+
+### Remaining gates
+
+Every other bundle field (report validation, prioritization, CVE/vulnerability
+ID assignment, exploit acquisition, fix/mitigation deployment and monitoring,
+report closure, publication, actor discovery, and the remaining embargo
+proposal/response evaluators) is a **local operational decision** — the actor's
+own triage, data retrieval, or content production — with no mechanism to impose
+canonical case state or an embargo consequence on another party. The
+ceiling/floor rule (BT-23-002/006/007) governs them.
+
+### Outcome
+
+No additional gates require flipping. The audit's normative product is the
+generalized rule **BT-23-012** (so the criterion binds future gate authors);
+its durable analysis is this section; its regression guard is
+`test/core/behaviors/call_out/test_security_significant_defaults.py`. ADR-0025's
+security-significant exception (and ADR-0076) already stand and needed no change
+(#2676 AC-5's "if additional gates are found" condition was not triggered).
 
 ---
 

--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -12,6 +12,7 @@ related_specs:
 related_notes:
   - notes/embargo-default-semantics.md
   - notes/participant-embargo-consent.md
+  - notes/call-out-configuration.md
 relevant_packages:
   - vultron/core/states/em.py
   - vultron/core/services/embargo_lifecycle.py

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -1307,3 +1307,43 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: BT-23-003
+  - id: BT-23-012
+    priority: MUST
+    kind: project
+    statement: >
+      A call-out gate whose permissive backend would let a party other than the
+      Case Owner unilaterally cause canonical case-state adoption or embargo
+      teardown on the received side MUST default to the conservative (floor)
+      backend regardless of its stochastic success probability. The
+      ceiling/floor rules BT-23-002, BT-23-006, and BT-23-007 apply only to
+      gates that do NOT have this property.
+    rationale: >
+      BT-23-002/006/007 select the DETERMINISTIC backend purely from the
+      simulation success probability, which for a security-significant gate
+      maps a high-p node to the permissive AlwaysSucceed — the exact defect
+      CONCERN-2092 filed. ADR-0076 established the project-wide exception: for a
+      gate where permissiveness is a protocol-security risk rather than a
+      prototype-stage convenience, the floor (most restrictive
+      semantically-correct backend) is the default and permissiveness is an
+      explicit, documented operator opt-in. This entry lifts that exception from
+      the two named status gates (RSH-07-001, RSH-07-002) to a general rule that
+      binds every future gate author, so the classification is applied when a
+      gate is added rather than rediscovered by audit. The current membership of
+      the security-significant set, and the rationale for gates that look similar
+      but do NOT qualify (the accept-direction CaseOwnerApprovesEmbargoResponse,
+      which EMB-15-001 requires to default accept; the trigger-side,
+      fail-closed-by-default EmbargoExitPolicyGuard), is design analysis and
+      lives in notes/call-out-configuration.md, not here.
+    relationships:
+    - rel_type: constrains
+      spec_id: BT-23-002
+      note: >
+        Carves out security-significant gates from the p>0.5 → AlwaysSucceed
+        rule; the same carve-out applies to BT-23-006 and BT-23-007.
+    - rel_type: refines
+      spec_id: RSH-07-001
+      note: Generalizes the two-gate conservative-default requirement.
+    adr:
+    - ADR-0076
+    lint_suppress:
+    - missing_story_reference

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -1333,7 +1333,15 @@ groups:
       but do NOT qualify (the accept-direction CaseOwnerApprovesEmbargoResponse,
       which EMB-15-001 requires to default accept; the trigger-side,
       fail-closed-by-default EmbargoExitPolicyGuard), is design analysis and
-      lives in notes/call-out-configuration.md, not here.
+      lives in notes/call-out-configuration.md, not here. This entry governs the
+      default-selection POSTURE (conservative floor, not p-driven), which is
+      orthogonal to how a qualifying gate is COMPOSED: for the two status gates
+      specifically, RSH-07-004 (ADR-0080, CONCERN-2812) supersedes the interim
+      unconditional-FAILURE RequireCaseOwnerApprovalNode mechanism with a
+      conversation-state routing subtree. The conservative posture BT-23-012
+      mandates is unchanged, but a compliant implementation MUST NOT rely on a
+      CallOutBackendFactory that returns an unconditional FAILURE as that default
+      (RSH-07-004 verification).
     relationships:
     - rel_type: constrains
       spec_id: BT-23-002
@@ -1343,7 +1351,14 @@ groups:
     - rel_type: refines
       spec_id: RSH-07-001
       note: Generalizes the two-gate conservative-default requirement.
+    - rel_type: refines
+      spec_id: RSH-07-004
+      note: >
+        Posture (conservative default) is orthogonal to composition; RSH-07-004
+        replaces the unconditional-FAILURE mechanism with a routing subtree
+        without changing the default posture BT-23-012 mandates.
     adr:
     - ADR-0076
+    - ADR-0080
     lint_suppress:
     - missing_story_reference

--- a/test/core/behaviors/call_out/test_security_significant_defaults.py
+++ b/test/core/behaviors/call_out/test_security_significant_defaults.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Security-significant call-out gate default audit guard (#2676, BT-23-012).
+
+ADR-0076 established a project-wide exception to the ceiling/floor rule
+(BT-23-002/006/007): a call-out gate whose permissive backend would let a party
+other than the Case Owner *unilaterally* cause canonical case-state adoption or
+embargo teardown on the received side MUST default to the conservative (floor)
+backend regardless of its stochastic ``p`` (BT-23-012). Issue #2676 audited
+every ``CallOutBackendFactory`` field across all core bundles against that
+criterion and found exactly two qualifying gates — both already flipped under
+ADR-0076 (RSH-07-001, RSH-07-002).
+
+This module is the regression guard for that audit. It fails in **both**
+directions:
+
+- if a non-qualifying gate is accidentally hardened to the blocking
+  :class:`RequireCaseOwnerApprovalNode` default, or
+- if a newly-added gate silently adopts the blocking default without being
+  reflected in the known security-significant set here.
+
+It also pins the two spec-mandated look-alike embargo gates permissive, so a
+future reader auditing for ``AlwaysSucceed`` on an authorization-flavored gate
+does not "harden" them (see ``notes/call-out-configuration.md`` §
+"Security-Significant Gate Audit").
+"""
+
+import dataclasses
+import importlib
+import pkgutil
+from typing import Any
+
+import pytest
+from py_trees.common import Status
+
+from vultron.core.behaviors.call_out import bundles as core_bundles
+from vultron.core.behaviors.call_out.bundles.embargo import (
+    EMBARGO_DETERMINISTIC,
+)
+from vultron.core.behaviors.call_out.bundles.status_authorization import (
+    STATUS_AUTHORIZATION_DETERMINISTIC,
+)
+from vultron.core.behaviors.call_out.nodes import RequireCaseOwnerApprovalNode
+
+# The exact set of (singleton, field) pairs whose DETERMINISTIC default is the
+# conservative blocking backend. Per the #2676 audit this is the two
+# received-side status gates and nothing else (RSH-07-001, RSH-07-002).
+EXPECTED_CONSERVATIVE_GATES = {
+    ("STATUS_AUTHORIZATION_DETERMINISTIC", "status_adoption_gate_factory"),
+    (
+        "STATUS_AUTHORIZATION_DETERMINISTIC",
+        "embargo_teardown_authorization_gate_factory",
+    ),
+}
+
+# Look-alike embargo gates that share surface structure with the qualifying set
+# but do NOT qualify, so they intentionally keep a permissive (SUCCESS) default.
+# - CaseOwnerApprovesEmbargoResponse: EMB-15-001 (MUST) requires accept-by-default;
+#   accepting an embargo is the protective direction, not teardown.
+# - EmbargoExitPolicyGuard: trigger-side voluntary exit (self-authorized), gated
+#   behind a fail-closed reason Selector; EMB-14-002 frames it as an optional veto.
+PERMISSIVE_EMBARGO_LOOKALIKE_FIELDS = (
+    "case_owner_approves_embargo_response_factory",
+    "embargo_exit_policy_guard_factory",
+)
+
+
+def _core_deterministic_singletons() -> dict[str, Any]:
+    """Collect every core ``<DOMAIN>_DETERMINISTIC`` bundle singleton.
+
+    Walks the ``bundles`` *package modules* directly (not the ``__init__``
+    namespace), so a newly-added bundle module is covered by the audit guard
+    below even if its author forgets to re-export it from
+    ``bundles/__init__.py``.  This matches the #2676 audit's scope claim — every
+    ``CallOutBackendFactory`` field across all bundles under ``.../bundles/``.
+    """
+    out: dict[str, Any] = {}
+    for mod_info in pkgutil.iter_modules(core_bundles.__path__):
+        module = importlib.import_module(
+            f"{core_bundles.__name__}.{mod_info.name}"
+        )
+        for name in dir(module):
+            if not name.endswith("_DETERMINISTIC"):
+                continue
+            obj = getattr(module, name)
+            # Frozen bundle *instances* only (skip classes / non-dataclasses).
+            # Keyed by singleton name so a re-import from another module dedups.
+            if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+                out[name] = obj
+    return out
+
+
+def test_at_least_the_known_bundles_are_discovered():
+    """Sanity: discovery finds the status + embargo bundles it must classify."""
+    names = set(_core_deterministic_singletons())
+    assert "STATUS_AUTHORIZATION_DETERMINISTIC" in names
+    assert "EMBARGO_DETERMINISTIC" in names
+
+
+@pytest.mark.spec("RSH-07-001")
+@pytest.mark.spec("RSH-07-002")
+@pytest.mark.spec("BT-23-012")
+def test_conservative_default_set_is_exactly_the_two_status_gates():
+    """Only the two received-side status gates default to RequireCaseOwnerApproval.
+
+    Polices the security-significant conservative default specifically —
+    :class:`RequireCaseOwnerApprovalNode` — not ``AlwaysFail``, which is a
+    legitimate ceiling/floor default for many operational gates (BT-23-006).
+    Fails if a non-security-significant gate is hardened to
+    ``RequireCaseOwnerApprovalNode``, or if a new gate adopts it without
+    updating EXPECTED_CONSERVATIVE_GATES (which must be a deliberate, reviewed
+    classification per BT-23-012).
+    """
+    found: set[tuple[str, str]] = set()
+    for singleton_name, singleton in _core_deterministic_singletons().items():
+        for f in dataclasses.fields(singleton):
+            node = getattr(singleton, f.name)(f.name)
+            if isinstance(node, RequireCaseOwnerApprovalNode):
+                found.add((singleton_name, f.name))
+    assert found == EXPECTED_CONSERVATIVE_GATES
+
+
+@pytest.mark.spec("RSH-07-001")
+@pytest.mark.spec("RSH-07-002")
+def test_status_gates_conservative_default_blocks():
+    """Conservative path: both status gates tick FAILURE by default (block)."""
+    for f in dataclasses.fields(STATUS_AUTHORIZATION_DETERMINISTIC):
+        node = getattr(STATUS_AUTHORIZATION_DETERMINISTIC, f.name)(f.name)
+        node.tick_once()
+        assert node.status == Status.FAILURE
+
+
+@pytest.mark.spec("EMB-15-001")
+@pytest.mark.spec("EMB-14-002")
+def test_embargo_lookalike_gates_stay_permissive():
+    """Permissive path: the two spec-mandated look-alike gates tick SUCCESS.
+
+    Locks in the #2676 finding that these must NOT be flipped conservative
+    (EMB-15-001 accept-by-default; EMB-14-002 trigger-side optional veto).
+    """
+    for field_name in PERMISSIVE_EMBARGO_LOOKALIKE_FIELDS:
+        node = getattr(EMBARGO_DETERMINISTIC, field_name)(field_name)
+        node.tick_once()
+        assert node.status == Status.SUCCESS

--- a/test/core/behaviors/call_out/test_security_significant_defaults.py
+++ b/test/core/behaviors/call_out/test_security_significant_defaults.py
@@ -34,6 +34,19 @@ It also pins the two spec-mandated look-alike embargo gates permissive, so a
 future reader auditing for ``AlwaysSucceed`` on an authorization-flavored gate
 does not "harden" them (see ``notes/call-out-configuration.md`` §
 "Security-Significant Gate Audit").
+
+.. note::
+   This guard pins the *interim* mechanism. RSH-07-004 (ADR-0080, CONCERN-2812)
+   supersedes the unconditional-``FAILURE`` :class:`RequireCaseOwnerApprovalNode`
+   with a conversation-state routing subtree, and its verification requires that
+   "no ``CallOutBackendFactory`` returns an unconditional ``FAILURE`` node as the
+   conservative default." The conservative-default *posture* asserted here is
+   unchanged, but when the routing subtree lands
+   ``test_status_gates_conservative_default_blocks`` (which asserts the
+   ``FAILURE`` tick) and the :class:`RequireCaseOwnerApprovalNode` membership in
+   ``EXPECTED_CONSERVATIVE_GATES`` must be revised to check the security
+   *property* rather than the interim mechanism. See
+   ``notes/call-out-configuration.md`` § "Mechanism vs. posture".
 """
 
 import dataclasses
@@ -134,7 +147,15 @@ def test_conservative_default_set_is_exactly_the_two_status_gates():
 @pytest.mark.spec("RSH-07-001")
 @pytest.mark.spec("RSH-07-002")
 def test_status_gates_conservative_default_blocks():
-    """Conservative path: both status gates tick FAILURE by default (block)."""
+    """Conservative path: both status gates tick FAILURE by default (block).
+
+    Pins the *interim* blocking-stub mechanism. RSH-07-004 (ADR-0080) replaces
+    it with a routing subtree and forbids a ``CallOutBackendFactory`` that
+    returns an unconditional ``FAILURE`` default; when that lands, this
+    assertion must be reframed to check the security property (a non-owner does
+    not obtain SUCCESS by default), not the ``FAILURE`` tick. See the module
+    docstring and ``notes/call-out-configuration.md`` § "Mechanism vs. posture".
+    """
     for f in dataclasses.fields(STATUS_AUTHORIZATION_DETERMINISTIC):
         node = getattr(STATUS_AUTHORIZATION_DETERMINISTIC, f.name)(f.name)
         node.tick_once()


### PR DESCRIPTION
- Closes #2676

## Summary

Audits every `CallOutBackendFactory` field across all call-out bundles for permissive defaults that would let a non–Case-Owner unilaterally force canonical case-state adoption or embargo teardown (the ADR-0076 criterion). The two qualifying received-side gates were already flipped conservative under #2092 (RSH-07-001/002); no other gate qualifies. Adds a normative rule generalizing the exception, the durable audit analysis, and a regression guard.

## Motivation

ADR-0076's conservative-default exception was written narrowly for the two named status gates, while the ceiling/floor rules (BT-23-002/006/007) select DETERMINISTIC backends purely from stochastic `p` with no carve-out — a latent contradiction for any future security-significant gate. #2676 closes that by lifting the exception to a general rule and locking in the enumeration.

## Changes

- **`specs/behavior-tree-integration.yaml`**: adds `BT-23-012` (MUST) — a gate whose permissive backend lets a non–Case-Owner unilaterally cause canonical case-state adoption or embargo teardown on the received side MUST default to the floor regardless of `p`; `constrains` BT-23-002 and `refines` RSH-07-001. Generalizes the ADR-0076 exception into a rule that binds future gate authors.
- **`notes/call-out-configuration.md`**: adds the "Security-Significant Gate Audit (#2676)" section — the criterion, the full enumeration outcome (2 qualifying gates, both already conservative), and the rationale for the two look-alike embargo gates that must stay permissive (`CaseOwnerApprovesEmbargoResponse` — EMB-15-001 accept-by-default, protective direction; `EmbargoExitPolicyGuard` — trigger-side, fail-closed reason selector). Frontmatter cross-refs updated (two-way).
- **`notes/embargo-lifecycle.md`**: back-link to `call-out-configuration.md` (two-way cross-link rule).
- **`test/core/behaviors/call_out/test_security_significant_defaults.py`**: new regression guard. Walks all bundle package modules and asserts the conservative (`RequireCaseOwnerApprovalNode`) default set is exactly the two status gates, that the status gates block (FAILURE) by default, and that the two spec-mandated embargo look-alikes stay permissive (SUCCESS).

## Verification

- Full unit suite passes (8201 passed, 4 new); integration suite passes (1254 passed) — both re-run after freshening onto `origin/main`
- Black, flake8, mypy, pyright clean; spec-lint/spec-dump clean (BT-23-012 loads); markdownlint clean
- No code flips required — the audit's product is the generalized rule, the analysis, and the guard
- [x] AC-1: enumerated all `CallOutBackendFactory` fields across all bundles; identified qualifying gates (documented in notes)
- [x] AC-2: conservative default + permissive alternative + spec entry (BT-23-012) recorded for the qualifying set
- [x] AC-3: `EmbargoTeardownAuthorizationGate` confirmed already conservative (RSH-07-002); no remaining gaps
- [x] AC-4: permissive backends wired explicitly where needed (`inbox_port_factories.py` already wires `STATUS_AUTHORIZATION_PERMISSIVE`); no other gate flipped, so no additional demo config needed
- [x] AC-5: no additional gates found → ADR-0025 exception already stands, no change required (condition not triggered)
- [x] AC-6: guard test covers conservative (block) and permissive (succeed) paths