### PR TITLE
Add CaseParticipant.new_at_rm() and new_at_received() named constructors; refactor CreateInviteeParticipantAtReceivedNode

### DIFF
--- a/test/core/models/test_participant.py
+++ b/test/core/models/test_participant.py
@@ -5,7 +5,9 @@ import logging
 import pytest
 
 from vultron.core.models.participant import VultronParticipant
+from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
+from vultron.errors import VultronValidationError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -202,3 +204,92 @@ class TestRemoveRole:
         p.remove_role(CVDRole.VENDOR)
         assert CVDRole.DEPLOYER in p.roles
         assert CVDRole.VENDOR not in p.roles
+
+
+# ---------------------------------------------------------------------------
+# new_at_rm() and new_at_received() (AC-1, AC-2 from issue #3072)
+# ---------------------------------------------------------------------------
+
+
+class TestNewAtRm:
+    """Tests for CaseParticipant.new_at_rm() (AC-1) and new_at_received() (AC-2)."""
+
+    def test_new_at_rm_received_returns_participant(self):
+        """new_at_rm(RM.RECEIVED, ...) returns a VultronParticipant."""
+        p = VultronParticipant.new_at_rm(RM.RECEIVED, _CONTEXT, _ACTOR)
+        assert isinstance(p, VultronParticipant)
+
+    def test_new_at_rm_received_sets_rm_state(self):
+        """new_at_rm(RM.RECEIVED, ...) leaves latest status at RM.RECEIVED."""
+        p = VultronParticipant.new_at_rm(RM.RECEIVED, _CONTEXT, _ACTOR)
+        assert p.participant_status is not None
+        assert p.participant_status.rm.state == RM.RECEIVED
+
+    def test_new_at_rm_sets_case_roles(self):
+        """new_at_rm() passes roles to the participant."""
+        p = VultronParticipant.new_at_rm(
+            RM.RECEIVED, _CONTEXT, _ACTOR, roles=[CVDRole.VENDOR]
+        )
+        assert CVDRole.VENDOR in p.case_roles
+
+    def test_new_at_rm_empty_roles(self):
+        """new_at_rm() with no roles produces an empty case_roles list."""
+        p = VultronParticipant.new_at_rm(RM.RECEIVED, _CONTEXT, _ACTOR)
+        assert p.case_roles == []
+
+    def test_new_at_rm_non_adjacent_state_raises(self):
+        """new_at_rm() raises VultronValidationError for a non-START-adjacent state."""
+        with pytest.raises(VultronValidationError):
+            VultronParticipant.new_at_rm(RM.VALID, _CONTEXT, _ACTOR)
+
+    def test_new_at_rm_accepted_raises(self):
+        """new_at_rm(RM.ACCEPTED, ...) raises because ACCEPTED is not adjacent to START."""
+        with pytest.raises(VultronValidationError):
+            VultronParticipant.new_at_rm(RM.ACCEPTED, _CONTEXT, _ACTOR)
+
+    def test_new_at_rm_closed_raises(self):
+        """new_at_rm(RM.CLOSED, ...) raises because CLOSED is not adjacent to START."""
+        with pytest.raises(VultronValidationError):
+            VultronParticipant.new_at_rm(RM.CLOSED, _CONTEXT, _ACTOR)
+
+    def test_new_at_rm_start_raises(self):
+        """new_at_rm(RM.START, ...) raises because START→START is not a valid transition."""
+        with pytest.raises(VultronValidationError):
+            VultronParticipant.new_at_rm(RM.START, _CONTEXT, _ACTOR)
+
+
+class TestNewAtReceived:
+    """Tests for CaseParticipant.new_at_received() (AC-2 from issue #3072)."""
+
+    def test_new_at_received_returns_participant(self):
+        """new_at_received() returns a VultronParticipant."""
+        p = VultronParticipant.new_at_received(_CONTEXT, _ACTOR)
+        assert isinstance(p, VultronParticipant)
+
+    def test_new_at_received_sets_rm_state(self):
+        """new_at_received() leaves latest status at RM.RECEIVED."""
+        p = VultronParticipant.new_at_received(_CONTEXT, _ACTOR)
+        assert p.participant_status is not None
+        assert p.participant_status.rm.state == RM.RECEIVED
+
+    def test_new_at_received_sets_roles(self):
+        """new_at_received() forwards roles to the participant."""
+        p = VultronParticipant.new_at_received(
+            _CONTEXT, _ACTOR, roles=[CVDRole.COORDINATOR]
+        )
+        assert CVDRole.COORDINATOR in p.case_roles
+
+    def test_new_at_received_no_roles(self):
+        """new_at_received() with no roles produces an empty case_roles list."""
+        p = VultronParticipant.new_at_received(_CONTEXT, _ACTOR)
+        assert p.case_roles == []
+
+    def test_new_at_received_equivalent_to_new_at_rm(self):
+        """new_at_received() is equivalent to new_at_rm(RM.RECEIVED, ...)."""
+        p1 = VultronParticipant.new_at_received(_CONTEXT, _ACTOR)
+        p2 = VultronParticipant.new_at_rm(RM.RECEIVED, _CONTEXT, _ACTOR)
+        assert p1.participant_status is not None
+        assert p2.participant_status is not None
+        assert p1.participant_status.rm.state == p2.participant_status.rm.state
+        assert p1.attributed_to == p2.attributed_to
+        assert p1.context == p2.context

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -66,7 +66,6 @@ from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC_Trigger
-from vultron.core.states.rm import RM
 from vultron.enums.roles import validate_roles
 from vultron.core.models._helpers import _as_id
 
