### PR TITLE
feat(msm): MSM mapping renderer and coverage ratchet

### DIFF
--- a/docs/reference/codebase/STRUCTURE.md
+++ b/docs/reference/codebase/STRUCTURE.md
@@ -14,7 +14,7 @@
 | `vultron/config/` | Layer-neutral configuration models and loading logic | `vultron/config/app.py`, `vultron/config/actor.py` |
 | `vultron/enums/` | Shared CVD-domain enums (roles, states) imported by config and core | `vultron/enums/` |
 | `vultron/demo/` | Demo scenario runners and seed-config helpers | `pyproject.toml` entry points |
-| `vultron/metadata/` | Spec registry, history CLI, notes metadata tooling | `vultron/metadata/specs/`, `vultron/metadata/history/` |
+| `vultron/metadata/` | Spec registry, history CLI, notes metadata tooling, message-semantics mapping renderer | `vultron/metadata/specs/`, `vultron/metadata/history/`, `vultron/metadata/msm/` |
 | `vultron/scripts/` | CLI entry points (`vultrabot`) | `pyproject.toml` `[project.scripts]` |
 | `vultron/semantic_registry/` | ActivityStreams semantic pattern registry | `vultron/semantic_registry/` |
 | `test/` | Pytest test suite (mirrors `vultron/` layout) | `pyproject.toml` `[tool.pytest.ini_options]` |

--- a/notes/message-type-reference.md
+++ b/notes/message-type-reference.md
@@ -214,9 +214,9 @@ years.
 
 MSM-06-002 requires a ratchet test asserting every `SEMANTIC_REGISTRY` entry
 reaches its designated primary reference page, so a new registry entry cannot be
-added without being documented or explicitly exempted. **That ratchet does not
-exist yet** — building it is #2998. Until it lands, nothing prevents the drift
-this section is warning about.
+added without being documented or explicitly exempted. **That ratchet is
+implemented in `test/architecture/test_msm_coverage_ratchet.py`**, landed in
+PR 2998.
 
 ## Diátaxis: these pages are an extraction, not a new surface
 

--- a/plan/incoming/learnings/2998-pre-existing-bugs-found.md
+++ b/plan/incoming/learnings/2998-pre-existing-bugs-found.md
@@ -1,0 +1,13 @@
+---
+title: "Pre-existing bugs found during #2998 code review"
+type: learning
+source: ISSUE-2998
+timestamp: "2026-09-02T00:00:00Z"
+---
+
+Code review during #2998 surfaced two pre-existing bugs unrelated to the PR:
+
+- #3096: `vultron/wire/as2/vocab/examples/_base.py` — `case()` raises `TypeError` when `kwargs` contains `name`, `id_`, or `attributed_to` (positional field collision).
+- #3097: `test/core/behaviors/bt_harness.py:189` — `assert_failure(allow_internal=True)` never asserts `result.internal_error is True`, so crash-path classification tests give false confidence.
+
+Both filed under Epic #607, milestone 26, size:S.

