### PR TITLE
fix(devcontainer): build knowledge graph once, share read-only across slots

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -73,34 +73,38 @@ After cloning, install the git hooks used in this project:
 # Code quality hooks (black, markdownlint, flake8, spec/ADR validators)
 pre-commit install
 
-# Knowledge graph hooks (rebuilds graphify-out/ after commits and branch switches)
-# Optional — requires graphify: pip install graphifyy
-graphify hook install
 ```
 
-The graphify hooks run in the background and only fire when `graphify-out/` already
-exists (i.e., after you've run `/graphify .` at least once). They won't interfere
-with the pre-commit hooks or slow down your commits.
+Do **not** install the graphify git hooks — see "Knowledge graph" below for why.
 
-### Knowledge graph hooks in a linked worktree
+## Knowledge graph (graphify)
 
-`graphify hook install` writes to the shared hooks directory, and its hook
-deliberately exits early in any linked worktree (it compares `git rev-parse
---git-dir` against `--git-common-dir` and bails when they differ). That guard is
-correct: hooks are shared across worktrees but `graphify-out/` is per-worktree, so
-without it a commit in one worktree would rebuild whichever `graphify-out/` happened
-to be in the current directory.
+The `graphify-out/` knowledge graph is a single derived artifact of `origin/main`,
+built by **one** authority and mounted **read-only** into every dev slot.
 
-To opt a single worktree back in, point that worktree at the tracked `.githooks/`
-directory:
+Do **not** run `graphify hook install`. Those hooks rebuild the entire graph
+(incremental AST extraction *plus* a full re-cluster of the whole graph) on every
+commit and every branch switch. With several slots running at once — and, worse,
+on the **uncapped** host clone — that saturates the machine for minutes. Building
+is centralized instead:
 
 ```shell
