### PR TITLE
fix(participant-status): collect all dimension errors in CreateParticipantStatusNode._validate_transitions

### DIFF
--- a/plan/incoming/learnings/20260902-filing-is-not-deferring.md
+++ b/plan/incoming/learnings/20260902-filing-is-not-deferring.md
@@ -1,0 +1,29 @@
+---
+title: Filing an issue is not the same as deferring the fix
+type: learning
+timestamp: "2026-09-02T00:00:00+00:00"
+source: ISSUE-2958
+signal: theme-candidate
+---
+
+When a code-review finding lands in a file your PR didn't touch, the right
+response is **file an issue AND fix it now** — not file an issue as a substitute
+for fixing it.
+
+Filing is a tracking action. Fixing is the actual work. The decision to file
+(so the finding isn't lost) is separate from the decision about timing (do it
+now vs. a future PR). A finding that is size:S and clearly scoped should be done
+immediately unless it would break the PR's coherence or require its own test
+infrastructure.
+
+**Why:** Parking a trivial fix in the backlog guarantees a second session
+rediscovers and re-reasons about it, paying the context cost twice. Filing felt
+like tracking it; it wasn't — it was postponing it. Several of the 8 findings
+from PR #3078's code review were one-liners that should have been applied in the
+same session rather than queued.
+
+**How to apply:** When the upward-reflection checklist fires BW-07-009 (findings
+in untouched files must be filed as issues), also ask: is this fix trivially
+small? If yes, apply it now and close the issue in the same PR. Filing without
+fixing is only correct when the fix is non-trivial, requires its own tests, or
+would substantially change the PR's character.

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -1080,6 +1080,42 @@ class TestCreateParticipantStatusNode:
         assert bt_result.status == Status.SUCCESS
         assert "status_id" in result_out
 
