### PR TITLE
fix: guard case() kwargs against identity-field overlap

### DIFF
--- a/test/wire/as2/vocab/test_vocab_case_examples.py
+++ b/test/wire/as2/vocab/test_vocab_case_examples.py
@@ -346,5 +346,38 @@ class TestVocabCaseStatusExamples(unittest.TestCase):
         self.assertEqual(activity.object_, status)
 
 
+class TestCaseKwargsOverlapGuard(unittest.TestCase):
+    def test_case_kwargs_overlap_name_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            examples.case(name="My Vuln")
+
+    def test_case_kwargs_overlap_id_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            examples.case(id_="custom-id")
+
+    def test_case_kwargs_overlap_attributed_to_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            examples.case(
+                attributed_to="urn:uuid:00000000-0000-0000-0000-000000000000"
+            )
+
+    def test_case_random_id_kwargs_overlap_name_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            examples.case(random_id=True, name="My Vuln")
+
+    def test_case_random_id_kwargs_overlap_id_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            examples.case(random_id=True, id_="custom-id")
+
+    def test_case_random_id_kwargs_overlap_attributed_to_raises_value_error(
+        self,
+    ):
+        with self.assertRaises(ValueError):
+            examples.case(
+                random_id=True,
+                attributed_to="urn:uuid:00000000-0000-0000-0000-000000000000",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vultron/wire/as2/vocab/examples/_base.py
+++ b/vultron/wire/as2/vocab/examples/_base.py
@@ -107,6 +107,9 @@ def case_actor() -> as_Service:
     return _CASE_ACTOR
 
 
+_IDENTITY_KEYS = frozenset({"name", "id_", "attributed_to"})
+
+
 def case(random_id=False, **kwargs) -> as_VulnerabilityCase:
     """The example case, optionally with extra fields populated.
 
@@ -115,16 +118,24 @@ def case(random_id=False, **kwargs) -> as_VulnerabilityCase:
     that same identity — id, name and attributor are preserved, so a populated
     case and the participants built against `case()` still agree on which case
     they belong to. Pass ``random_id=True`` for a case with a fresh id instead.
+
+    ``kwargs`` must not include ``name``, ``id_``, or ``attributed_to`` — those
+    identity fields are always supplied by this helper and cannot be overridden.
+    Passing any of them raises ``ValueError``.
     """
+    overlap = _IDENTITY_KEYS & kwargs.keys()
+    if overlap:
+        raise ValueError(
+            f"kwargs must not override identity fields: {sorted(overlap)!r}"
+        )
     if random_id:
         _case_number = random.randint(10000000, 99999999)
-        _case = as_VulnerabilityCase(
+        return as_VulnerabilityCase(
             name=f"{_VENDOR.name} Case #{_case_number}",
             id_=_make_id("VulnerabilityCase"),
             attributed_to=_VENDOR.id_,
             **kwargs,
         )
-        return _case
     if kwargs:
         return as_VulnerabilityCase(
             name=_CASE.name,


### PR DESCRIPTION
- Closes #3096

## Summary

Both branches of the `case()` helper in `examples/_base.py` forwarded
`**kwargs` directly alongside explicitly-bound identity keys (`name`,
`id_`, `attributed_to`), causing Python to raise a confusing `TypeError`
on any overlap. This PR adds an explicit `ValueError` guard and 6
regression tests.

## Changes

- **`vultron/wire/as2/vocab/examples/_base.py`**: Add module-level
  `_IDENTITY_KEYS = frozenset({"name", "id_", "attributed_to"})`.
  Check for overlap before either `as_VulnerabilityCase(...)` construction
  call; raise `ValueError` naming the offending keys. Update docstring to
  document the constraint. Simplify the `random_id=True` branch to use a
  direct `return` (no temporary variable).
- **`test/wire/as2/vocab/test_vocab_case_examples.py`**: Add
  `TestCaseKwargsOverlapGuard` with 6 tests covering all three identity
  keys in both the normal and `random_id=True` branches.

## Verification

- 8387 unit tests pass (6 new)
- 1254 integration tests pass
- Black, flake8, mypy, pyright clean