-git config extensions.worktreeConfig true
-git config --worktree core.hooksPath .githooks
+# Rebuild the shared graph on demand (CPU-capped, from origin/main). Running
+# slots pick up the new graph on their next restart.
+./start-dev.sh --build-graph
 ```
 
-Use `--worktree`, not `--local`: `--local` writes to the shared `.git/config` and
-would apply to every worktree at once.
+Inside a slot, `graph.json` is mounted read-only, so agents can
+`graphify query`/`path`/`explain` but cannot trigger a rebuild. The query flow's
+scratch (`.vocab.txt`, `memory/`) writes to a throwaway in-container `graphify-out/`
+and is discarded on teardown.
+
+If you previously ran `graphify hook install` in your host checkout, remove it —
+the host hooks run with no CPU cap and are the worst offender:
+
+```shell
+graphify hook uninstall   # run once in your ~/dev/<repo> host checkout
+```
 
 Two caveats:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -150,7 +150,16 @@ RUN git -C /app rev-parse --verify --quiet refs/remotes/origin/main >/dev/null \
         | xargs -r -n1 git -C /app branch -D \
     && git -C /app stash clear \
     && git -C /app reflog expire --expire=all --all \
-    && git -C /app gc --prune=now --quiet
+    && git -C /app gc --prune=now --quiet \
+    # Strip any graphify auto-rebuild hooks baked in from the host .git. These
+    # rebuild the whole knowledge graph on every commit/branch-switch; with 8
+    # slots that saturated the host. The graph is now built once, centrally, via
+    # `start-dev.sh --build-graph` and mounted read-only. See README-DEV.md.
+    && rm -f /app/.git/hooks/post-commit /app/.git/hooks/post-checkout \
+    # Ship a writable graphify-out so start-dev.sh can mount the shared graph.json
+    # read-only INTO it while the query flow's scratch (.vocab.txt, memory/) still
+    # writes locally. Created here so the later `chown -R vscode:vscode /app` owns it.
+    && mkdir -p /app/graphify-out
 
 # Create non-root developer user matching the VS Code devcontainer convention
 RUN groupadd --gid 1000 vscode \

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -10,11 +10,13 @@ set -euo pipefail
 
 SLOT=""
 REBUILD=false
+BUILD_GRAPH=false
 
 for arg in "$@"; do
     case "$arg" in
-        --rebuild) REBUILD=true ;;
-        --*)       echo "Unknown option: $arg"; exit 1 ;;
+        --rebuild)     REBUILD=true ;;
+        --build-graph) BUILD_GRAPH=true ;;
+        --*)           echo "Unknown option: $arg"; exit 1 ;;
         *)
             if [ -n "$SLOT" ]; then
                 echo "Unexpected argument: $arg"; exit 1
@@ -24,11 +26,15 @@ for arg in "$@"; do
     esac
 done
 
-if [ -z "$SLOT" ]; then
+if [ "$BUILD_GRAPH" = false ] && [ -z "$SLOT" ]; then
     echo "Usage: ./start-dev.sh <slot> [--rebuild]"
+    echo "       ./start-dev.sh --build-graph"
     echo ""
-    echo "  slot       Name for this dev slot (e.g. inky, pinky, blinky)."
-    echo "  --rebuild  Remove and rebuild the Docker image from scratch."
+    echo "  slot           Name for this dev slot (e.g. inky, pinky, blinky)."
+    echo "  --rebuild      Remove and rebuild the Docker image from scratch."
+    echo "  --build-graph  Rebuild the ONE shared knowledge graph (from origin/main,"
+    echo "                 CPU-capped) that every slot mounts read-only. Run this on"
+    echo "                 demand when the graph feels stale; slots pick it up on restart."
     exit 1
 fi
 
@@ -45,6 +51,55 @@ if [ ! -f "$ENV_FILE" ]; then
     bash "$SCRIPT_DIR/.devcontainer/setup.sh"
 fi
 
+# The knowledge graph is a single derived artifact of origin/main, built by ONE
+# authority and mounted read-only into every slot. This dir holds that one graph.
+SHARED_GRAPH="$HOME/dev/graphify-out/shared"
+mkdir -p "$SHARED_GRAPH"
+
+# --build-graph: rebuild the shared graph in a throwaway, CPU-capped container.
+# This is the ONLY place graphify extraction runs — no git-hook stampede, no
+# per-slot rebuilds. `graphify update .` bootstraps from empty and holds a
+# per-repo lock, so re-running while a build is in flight is safe.
+if [ "$BUILD_GRAPH" = true ]; then
+    if ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+        echo "Building image '$IMAGE_NAME'..."
+        docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/docker/Dockerfile" --target dev "$SCRIPT_DIR"
+    fi
+
+    echo "Rebuilding shared knowledge graph from origin/main (capped at ${GRAPH_BUILD_CPUS:-4} CPUs)..."
+    BUILD_ARGS=(
+        --rm
+        --env-file "$ENV_FILE"
+        --cpus "${GRAPH_BUILD_CPUS:-4}"
+        --memory "${GRAPH_BUILD_MEMORY:-8g}"
+        --memory-swap "${GRAPH_BUILD_MEMORY:-8g}"
+        -e GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-4}"
+        -e GRAPHIFY_SKIP_HOOK=1
+        -v "$SHARED_GRAPH:/app/graphify-out"
+        -u vscode -w /app
+    )
+    if [ -f "$HOME/.gitconfig" ]; then
+        BUILD_ARGS+=(-v "$HOME/.gitconfig:/home/vscode/.gitconfig:ro")
+    fi
+    if [ -S "/run/host-services/ssh-auth.sock" ]; then
+        BUILD_ARGS+=(
+            -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+            -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
+        )
+    fi
+    docker run "${BUILD_ARGS[@]}" "$IMAGE_NAME" bash -lc '
+        set -euo pipefail
+        git fetch --prune --quiet origin
+        git checkout -q -f -B main origin/main
+        git clean -fdq
+        graphify update .
+    '
+    echo ""
+    echo "Shared graph updated at $SHARED_GRAPH"
+    echo "Restart any running slots to pick it up."
+    exit 0
+fi
+
 # Ensure wip_notes/ and wip_outputs/ exist on the host (both gitignored)
 if [ ! -d "$MAIN_DIR/wip_notes" ]; then
     mkdir -p "$MAIN_DIR/wip_notes"
@@ -56,10 +111,6 @@ if [ ! -d "$MAIN_DIR/wip_outputs" ]; then
 fi
 mkdir -p "$MAIN_DIR/wip_outputs/$SLOT"
 WIP_OUTPUTS_SLOT="$MAIN_DIR/wip_outputs/$SLOT"
-
-# Ensure per-slot graphify-out dir exists on the host
-GRAPHIFY_HOST="$HOME/dev/graphify-out/$SLOT"
-mkdir -p "$GRAPHIFY_HOST"
 
 # --rebuild: remove container and image
 if [ "$REBUILD" = true ]; then
@@ -109,6 +160,10 @@ DOCKER_ARGS=(
     -e WIP_NOTES=/app/wip_notes
     -e WIP_OUTPUTS=/app/wip_outputs
     -e GRAPHIFY_MAX_WORKERS=4
+    # Belt-and-braces: the graphify git hooks are stripped from the image (see
+    # docker/Dockerfile), but this also neutralizes them if anything reinstalls
+    # them inside a running slot. A slot must never rebuild the graph.
+    -e GRAPHIFY_SKIP_HOOK=1
     -v "${MAIN_NAME}-data:/home/vscode/.data"
     -v "${MAIN_NAME}-${SLOT}-claude:/home/vscode/.claude"
     # NOTE: .devcontainer is NOT mounted. It is baked into the image and belongs
@@ -117,9 +172,26 @@ DOCKER_ARGS=(
     # any git operation in one slot dirtied all the others.
     -v "$MAIN_DIR/wip_notes:/app/wip_notes:ro"
     -v "$WIP_OUTPUTS_SLOT:/app/wip_outputs"
-    -v "$GRAPHIFY_HOST:/app/graphify-out"
     -w "$WORKSPACE"
 )
+
+# Knowledge graph: mount the heavy artifacts read-only from the single shared
+# build. The image ships a writable, vscode-owned /app/graphify-out, so the
+# query flow's disposable scratch (.vocab.txt, memory/) still writes there and
+# is discarded on teardown — but graph.json is read-only, so a slot physically
+# cannot rebuild or corrupt the shared graph. Mounts are added only if the graph
+# exists; otherwise the slot starts graph-less and queries fall back gracefully.
+if [ -f "$SHARED_GRAPH/graph.json" ]; then
+    DOCKER_ARGS+=(-v "$SHARED_GRAPH/graph.json:/app/graphify-out/graph.json:ro")
+    for _gf in .graphify_python manifest.json .graphify_root; do
+        if [ -e "$SHARED_GRAPH/$_gf" ]; then
+            DOCKER_ARGS+=(-v "$SHARED_GRAPH/$_gf:/app/graphify-out/$_gf:ro")
+        fi
+    done
+else
+    echo "NOTE: no shared graph at $SHARED_GRAPH — run './start-dev.sh --build-graph' to build it."
+    echo "      This slot starts without a knowledge graph."
+fi
 
 # Mount user-level skills read-only if present on the host
 if [ -d "$HOME/.agents/skills" ]; then


### PR DESCRIPTION
## Problem

`graphify update` was saturating the 20-core dev host for minutes, locking out the other dev-slot containers.

Root cause (verified in-repo, not guessed):

- The graphify git hooks (`post-commit` + `post-checkout`) rebuild the **entire ~33k-node graph** — incremental AST extraction **plus a full Louvain re-cluster + `graph.html` regen** — on every commit and every branch switch.
- `docker/Dockerfile` does `COPY . /app/` with **no `.git` exclusion**, so those hooks are baked verbatim from the host `.git` into every slot image. That also proves they exist on the **host** `~/dev/vultron` clone.
- Host processes get **no Docker `--cpus` cap**, so a `git commit`/`git checkout` on the host runs graphify at `cpu_count` (20 workers) → whole-machine lockup. The per-slot `--cpus 2` caps never applied to it.
- `poststart.sh`'s `git checkout -f` fires the hook again on every slot creation.

## Fix: one builder, many read-only readers

The graph is a single derived artifact of `origin/main` (and ~95% / last-commit-on-main freshness is acceptable here), so there should be **one** graph, built **once**, shared read-only.

- **`start-dev.sh --build-graph`** — the only place graphify extraction runs. A throwaway, CPU-capped (`--cpus 4`, `GRAPHIFY_MAX_WORKERS=4`) container resets to `origin/main` and runs `graphify update .` into `~/dev/graphify-out/shared`. `update` bootstraps from empty and holds a per-repo lock. Run on demand; slots pick it up on restart.
- **Slots** mount `graph.json` (+ `.graphify_python`, `manifest.json`, `.graphify_root`) **read-only** from that shared build. The query flow's disposable scratch (`.vocab.txt`, `save-result` `memory/`) writes to a throwaway in-container `graphify-out/` and is discarded on teardown. A slot **physically cannot rebuild or corrupt** the shared graph.
- **`docker/Dockerfile`** strips the baked hooks (`rm -f .git/hooks/post-commit .git/hooks/post-checkout`) and ships a writable, `vscode`-owned `/app/graphify-out`. `start-dev.sh` also sets `GRAPHIFY_SKIP_HOOK=1` as belt-and-braces.
- **README-DEV** stops recommending `graphify hook install` and documents the new model.

Why the query flow's writes are safe to discard: `save-result` writes only to `graphify-out/memory/` (never `graph.json`), and is folded in only by a later `graphify update` — which slots never run — so it's inert here. `.vocab.txt` is regenerated from `graph.json` each query.

## ⚠️ Required manual host step (cannot be done in-repo)

Existing host clones still carry the **uncapped** hooks. Run once on the host:

```shell
graphify hook uninstall   # in ~/dev/vultron (or your host checkout)
```

Slots rebuilt from this branch (`start-dev.sh <slot> --rebuild`) get the stripped image automatically.

## Testing

- `bash -n start-dev.sh` passes; markdownlint + flake8 pass via pre-commit.
- `graphifyy` (the `graphify` CLI) is a locked `dev` dependency, so the builder image has it.
- Not yet exercised end-to-end on the Mac host (needs Docker Desktop): `start-dev.sh --build-graph` then a slot start + a `graphify query`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)