### PR TITLE
fix(bt-harness): assert internal_error=True when allow_internal=True

### DIFF
--- a/notes/testing-pitfalls.md
+++ b/notes/testing-pitfalls.md
@@ -309,8 +309,9 @@ test passes `allow_internal=True` (see `BTExecutionResult.internal_error`). Use
 that flag **only** when the crash path is the subject of the test; reaching for it
 to quiet an unexplained failure re-creates the problem it detects. Because it
 switches the classification guard off, it is accepted **only together with
-`reason`** — a test that opts out of the automatic check has to name what it
-expects instead, or the reason lives in a comment again:
+`reason`** and it also enforces `result.internal_error is True` — a test that
+opts out of the automatic check has to name what it expects and must be testing
+a genuine crash path, not a protocol FAILURE whose message happens to match:
 
 ```python
 bt_scenario.assert_failure(

--- a/test/core/behaviors/bt_harness.py
+++ b/test/core/behaviors/bt_harness.py
@@ -191,6 +191,12 @@ class BTTestScenario:
                 "allow_internal=True disables the crash guard, so it requires "
                 "reason='<substring>' naming the failure the test expects."
             )
+            assert result.internal_error is True, (
+                "allow_internal=True is for crash-path tests only. "
+                "The tree returned a plain protocol FAILURE (internal_error=False). "
+                "Remove allow_internal=True, or fix the node so it raises rather "
+                "than returning FAILURE for this condition."
+            )
         else:
             assert not result.internal_error, (
                 "Expected a protocol FAILURE but the tree raised: "

--- a/test/core/behaviors/test_bt_harness.py
+++ b/test/core/behaviors/test_bt_harness.py
@@ -244,6 +244,24 @@ class TestAssertFailureRequiresAReason:
                 result, reason="embargo not found", allow_internal=True
             )
 
+    def test_allow_internal_rejects_a_plain_protocol_failure(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """allow_internal=True must fail when internal_error is False.
+
+        A plain protocol FAILURE whose feedback_message contains the expected
+        substring must not pass — the caller opted into crash-path testing, so
+        the result must actually be a crash (internal_error=True).
+        """
+        result = BTExecutionResult(
+            status=Status.FAILURE,
+            feedback_message="Input port 'case_id' not set",
+        )
+        with pytest.raises(AssertionError):
+            bt_scenario.assert_failure(
+                result, reason="Input port", allow_internal=True
+            )
+
     def test_reason_is_checked_on_a_protocol_failure_too(
         self, bt_scenario: BTTestScenario
     ) -> None:

--- a/test/core/behaviors/test_bt_harness.py
+++ b/test/core/behaviors/test_bt_harness.py
@@ -257,7 +257,7 @@ class TestAssertFailureRequiresAReason:
             status=Status.FAILURE,
             feedback_message="Input port 'case_id' not set",
         )
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError, match="crash-path"):
             bt_scenario.assert_failure(
                 result, reason="Input port", allow_internal=True
             )


### PR DESCRIPTION
- Closes #3097

## Summary

`assert_failure(allow_internal=True)` did not assert `result.internal_error is True`, so a plain protocol `FAILURE` whose `feedback_message` contained the expected substring passed silently, giving false confidence that crash classification was verified.

## Changes

- **`test/core/behaviors/bt_harness.py`**: Add `assert result.internal_error is True` inside the `allow_internal=True` branch. Error message clearly states the constraint so future callers know what they opted into.
- **`test/core/behaviors/test_bt_harness.py`**: Add `test_allow_internal_rejects_a_plain_protocol_failure` to `TestAssertFailureRequiresAReason`. Constructs a `BTExecutionResult` with `internal_error=False` and a matching `feedback_message`, confirms `assert_failure(..., allow_internal=True)` raises `AssertionError`.
- **`notes/testing-pitfalls.md`**: Update `allow_internal=True` description to document the new `internal_error=True` enforcement.

## Verification

- All 8382 unit tests pass (1 new regression test)
- All 1254 integration tests pass
- Black, flake8, mypy, pyright clean