### PR TITLE
Doctrine: separate FILE from DEFER; make fix-now the default

### DIFF
--- a/.agents/skills/bugfix/REFERENCE.md
+++ b/.agents/skills/bugfix/REFERENCE.md
@@ -79,7 +79,7 @@ Reference newly filed issues in the PR description:
 
 ```text
 Fixes #<N>.
-Also filed: #<NNN> (sibling instance discovered during analysis).
+Closes #<NNN> (sibling instance discovered during analysis and fixed here).
 ```
 
 ---

--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -186,8 +186,9 @@ Ask: **"Proceed with this plan, redirect, or narrow scope?"**
 - **Confirms**: proceed to Phase 4.
 - **Redirects** to a different area: update understanding and return to
   Phase 2 for the redirected scope.
-- **Narrows scope**: note which sibling hits will be filed as new Bug issues
-  rather than fixed in this PR.
+- **Narrows scope**: the user is explicitly deferring specific sibling hits —
+  this *is* Gate 1 approval, given directly. File each deferred hit as a Bug
+  issue. Everything not narrowed out is still fixed now.
 
 **Do not begin implementation until the user confirms the plan.**
 
@@ -207,15 +208,21 @@ Once the plan is confirmed:
    disproportionate, skip the test but create a follow-up Bug issue explaining
    why. Do not silently omit the test.
 
-2. **Fix the root cause** — not just the symptom. If the root cause is
-   provably out of scope, fix the symptom and create a Bug issue for the
-   root cause before closing this one.
+2. **Fix the root cause** — not just the symptom. "The root cause is out of
+   scope" is a deferral: it must clear Gate 1 in
+   `.agents/skills/shared/completeness-doctrine.md` (a **measured remainder** and
+   explicit approval), not be asserted. If it clears the gate, fix the symptom,
+   file a Bug issue for the root cause, and document the cause before closing.
 
-3. **Handle sibling hits**:
-   - Hits small enough to fix in the same PR: fix them.
-   - Hits out of scope: file each as a new Bug-type issue via the
-     `manage-github-issue` helper. Reference each in the PR description
-     (`Also filed: #NNN`). See [REFERENCE.md](REFERENCE.md) § "Escalation".
+3. **Handle sibling hits** (these are *first-order* findings — revealed by the
+   original bug — so the default is **fix now**, never defer):
+   - Fix each one in this PR.
+   - If a hit is an **"also" excursion** (fails the "also" test in the
+     completeness doctrine), also file a Bug issue via `manage-github-issue`
+     and have this PR **close** it: add `- Closes #NNN` to the PR body with a
+     one-line "why". Filing the record does not mean leaving the work.
+   - Defer a sibling hit only through Gate 1 (measured remainder + approval).
+     See [REFERENCE.md](REFERENCE.md) § "Escalation".
 
 4. **Iterate**: run `format-code`, `run-linters`, `run-tests`; refine until
    all relevant tests pass. Apply branch-ownership and pre-existing-failure

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -251,15 +251,23 @@ on what "done" means — loaded by `orient-agent` in Phase 1.
      exists under `test/core/use_cases/triggers/` (see
      `notes/triggers-test-coverage.md`).
 
-**Scope expansion judgment:** If implementing this task reveals adjacent work
-that clearly belongs with it, apply the following:
+**Scope expansion judgment:** If implementing this task reveals adjacent work,
+the default is to **fix it now** — FILE (keep a record) and DEFER (leave it for
+later) are separate decisions. Apply
+`.agents/skills/shared/completeness-doctrine.md`:
 
-- Would it require a new GitHub issue, a design decision, or an irreversible
-  change? → Ask the user if present. If unattended, make the best-judgment
-  call, record the rationale as a learning file in `plan/incoming/learnings/`,
-  and continue.
-- Trivially additive (clearly-missing test, obvious type annotation fix)?
-  → Just do it.
+- Not an "also" excursion (you can explain it and the task in one sentence
+  without "also") → just do it; no issue, the diff is the record.
+- An "also" excursion → fix it now **and** file an issue this PR closes
+  (`- Closes #N`, one-line "why"). Filing is not deferring.
+- Genuinely too big to finish now → defer only via Gate 1: file, present a
+  **measured remainder** in plain language, and get explicit approval. On
+  silence (unattended), **fix it now** — do not defer, and do not park the
+  rationale in a learning file as a substitute for doing or tracking the work.
+  Only second-order findings are eligible.
+- Inverts a premise the issue or its specs/ADRs rested on → Gate 2: explain the
+  overturned premise, ask if/what to file. On silence (unattended), **halt** —
+  leave the PR blocked rather than acting on the new premise unreviewed.
 
 ### Phase 6 — Validate
 

--- a/.agents/skills/pr-execute/REFERENCE.md
+++ b/.agents/skills/pr-execute/REFERENCE.md
@@ -125,15 +125,17 @@ After running the test suite, scan `XFAIL` lines in pytest output. For each:
 1. Extract `#<N>` from the `reason` string (regex `#(\d+)`).
 2. If no issue number found: this is an unmanaged xfail — file a new `bug` +
    `flaky-test` issue, update the `reason` string in the PR to reference it,
-   record as `outcome: filed`.
+   record as `outcome: fixed` with the new `issue_number` (the xfail now points to
+a live issue — the finding is resolved).
 3. If issue number found: `gh issue view <N> --json state`
    - `open` → fine, no action needed.
    - `closed` → the fix landed without removing the marker; file a new tracking
-     issue, update the reason string, record as `outcome: filed`.
+     issue, update the reason string, record as `outcome: fixed` with the new `issue_number` (the xfail now points to
+a live issue — the finding is resolved).
 
 The rule: **every `xfail` must point to a live open issue**. An xfail with a
 dead or missing reference is treated as unmanaged debt and triggers a
-`new-issue-no-ask` finding.
+NEW-ISSUE finding — file a fresh tracking issue for it.
 
 > **xfail-tracking issues vs flaky-test issues**: these are distinct categories.
 > An xfail-tracking issue documents a known architectural violation or pre-existing