@@ -454,17 +453,11 @@ class CreateInviteeParticipantAtReceivedNode(DataLayerActionWithPorts):
             return Status.SUCCESS
 
         roles = self._read_invite_roles()
-        participant = VultronParticipant(
-            id_=f"{self.case_id}/participants/{self.invitee_id.split('/')[-1]}",
-            attributed_to=self.invitee_id,
-            context=self.case_id,
-            case_roles=roles,
-        )
         # CM-11-001: Accept(Invite) records RM.RECEIVED only. The full
         # triage cycle is a distinct step run by the invitee after replica
         # delivery (PCR-08-010).
-        participant.append_rm_state(
-            RM.RECEIVED, actor=self.invitee_id, context=self.case_id
+        participant = VultronParticipant.new_at_received(
+            self.case_id, self.invitee_id, roles
         )
         if roles:
             self.logger.info(

--- a/vultron/core/models/case_participant.py
+++ b/vultron/core/models/case_participant.py
@@ -262,6 +262,73 @@ class CaseParticipant(CoreObject):
         )
         return True
 
+    @classmethod
+    def new_at_rm(
+        cls,
+        rm_state: RM,
+        case_id: str,
+        invitee_id: str,
+        roles: list[CVDRole] | None = None,
+    ) -> "CaseParticipant":
+        """Create a participant placed at *rm_state* in one step (CM-11-001).
+
+        Validates that *rm_state* is reachable from ``RM.START`` in a single
+        hop via :func:`~vultron.core.states.rm.is_valid_rm_transition`.  This
+        encodes the invariant structurally: callers cannot over-advance the RM
+        ladder by calling :meth:`append_rm_state` multiple times.
+
+        Args:
+            rm_state: Target RM state; must be adjacent to ``RM.START``.
+            case_id: URI of the case this participant belongs to.
+            invitee_id: URI of the actor being added as participant.
+            roles: CVD roles to assign; defaults to an empty list.
+
+        Returns:
+            A new :class:`CaseParticipant` whose latest
+            :class:`~vultron.core.models.participant_status.ParticipantStatus`
+            carries *rm_state*.
+
+        Raises:
+            VultronValidationError: when *rm_state* is not adjacent to
+                ``RM.START``.
+        """
+        if not is_valid_rm_transition(RM.START, rm_state):
+            raise VultronValidationError(
+                f"RM state {rm_state!r} is not reachable from RM.START"
+                " in one hop; use append_rm_state() for multi-hop advances"
+            )
+        participant = cls(
+            id_=f"{case_id}/participants/{invitee_id.split('/')[-1]}",
+            attributed_to=invitee_id,
+            context=case_id,
+            case_roles=roles or [],
+        )
+        participant.append_rm_state(
+            rm_state, actor=invitee_id, context=case_id
+        )
+        return participant
+
+    @classmethod
+    def new_at_received(
+        cls,
+        case_id: str,
+        invitee_id: str,
+        roles: list[CVDRole] | None = None,
+    ) -> "CaseParticipant":
+        """Create a participant at ``RM.RECEIVED`` (CM-11-001 convenience factory).
+
+        Equivalent to ``new_at_rm(RM.RECEIVED, case_id, invitee_id, roles)``.
+
+        Args:
+            case_id: URI of the case this participant belongs to.
+            invitee_id: URI of the actor being added as participant.
+            roles: CVD roles to assign; defaults to an empty list.
+
+        Returns:
+            A new :class:`CaseParticipant` at ``RM.RECEIVED``.
+        """
+        return cls.new_at_rm(RM.RECEIVED, case_id, invitee_id, roles)
+
     def add_participant_status(self, status: ParticipantStatus) -> None:
         """Append a ParticipantStatus to this participant's history.
 


### PR DESCRIPTION
- Closes #3072

## Summary

Encodes the CM-11-001 invariant structurally by adding named constructors to `CaseParticipant` that call `append_rm_state` exactly once, preventing BT nodes from silently over-advancing the RM ladder through multiple calls.

## Changes

- **`vultron/core/models/case_participant.py`**: Adds `new_at_rm(rm_state, case_id, invitee_id, roles)` — validates adjacency from `RM.START` via `is_valid_rm_transition` (raises `VultronValidationError` on failure) and calls `append_rm_state` exactly once. Adds `new_at_received(case_id, invitee_id, roles)` as a convenience wrapper.
- **`vultron/core/behaviors/case/accept_invite_tree.py`**: Refactors `CreateInviteeParticipantAtReceivedNode.update()` to use `new_at_received(...)` instead of the manual three-line construct + `append_rm_state` call. Removes now-unused `RM` import.
- **`test/core/models/test_participant.py`**: Adds 13 tests across `TestNewAtRm` and `TestNewAtReceived` covering happy path, role propagation, and adjacency-guard raises for non-START-adjacent states.

## Design notes

`new_at_rm` is intentionally limited to states adjacent to `RM.START` (currently only `RM.RECEIVED`). The reporter-at-`RM.ACCEPTED` path in `_AddReporterParticipantNode` is a separate protocol concern per ADR-0041 AC-2: it bypasses `append_rm_state` entirely via `_get_or_create_accepted_status`, and is not subject to the multi-call over-advancement bug this issue targets.

## Verification

- 8286 unit tests pass (13 new)
- 1254 integration tests pass
- Black, flake8, mypy, pyright all clean