+    def test_validate_transitions_reports_all_dimension_errors(self):
+        """#2112 AC-1/AC-2: _validate_transitions() collects all dimension failures.
+
+        When VF and D are simultaneously invalid (actor lacks both VENDOR and
+        DEPLOYER roles), both error messages must appear in feedback_message.
+        Regression test for the first-error-only bug in _validate_transitions().
+        """
+        from py_trees.common import Status
+        from vultron.core.models.case_participant import CaseParticipant
+        from vultron.core.states.cs import CS_d, CS_vf
+        from vultron.enums.roles import CVDRole
+
+        # Actor has neither VENDOR nor DEPLOYER role → both role guards fire.
+        participant = self.dl.read(self.actor_participant.id_)
+        assert isinstance(participant, CaseParticipant)
+        participant.case_roles = [CVDRole.REPORTER]
+        self.dl.save(participant)
+
+        bt_result, result_out = self._run_node(
+            rm_state=None,
+            vf_state=CS_vf.Vf,  # requires VENDOR (ADR-0075)
+            d_state=CS_d.D,  # requires DEPLOYER (CSB-15-002)
+            pxa_state=None,
+        )
+
+        assert bt_result.status == Status.FAILURE
+        assert "status_id" not in result_out
+        assert "ADR-0075" in bt_result.feedback_message, (
+            f"Expected VF role error (ADR-0075) in feedback_message;"
+            f" got: {bt_result.feedback_message!r}"
+        )
+        assert "CSB-15-002" in bt_result.feedback_message, (
+            f"Expected D role error (CSB-15-002) in feedback_message;"
+            f" got: {bt_result.feedback_message!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # ValidateTriggerTransitionsNode — AC-1 through AC-6 (issues #2081, #1903)

--- a/vultron/core/behaviors/bridge.py
+++ b/vultron/core/behaviors/bridge.py
@@ -510,7 +510,7 @@ class BTBridge:
             # VultronActivityConstructionError wraps what is really a factory
             # misuse.  Consult the exception, not just the flag.
             error_msg = f"BT execution failed: {type(e).__name__}: {e}"
-            self.logger.exception(error_msg)
+            self.logger.warning(error_msg)
             errors.append(error_msg)
             return BTExecutionResult(
                 status=Status.FAILURE,
@@ -596,7 +596,12 @@ class BTBridge:
                 feedback_message=msg,
             )
         with _BT_GLOBAL_LOCK:
-            managed_keys = ["datalayer", "trigger_activity_factory"]
+            managed_keys = [
+                "datalayer",
+                "trigger_activity_factory",
+                "sync_port",
+                "wire_render_port",
+            ]
             storage = py_trees.blackboard.Blackboard.storage
             key_aliases: set[str] = set()
             for key in managed_keys:
@@ -618,7 +623,7 @@ class BTBridge:
                 return self.execute_tree(bt, max_iterations)
             except VultronError as e:
                 error_msg = f"BT setup failed: {type(e).__name__}: {e}"
-                self.logger.exception(error_msg)
+                self.logger.warning(error_msg)
                 return BTExecutionResult(
                     status=Status.FAILURE,
                     feedback_message=error_msg,

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -361,6 +361,53 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
             eff_vf = CS_vf.Vf
         return eff_vf, eff_pxa
 
+    def _validate_transitions(
+        self,
+        current_vf: "CS_vf | None",
+        current_d: "CS_d | None",
+        pxa_before: CS_pxa,
+        eff_vf: "CS_vf | None",
+        eff_d: "CS_d | None",
+        eff_pxa: CS_pxa,
+        participant_obj: object,
+    ) -> "Status | None":
+        """EH-07-001/BTND-10-002: collect all per-dimension failures (#2112).
+
+        Runs every per-dimension check and collects errors before returning, so
+        callers always receive a complete diagnostic.  The compound CS-transition
+        check is only run when all per-dimension checks pass — it is derived when
+        any single-dimension violation is already present (EH-07-002).
+
+        Returns ``Status.FAILURE`` with a joined ``feedback_message`` when any
+        check fails; ``None`` when all checks pass.
+        """
+        errors: list[str] = []
+
+        if (
+            self._check_vf_precondition(current_vf, participant_obj)
+            is not None
+        ):
+            errors.append(self.feedback_message)
+        if self._check_d_precondition(current_d, participant_obj) is not None:
+            errors.append(self.feedback_message)
+        if self._pxa_state is not None:
+            if self._check_pxa_precondition(pxa_before) is not None:
+                errors.append(self.feedback_message)
+
+        if not errors:
+            if (
+                self._check_compound_transition(
+                    current_vf, current_d, pxa_before, eff_vf, eff_d, eff_pxa
+                )
+                is not None
+            ):
+                errors.append(self.feedback_message)
+
+        if errors:
+            self.feedback_message = "; ".join(errors)
+            return Status.FAILURE
+        return None
+
     def update(self) -> Status:
         dl = self.datalayer
         if dl is None:
@@ -396,21 +443,7 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
             dl, participant_id
         )
         participant_obj = dl.read(participant_id)
-
-        guard = self._check_vf_precondition(current_vf, participant_obj)
-        if guard is not None:
-            return guard
-
-        guard = self._check_d_precondition(current_d, participant_obj)
-        if guard is not None:
-            return guard
-
         pxa_before = _resolve_pxa_state(case, participant_obj)
-
-        if self._pxa_state is not None:
-            guard = self._check_pxa_precondition(pxa_before)
-            if guard is not None:
-                return guard
 
         # Effective states before promotion (what the caller requested)
         eff_vf = self._vf_state if self._vf_state is not None else current_vf
@@ -419,9 +452,14 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
             self._pxa_state if self._pxa_state is not None else pxa_before
         )
 