@@ -250,11 +252,14 @@ The immediate issue is fixed but something related cannot be addressed now.
 
 ### ❌ Cannot Address / Needs Discussion
 
-The comment raises something outside the PR's scope or requiring design work.
+The comment raises something genuinely too big to finish now. "Separate
+treatment" is a deferral — it must clear Gate 1 (measured remainder + explicit
+approval), not be asserted by the act of filing. If you can just fix it, fix it.
 
 **Reply template**:
-> "This would require {brief explanation}. Filed as #{issue_number} for
-> separate treatment. Can we discuss whether this should block merge?"
+> "This would require {brief explanation}. I did {what}, and {measured
+> remainder} concretely remains. Filed as #{issue_number}. Can we discuss
+> whether to fold it in here or leave it for #{issue_number}?"
 
 ### Do NOT Resolve If
 
@@ -312,12 +317,12 @@ File: `.claude/pr-{number}-execute.json`
       "comment_resolution": null
     },
     {
-      "finding_id": "phase9-distant-refactor-0",
-      "outcome": "deferred-ask",
-      "commit_ref": null,
+      "finding_id": "phase9-retry-logic-0",
+      "outcome": "fixed",
+      "commit_ref": "abc1234",
       "issue_number": 999,
-      "skip_reason": "Non-trivial, distant cousin — filed as #999, awaiting user decision on fold-in.",
-      "comment_resolution": null
+      "skip_reason": null,
+      "comment_resolution": "'also' excursion — filed #999 and fixed it in this PR; PR closes #999."
     }
   ],
   "execute_comment_url": "https://github.com/CERTCC/Vultron/pull/1234#issuecomment-..."
@@ -328,10 +333,15 @@ File: `.claude/pr-{number}-execute.json`
 
 | Value | Meaning |
 |---|---|
-| `fixed` | Applied inline; commit_ref recorded |
-| `filed` | GitHub issue created; issue_number recorded |
-| `deferred-ask` | Issue filed; user asked whether to fold in; awaiting decision |
-| `skipped` | Could not address; skip_reason explains why |
+| `fixed` | Applied inline; commit_ref recorded. `issue_number` is `null` for a plain `fix-now`, or set for a `fix-now-file` excursion the PR closes |
+| `deferred-ask` | Gate 1: issue filed, a measured remainder presented, and the user **explicitly approved** deferral. Silence does not produce this outcome — silence produces `fixed` |
+| `halted` | Gate 2: an inversion the user did not resolve; PR set to draft/blocked; pipeline stopped |
+| `skipped` | Could not address (e.g., unresolved conflict, pre-existing failure filed with evidence); skip_reason explains why |
+
+There is no standalone `filed` outcome — filing a record is not an endpoint.
+A filed finding is either `fixed` (the PR closes it) or `deferred-ask`
+(explicitly approved). See `.claude/skills/shared/completeness-doctrine.md`
+§ "Filing Is Not Deferring".
 
 **Integrity check**: `len(results)` must equal `len(triage.findings)`. Every
 finding must have an outcome. `pr-verify` checks this count and warns if they
@@ -361,8 +371,9 @@ cannot produce a READY-TO-MERGE verdict.
 ## PR Execute: #<number> — <title>
 
 **Fixes applied**: <N> commits
-**Issues filed**: <M>
-**Deferred (awaiting your input)**: <K>
+**Excursions filed and fixed**: <M> (PR closes them)
+**Deferred (you approved)**: <K>
+**Halted (inversion, awaiting you)**: <H>
 **Tests run**: unit only / unit + integration
 **CI status**: ✅ passing / ❌ failing / ⏳ timed out
 **Base sync**: ✅ merged `<base_ref>` @ `def5678` — <N> conflicts resolved / ✅ already current / ❌ conflicts unresolved
@@ -382,22 +393,31 @@ _Omit this section entirely when the merge was clean._
 
 ### Fixed
 
-| Finding | Commit |
-|---|---|
-| phase5-missing-nonemptystring-0: Field must use OptionalNonEmptyString | `abc1234` |
-| phase8-unused-import-0: Remove unused import | `abc1234` |
-
-### Filed as Issues
-
-| Finding | Issue |
-|---|---|
-| phase9-distant-refactor-0: Refactor dispatcher | #999 |
-
-### Deferred — Awaiting Your Input
-
-| Finding | Issue | Question |
+| Finding | Commit | Closes |
 |---|---|---|
-| phase8-extract-helper-0: Extract helper function | #1000 | Fold into this PR or leave for #1000? |
+| phase5-missing-nonemptystring-0: Field must use OptionalNonEmptyString | `abc1234` | — |
+| phase8-unused-import-0: Remove unused import | `abc1234` | — |
+| phase9-retry-logic-0: "also" excursion — rewrote retry logic | `abc1234` | #999 |
+
+_The `Closes` column shows `fix-now-file` excursions the PR closes; `—` means a
+plain `fix-now` recorded by the diff alone._
+
+### Deferred — You Approved
+
+| Finding | Issue | Measured remainder |
+|---|---|---|
+| phase9-migrate-callsites-0: Migrate remaining call sites | #1000 | 3 of 47 done; 44 remain, each a distinct signature change |
+
+_Only appears when you **explicitly approved** deferral. Silence produces a fix,
+not a deferral._
+
+### Halted — Inversion, Awaiting You
+
+| Finding | Overturned premise |
+|---|---|
+| phase6-embargo-premise-0 | Issue assumed embargo state is single-owner; the fix requires multi-owner, which contradicts ADR-0012 |
+
+_PR is set to draft/blocked until you resolve the inversion._
 
 ### Skipped
 

--- a/.agents/skills/pr-execute/SKILL.md
+++ b/.agents/skills/pr-execute/SKILL.md
@@ -60,8 +60,8 @@ Run /pr-triage first (or /pr-ship to run the full pipeline).
 
 ### Phase 2 — Apply fix-now Fixes
 
