### PR TITLE
Fix current_status UUID tiebreaker in VulnerabilityCase

### DIFF
--- a/plan/incoming/learnings/20260902-2979-current-status-recency-core-unreachable.md
+++ b/plan/incoming/learnings/20260902-2979-current-status-recency-core-unreachable.md
@@ -3,7 +3,7 @@ title: "current_status id_ tiebreaker: core path is unreachable; the bug lives o
 type: learning
 timestamp: "2026-09-02T00:00:00Z"
 source: ISSUE-2979
-signal: concern
+signal: spec-ambiguity
 ---
 
 # current_status id_ tiebreaker: core path is unreachable; bug lives on the wire branch
@@ -48,6 +48,8 @@ UTC (consistent with `_now_utc`) and floors timestampless statuses at
 
 CM-29-001's `verification` text implies the core `VulnerabilityCase` can hold
 timestampless statuses; it cannot. Consider refining the spec verification to
-target the wire projection (or note the core path is defensive/unreachable),
-and consider whether wire `validate_datetime` should normalize naive datetimes
-at the edge (ADR-0032) rather than each consumer coercing.
+target the wire projection (or note the core path is defensive/unreachable).
+
+The related wire-layer question — whether `validate_datetime` should normalize
+naive datetimes at the edge (ADR-0032) rather than each consumer coercing — is
+tracked separately as Concern #3098 (do not re-track it here).

--- a/plan/incoming/learnings/20260902-2979-current-status-recency-core-unreachable.md
+++ b/plan/incoming/learnings/20260902-2979-current-status-recency-core-unreachable.md
@@ -1,0 +1,53 @@
+---
+title: "current_status id_ tiebreaker: core path is unreachable; the bug lives on the wire branch"
+type: learning
+timestamp: "2026-09-02T00:00:00Z"
+source: ISSUE-2979
+signal: concern
+---
+
+# current_status id_ tiebreaker: core path is unreachable; bug lives on the wire branch
+
+Task: #2979 (Fix current_status UUID tiebreaker), spec CM-29-001.
+
+## What was non-obvious
+
+CM-29-001 and #2979 name `VulnerabilityCase.current_status` (the **core**
+type) and prescribe a test that "construct[s] a VulnerabilityCase with an
+auto-seeded status (urn:uuid ID, no timestamps) and a received status (HTTPS
+ID, no timestamps)". That scenario is **not constructible on the core
+branch**: core `CaseStatus` inherits `published`/`updated` with
+`default_factory=_now_utc` re-narrowed to non-Optional `datetime`
+(`vultron/core/models/base.py` CoreObject), so Pydantic rejects
+`updated=None`/`published=None`. Because `cs.updated` is therefore always a
+truthy aware datetime in core, the `cs.id_` fallback in the core
+`current_status` was **dead code** — the fix there is CM-29-001 compliance,
+not a reachable behavior change.
+
+The bug is reachable only on the **wire** branch
+(`vultron/wire/as2/vocab/objects/vulnerability_case.py`): `as_CaseStatus`
+keeps `datetime | None` and permits explicit `None` timestamps. That is where
+a timestampless auto-seeded status (`urn:uuid…` sorts lexically above
+`https…`) beat a received status via the `id_` tiebreaker, and where the
+regression test that actually fails pre-fix must live
+(`test/wire/as2/vocab/test_vulnerability_case.py`).
+
+## Second-order edge: naive wire timestamps
+
+`as_*` `validate_datetime` (`vultron/wire/as2/vocab/base/objects/base.py`)
+does `datetime.fromisoformat(value)` with **no tz normalization**, so an
+offset-less ISO string deserializes to a *naive* datetime. Replacing the
+`id_` fallback with an aware `datetime.min` would then make `max()` compare
+naive vs aware → `TypeError`. The recency key must normalize naive→UTC. Both
+`current_status` implementations now delegate to
+`vultron/core/models/_helpers.py::status_recency_key`, which coerces naive to
+UTC (consistent with `_now_utc`) and floors timestampless statuses at
+`datetime.min` (UTC).
+
+## Suggested follow-up for `learn`
+
+CM-29-001's `verification` text implies the core `VulnerabilityCase` can hold
+timestampless statuses; it cannot. Consider refining the spec verification to
+target the wire projection (or note the core path is defensive/unreachable),
+and consider whether wire `validate_datetime` should normalize naive datetimes
+at the edge (ADR-0032) rather than each consumer coercing.

--- a/test/core/models/test_case.py
+++ b/test/core/models/test_case.py
@@ -13,6 +13,8 @@
 
 """Tests for the core VulnerabilityCase domain model (step 6 of issue #699)."""
 