--- a/test/architecture/test_msm_coverage_ratchet.py
+++ b/test/architecture/test_msm_coverage_ratchet.py
@@ -1,0 +1,137 @@
+"""Architecture ratchet: every ``SEMANTIC_REGISTRY`` entry has exactly one
+primary page in the MSM mapping table.
+
+AC-5: a ratchet test asserts every ``SEMANTIC_REGISTRY`` entry that is not
+in ``EXEMPTED_SEMANTICS`` appears exactly once in ``ROW_SPECS``.
+
+This test is intentionally a *hard* assertion (not a ratchet integer ceiling)
+because the mapping table is maintained alongside the registry: adding a new
+``SemanticEntry`` without a corresponding ``RowSpec`` is always wrong.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from collections import Counter
+
+import pytest
+
+from vultron.core.models.events.base import MessageSemantics
+from vultron.metadata.msm._mapping import (
+    EXEMPTED_SEMANTICS,
+    ROW_SPECS,
+    PAGE_SLUGS,
+)
+from vultron.semantic_registry import SEMANTIC_REGISTRY
+
+# ---------------------------------------------------------------------------
+# Pre-compute the coverage map once at module level (fast; no fixture needed).
+# ---------------------------------------------------------------------------
+
+_ALL_SEMANTICS: frozenset[MessageSemantics] = frozenset(MessageSemantics)
+_REQUIRED_SEMANTICS: frozenset[MessageSemantics] = (
+    _ALL_SEMANTICS - EXEMPTED_SEMANTICS
+)
+_ROW_SEMANTICS: list[MessageSemantics] = [row.semantics for row in ROW_SPECS]
+_ROW_SEMANTICS_COUNTER: Counter = Counter(_ROW_SEMANTICS)
+_ROW_SEMANTICS_SET: frozenset[MessageSemantics] = frozenset(_ROW_SEMANTICS)
+
+
+@pytest.mark.spec("MSM-06-002")
+def test_every_required_semantics_has_a_row():
+    """Every non-exempted ``MessageSemantics`` value has at least one
+    ``RowSpec`` in ``ROW_SPECS``.
+
+    Failure here means a new ``SemanticEntry`` was added to
+    ``SEMANTIC_REGISTRY`` without a corresponding entry in
+    ``vultron/metadata/msm/_mapping.py``.
+    """
+    missing = sorted(
+        s.name for s in _REQUIRED_SEMANTICS if s not in _ROW_SEMANTICS_SET
+    )
+    assert missing == [], (
+        f"{len(missing)} MessageSemantics value(s) are in SEMANTIC_REGISTRY "
+        f"but have no RowSpec:\n  " + "\n  ".join(missing)
+    )
+
+
+@pytest.mark.spec("MSM-06-002")
+def test_every_row_semantics_is_a_known_value():
+    """Every ``RowSpec.semantics`` is a valid ``MessageSemantics`` member.
+
+    Failure means a typo or stale enum value in ``_mapping.py``.
+    """
+    for row in ROW_SPECS:
+        assert (
+            row.semantics in _ALL_SEMANTICS
+        ), f"RowSpec references unknown semantics: {row.semantics!r}"
+
+
+@pytest.mark.spec("MSM-06-002")
+def test_every_row_page_is_a_known_slug():
+    """Every ``RowSpec.page`` is one of the eight canonical page slugs."""
+    for row in ROW_SPECS:
+        assert (
+            row.page in PAGE_SLUGS
+        ), f"RowSpec for {row.semantics.name!r} has unknown page {row.page!r}"
+
+
+@pytest.mark.spec("MSM-06-002")
+def test_each_semantics_has_exactly_one_primary_page():
+    """Each ``MessageSemantics`` value appears on at most one page.
+
+    Multiple ``RowSpec`` entries for the same semantics are allowed (that is
+    how expansion is expressed), but they MUST all share the same ``page``
+    value — a semantics value cannot have two different primary pages.
+    """
+    page_for: dict[MessageSemantics, set[str]] = {}
+    for row in ROW_SPECS:
+        page_for.setdefault(row.semantics, set()).add(row.page)
+
+    violations = [
+        f"{sem.name}: pages={sorted(pages)}"
+        for sem, pages in page_for.items()
+        if len(pages) > 1
+    ]
+    assert violations == [], (
+        "Some semantics values appear on more than one primary page:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+@pytest.mark.spec("MSM-06-002")
+def test_registry_and_mapping_have_same_semantics_set():
+    """The set of semantics in ``SEMANTIC_REGISTRY`` equals the set in
+    ``ROW_SPECS`` union ``EXEMPTED_SEMANTICS``.
+
+    This cross-check catches any drift between the two files: a new registry
+    entry without a row, or a stale row for a deleted semantics value.
+    """
+    registry_semantics = frozenset(e.semantics for e in SEMANTIC_REGISTRY)
+    mapping_semantics = _ROW_SEMANTICS_SET | EXEMPTED_SEMANTICS
+
+    in_registry_not_mapping = sorted(
+        s.name for s in registry_semantics - mapping_semantics
+    )
+    in_mapping_not_registry = sorted(
+        s.name for s in mapping_semantics - registry_semantics
+    )
+
+    assert in_registry_not_mapping == [], (
+        "In SEMANTIC_REGISTRY but not in ROW_SPECS (or EXEMPTED_SEMANTICS):\n  "
+        + "\n  ".join(in_registry_not_mapping)
+    )
+    assert in_mapping_not_registry == [], (
+        "In ROW_SPECS (or EXEMPTED_SEMANTICS) but not in SEMANTIC_REGISTRY:\n  "
+        + "\n  ".join(in_mapping_not_registry)
+    )

--- a/test/metadata/test_msm_render.py
+++ b/test/metadata/test_msm_render.py
@@ -1,0 +1,193 @@
+"""Unit tests for the MSM mapping renderer.
+
+Covers the AC-6 acceptance criteria:
+- collapse row (multiple shorthands, one wire form, discriminator cell)
+- expansion row (one shorthand appearing in multiple rows)
+- none-status row (no formal shorthand, pattern present)
+- invalid slug raises ValueError
+- every page slug produces a non-empty table
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import pytest
+
+from vultron.metadata.msm import (
+    PAGE_SLUGS,
+    MappingStatus,
+    render_page,
+)
+from vultron.metadata.msm._mapping import ROW_SPECS, SEMANTICS_TO_ROW
+from vultron.metadata.msm.render import (
+    _format_pattern,
+    _render_table_row,
+    _wire_form,
+)
+from vultron.core.models.events.base import MessageSemantics
+from vultron.semantic_registry import lookup_entry
+
+# ---------------------------------------------------------------------------
+# _format_pattern
+# ---------------------------------------------------------------------------
+
+
+def test_format_pattern_scalar_object():
+    """Scalar activity+object renders as Verb(ObjectType)."""
+    entry = lookup_entry(MessageSemantics.SUBMIT_REPORT)
+    assert entry is not None and entry.pattern is not None
+    result = _format_pattern(entry.pattern)
+    assert result == "Offer(VulnerabilityReport)"
+
+
+def test_format_pattern_nested_object():
+    """Nested ActivityPattern renders recursively, e.g. Read(Offer(X))."""
+    entry = lookup_entry(MessageSemantics.ACK_REPORT)
+    assert entry is not None and entry.pattern is not None
+    result = _format_pattern(entry.pattern)
+    assert "(" in result and ")" in result
+    assert result.startswith("Read(")
+
+
+def test_format_pattern_with_target_qualifier():
+    """Patterns with a target include [target=X] qualifier."""
+    entry = lookup_entry(MessageSemantics.ADD_CASE_STATUS_TO_CASE)
+    assert entry is not None and entry.pattern is not None
+    result = _format_pattern(entry.pattern)
+    assert "target=" in result
+
+
+# ---------------------------------------------------------------------------
+# Collapse row — multiple shorthands share one wire form
+# ---------------------------------------------------------------------------
+
+
+def test_collapse_row_shorthand_cell():
+    """Collapse rows show all shorthands separated by spaces."""
+    row = SEMANTICS_TO_ROW[MessageSemantics.ADD_CASE_STATUS_TO_CASE]
+    assert row.status == MappingStatus.COLLAPSE
+    rendered = _render_table_row(row)
+    # CP, CX, CA should all appear
+    for shorthand in ("CP", "CX", "CA"):
+        assert f"`{shorthand}`" in rendered
+
+
+def test_collapse_row_discriminator_cell():
+    """Collapse rows show the discriminator field."""
+    row = SEMANTICS_TO_ROW[MessageSemantics.ADD_CASE_STATUS_TO_CASE]
+    rendered = _render_table_row(row)
+    assert "pxa_state" in rendered
+
+
+def test_collapse_row_status_cell():
+    row = SEMANTICS_TO_ROW[MessageSemantics.ADD_CASE_STATUS_TO_CASE]
+    rendered = _render_table_row(row)
+    assert "| collapse |" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Expansion row — one shorthand across multiple wire forms (GI)
+# ---------------------------------------------------------------------------
+
+
+def test_expansion_row_create_note():
+    """GI expansion rows show the GI shorthand and 'expansion' status."""
+    row = SEMANTICS_TO_ROW[MessageSemantics.CREATE_NOTE]
+    assert row.status == MappingStatus.EXPANSION
+    rendered = _render_table_row(row)
+    assert "`GI`" in rendered
+    assert "| expansion |" in rendered
+
+
+def test_expansion_gi_appears_in_multiple_rows():
+    """GI shorthand is present in more than one RowSpec (expansion by definition)."""
+    gi_rows = [row for row in ROW_SPECS if "GI" in row.shorthands]
+    assert len(gi_rows) > 1, "GI should appear in multiple rows (expansion)"
+
+
+def test_expansion_ep_appears_in_multiple_rows():
+    """EP shorthand is present in more than one RowSpec."""
+    ep_rows = [row for row in ROW_SPECS if "EP" in row.shorthands]
+    assert len(ep_rows) > 1, "EP should appear in multiple rows (expansion)"
+
+
+# ---------------------------------------------------------------------------
+# None-status row — no formal shorthand, but wire form present
+# ---------------------------------------------------------------------------
+
+
+def test_none_status_row_no_shorthand():
+    """NONE rows render '—' in the shorthand cell."""
+    row = SEMANTICS_TO_ROW[MessageSemantics.CREATE_REPORT]
+    assert row.status == MappingStatus.NONE
+    rendered = _render_table_row(row)
+    # First cell should be —
+    assert rendered.startswith("| — |")
+
+
+def test_none_status_row_wire_form_present():
+    """NONE rows still include the wire form (pattern is defined)."""
+    row = SEMANTICS_TO_ROW[MessageSemantics.CREATE_REPORT]
+    entry = lookup_entry(MessageSemantics.CREATE_REPORT)
+    assert entry is not None
+    rendered = _render_table_row(row)
+    # Wire form column should not be just —
+    wire = _wire_form(entry)
+    assert wire != "—"
+    assert wire in rendered
+
+
+# ---------------------------------------------------------------------------
+# render_page integration
+# ---------------------------------------------------------------------------
+
+
+def test_render_page_rm_is_markdown_table():
+    """render_page('rm') returns a string containing a markdown table."""
+    output = render_page("rm")
+    assert "| Shorthand(s) |" in output
+    assert "|---|" in output
+    assert "## Report Management" in output
+
+
+def test_render_page_em_contains_embargo_semantics():
+    output = render_page("em")
+    assert "INVITE_TO_EMBARGO_ON_CASE" in output
+    assert "EM state context" in output
+
+
+def test_render_page_cs_contains_collapse_discriminators():
+    output = render_page("cs")
+    assert "pxa_state" in output
+    assert "vf_state" in output
+
+
+def test_render_page_general_shows_gi_expansion():
+    output = render_page("general")
+    # GI should appear many times (once per expansion row)
+    assert output.count("`GI`") >= 4
+
+
+def test_render_page_invalid_slug_raises():
+    with pytest.raises(ValueError, match="Unknown page slug"):
+        render_page("nonexistent_page")
+
+
+@pytest.mark.parametrize("slug", list(PAGE_SLUGS))
+def test_render_page_all_slugs_produce_table(slug):
+    """Every page slug renders a non-empty table with the header row."""
+    output = render_page(slug)
+    assert "| Shorthand(s) |" in output
+    # Must have at least one data row (beyond the header and separator)
+    lines = [line for line in output.splitlines() if line.startswith("|")]
+    assert len(lines) >= 3  # header + separator + ≥1 data row

