### PR TITLE
docs: plan concern #2665 — CSB-15-004 causal gate implementation guidance

### DIFF
--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -336,6 +336,28 @@ Getting this wrong — e.g., updating `CaseStatus.em_state` with a
 participant-specific value, or forgetting to scope RM updates to the correct
 participant — would produce incorrect case state representations.
 
+### CSB-15-004 Causal Gate: DEPLOYER-only d→D
+
+A DEPLOYER-only participant (holds `CVDRole.DEPLOYER`, `vf=None`) may advance
+`d.state` from `CS_d.d` to `CS_d.D` only when at least one VENDOR participant
+in the same case has `vf.state=CS_vf.VF` (fix-ready). This causal gate prevents
+a deployer from recording fix deployment before any vendor has produced a fix.
+
+**Implementation** (CSB-15-004):
+
+- **Predicate**: `some_vendor_at_vf(participants: list[CaseParticipant]) -> bool`
+  in `vultron/core/predicates/participants.py`. Pure function; no I/O.
+- **BT node**: `CheckSomeVendorAtVFNode` in
+  `vultron/core/behaviors/case/nodes/vfd_role_guards.py`. Reads all case
+  participants from the DataLayer and delegates to the predicate.
+- **BT wiring**: in `add_participant_status_trigger_tree.py`, when `d_state`
+  is non-None the sequence is `CheckDeployerRoleNode` (role check) →
+  `CheckSomeVendorAtVFNode` (causal precondition) → `ValidateTriggerTransitionsNode`
+  → `CreateParticipantStatusNode` → emit.
+
+The gate is generic — "some vendor at VF" — because per-deployer/per-vendor
+dependency tracking is intentionally out of scope (Concern #2665).
+
 ### OPP-06 — Future VFD/PXA transition handling
 
 When vendor-fix or public/exploit/attack transitions are implemented beyond

--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -343,7 +343,7 @@ A DEPLOYER-only participant (holds `CVDRole.DEPLOYER`, `vf=None`) may advance
 in the same case has `vf.state=CS_vf.VF` (fix-ready). This causal gate prevents
 a deployer from recording fix deployment before any vendor has produced a fix.
 
-**Implementation** (CSB-15-004):
+**Planned implementation** (CSB-15-004, pending #3109):
 
 - **Predicate**: `some_vendor_at_vf(participants: list[CaseParticipant]) -> bool`
   in `vultron/core/predicates/participants.py`. Pure function; no I/O.

--- a/plan/history/2609/learning/CONCERN-2665.md
+++ b/plan/history/2609/learning/CONCERN-2665.md
@@ -1,0 +1,40 @@
+---
+source: CONCERN-2665
+timestamp: '2026-09-03T14:23:54.683031+00:00'
+title: per-deployer/per-vendor dependency tracking for fine-grained VF→D causal gate
+type: learning
+---
+
+## Concern
+
+The current CSB-15-004 causal gate enforces a generic constraint: a DEPLOYER-only
+actor may advance `d → D` only when *some* VENDOR participant in the case has reached
+`vf.state = VF` (fix-ready). This is correct but coarse.
+
+The finer-grained question — *which specific vendor* does a given deployer depend on
+before they can deploy — has no answer in the current data model. The system
+does not track which vendor produced the fix that a particular deployer is applying.
+
+## Example gap
+
+If a case has two vendor participants (Vendor A at `VF`, Vendor B still at `Vf`)
+and a deployer that depends only on Vendor B's fix, the current causal gate would
+permit the deployer to advance to `D` even though the fix they need is not ready.
+
+## Out of scope for #2595
+
+This gap was explicitly identified during planning for #2595 and deferred. The VFD
+structural split (#2662–#2664) implements the generic gate, which is a sound
+improvement over the previous state. The fine-grained dependency is a separate concern.
+
+## Possible directions
+
+1. Add a `depends_on: list[participant_id]` field to `ParticipantStatus` or `CaseParticipant`
+2. Track vendor-deployer dependency at the case graph level (edges)
+3. Leave the generic gate in place and document the known limitation
+
+**Resolved**: 2026-09-03 — per-deployer/per-vendor pairing out of scope (too complex to
+manage in real cases); implementing the generic "some vendor at VF" gate only.
+Implementation tracked in #3109.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/3108>.
+Notes: `notes/case-state-model.md` § "CSB-15-004 Causal Gate: DEPLOYER-only d→D".


### PR DESCRIPTION
- Closes #2665

## Summary

Documents the CSB-15-004 causal gate design in `notes/case-state-model.md`:
the `some_vendor_at_vf()` predicate, the `CheckSomeVendorAtVFNode` BT node,
and BT wiring in `add_participant_status_trigger_tree.py`. Records that
per-deployer/per-vendor dependency tracking is intentionally out of scope.

## Changes

- **`notes/case-state-model.md`**: new §"CSB-15-004 Causal Gate: DEPLOYER-only
  d→D" section describing predicate location, BT node, wiring order, and scope
  boundary for fine-grained dependency tracking

## Implementation Issues

- #3109