### PR TITLE
fix(devcontainer): use `uv run graphify` in the graph builder

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -87,12 +87,16 @@ if [ "$BUILD_GRAPH" = true ]; then
             -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
         )
     fi
-    docker run "${BUILD_ARGS[@]}" "$IMAGE_NAME" bash -lc '
+    # Non-login shell: `bash -lc` would source /etc/profile and reset PATH to the
+    # system default, dropping /app/.venv/bin. `uv run` resolves the project venv
+    # regardless of PATH (uv itself lives on the system PATH), matching how every
+    # Dockerfile CMD invokes project tools.
+    docker run "${BUILD_ARGS[@]}" "$IMAGE_NAME" bash -c '
         set -euo pipefail
         git fetch --prune --quiet origin
         git checkout -q -f -B main origin/main
         git clean -fdq
-        graphify update .
+        uv run graphify update .
     '
     echo ""
     echo "Shared graph updated at $SHARED_GRAPH"


### PR DESCRIPTION
Follow-up to #3116 (merged). The `--build-graph` container failed with `graphify: command not found`.

**Cause:** the builder ran `bash -lc`, and the **login** shell sources `/etc/profile`, which resets `PATH` to the system default and drops `/app/.venv/bin` (where the `graphify` entry point lives). Bare `graphify` resolves in an attached slot but not under a login shell.

**Fix:** switch to a non-login `bash -c` and invoke via `uv run graphify update .`, which resolves the project venv independent of `PATH` (uv itself is on the system `PATH`) — matching how every Dockerfile `CMD` runs project tools.

Tested: `bash -n start-dev.sh` passes; flake8/markdownlint pass via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)