+from datetime import datetime, timezone
+
 import pytest
 
 from vultron.core.models.base import CoreObject
@@ -131,6 +133,30 @@ class TestVulnerabilityCaseCurrentStatus:
         c = VulnerabilityCase(id_=_CASE_ID)
         with pytest.raises(ValueError):
             _ = c.current_status
+
+    def test_current_status_prefers_newer_timestamp_over_id_scheme(self):
+        """A newer ``updated`` wins even when its ``id_`` sorts lower.
+
+        Guards CM-29-001: the ``id_`` scheme must never arbitrate recency. A
+        urn:uuid ID (``'u'``) sorts lexically above an https ID (``'h'``), so
+        this catches any regression that reintroduced ``id_`` as a tiebreaker
+        overriding an authoritative timestamp. (In the core branch timestamps
+        are always populated, so the timestampless path is exercised on the
+        wire branch — see test/wire/as2/vocab/test_vulnerability_case.py.)
+        """
+        older = CaseStatus(
+            id_="urn:uuid:00000000-0000-0000-0000-000000000001",
+            context=_CASE_ID,
+            updated=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        )
+        newer = CaseStatus(
+            id_="https://coord.example/status/1",
+            context=_CASE_ID,
+            updated=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        c = VulnerabilityCase(id_=_CASE_ID)
+        c.case_statuses = [older, newer]
+        assert c.current_status is newer
 
 
 class TestVulnerabilityCaseAddReport:

--- a/test/core/models/test_helpers.py
+++ b/test/core/models/test_helpers.py
@@ -108,6 +108,55 @@ def test_report_phase_status_id_different_states():
     assert id_received != id_valid
 
 
+# --- status_recency_key (CM-29-001) ---------------------------------------
+
+
+def test_status_recency_key_prefers_updated_over_published():
+    from datetime import datetime, timezone
+
+    from vultron.core.models._helpers import status_recency_key
+
+    updated = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    published = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert status_recency_key(updated, published) == updated
+
+
+def test_status_recency_key_falls_back_to_published():
+    from datetime import datetime, timezone
+
+    from vultron.core.models._helpers import status_recency_key
+
+    published = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert status_recency_key(None, published) == published
+
+
+def test_status_recency_key_timestampless_sorts_to_bottom():
+    from datetime import datetime, timezone
+
+    from vultron.core.models._helpers import status_recency_key
+
+    key = status_recency_key(None, None)
+    assert key == datetime.min.replace(tzinfo=timezone.utc)
+    assert key.tzinfo is timezone.utc
+
+
+def test_status_recency_key_normalises_naive_to_utc():
+    """Naive timestamps (wire ISO strings without offset) are treated as UTC.
+
+    Regression for #2979: a naive ``updated`` compared against the aware
+    ``datetime.min`` floor would otherwise raise ``TypeError`` in ``max()``.
+    """
+    from datetime import datetime, timezone
+
+    from vultron.core.models._helpers import status_recency_key
+
+    naive = datetime(2026, 1, 1)  # no tzinfo
+    key = status_recency_key(naive, None)
+    assert key == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    # Comparable against the timestampless floor without raising.
+    assert key > status_recency_key(None, None)
+
+
 # --- has_case_statuses ----------------------------------------------------
 
 

--- a/test/wire/as2/vocab/test_vulnerability_case.py
+++ b/test/wire/as2/vocab/test_vulnerability_case.py
@@ -30,6 +30,80 @@ class TestVulnerabilityCase:
         # Should return the only element without error
         assert case.current_status.id_ == cs.id_
 
+    def test_current_status_ignores_id_scheme_when_timestamps_absent(self):
+        """Regression for #2979 / CM-29-001.
+
+        When two statuses both lack ``updated``/``published``, the ``id_``
+        scheme MUST NOT decide recency. Before the fix a urn:uuid ID
+        (starting ``'u'``) sorted lexically above an https ID (``'h'``), so an
+        auto-seeded status beat a received one regardless of insertion order.
+        After the fix both timestampless statuses tie at ``datetime.min``, so
+        insertion order — not the ID scheme — resolves the tie.
+        """
+        received = as_CaseStatus(
+            id_="https://coord.example/status/1",
+            updated=None,
+            published=None,
+        )
+        auto_seeded = as_CaseStatus(
+            id_="urn:uuid:00000000-0000-0000-0000-000000000001",
+            updated=None,
+            published=None,
+        )
+        case = as_VulnerabilityCase(case_statuses=[received, auto_seeded])
+        assert case.current_status.id_ == received.id_
+
+    def test_current_status_timestampless_status_loses_to_timestamped(self):
+        """A timestampless status must sort below a timestamped one.
+
+        Before the fix, mixing a timestampless status (fallback: ``id_`` str)
+        with a timestamped one (key: ``datetime``) made ``max`` compare a
+        ``str`` against a ``datetime`` and raise ``TypeError``. The fix maps
+        the timestampless status to ``datetime.min`` so the timestamped
+        received status wins deterministically, whatever the insertion order.
+        """
+        auto_seeded = as_CaseStatus(
+            id_="urn:uuid:00000000-0000-0000-0000-000000000001",
+            updated=None,
+            published=None,
+        )
+        received = as_CaseStatus(
+            id_="https://coord.example/status/1",
+            updated=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        # Timestamped status wins regardless of insertion order.
+        auto_first = as_VulnerabilityCase(
+            case_statuses=[auto_seeded, received]
+        )
+        received_first = as_VulnerabilityCase(
+            case_statuses=[received, auto_seeded]
+        )
+        assert auto_first.current_status.id_ == received.id_
+        assert received_first.current_status.id_ == received.id_
+
+    def test_current_status_handles_naive_timestamp(self):
+        """A naive (offset-less) wire timestamp must not crash current_status.
+
+        Regression for #2979: wire deserialization of an ISO string without an
+        offset yields a naive datetime; comparing it against the aware
+        ``datetime.min`` floor of a timestampless status would raise
+        ``TypeError`` in ``max()``. The recency key normalizes naive values to
+        UTC so the timestamped status still wins.
+        """
+        auto_seeded = as_CaseStatus(
+            id_="urn:uuid:00000000-0000-0000-0000-000000000001",
+            updated=None,
+            published=None,
+        )
+        received = as_CaseStatus(
+            id_="https://coord.example/status/1",
+            updated=datetime(2026, 1, 1),  # naive — no tzinfo
+        )
+        assert received.updated is not None
+        assert received.updated.tzinfo is None
+        case = as_VulnerabilityCase(case_statuses=[auto_seeded, received])
+        assert case.current_status.id_ == received.id_
+
 
 class TestActorParticipantIndex:
     """Tests for actor_participant_index on the wire projection."""

--- a/vultron/core/models/_helpers.py
+++ b/vultron/core/models/_helpers.py
@@ -24,6 +24,42 @@ def _now_utc() -> datetime:
     return datetime.now(timezone.utc).replace(microsecond=0)
 
 
+#: Recency floor for statuses that carry no timestamps: they sort to the
+#: bottom. ``id_`` MUST NOT be used as a recency tiebreaker (CM-29-001) — its
+#: scheme (``urn:uuid`` vs ``https``) is an implementation artefact, not a
+#: time proxy.
+_MIN_UTC = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Return *value* as a timezone-aware UTC datetime, or ``None``.
+
+    Wire-deserialized timestamps may be naive (``datetime.fromisoformat`` on an
+    offset-less ISO string yields a naive datetime). Assume naive datetimes are
+    UTC — consistent with :func:`_now_utc` — so recency comparisons never mix
+    naive and aware values, which would raise ``TypeError``.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def status_recency_key(
+    updated: datetime | None, published: datetime | None
+) -> datetime:
+    """Return the recency sort key for a status: ``updated`` else ``published``.
+
+    Both are normalised to timezone-aware UTC. When both are absent the key is
+    ``datetime.min`` (UTC) so timestampless statuses sort to the bottom rather
+    than by ``id_`` scheme (CM-29-001). Shared by the core and wire
+    ``VulnerabilityCase.current_status`` implementations so the invariant lives
+    in one place.
+    """
+    return _as_utc(updated) or _as_utc(published) or _MIN_UTC
+
+
 def _new_urn() -> str:
     return f"urn:uuid:{uuid.uuid4()}"
 

--- a/vultron/core/models/case.py
+++ b/vultron/core/models/case.py
@@ -23,7 +23,11 @@ from typing import Any, Literal
 
 from pydantic import Field, model_validator
 
-from vultron.core.models._helpers import _new_urn, _now_utc
+from vultron.core.models._helpers import (
+    _new_urn,
+    _now_utc,
+    status_recency_key,
+)
 from vultron.core.models.base import CoreObject
 from vultron.core.models.case_ledger import compute_genesis_hash
 from vultron.core.models.case_participant import CaseParticipant
@@ -359,8 +363,11 @@ class VulnerabilityCase(CoreObject):
     def current_status(self) -> CaseStatus:
         """Return the most recent materialized :class:`CaseStatus`.
 
-        Uses ``updated`` then ``published`` then ``id_`` as sort key to
-        handle cases where timestamps may be equal or absent.
+        Recency is resolved by ``updated`` then ``published`` via
+        :func:`status_recency_key`. When both are absent the status sorts to
+        the bottom (``datetime.min``); ``id_`` MUST NOT be used as a tiebreaker
+        because its scheme is an implementation artefact, not a time proxy
+        (CM-29-001).
 
         Raises:
             ValueError: When no materialized :class:`CaseStatus` exists.
@@ -374,7 +381,7 @@ class VulnerabilityCase(CoreObject):
             )
         return max(
             materialized,
-            key=lambda cs: cs.updated or cs.published or cs.id_,
+            key=lambda cs: status_recency_key(cs.updated, cs.published),
         )
 
     @property

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -22,6 +22,7 @@ from typing import ClassVar, TypeAlias
 from pydantic import Field, model_validator
 
 from vultron.core.models.base import NonEmptyString
+from vultron.core.models._helpers import status_recency_key
 from vultron.core.models.case import VulnerabilityCase as CoreVulnerabilityCase
 from vultron.core.models.case_ledger import compute_genesis_hash
 from vultron.errors import VultronValidationError
@@ -210,7 +211,13 @@ class as_VulnerabilityCase(VultronAS2Object):
 
     @property
     def current_status(self) -> as_CaseStatus:
-        """Return the most recent as_CaseStatus, sorted by updated timestamp."""
+        """Return the most recent as_CaseStatus.
+
+        Recency is resolved by ``updated`` then ``published`` via
+        :func:`status_recency_key`; when both are absent the status sorts to
+        the bottom (``datetime.min``). ``id_`` MUST NOT be used as a tiebreaker
+        (CM-29-001).
+        """
         materialized_statuses = _materialized_case_statuses(self.case_statuses)
         if not materialized_statuses:
             raise ValueError(
@@ -218,7 +225,7 @@ class as_VulnerabilityCase(VultronAS2Object):
             )
         return max(
             materialized_statuses,
-            key=lambda cs: cs.updated or cs.published or cs.id_,
+            key=lambda cs: status_recency_key(cs.updated, cs.published),
         )
 
     @property


### PR DESCRIPTION
- Closes #2979

## Summary

`VulnerabilityCase.current_status` resolved the most-recent `CaseStatus` with
`max(key=lambda cs: cs.updated or cs.published or cs.id_)`. The `cs.id_`
fallback made status recency depend on the ID *scheme*: auto-seeded UUID IDs
(`urn:uuid:…`, `'u'`) sort lexically above HTTPS IDs (`https://…`, `'h'`), so a
timestampless auto-seeded status beat a legitimately newer received status.
Per CM-29-001, `id_` MUST NOT be a recency tiebreaker.

## Changes

- **`vultron/core/models/_helpers.py`**: new shared
  `status_recency_key(updated, published)` helper (and `_MIN_UTC` constant) so
  the CM-29-001 invariant lives in one place. Resolves `updated` then
  `published`; floors timestampless statuses at `datetime.min` (UTC) instead of
  `id_`; normalizes naive datetimes to UTC.
- **`vultron/core/models/case.py`** and
  **`vultron/wire/as2/vocab/objects/vulnerability_case.py`**: both
  `current_status` implementations delegate to the shared helper.

Wire `validate_datetime` does no tz normalization, so an offset-less ISO
timestamp deserializes to a naive datetime; comparing it against the aware
`datetime.min` floor would otherwise raise `TypeError` in `max()`. The helper
coerces naive→UTC to keep the comparison total.

## Tests

- `test/wire/as2/vocab/test_vulnerability_case.py`: `id_` scheme no longer
  arbitrates when both statuses lack timestamps; a timestamped status wins over
  a timestampless one regardless of order; naive wire timestamps do not crash.
- `test/core/models/test_helpers.py`: unit tests for `status_recency_key`
  (updated>published, published fallback, timestampless floor, naive→UTC).
- `test/core/models/test_case.py`: a newer `updated` wins over a status whose
  `id_` sorts higher.

## Verification

- Full unit suite: 8281 passed. Integration suite: 1254 passed.
- Black, flake8, mypy, pyright clean.

## Notes

The core `id_` fallback was effectively unreachable — core `CaseStatus` always
populates `updated`/`published` (`default_factory=_now_utc`, non-Optional). The
reachable bug is on the wire branch, where `as_CaseStatus` permits `None`
timestamps. Recorded a learning flagging CM-29-001's verification text (which
implies core statuses can be timestampless) for refinement.