--- a/vultron/metadata/msm/__init__.py
+++ b/vultron/metadata/msm/__init__.py
@@ -1,0 +1,47 @@
+"""MSM mapping and rendering infrastructure.
+
+Public API for the ``vultron.metadata.msm`` package:
+
+- :func:`render_page` — render a shorthand↔wire-form mapping table for a
+  ``docs/reference/messages/`` page.
+- :data:`PAGE_SLUGS` — canonical tuple of valid page slugs.
+- :class:`MappingStatus` — enum of mapping relationship types.
+- :class:`RowSpec` — one registry entry with its page assignment and metadata.
+- :data:`ROW_SPECS` — complete mapping table.
+- :data:`SEMANTICS_TO_ROW` — O(1) lookup from ``MessageSemantics`` → ``RowSpec``.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from vultron.metadata.msm._mapping import (
+    EXEMPTED_SEMANTICS,
+    MappingStatus,
+    PAGE_ROWS,
+    PAGE_SLUGS,
+    ROW_SPECS,
+    SEMANTICS_TO_ROW,
+    RowSpec,
+)
+from vultron.metadata.msm.render import render_page
+
+__all__ = [
+    "render_page",
+    "PAGE_SLUGS",
+    "PAGE_ROWS",
+    "MappingStatus",
+    "RowSpec",
+    "ROW_SPECS",
+    "SEMANTICS_TO_ROW",
+    "EXEMPTED_SEMANTICS",
+]

--- a/vultron/metadata/msm/_mapping.py
+++ b/vultron/metadata/msm/_mapping.py
@@ -1,0 +1,424 @@
+"""Authoritative MSM shorthand → ``MessageSemantics`` mapping table.
+
+Derived from ``specs/message-semantics-mapping.yaml`` (MSM-01 through MSM-04)
+and ``notes/message-type-reference.md``.  Each :class:`RowSpec` records one
+``SEMANTIC_REGISTRY`` entry's primary page assignment, formal shorthand(s), and
+mapping status.
+
+This module is the machine-readable complement to the MSM spec YAML, which
+encodes the same information in normative prose.  Keeping it in Python lets the
+renderer and ratchet join against ``SEMANTIC_REGISTRY`` without fragile text
+parsing.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from vultron.core.models.events.base import MessageSemantics
+
+
+class MappingStatus(StrEnum):
+    """How a protocol shorthand relates to a ``SEMANTIC_REGISTRY`` entry."""
+
+    DIRECT = "direct"
+    """One shorthand maps to exactly one semantics value."""
+    COLLAPSE = "collapse"
+    """Multiple shorthands share one wire form; discriminated by a payload field."""
+    EXPANSION = "expansion"
+    """One shorthand expands across multiple wire forms."""
+    EVOLVED = "evolved"
+    """The shorthand's purpose is served by a mechanism on a different axis."""
+    NONE = "none"
+    """No formal protocol shorthand; wire activity with no direct formal counterpart."""
+
+
+@dataclass(frozen=True)
+class RowSpec:
+    """One ``SEMANTIC_REGISTRY`` entry with its page and mapping metadata.
+
+    Attributes:
+        semantics: The ``MessageSemantics`` enum value.
+        page: Primary page slug under ``docs/reference/messages/`` (no ``.md``).
+        shorthands: Formal protocol shorthand(s), e.g. ``("RS",)`` or
+            ``("CV", "CF")`` for a collapse.  Empty tuple when
+            :attr:`status` is ``NONE`` or ``EVOLVED``.
+        status: How the shorthand(s) relate to this wire form.
+        discriminator: For ``COLLAPSE`` entries: the payload field whose value
+            distinguishes the shorthands (e.g. ``"vf_state"``).  ``None``
+            otherwise.
+    """
+
+    semantics: MessageSemantics
+    page: str
+    shorthands: tuple[str, ...] = field(default_factory=tuple)
+    status: MappingStatus = MappingStatus.NONE
+    discriminator: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Exempted semantics — dispatcher fallbacks, not protocol messages.
+# Ratchet test allows these to have no primary page (MSM-06-002).
+# ---------------------------------------------------------------------------
+
+EXEMPTED_SEMANTICS: frozenset[MessageSemantics] = frozenset(
+    {
+        MessageSemantics.UNKNOWN,
+        MessageSemantics.UNKNOWN_UNRESOLVABLE_OBJECT,
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Mapping table.  One RowSpec per non-exempted SEMANTIC_REGISTRY entry.
+# Source: specs/message-semantics-mapping.yaml MSM-01 through MSM-04,
+# notes/message-type-reference.md.
+# ---------------------------------------------------------------------------
+#
+# Design note (MSM-06-002, notes/message-type-reference.md):
+#   A few entries legitimately appear on a second page (collapse/expansion
+#   semantics give them a secondary home).  The primary page is what this
+#   table records; secondary appearances are a renderer concern, not a
+#   ratchet concern.  See notes for the three entries with a second home:
+#     ADD_PARTICIPANT_STATUS_TO_PARTICIPANT  (cs primary, rm secondary)
+#     CLOSE_REPORT                           (rm primary, faults secondary)
+#     REJECT_CASE_LEDGER_ENTRY               (ledger primary, faults secondary)
+
+ROW_SPECS: tuple[RowSpec, ...] = (
+    # ------------------------------------------------------------------
+    # rm.md — Report Management (RM) shorthands
+    # Source: MSM-01, plus the Create(VulnerabilityReport) wire activity
+    # that has no formal shorthand but belongs in the RM family.
+    # ------------------------------------------------------------------
+    RowSpec(
+        semantics=MessageSemantics.CREATE_REPORT,
+        page="rm",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.SUBMIT_REPORT,
+        page="rm",
+        shorthands=("RS",),
+        status=MappingStatus.DIRECT,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ACK_REPORT,
+        page="rm",
+        shorthands=("RK",),
+        status=MappingStatus.DIRECT,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.VALIDATE_REPORT,
+        page="rm",
+        shorthands=("RV",),
+        status=MappingStatus.DIRECT,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.INVALIDATE_REPORT,
+        page="rm",
+        shorthands=("RI",),
+        status=MappingStatus.DIRECT,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.CLOSE_REPORT,
+        page="rm",
+        shorthands=("RC",),
+        status=MappingStatus.DIRECT,
+    ),
+    # RA and RD use case-level verbs (Join / Ignore) because the act is a
+    # case-participation decision, not a report-validity judgment (MSM-01-004,
+    # MSM-01-005).  Primary page is rm.md; they appear in case.py.
+    RowSpec(
+        semantics=MessageSemantics.ENGAGE_CASE,
+        page="rm",
+        shorthands=("RA",),
+        status=MappingStatus.DIRECT,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.DEFER_CASE,
+        page="rm",
+        shorthands=("RD",),
+        status=MappingStatus.DIRECT,
+    ),
+    # ------------------------------------------------------------------
+    # em.md — Embargo Management (EM) shorthands
+    # Source: MSM-02.
+    # EP expands into four wire activities; EV/EJ/EC collapse with
+    # EP/ER/EA respectively, distinguished by EM context not payload.
+    # ------------------------------------------------------------------
+    RowSpec(
+        semantics=MessageSemantics.CREATE_EMBARGO_EVENT,
+        page="em",
+        shorthands=("EP",),
+        status=MappingStatus.EXPANSION,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ADD_EMBARGO_EVENT_TO_CASE,
+        page="em",
+        shorthands=("EP",),
+        status=MappingStatus.EXPANSION,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ANNOUNCE_EMBARGO_EVENT_TO_CASE,
+        page="em",
+        shorthands=("EP",),
+        status=MappingStatus.EXPANSION,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
+        page="em",
+        # EV (revision proposal) shares the same wire form as EP (initial
+        # proposal); discriminated by EM state context, not a payload field.
+        shorthands=("EP", "EV"),
+        status=MappingStatus.COLLAPSE,
+        discriminator="EM state context",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
+        page="em",
+        shorthands=("EA", "EC"),
+        status=MappingStatus.COLLAPSE,
+        discriminator="EM state context",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE,
+        page="em",
+        shorthands=("ER", "EJ"),
+        status=MappingStatus.COLLAPSE,
+        discriminator="EM state context",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REMOVE_EMBARGO_EVENT_FROM_CASE,
+        page="em",
+        shorthands=("ET",),
+        status=MappingStatus.DIRECT,
+    ),
+    # ------------------------------------------------------------------
+    # cs.md — Case State (CS) shorthands
+    # Source: MSM-03.
+    # CV/CF collapse onto vf_state; CD collapses onto d_state; both share
+    # ADD_PARTICIPANT_STATUS_TO_PARTICIPANT.  CP/CX/CA collapse onto pxa_state.
+    # ADD_PARTICIPANT_STATUS_TO_PARTICIPANT also carries RM state via rm_state —
+    # its secondary home is rm.md (see notes/message-type-reference.md).
+    # ------------------------------------------------------------------
+    RowSpec(
+        semantics=MessageSemantics.CREATE_CASE_STATUS,
+        page="cs",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ADD_CASE_STATUS_TO_CASE,
+        page="cs",
+        shorthands=("CP", "CX", "CA"),
+        status=MappingStatus.COLLAPSE,
+        discriminator="pxa_state",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.CREATE_PARTICIPANT_STATUS,
+        page="cs",
+    ),
+    # CV and CF use vf_state; CD uses d_state.  All share this one semantics
+    # value.  The renderer notes the two discriminators; the ratchet sees one
+    # primary page (cs.md).
+    RowSpec(
+        semantics=MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
+        page="cs",
+        shorthands=("CV", "CF", "CD"),
+        status=MappingStatus.COLLAPSE,
+        # vf_state carries CV/CF; d_state carries CD; rm_state carries the RM
+        # ladder.  Show all three so no dimension is hidden.
+        discriminator="vf_state / d_state / rm_state",
+    ),
+    # ------------------------------------------------------------------
+    # general.md — General (GI) shorthands
+    # Source: MSM-04.
+    # GI expands: note lifecycle + actor-suggestion exchange.
+    # GK/GE are evolved (no dedicated semantics; see MSM-05).
+    # ------------------------------------------------------------------
+    RowSpec(
+        semantics=MessageSemantics.CREATE_NOTE,
+        page="general",
+        shorthands=("GI",),
+        status=MappingStatus.EXPANSION,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ADD_NOTE_TO_CASE,
+        page="general",
+        shorthands=("GI",),
+        status=MappingStatus.EXPANSION,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REMOVE_NOTE_FROM_CASE,
+        page="general",
+        shorthands=("GI",),
+        status=MappingStatus.EXPANSION,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.OFFER_ACTOR_TO_CASE,
+        page="general",
+        shorthands=("GI",),
+        status=MappingStatus.EXPANSION,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.OFFER_CASE_PARTICIPANT,
+        page="general",
+        shorthands=("GI",),
+        status=MappingStatus.EXPANSION,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ACCEPT_OFFER_CASE_PARTICIPANT,
+        page="general",
+        shorthands=("GI",),
+        status=MappingStatus.EXPANSION,
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REJECT_OFFER_CASE_PARTICIPANT,
+        page="general",
+        shorthands=("GI",),
+        status=MappingStatus.EXPANSION,
+    ),
+    # ------------------------------------------------------------------
+    # faults_and_acknowledgements.md — fault / ack mechanisms
+    # Source: MSM-05.
+    # RE/EE/CE/GE and EK/CK/GK have no dedicated dispatch values; their
+    # purposes are served by the mechanisms partitioned on a different axis.
+    # CREATE_PROCESSING_FAULT is the primary "not understood" fault mechanism.
+    # CLOSE_REPORT and REJECT_CASE_LEDGER_ENTRY also appear here as secondary
+    # homes; their primary pages are rm.md and ledger_replication.md.
+    # ------------------------------------------------------------------
+    RowSpec(
+        semantics=MessageSemantics.CREATE_PROCESSING_FAULT,
+        page="faults_and_acknowledgements",
+    ),
+    # ------------------------------------------------------------------
+    # case_management.md — case lifecycle and roster wire activities
+    # No formal shorthand; not modelled by the 28-shorthand protocol set.
+    # ------------------------------------------------------------------
+    RowSpec(semantics=MessageSemantics.CREATE_CASE, page="case_management"),
+    RowSpec(semantics=MessageSemantics.UPDATE_CASE, page="case_management"),
+    RowSpec(
+        semantics=MessageSemantics.ADD_REPORT_TO_CASE, page="case_management"
+    ),
+    RowSpec(semantics=MessageSemantics.CLOSE_CASE, page="case_management"),
+    RowSpec(
+        semantics=MessageSemantics.OFFER_CASE_PARTICIPANT_ROLE,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ACCEPT_CASE_PARTICIPANT_ROLE,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REJECT_CASE_PARTICIPANT_ROLE,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.OFFER_CASE_OWNERSHIP_TRANSFER,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ACCEPT_CASE_OWNERSHIP_TRANSFER,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REJECT_CASE_OWNERSHIP_TRANSFER,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.INVITE_ACTOR_TO_CASE,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REJECT_INVITE_ACTOR_TO_CASE,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ANNOUNCE_VULNERABILITY_CASE,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.CREATE_CASE_PARTICIPANT,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ADD_CASE_PARTICIPANT_TO_CASE,
+        page="case_management",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REMOVE_CASE_PARTICIPANT_FROM_CASE,
+        page="case_management",
+    ),
+    # ------------------------------------------------------------------
+    # case_proposal.md — pre-case bootstrap (ADR-0023)
+    # No formal shorthand; not a case-management message (no case exists yet).
+    # ------------------------------------------------------------------
+    RowSpec(
+        semantics=MessageSemantics.CREATE_CASE_PROPOSAL,
+        page="case_proposal",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.ACCEPT_CASE_PROPOSAL,
+        page="case_proposal",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REJECT_CASE_PROPOSAL,
+        page="case_proposal",
+    ),
+    # ------------------------------------------------------------------
+    # ledger_replication.md — SYNC substrate (ADR-0077)
+    # REJECT_CASE_LEDGER_ENTRY also appears in faults_and_acknowledgements.md
+    # as a secondary home (ledger NAK = acknowledgement story).
+    # ------------------------------------------------------------------
+    RowSpec(
+        semantics=MessageSemantics.ANNOUNCE_CASE_LEDGER_ENTRY,
+        page="ledger_replication",
+    ),
+    RowSpec(
+        semantics=MessageSemantics.REJECT_CASE_LEDGER_ENTRY,
+        page="ledger_replication",
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Derived fast-lookup indices.
+# ---------------------------------------------------------------------------
+
+#: Mapping from page slug → tuple of RowSpecs assigned to that page.
+_page_rows_builder: dict[str, list[RowSpec]] = {}
+for _row in ROW_SPECS:
+    _page_rows_builder.setdefault(_row.page, []).append(_row)
+PAGE_ROWS: dict[str, tuple[RowSpec, ...]] = {
+    k: tuple(v) for k, v in _page_rows_builder.items()
+}
+
+#: All known page slugs, in canonical display order.
+PAGE_SLUGS: tuple[str, ...] = (
+    "rm",
+    "em",
+    "cs",
+    "general",
+    "faults_and_acknowledgements",
+    "case_management",
+    "case_proposal",
+    "ledger_replication",
+)
+
+#: Mapping from ``MessageSemantics`` → ``RowSpec`` for O(1) lookup.
+SEMANTICS_TO_ROW: dict[MessageSemantics, RowSpec] = {
+    row.semantics: row for row in ROW_SPECS
+}

--- a/vultron/metadata/msm/render.py
+++ b/vultron/metadata/msm/render.py
@@ -1,0 +1,226 @@
+"""MkDocs Material markdown renderer for ``docs/reference/messages/`` pages.
+
+Produces shorthand↔wire-form mapping tables for the consolidated per-message-type
+reference pages.  Each page covers one family of protocol messages; the tables
+are rendered from the MSM mapping table (:mod:`vultron.metadata.msm._mapping`)
+joined against ``SEMANTIC_REGISTRY``.
+
+Usage (in a ``markdown-exec`` Python block)::
+
+    from vultron.metadata.msm.render import render_page
+    print(render_page("rm"))
+
+Page slugs correspond to filenames under ``docs/reference/messages/``:
+``rm``, ``em``, ``cs``, ``general``, ``faults_and_acknowledgements``,
+``case_management``, ``case_proposal``, ``ledger_replication``.
+
+Column semantics:
+
+- **Shorthand(s)**: formal protocol shorthand symbol(s) from the 28-message
+  set, or ``—`` when the wire activity has no formal counterpart.
+- **`MessageSemantics`**: the ``SEMANTIC_REGISTRY`` key used for dispatch.
+- **Wire Form**: ActivityStreams 2.0 verb+object(±qualifier) derived from the
+  entry's :class:`~vultron.wire.as2.extractor.ActivityPattern`.
+- **Discriminator**: the payload field that distinguishes shorthands in a
+  collapse mapping, or ``—`` for direct/expansion/none rows.
+- **Status**: one of ``direct``, ``collapse``, ``expansion``,
+  ``evolved``, or ``none`` (MSM-06-003).
+
+The *many-to-many* relationship is expressed as follows:
+
+- A shorthand appearing in **multiple rows** is an expansion (one shorthand,
+  many wire forms — e.g. ``GI`` or ``EP``).
+- **Multiple shorthands in one row** is a collapse (many shorthands, one wire
+  form — e.g. ``CP CX CA`` → ``Add(CaseStatus)``).
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from __future__ import annotations
+
+from vultron.metadata.msm._mapping import (
+    PAGE_ROWS,
+    PAGE_SLUGS,
+    MappingStatus,
+    RowSpec,
+)
+from vultron.semantic_registry import SEMANTIC_REGISTRY
+from vultron.semantic_registry._entry import SemanticEntry
+from vultron.wire.as2.extractor._pattern import ActivityPattern
+
+# ---------------------------------------------------------------------------
+# Internal fast-lookup: MessageSemantics → SemanticEntry.
+# ---------------------------------------------------------------------------
+
+_ENTRY_MAP: dict = {e.semantics: e for e in SEMANTIC_REGISTRY}
+
+# ---------------------------------------------------------------------------
+# Wire form string extraction from ActivityPattern.
+# ---------------------------------------------------------------------------
+
+# Page titles shown in rendered output.
+_PAGE_TITLES: dict[str, str] = {
+    "rm": "Report Management (RM) Messages",
+    "em": "Embargo Management (EM) Messages",
+    "cs": "Case State (CS) Messages",
+    "general": "General (GI) Messages",
+    "faults_and_acknowledgements": "Fault and Acknowledgement Mechanisms",
+    "case_management": "Case Management Wire Activities",
+    "case_proposal": "Case Proposal Wire Activities",
+    "ledger_replication": "Ledger Replication Wire Activities",
+}
+
+
+def _type_name(value: object) -> str:
+    """Return the human-readable type name from a ``VOtype``, ``AOtype``, or
+    ``TAtype`` / ``IAtype`` enum value.
+
+    All four enums are ``StrEnum``; their string representation is the value
+    (e.g. ``"VulnerabilityReport"``, ``"Create"``).
+    """
+    return str(value)
+
+
+def _format_pattern(pattern: ActivityPattern) -> str:
+    """Render *pattern* as a compact wire-form string.
+
+    Examples::
+
+        Offer(VulnerabilityReport)
+        Accept(Invite(Event)[context=VulnerabilityCase])
+        Add(CaseStatus)[target=VulnerabilityCase]
+    """
+    act = _type_name(pattern.activity_)
+    parts: list[str] = []
+
+    if pattern.object_ is not None:
+        if isinstance(pattern.object_, ActivityPattern):
+            parts.append(f"({_format_pattern(pattern.object_)})")
+        else:
+            parts.append(f"({_type_name(pattern.object_)})")
+
+    qualifiers: list[str] = []
+    if pattern.target_ is not None:
+        if isinstance(pattern.target_, ActivityPattern):
+            qualifiers.append(f"target={_format_pattern(pattern.target_)}")
+        else:
+            qualifiers.append(f"target={_type_name(pattern.target_)}")
+    if pattern.context_ is not None:
+        if isinstance(pattern.context_, ActivityPattern):
+            qualifiers.append(f"context={_format_pattern(pattern.context_)}")
+        else:
+            qualifiers.append(f"context={_type_name(pattern.context_)}")
+
+    qualifier_str = "[" + ", ".join(qualifiers) + "]" if qualifiers else ""
+    return act + "".join(parts) + qualifier_str
+
+
+def _wire_form(entry: SemanticEntry) -> str:
+    """Return the wire form string for *entry*, or ``—`` if no pattern."""
+    if entry.pattern is None:
+        return "—"
+    return f"`{_format_pattern(entry.pattern)}`"
+
+
+# ---------------------------------------------------------------------------
+# Status badge.
+# ---------------------------------------------------------------------------
+
+_STATUS_LABELS: dict[MappingStatus, str] = {
+    MappingStatus.DIRECT: "direct",
+    MappingStatus.COLLAPSE: "collapse",
+    MappingStatus.EXPANSION: "expansion",
+    MappingStatus.EVOLVED: "evolved",
+    MappingStatus.NONE: "—",
+}
+
+
+def _status_cell(status: MappingStatus) -> str:
+    return _STATUS_LABELS[status]
+
+
+# ---------------------------------------------------------------------------
+# Table row rendering.
+# ---------------------------------------------------------------------------
+
+
+def _shorthand_cell(row: RowSpec) -> str:
+    if not row.shorthands:
+        return "—"
+    return " ".join(f"`{s}`" for s in row.shorthands)
+
+
+def _render_table_row(row: RowSpec) -> str:
+    entry: SemanticEntry | None = _ENTRY_MAP.get(row.semantics)
+    if entry is None:
+        wire = "—"
+    else:
+        wire = _wire_form(entry)
+
+    shorthand = _shorthand_cell(row)
+    semantics_cell = f"`{row.semantics.name}`"
+    discriminator = f"`{row.discriminator}`" if row.discriminator else "—"
+    status = _status_cell(row.status)
+
+    # Escape pipe chars inside cells
+    wire = wire.replace("|", "&#124;")
+    return f"| {shorthand} | {semantics_cell} | {wire} | {discriminator} | {status} |"
+
+
+def _render_table(rows: tuple[RowSpec, ...]) -> str:
+    lines: list[str] = [
+        "| Shorthand(s) | `MessageSemantics` | Wire Form | Discriminator | Status |",
+        "|---|---|---|---|---|",
+    ]
+    for row in rows:
+        lines.append(_render_table_row(row))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public API.
+# ---------------------------------------------------------------------------
+
+
+def render_page(slug: str) -> str:
+    """Render the mapping table for *slug* as MkDocs Material markdown.
+
+    Args:
+        slug: Page slug from :data:`~vultron.metadata.msm._mapping.PAGE_SLUGS`
+            (e.g. ``"rm"``, ``"em"``, ``"cs"``).
+
+    Returns:
+        A markdown string containing a heading and a mapping table, ready for
+        embedding via ``markdown-exec``.
+
+    Raises:
+        ValueError: When *slug* is not a known page.
+    """
+    if slug not in PAGE_ROWS:
+        valid = ", ".join(PAGE_SLUGS)
+        raise ValueError(f"Unknown page slug {slug!r}. Valid slugs: {valid}")
+
+    title = _PAGE_TITLES.get(slug, slug.replace("_", " ").title())
+    rows = PAGE_ROWS[slug]
+    table = _render_table(rows)
+
+    lines = [
+        f"## {title}",
+        "",
+        table,
+    ]
+    return "\n".join(lines)
+
+
+__all__ = ["render_page", "PAGE_SLUGS", "_format_pattern", "_wire_form"]


### PR DESCRIPTION
- Closes #2998

## Summary

Adds `vultron/metadata/msm/` — the shorthand↔wire-form mapping table, MkDocs renderer, and coverage ratchet for issue #2998 (MSM message-type mapping infrastructure). No new reference page content; only the build-time machinery.

## Changes

- **`vultron/metadata/msm/_mapping.py`**: authoritative `RowSpec` table (49 entries covering all non-exempted `MessageSemantics`), `MappingStatus` enum, `EXEMPTED_SEMANTICS`, `PAGE_ROWS`, `PAGE_SLUGS`, `SEMANTICS_TO_ROW`
- **`vultron/metadata/msm/render.py`**: `render_page(slug) -> str` renderer; joins `PAGE_ROWS` against `SEMANTIC_REGISTRY`, extracts wire forms from `ActivityPattern` (scalar, nested, qualified), produces MkDocs Material markdown tables (5 columns: Shorthand(s), `MessageSemantics`, Wire Form, Discriminator, Status)
- **`vultron/metadata/msm/__init__.py`**: public API exports
- **`test/metadata/test_msm_render.py`**: unit tests for collapse (CP/CX/CA + pxa_state discriminator), expansion (GI and EP in multiple rows), none-status (no shorthand, wire form present), invalid slug ValueError, all 8 slugs render non-empty tables (AC-6)
- **`test/architecture/test_msm_coverage_ratchet.py`**: 5 hard ratchet assertions — every non-exempted registry entry has a `RowSpec`, every row references a valid enum, every page slug is canonical, each semantics has exactly one primary page, registry and mapping have the same semantics set (AC-5)

### Pre-existing bugs discovered during code review

- #3096: `case()` in `examples/_base.py` raises `TypeError` when kwargs overlap positional field names
- #3097: `assert_failure(allow_internal=True)` in `bt_harness.py` never asserts `result.internal_error is True`

Neither is in files touched by this PR; both filed for follow-up.

## Verification

- All 8302 unit tests pass (29 new); 1254 integration tests pass
- black, flake8, mypy, pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)