-        # AC-3: validate compound CS transition (SM-09-002)
-        guard = self._check_compound_transition(
-            current_vf, current_d, pxa_before, eff_vf, eff_d, eff_pxa
+        guard = self._validate_transitions(
+            current_vf,
+            current_d,
+            pxa_before,
+            eff_vf,
+            eff_d,
+            eff_pxa,
+            participant_obj,
         )
         if guard is not None:
             return guard

--- a/vultron/metadata/history/cli.py
+++ b/vultron/metadata/history/cli.py
@@ -43,6 +43,7 @@ See ``specs/build-workflow.yaml`` BW-01 for the incoming-learnings queue.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime
 import re
 import subprocess
@@ -351,7 +352,11 @@ def append_history_entry(
     if entry_file.exists() and discriminator:
         disc = _sanitize_entry_id(discriminator)
         # The incoming slug often already embeds the entry id; don't repeat it.
-        stem = disc if entry_id in disc else f"{entry_id}-{disc}"
+        stem = (
+            disc
+            if (disc == entry_id or disc.startswith(entry_id + "-"))
+            else f"{entry_id}-{disc}"
+        )
         entry_file = entry_dir / f"{stem}.md"
     if entry_file.exists():
         raise FileExistsError(f"history entry already exists: {entry_file}")
@@ -363,6 +368,8 @@ def append_history_entry(
         regenerate_readme(month_dir)
     except Exception as exc:
         entry_file.unlink(missing_ok=True)
+        with contextlib.suppress(OSError):
+            entry_dir.rmdir()
         raise ValueError(
             f"README generation failed; entry rolled back: {exc}"
         ) from exc

--- a/vultron/metadata/specs/lint.py
+++ b/vultron/metadata/specs/lint.py
@@ -189,7 +189,7 @@ _SPEC_SYMBOL_RE = re.compile(r"`([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)`")
 #: textual scan rather than an AST walk on purpose: a spec may legitimately
 #: name a symbol that appears only in a docstring, a comment, or a string
 #: literal, and none of those are bindings an AST pass would report.
-_SOURCE_SYMBOL_RE = re.compile(r"\b[A-Z][A-Z0-9_]*\b")
+_SOURCE_SYMBOL_RE = re.compile(r"\b[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+\b")
 
 #: Directories (relative to repo root) whose Python files legitimately cite
 #: synthetic fixture IDs and are therefore excluded from the phantom-ID scan.


### PR DESCRIPTION
- Closes #2958
- Closes #3079
- Closes #3080
- Closes #3081
- Closes #3082
- Closes #3086

## Summary

Fixes two classes of defect in one pass:

1. **#2958** — `CreateParticipantStatusNode._validate_transitions()`: collects all per-dimension validation failures before returning, so callers receive a complete diagnostic instead of first-error-only. The compound CS-transition check is deferred until all per-dimension checks pass (EH-07-002).

2. **Pre-existing trivial fixes** from code review (were filed as issues and fixed immediately per the same-session rule):
   - **#3079** `bridge.py` — `sync_port`/`wire_render_port` added to `managed_keys` so connections are released promptly, matching the fix PR #3064 applied to `trigger_activity_factory`
   - **#3080** `bridge.py` — `logger.exception` → `logger.warning` for `VultronError` in both `execute_tree` and `execute_with_setup`; protocol outcomes are not unexpected failures (AGENTS.md rule 310)
   - **#3081** `history/cli.py` — discriminator-embed check replaced with word-boundary-safe `startswith` test to prevent filename collisions for numeric-prefix IDs
   - **#3082** `history/cli.py` — rollback now also removes the newly-created entry directory if it is empty after the entry file is unlinked
   - **#3086** `specs/lint.py` — `_SOURCE_SYMBOL_RE` narrowed to require at least one underscore group, filtering noise tokens that can never match a spec citation

## Changes

- **`vultron/core/behaviors/case/nodes/participant/status.py`**: `_validate_transitions()` added; `update()` refactored to call it once instead of four early-return guards
- **`test/.../test_add_participant_status.py`**: `test_validate_transitions_reports_all_dimension_errors` regression test
- **`vultron/core/behaviors/bridge.py`**: managed_keys extended; log levels corrected
- **`vultron/metadata/history/cli.py`**: discriminator-embed fix; rollback cleanup
- **`vultron/metadata/specs/lint.py`**: `_SOURCE_SYMBOL_RE` narrowed

## Verification

- All 8198 unit tests pass; 1254 integration tests pass
- Black, flake8, mypy, pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)