-For each finding where `decision_outcome` is `fix-now` or `fix-now-expand-scope`
-and `severity` is `FAIL` or `IMPROVE`:
+For each finding where `decision_outcome` is `fix-now` and `severity` is `FAIL`
+or `IMPROVE`:
 
 > Note: findings with `severity: NEW-ISSUE` are handled exclusively in Phase 3,
 > regardless of their `decision_outcome`. Do not process them here.
@@ -85,21 +85,42 @@ every push includes the sync commit and passes local tests first.
 
 ### Phase 3 — Handle NEW-ISSUE Findings
 
-For each finding with `severity: NEW-ISSUE`:
+For each finding with `severity: NEW-ISSUE`. **Filing a record is not the same
+as deferring the work** — the default is to fix now and let the PR close the
+issue. See `.claude/skills/shared/completeness-doctrine.md` § "Filing Is Not
+Deferring" and "The Two Gates".
 
-**`new-issue-ask`** (non-trivial, distant cousin):
+**`fix-now-file`** (an "also" excursion you fix now):
 
-1. File a GitHub issue via `manage-github-issue` capturing the finding description.
+1. File a GitHub issue via `manage-github-issue` capturing the finding.
 2. Add the issue to Project #24: `bash .agents/skills/shared/add-to-project.sh <N>`.
-3. Record the finding as `outcome: deferred-ask` with the new `issue_number`.
-4. Do NOT fold the work into this PR yet — the deferred-ask items are surfaced
-   in the execute comment and again in pr-verify for the user to decide.
+3. **Fix it in this PR** (fold into the Phase 2 batch). Add `- Closes #N` to the
+   PR body and a one-line "why" in the Changes section (see `pr-body-guide.md`).
+4. Record `outcome: fixed` with the `issue_number`.
 
-**`new-issue-no-ask`** (requires separate design effort):
+**`defer-ask`** (Gate 1 — second-order work genuinely too big to finish now):
 
-1. File a GitHub issue via `manage-github-issue`.
-2. Add to Project #24.
-3. Record as `outcome: filed` with `issue_number`.
+1. File a GitHub issue via `manage-github-issue` and add it to Project #24.
+2. Post the deferral-ask (see "No User Prompts (Except Two)" below): describe
+   the remainder in plain language with a **measured remainder** (what you did,
+   what concretely remains, the ratio) — not an attempt count.
+3. **On explicit approval**: record `outcome: deferred-ask` with `issue_number`
+   and leave the work for the filed issue.
+4. **On silence or no approval**: fix it now (fold into the Phase 2 batch),
+   `- Closes #N`, and record `outcome: fixed`. Silence is never consent to
+   defer.
+
+Only *second-order* findings are eligible for `defer-ask`. A first-order
+finding is never deferred — fix it.
+
+**`inversion-halt`** (Gate 2 — the work inverts an issue/spec/ADR premise):
+
+1. Do **not** file autonomously and do **not** act on the new premise.
+2. Post the inversion-ask (see below): explain the overturned premise in plain
+   language and ask if/what to file.
+3. **On response**: act as directed (file and/or fix per the human's call).
+4. **On silence**: record `outcome: halted`, mark the PR draft/blocked, and
+   stop. An inversion is a circuit breaker.
 
 **Pre-existing findings are not exempt (BW-07-009).** A finding in a file this
 PR did not touch still gets a `type:Bug` or `type:Concern` issue here, before
@@ -273,20 +294,32 @@ Record `final_ci_status: "failing"`. List the unresolved CI failures. Run
 4. Record `execute_comment_url` in the artifact; re-write the file with the URL.
 5. Print artifact path and outcome summary to stdout.
 
-## No User Prompts (Except One)
+## No User Prompts (Except Two)
 
-Execute runs to completion without user prompts, with one exception:
+Execute runs to completion without user prompts, with two exceptions — the two
+gates from `.claude/skills/shared/completeness-doctrine.md`. Note the default is
+always fix-now; a gate is the exception, not the reflex.
 
-**`new-issue-ask` findings**: after filing the issue, post a comment noting the
-finding, then stop and ask the user:
+**Gate 1 — `defer-ask`**: after filing the issue, post the deferral-ask and ask:
 
-> "Found a non-trivial issue (distant cousin): <description> — filed as #N.
-> Should I fold this into the current PR, or leave it for the new issue?
-> (If no response, I'll leave it for the issue and continue.)"
+> "This is genuinely too big to finish in this PR. Here's what I did and what
+> concretely remains: <measured remainder — the ratio, in plain language>.
+> Filed as #N. May I defer the remainder to that issue?
+> (If no response, I'll fix it now rather than defer.)"
 
-Wait for a response. If no response within the session, record as `deferred-ask`
-and continue. The question is genuine — do not treat silence as approval to
-expand scope.
+Wait for a response. **On silence: fix it now** — fold the work in, `- Closes #N`,
+record `outcome: fixed`. Silence is never approval to defer. Do not present an
+attempt count in place of a measured remainder.
+
+**Gate 2 — `inversion-halt`**: do not file or act autonomously. Post the
+inversion-ask:
+
+> "This work overturns an assumption the issue/spec/ADR rested on:
+> <the premise, in plain language>. That may invalidate other issues or docs
+> that shared it. Is this a real inversion, and if so what should I file?"
+
+Wait for a response. **On silence: halt** — record `outcome: halted`, set the PR
+to draft/blocked, and stop. Do not proceed on the new premise unreviewed.
 
 ## Artifact Location
 

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -33,14 +33,17 @@ changes, and note them in a PR comment. Do not just flag and stop.
 The scope boundary is **the problem the issue describes and its close relatives**
 — not just the files already in the diff.
 
-Use this decision tree for anything you find beyond the original issue:
+Use this decision tree for anything you find beyond the original issue. FILE
+(does this warrant a record?) and DEFER (fix now, or leave for later?) are
+**separate** decisions; the default is fix-now. See
+`.agents/skills/shared/completeness-doctrine.md`.
 
-1. **Trivial fix, any conceptual distance** → fix it now, mention it in the PR comment. Don't cut an issue.
-2. **Non-trivial, same family** → fix it now. Expand the PR scope. Cut a GitHub issue if useful for tracking, but close it in this same PR.
-3. **Non-trivial, distant cousin** → cut a GitHub issue, then ask the user: "I found X — should I fold it into this PR or leave it for the new issue?" Give a recommendation based on effort ratio (if fixing now is cheaper than reloading context later, lean toward fixing now).
-4. **Requires separate design effort** (you recognize the problem but don't have the solution, or solving it requires deep investigation of a different domain) → cut a GitHub issue, keep this PR focused, do not ask.
+1. **Not an "also" excursion** — you can explain fixing it and the original thing in one sentence without the word "also" → fix it now, no issue. The diff is the record.
+2. **An "also" excursion** → fix it now **and** file an issue this PR closes (`- Closes #N`), with a one-line "why". Filing does not mean deferring.
+3. **Genuinely too big to finish now** → defer only through Gate 1: file, present a *measured remainder* (what you did, what concretely remains) in plain language, and get explicit approval. On silence, fix it now. Only *second-order* findings (revealed while fixing an excursion) are eligible.
+4. **Inverts a premise** the issue or its backing specs/ADRs rested on → Gate 2: explain the overturned premise in plain language, ask if/what to file, and do not act on it unreviewed. On silence, halt the PR.
 
-**Same family** means: if you had to explain why you fixed both things in this PR, you could do it in one sentence without using the word "also." Siblings, cousins, aunts/uncles of the original problem — things that share the same parent concept. Distant cousins share an ancestor if you trace far enough, but the connection requires too many hops to justify expanding this PR.
+**The "also" test**: if explaining why you fixed both things needs the word "also," it is a genuine excursion (file it). If not, it is simply doing the task (no file). Siblings, cousins, aunts/uncles of the original problem share the same parent concept; a fix that needs "also" has drifted far enough to warrant its own record.
 
 **Never** create a NEW-ISSUE finding and leave it unaddressed in the report without following the decision tree above.
 

--- a/.agents/skills/pr-ship/SKILL.md
+++ b/.agents/skills/pr-ship/SKILL.md
@@ -4,7 +4,7 @@ description: >
   End-to-end PR review pipeline. Detects the PR on the current branch, then
   runs pr-triage → pr-execute → pr-verify in sequence. Supports resume: if
   artifacts already exist from a prior run, skips forward to the right phase.
-  No user prompts except the one deferred-ask pause in pr-execute. Precondition:
+  No user prompts except the two gate pauses (defer-ask, inversion-halt) in pr-execute. Precondition:
   an open PR must exist for the current branch (or provide an explicit PR number).
 ---
 
@@ -14,7 +14,8 @@ description: >
 
 Single entry point for the full triage → execute → verify pipeline. Run this
 after pushing a branch with an open PR and let it complete. The only expected
-pause is a `new-issue-ask` finding in execute — all other steps run unattended.
+pauses are the two gates in execute — a `defer-ask` (may I defer this?) and an
+`inversion-halt` (a premise was overturned) — all other steps run unattended.
 
 ## Quick Start
 
@@ -81,9 +82,9 @@ sends the pipeline back through execute.
 
 **Run all steps in a single uninterrupted pass.** Do not end your turn or wait
 for user input between steps. When a sub-skill returns, proceed immediately to
-the next step without pausing. The only valid mid-pipeline stop is a
-`new-issue-ask` prompt inside pr-execute. Every other step transition is
-automatic.
+the next step without pausing. The only valid mid-pipeline stops are the two
+gate prompts inside pr-execute — `defer-ask` and `inversion-halt`. Every other
+step transition is automatic.
 
 ## Workflow
 
@@ -151,8 +152,10 @@ If resuming past execute: print `⏩ Skipping execute — artifact found at .cla
 
 Otherwise: invoke the `pr-execute` skill with the PR number.
 
-If execute pauses for a `new-issue-ask` decision: wait for the user's response,
-then continue. This is the only interactive pause in the pipeline.
+If execute pauses for a `defer-ask` or `inversion-halt` decision: wait for the
+user's response, then continue. On silence, execute applies its own rule
+(fix-now for a defer-ask; halt the PR for an inversion-halt). These are the only
+interactive pauses in the pipeline.
 
 If execute stops due to a blocking test failure (pre-existing with linked Bug
 issue): report the blocked status and stop pr-ship. The user must resolve the

--- a/.agents/skills/pr-triage/REFERENCE.md
+++ b/.agents/skills/pr-triage/REFERENCE.md
@@ -184,8 +184,8 @@ by GitHub, so check both.
 A conflict means the PR cannot be merged at all — it is the most complete form
 of "broken" in the FAIL/IMPROVE/NEW-ISSUE taxonomy. Resolving it is never out of
 scope and never a separate issue: only the conflicted branch can be fixed, and
-only by whoever holds it. Do not tag a conflict `new-issue-ask` or
-`new-issue-no-ask`.
+only by whoever holds it. Do not tag a conflict `defer-ask` or
+`inversion-halt`.
 
 ### Stacked PRs
 
@@ -248,10 +248,14 @@ File: `.claude/pr-{number}-triage.json`
 
 | Value | When to use |
 |---|---|
-| `fix-now` | Trivial fix OR non-trivial but same family |
-| `fix-now-expand-scope` | Non-trivial, same family, expands PR scope meaningfully |
-| `new-issue-ask` | Non-trivial, distant cousin — execute files issue then asks user |
-| `new-issue-no-ask` | Requires separate design effort — execute files issue and continues |
+| `fix-now` | Anything the agent can just do that is not an "also" excursion — fixed inline, no issue filed (the diff is the record) |
+| `fix-now-file` | An "also" excursion, fixed now and filed so the PR closes it (replaces `fix-now-expand-scope`; size is not a constraint) |
+| `defer-ask` | Second-order work too big to finish now — execute files, presents a measured remainder, and asks; on silence, fixes it now (replaces `new-issue-ask`) |
+| `inversion-halt` | Work that inverts an issue/spec/ADR premise — execute explains and asks if/what to file; on silence, halts the PR |
+
+`new-issue-no-ask` is removed — silent deferral does not exist. See
+`.claude/skills/shared/completeness-doctrine.md` § "Filing Is Not Deferring" and
+"The Two Gates".
 
 ---
 

--- a/.agents/skills/pr-triage/SKILL.md
+++ b/.agents/skills/pr-triage/SKILL.md
@@ -31,22 +31,35 @@ This skill uses the three-category system from
 |---|---|---|
 | **FAIL** | Broken: won't work correctly, spec violated, changed behavior untested | Must be fixed before merge |
 | **IMPROVE** | Works but incomplete: missing adjacent test, stale doc, obvious gap in scope | Fix in the same session |
-| **NEW-ISSUE** | Distinct problem, out of this PR's family | Cut a GitHub issue; apply decision tree |
+| **NEW-ISSUE** | A finding that warrants its own record: an "also" excursion, or a premise inversion | Apply the decision tree below (`fix-now-file`, `defer-ask`, or `inversion-halt`) — filing a record is **not** the same as deferring the work |
 
 ### Decision-Tree Outcomes
 
 Each finding is tagged with one of four outcomes. Triage records the outcome
-but does NOT act on it — `pr-execute` acts.
+but does NOT act on it — `pr-execute` acts. **Fix-now is the default**; the FILE
+decision and the DEFER decision are separate (see
+`.claude/skills/shared/completeness-doctrine.md` § "Filing Is Not Deferring").
 
 | Outcome | Condition | What execute does |
 |---|---|---|
-| `fix-now` | Trivial fix, any conceptual distance; OR non-trivial but same family (does not meaningfully expand PR scope) | Fix inline, mention in comment |
-| `fix-now-expand-scope` | Non-trivial, same family, and the fix meaningfully expands the PR's stated scope | Fix inline, expand PR scope |
-| `new-issue-ask` | Non-trivial, distant cousin | File issue, stop and ask user whether to fold in |
-| `new-issue-no-ask` | Requires separate design effort | File issue, continue without asking |
+| `fix-now` | Anything the agent can just do, and which is *not* an "also" excursion | Fix inline, no issue filed — the diff is the record |
+| `fix-now-file` | An "also" excursion (fails the "also" test) that the agent still fixes now | Fix inline **and** file an issue the PR closes; add a one-line "why" |
+| `defer-ask` | Work genuinely too big to finish now — must be *earned* with evidence | Gate 1: file, present a **measured remainder** in plain language, ask. On silence, fix it now |
+| `inversion-halt` | The work inverts a premise from the issue *or its backing specs/ADRs* | Gate 2: explain the overturned premise, ask if/what to file. On silence, **halt** the PR |
 
-**Same family** means: if you had to explain why you fixed both things in this
-PR, you could do it in one sentence without using the word "also."
+**The "also" test** decides filing (breadth surprise): if explaining why you
+fixed both the original thing and the discovered thing needs the word "also,"
+it is a genuine excursion → file it. If you can explain both in one sentence
+*without* "also," it is just doing the task → do not file; the diff is the
+record.
+
+**Depth cap**: `defer-ask` is only legal for *second-order* findings (revealed
+while fixing an excursion). *First-order* findings (revealed by the original
+work) are always "just do it" — never `defer-ask`.
+
+There is no `new-issue-no-ask`: silent deferral does not exist. There is no
+`fix-now-expand-scope`: size is not a constraint, so an "also" excursion that
+grows the PR is simply `fix-now-file` (see the doctrine § "Clarity Over Size").
 
 ## Quick Start
 

--- a/.agents/skills/pr-verify/REFERENCE.md
+++ b/.agents/skills/pr-verify/REFERENCE.md
@@ -62,7 +62,7 @@ this PR. Please decide whether to fold them in before merge:
 | ✅ CONFIRMED | Fix present at HEAD; commit ref valid |
 | ❌ UNRESOLVED | Commit ref found but HEAD does not show the fix |
 | ❌ MISSING-COMMIT | Commit ref not found on branch |
-| 📋 NOTED | filed/skipped/deferred-ask — no code check; issue confirmed open |
+| 📋 NOTED | skipped/deferred-ask/halted — no code check; issue confirmed open |
 | ⚠️ INCOMPLETE-EXECUTE | Finding count mismatch; execute likely interrupted |
 | ⚠️ UNVERIFIED-CI-FAILING | CI still failing after execute's push; fix may be correct but cannot be confirmed |
 | 🔀 MERGE-CONFLICT | `mergeable: CONFLICTING`, `mergeStateStatus: DIRTY`, or conflict markers found at HEAD |

--- a/.agents/skills/pr-verify/SKILL.md
+++ b/.agents/skills/pr-verify/SKILL.md
@@ -166,7 +166,7 @@ Lighter check:
 2. Check the file at HEAD for the improvement (same HEAD-check as Phase 4).
 3. Assign `CONFIRMED` or `UNRESOLVED`.
 
-For findings with `outcome: filed`, `skipped`, or `deferred-ask`: assign
+For findings with `outcome: deferred-ask`, `halted`, or `skipped`: assign
 `NOTED` — no code check needed, just confirm the issue number is real:
 `gh issue view <issue_number> --json number,state` must return an open issue.
 
@@ -192,7 +192,8 @@ For findings with `outcome: filed`, `skipped`, or `deferred-ask`: assign
 3. Always print the merge-state line in the comment, including on the happy path.
    A verdict that does not state its merge state is the bug this gate exists to
    prevent.
-4. If `deferred-ask` items exist: list them explicitly for user decision.
+4. If `deferred-ask` or `halted` items exist: list them explicitly for user
+   decision (a `halted` inversion means the PR is blocked, not mergeable).
 5. Post comment: `gh pr review <number> --comment --body "<verdict>"`
 
 See [REFERENCE.md](REFERENCE.md) § "Verify Comment Format" for the template.

--- a/.agents/skills/shared/completeness-doctrine.md
+++ b/.agents/skills/shared/completeness-doctrine.md
@@ -3,8 +3,16 @@
 **Boil the lake, not the ocean.**
 
 Complete what is in front of you — thoroughly, with tests, with edge cases
-handled, with documentation current. Do not unilaterally expand into adjacent
-work that was not scoped here. There will be other lakes.
+handled, with documentation current. Do not unilaterally expand into unrelated
+work that has nothing to do with what you were asked. There will be other
+lakes.
+
+But "boil the lake, not the ocean" is not a license to leave puddles. Most of
+the work an agent discovers while doing a task is *part of that task* or sits
+right next to it with the context already loaded. That work should get **done**,
+not filed-and-forgotten. This doctrine exists to make the difference between
+"boil this lake" and "leave a puddle for a future session" a decision you make
+on purpose, with evidence — not a reflex.
 
 ## What "Done" Means
 
@@ -19,25 +27,197 @@ A task is not done until:
 A happy-path-only implementation is not done. A behavior with no test is not
 done. A changed interface with a stale type annotation is not done.
 
-## Depth vs. Scope Expansion
+## Filing Is Not Deferring
 
-**Depth** (within the current task's scope) is **never optional**. Do not
-offer to "come back to" edge cases, missing tests, or documentation gaps that
-clearly belong to the current task. Do not leave dangling threads when tying
-them off is within reach.
+This is the load-bearing distinction in this doctrine. Read it slowly.
 
-**Scope expansion** (adjacent work that crosses into a different issue,
-domain, or design space) requires a judgment call:
+When you are working on issue A and you discover problem B, you face **two
+separate decisions**, and they are routinely — and wrongly — collapsed into
+one:
 
-| Signal | Action |
-|---|---|
-| Would require creating a new GitHub issue | Ask the user if present; make best-judgment call if unattended — record rationale as a learning file |
-| Requires a design decision about *how* it should work | Ask the user if present; make best-judgment call if unattended — record rationale as a learning file |
-| Hard to reverse (API change, schema change, spec change) | Ask the user if present; make best-judgment call if unattended — record rationale as a learning file |
-| Trivially additive (clearly-missing test, obvious type fix) | Just do it — no permission needed |
+1. **FILE** — do you create a durable record that B exists? Filing captures the
+   fact that something needed doing. It is about *tracking*, not *timing*.
+2. **DEFER** — do you leave B for a *later* session, or fix it *now* while the
+   context that surfaced it is still loaded? Deferring is about *timing*, not
+   *tracking*.
 
-When unattended: choose whatever seems most correct, document the reasoning
-explicitly in a learning file, and let the user review and override.
+The failure mode this doctrine is built to kill: an agent finds B, files an
+issue for B, and treats the act of filing as if it were a decision to *not do
+the work* — "I recorded it, so I'm done with it." That is "file and pretend you
+didn't just create more work." Every issue processed this way spawns one to
+five new deferred issues, and the backlog grows without bound. In the
+2026-09-02 audit, nearly every finding parked this way was eventually re-found
+and re-filed by a later session: the deferral bought nothing but the
+rediscovery cost, and several findings fell through entirely.
+
+**The default is: FILE if the record is warranted (see below), and FIX NOW.**
+Filing and fixing are not in tension — a fixed finding still gets its record,
+and the PR closes it. Deferral is the exception you must *earn*, not the
+default you fall into because you happened to open an issue.
+
+Do not "optimize" this default away, because the reason for it is strong:
+**you, working this finding right now, have the most context anyone will ever
+have on it.** A follow-up issue is a lossy snapshot of that context, not a
+reliable handoff. Starting a fresh issue-to-merge cycle later — re-orienting,
+re-loading specs, re-deriving the fix — is far more expensive than folding the
+fix into the PR whose context you already hold. Cheap-now, expensive-later. So
+when the finding is trivial, small, overlaps the current work, or you already
+know the fix, *just do it*. Do not file-and-walk.
+
+## When To FILE (Keep A Record)
+
+Not every fix needs a filed issue, or the issue tracker fills with closed
+micro-issues (`Closes #847: fixed typo in docstring`) and stops meaning
+anything. Filing is gated on one question:
+
+> **Would the PR be *surprising* if a reviewer compared it to the issue(s) it
+> closes?**
+
+A PR must clearly say what it does and *why*, mapped to the issues it closes.
+That clarity — not small size — is the hard constraint (see "Clarity Over
+Size, Always"). Two tests detect surprise:
+
+1. **The "also" test (breadth surprise).** If explaining why you fixed both the
+   original thing and the discovered thing requires the word "also" — "I fixed
+   the parser bug, and *also* rewrote the retry logic" — then the discovered
+   thing is a genuine excursion. **File it.** It needs its own record so the PR
+   can close it and the "why" has somewhere to live. If you can explain both in
+   one sentence *without* "also," it is simply part of doing the task
+   correctly: **do not file it** — the diff is its record.
+
+2. **The inversion test (foundation surprise).** If the work *inverts an
+   assumption* the issue rested on — you did the exact thing asked, but on a
+   premise that contradicts what the issue was built on — that is not a scope
+   excursion, it is an *epistemic* event: something the project believed is now
+   wrong. The reference frame for "was this assumption already known" is the
+   **issue text plus the specs and ADRs the issue rests on** (loaded via
+   `orient-agent` and `deepen-context`), not the issue text alone — because the
+   most dangerous inversions overturn a spec- or ADR-level premise the issue
+   never restated. Inversions are handled by a dedicated gate, below; they are
+   never filed silently, and never *acted on* silently.
+
+The failure modes are asymmetric, which is why the bar leans toward "when in
+doubt, don't file":
+
+- **Under-filing** (you rode an excursion in the diff without a record) is
+  **self-correcting** — it shows up as scope-creep the moment anyone reads the
+  diff against the closed issue. The diff *is* the audit.
+- **Over-filing** (a record for every trivial change) is **not**
+  self-correcting — the closed-micro-issue noise accumulates in the tracker
+  forever and nothing ever cleans it.
+
+## The Fix-Now Floor and How Far It Reaches
+
+Fix-now is the floor, not a branch you sometimes land on. Two rules bound how
+far it reaches, so a session does not eat its own tail.
+
+### Depth: first-order vs. second-order
+
+- **First-order** findings — discovered by the *original* work on A — are
+  **"don't ask, just do."** You never defer first-order work. Fixing it *is*
+  finishing A.
+- **Second-order** findings — discovered *while fixing* a first-order
+  excursion (B revealed C) — are the *only* findings eligible for a
+  deferral-ask. Without this cap, every fix is a new surface revealing more
+  fixes, "the context is loaded" justifies descending forever, and the PR never
+  terminates. First-order-only bounds the chain at one hop.
+
+### Breadth: the effort floor is the evidence contract
+
+You may not raise the "should I stop / can I defer this?" question until you
+have **earned** it by producing real output. The floor is defined on **output
+you produced** — the diff you have written, the count of things you have
+already fixed — never on **resources consumed** (tokens, turns, wall-clock).
+A floor defined on consumption is satisfiable by *flailing*: an agent can burn
+tokens thrashing and then claim it "worked hard enough" to bail. A floor
+defined on output can only be cleared by *actually changing code*.
+
+Critically, **the floor and the deferral-evidence requirement are the same
+mechanism.** You cannot legally ask to defer until you can show a *measured
+remainder* — "I converted 3 of the 47 call sites; the other 44 each need their
+own signature change" — and you cannot produce a measured remainder without
+having already done the output-work that clears the floor. There is **no
+separate threshold number to define**: the evidence contract *is* the floor.
+(Wall-clock is unreliable anyway — an agent has no proprioceptive sense that an
+hour has passed and will blow past any time budget without noticing. Do not
+gate anything on it.)
+
+## The Two Gates
+
+Everything else — first-order fixes, "also" excursions you file autonomously —
+the agent does without pausing. Exactly two situations require a human, each
+with a defined rule for what happens on silence (because these skills routinely
+run unattended).
+
+### Gate 1 — The deferral-ask
+
+You want to *not* do work you could do. To defer, you must:
+
+1. Describe the deferral candidate to the human in **plain domain language, no
+   jargon** — if you cannot describe it simply, you do not understand it well
+   enough to know it should be deferred.
+2. Present **evidence, not opinion** — a *measured remainder*, not a forecast
+   and not an attempt count. "I tried three times" is effort-theater and is
+   gameable by flailing shallowly three times. "I did X, here is concretely
+   what remains, here is the ratio" is not gameable, because you have to
+   enumerate the remainder. The standard is: **try first and show it is too big
+   to finish now; otherwise just finish it.**
+3. Get **explicit approval.** Then, and only then, defer.
+
+Note what "needs separate design effort" is *not*: it is not a category that
+authorizes deferral. If a few questions to the human would resolve the design,
+that is not deferral — that is *asking the questions and then fixing it*. Only
+a genuine, evidenced multi-session design problem earns a deferral-ask.
+
+**On silence (no human response): FIX IT NOW.** No response means no approval,
+so the fix-now default stands. Silence is *never* consent to defer. (This
+overturns the older "silence → record as deferred and continue" behavior, which
+was the defer-by-default reflex in disguise.)
+
+### Gate 2 — The inversion-ask
+
+You discovered that the work *inverts a premise* (per the inversion test
+above). Because a premise is usually *shared* — other issues, specs, and ADRs
+likely rested on it too — inverting it has blast radius the current PR cannot
+contain, and acting on it unreviewed is exactly the kind of silent
+foundation-change that bites later.
+
+**Explain the overturned premise to the human in plain language, and ask if and
+what to file.** You do not autonomously file an inversion (unlike an "also"
+excursion) and you do not autonomously act on the new premise. The human decides
+whether it is real and what the record should say.
+
+**On silence (no human response): HALT the PR and block on a human.** Mark it
+draft/blocked and stop. An inversion is a circuit breaker. This is safe *and*
+self-correcting: a mistaken halt lands in front of a human immediately and
+visibly ("that's not an inversion, proceed"), whereas a silent
+act-on-new-premise would ship an unreviewed foundation-change that surfaces only
+when it breaks something.
+
+## Clarity Over Size, Always
+
+**It is more important that a PR is CLEAR about what it does and why — with
+respect to the issues it closes — than that it is small.**
+
+Do not split work, decline a fix, or leave a rabbit uncaught in the name of
+keeping a PR small. If chasing rabbits lands more work in one PR, so be it —
+package it as **one PR**. This doctrine deliberately contains no "when to split
+a PR" guide, because size is not a constraint.
+
+What keeps a large, rabbit-chasing PR honest is not smallness — it is the
+machinery above, which *is* the clarity engine:
+
+- Non-"also" work needs no record because it is self-evidently part of the
+  task.
+- Every "also" excursion gets a filed issue, so every excursion has a number to
+  close and a place for its "why."
+- Every inversion gets explained before it can distort the PR.
+- Every deferral is stated with its measured remainder.
+
+Concretely, in the PR body: **every filed excursion the PR fixed appears as its
+own `- Closes #N` bullet**, and each non-obvious excursion gets a one-line "why"
+in the Changes section (see `pr-body-guide.md`). A reviewer reading the closing
+list and the Changes section should never be surprised.
 
 ## Finding Severity (build, pr-triage, bugfix)
 
@@ -46,16 +226,20 @@ Both FAIL and IMPROVE require action before the PR merges:
 | Category | Meaning | Action |
 |---|---|---|
 | **FAIL** | Broken: won't work correctly, spec violated, changed behavior untested | Fix before the PR opens or merges |
-| **IMPROVE** | Works but incomplete: missing adjacent test, stale doc, extractable helper, obvious gap in scope | Fix in the same session; document in a follow-up commit and PR comment |
+| **IMPROVE** | Works but incomplete: missing adjacent test, stale doc, extractable helper, obvious gap in scope | Fix in the same session; file a record only if it passes the "also" test |
 
-One exceptional category for genuinely out-of-scope work:
+One exceptional category for work genuinely left for later:
 
 | Category | Gate |
 |---|---|
-| **DEFER** | 1. Create a follow-up GitHub issue immediately with specific justification. 2. Get explicit user acknowledgment. No unilateral deferral. |
+| **DEFER** | The full deferral-ask (Gate 1): file the record, present a *measured remainder* in plain language, and get **explicit** human approval. On silence, fix it now. No unilateral deferral, no attempt-count justification, no "silence counts as yes." |
 
 **WARN** (flagged but no required action) does not exist in this project.
-If something is worth noting, it is worth fixing or DEFER-gating.
+If something is worth noting, it is worth fixing or DEFER-gating. Posting a
+finding only as an `[ADVISORY]` PR comment, or describing it in a
+`plan/incoming/learnings/` file, does **not** count as tracking it — neither can
+be assigned, scheduled, or closed, and citing the PR that surfaced it is not a
+tracking reference either. If it warrants a record, it gets a real issue.
 
 ## The Regression Test Rule (bugfix)
 
@@ -67,9 +251,11 @@ may ship — the debt is tracked, not silently discarded.
 
 ## Root Cause vs. Symptom (bugfix)
 
-Fix the root cause, not the symptom, unless the root cause is provably out of
-scope. Even then: create an issue. Never ship a symptom-only fix without
-documenting the underlying cause.
+Fix the root cause, not the symptom. "The root cause is out of scope" is a
+deferral, so it must clear Gate 1: prove it with a measured remainder and get
+approval, not merely assert it. Even when a genuine root-cause fix is deferred,
+file the issue and document the underlying cause. Never ship a symptom-only fix
+without a tracked, evidenced record of the root cause.
 
 ## The Cost of Deferral
 
@@ -78,4 +264,5 @@ That bet is usually wrong. The agent working an issue now has the most context
 it will ever have. A follow-up issue is a lossy description of that context,
 not a reliable handoff.
 
-Defer when you genuinely must. Never defer when you could just finish.
+Defer when you genuinely must — and can prove it. Never defer when you could
+just finish.

--- a/.agents/skills/shared/pr-body-guide.md
+++ b/.agents/skills/shared/pr-body-guide.md
@@ -44,6 +44,14 @@ captures the full rationale.>
   bullet line, **before any `##` section header**, so GitHub expands the issue
   title in the PR sidebar. **This is the single most commonly missed rule —
   every PR triage flags it when violated.**
+- **Every "also" excursion this PR fixed gets its own `- Closes #N` bullet.**
+  If, while doing the original work, you fixed something that warranted its own
+  filed issue (an "also" excursion per
+  `.agents/skills/shared/completeness-doctrine.md`), that issue must appear as a
+  closing bullet, and the Changes section must give it a one-line "why." A
+  reviewer comparing the closing list to the diff should never be surprised —
+  clarity about what the PR does and why, mapped to the issues it closes,
+  matters more than keeping the PR small.
 - **Summary**: required; 1–2 sentences, present tense.
 - **Motivation**: optional; omit when Summary is self-explanatory.
 - **Changes**: required; use backtick-wrapped file paths and concrete


### PR DESCRIPTION
- Closes #3091

## Summary

Separate the **FILE** decision (keep a record) from the **DEFER** decision (leave work for later) in the completeness doctrine, make fix-now the default, gate deferral on evidence rather than opinion, and propagate the change through every skill the doctrine governs so the machinery obeys the philosophy the doctrine already stated.

## Changes

- **`.agents/skills/shared/completeness-doctrine.md`**: add "Filing Is Not Deferring", "When To FILE" (the "also"/inversion tests; inversion reference frame = issue plus its backing specs/ADRs), "The Fix-Now Floor" (first- vs second-order depth cap; output-defined floor that *is* the measured-remainder evidence contract), "The Two Gates" (`defer-ask` and `inversion-halt`, each with a silence rule), and "Clarity Over Size"; remove the "unattended → best-judgment + learning-file" deferral escape hatch. Every rule is stated with the failure mode it prevents.
- **`.agents/skills/pr-triage/SKILL.md`**, **`REFERENCE.md`**: replace the four-outcome tree with `fix-now` / `fix-now-file` / `defer-ask` / `inversion-halt`; drop `new-issue-no-ask` and `fix-now-expand-scope`.
- **`.agents/skills/pr-execute/SKILL.md`**, **`REFERENCE.md`**: reframe Phase 3 and the user-prompt gates; silence on a `defer-ask` now fixes the work (was: silently defer); add `inversion-halt`; drop the standalone `filed` outcome and add `halted`; align the xfail ratchet and comment-resolution templates.
- **`.agents/skills/pr-verify/SKILL.md`**, **`REFERENCE.md`**: align outcome vocabulary; treat a `halted` inversion as blocking.
- **`.agents/skills/pr-ship/SKILL.md`**: describe the two gate pauses and their silence rules.
- **`.agents/skills/pr-review/SKILL.md`**: align the (deprecated) prose decision tree.
- **`.agents/skills/bugfix/SKILL.md`**, **`REFERENCE.md`**: sibling hits default to fix-now; deferral clears Gate 1; `Also filed:` → `Closes`.
- **`.agents/skills/build/SKILL.md`**: replace the scope-expansion judgment block with the FILE/DEFER model and the two gates' silence rules.
- **`.agents/skills/shared/pr-body-guide.md`**: require a `- Closes #N` bullet per fixed "also" excursion.