### PR TITLE
docs: plan issue #2834 — G06 lifecycle state representation

### DIFF
--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -725,3 +725,46 @@ call is an alternative to fixed heuristics.
 **See**: `specs/agentic-readiness.yaml` and `specs/case-management.yaml` for
 the CVD action rules; `notes/bt-fuzzer-nodes.md` for related external
 touchpoints.
+
+---
+
+## CS Representation: Keep the Compound Enum (do not introduce `CaseState(BaseModel)`)
+
+**Decision (CONCERN-2099, planning group G06 / #2834):** The case-state
+representation stays as it is. The top-level `CS` enum in
+`vultron/core/states/cs.py` is already composed from the two sub-machine enums —
+it is `CompoundState(CS_vfd, CS_pxa)` yielding the 32 reachable states — which is
+exactly the decomposition the long-standing `# TODO consider replacing this with
+a combination of VfdState and PxaState / either directly or just creating
+CaseState(BaseModel)` comment contemplated. That TODO is now **resolved by the
+code that already exists**, and the resolution is "keep the compound enum," so
+the stale TODO is to be retired (tracked as a small follow-on Task under
+Epic #2684).
+
+Why not a `CaseState(BaseModel)` structured model:
+
+- New `vultron/core/` protocol code already consumes the **split** sub-machine
+  enums directly (`CS_vfd` / `CS_pxa`, and the ADR-0075 per-participant `CS_vf` /
+  `CS_d`). It does not reach for the monolithic `CS`.
+- The monolithic 32-member `CS` enum is retained mainly for the legacy
+  `vultron/bt/` simulator, which indexes states as compound labels. Replacing it
+  with a Pydantic model would churn the legacy simulator for no core benefit.
+- Structured, per-dimension decomposition of live status already exists via the
+  **ADR-0036 dimension objects** on `CaseStatus` / `ParticipantStatus`. A second
+  structured representation (`CaseState(BaseModel)`) would duplicate that surface
+  and create a divergence risk with no consumer that needs it.
+
+**Companion verdict (CONCERN-1912):** explicit transition constructors are **not**
+adopted; the field-mutation write path is retained. ADR-0033 already rejected
+transition constructors as a second write path and set the bar for reopening the
+question — the migration audit must show the field-mutation path is error-prone in
+practice (concretely, ≥2 distinct field-mutation error classes at promotion
+sites). The staged types now exist (`vultron/core/models/staged_case.py`:
+`IncomingReport` / `Case` / `EmbargoedCase`), so the migration is substantially
+real, but no such error evidence has surfaced. The ADR-0033 reopen precondition is
+therefore unmet and #1912 resolves to "no change." See
+`notes/lifecycle-staged-types.md`.
+
+**See**: `docs/adr/0033-lifecycle-staged-case-types.md`,
+`docs/adr/0036-status-dimension-objects.md`,
+`docs/adr/0075-split-vfd-state-machine.md`; `vultron/core/states/cs.py`.

--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -315,3 +315,65 @@ call-out seams in `create_manage_embargo_tree`, and the **active-embargo
 review loop** (`CurrentEmbargoAcceptable`) is a continuous-monitoring
 Sentinel with no event trigger — tracked separately for monitoring
 epic #1147 (companion Idea to #1257), not built here.
+
+## Owner-Close With an Active Embargo: Decline, Do Not Auto-Tear-Down
+
+**Decision (CONCERN-2955, planning group G06 / #2834):** when the Case Owner
+tries to close a case that still holds an **active embargo**, the Case Actor
+**declines the close** rather than closing. It does not silently tear the embargo
+down as part of closure.
+
+The problem: owner-close is a hard, global, terminal write boundary (ADR-0085) —
+once the owner leaves, "the front door locks" and the Case Actor accepts no
+further external ledger writes. The owner-close path
+(`create_close_case_received_tree` → `case_fully_closed`) currently has **no
+embargo precondition**, so an owner could close a case out from under an active
+embargo, leaving participants under a confidentiality obligation that can never be
+discharged through the normal protocol path (no authority remains to lift it).
+
+**Relation to the existing participant-level rules.** The protocol already covers
+a *participant* closing/deferring their own report while an embargo is in force,
+but only softly and only for the non-terminal case: VP-13-005 (participants
+SHOULD NOT close while embargoed), VP-13-007 (a closing participant SHOULD
+communicate whether they keep adhering), and VP-13-009 (a participant close
+*while other Participants remain engaged* MUST NOT auto-terminate the embargo —
+the embargo lives on for the others). Owner-close is the case those rules
+explicitly do not reach: it is global and terminal, so there are no "other
+Participants" to keep the embargo alive and no authority left to lift it. That is
+why the soft participant-level SHOULD_NOT is raised to a hard case-actor MUST
+refusal for owner-close specifically (CM-23-011 `refines` VP-13-005).
+
+**The refusal does not terminate the embargo.** Declining the close is *only* a
+refusal — it does not tear the embargo down as a side effect. The embargo stays
+active until terminated through the normal EM path; only then may the owner
+re-issue the close. "Case MUST NOT close while an embargo is live" is the rule —
+*not* "case close implies embargo termination."
+
+**Options weighed:**
+
+- **Option A — decline the premature close (chosen).** The Case Actor refuses the
+  owner `Leave(VulnerabilityCase)` while an embargo is active and requires an
+  explicit terminate-embargo-then-close ordering. Keeps the closure sequence
+  simple and atomic, and makes the embargo teardown a deliberate, auditable act by
+  the owner rather than an implicit side effect of leaving.
+- **Option B — atomic teardown on close (rejected).** Have close implicitly invoke
+  the existing `terminate_active_embargo_tree` / `embargo/nodes/teardown.py` as
+  part of `case_fully_closed`. Rejected: it buries a significant protocol event
+  (embargo termination, which has its own notifications and downstream effects)
+  inside the close path, and couples two lifecycle transitions that are cleaner
+  kept explicit.
+
+**How the refusal is expressed:** as an **`as:Reject`** response — "received and
+understood but declined" (MSM-05-001). The owner's `Leave` is well-formed and
+understood; it is *declined* because the embargo is active. It is therefore **not**
+a `Create(ProcessingFault)` (that mechanism is for messages received but *not*
+understood). Do not use `TentativeReject` — that verb is reserved for declining an
+`Offer` (e.g. embargo RSVP / `INVALIDATE_REPORT`), not for refusing a close.
+
+Normative requirement: `specs/case-management.yaml` **CM-23-011**. Implementation
+is tracked as a follow-on Task under Epic #2684.
+
+**See**: `docs/adr/0085-case-lifecycle-boundaries.md`;
+`specs/case-management.yaml` CM-23-002 / CM-23-011;
+`specs/message-semantics-mapping.yaml` MSM-05-001;
+`vultron/core/behaviors/case/receive_close_case_tree.py`.

--- a/notes/lifecycle-staged-types.md
+++ b/notes/lifecycle-staged-types.md
@@ -177,3 +177,30 @@ folded into the staged-types work. Tracked as a separate Idea issue.
 **Resolved**: ADR-0036 and `specs/status-dimension-objects.yaml` capture the
 design and normative requirements. See `notes/status-dimension-objects.md`
 for implementation guidance.
+
+## Transition Constructors: Not Adopted (field-mutation retained)
+
+**Decision (CONCERN-1912, planning group G06 / #2834):** the write path stays as
+field mutation on the staged types; explicit transition constructors (a second,
+transition-verb-shaped write API) are **not** introduced.
+
+ADR-0033 already evaluated and rejected transition constructors as a second write
+path that risks divergence from the field-mutation path, and set an explicit
+reopen bar: the option "may be reopened if the migration audit shows the
+field-mutation path is error-prone in practice." The concrete threshold applied
+here for "error-prone in practice" is **≥2 distinct classes of field-mutation
+error** observed at staged-type promotion sites (e.g., promoting to
+`EmbargoedCase` without setting `active_embargo`, or mutating `case_statuses`
+without materialising a `CaseStatus`).
+
+State of the evidence: the staged types are substantially implemented
+(`vultron/core/models/staged_case.py` defines `IncomingReport`, `Case`, and
+`EmbargoedCase`, each with `model_validator` invariants keyed to LST-02), so the
+migration is real enough to audit — but no recurring field-mutation error classes
+have surfaced. The ADR-0033 reopen precondition is therefore **unmet**, and #1912
+resolves to "no change; retain field mutation." Re-open only if the bar above is
+later met. The companion CS-representation verdict (CONCERN-2099) is recorded in
+`notes/case-state-model.md`.
+
+**See**: `docs/adr/0033-lifecycle-staged-case-types.md`;
+`vultron/core/models/staged_case.py`; `notes/case-state-model.md`.

--- a/plan/history/2609/learning/CONCERN-2834.md
+++ b/plan/history/2609/learning/CONCERN-2834.md
@@ -1,0 +1,52 @@
+---
+source: CONCERN-2834
+timestamp: '2026-09-03T18:11:13.047779+00:00'
+title: G06 lifecycle state representation
+type: learning
+---
+
+Planning group **G06 — lifecycle state representation** (umbrella #2834, parent
+epic #2828). Docs PR: <https://github.com/CERTCC/Vultron/pull/3136>
+
+## Outcome
+
+Three live members were resolved as recorded decisions (spec + notes; no ADR —
+the two representation verdicts are "keep as-is" and the close rule is a spec
+MUST). Three members (#2665, #3008, #3009) had already been planned/closed in
+prior sessions (AC-3 and most of AC-6).
+
+### Per-member disposition
+
+- **#2099 — CS representation.** Verdict: **keep the compound `CS` enum**. It is
+  already `CompoundState(CS_vfd, CS_pxa)`; new `vultron/core/` code consumes the
+  split sub-machine enums; the monolithic `CS` is retained for the legacy
+  `vultron/bt/` simulator. No `CaseState(BaseModel)` (ADR-0036 dimension objects
+  already decompose status). Recorded in `notes/case-state-model.md`. Follow-on:
+  retire the resolved `cs.py` TODO → Task #3138 under #2684.
+- **#1912 — transition constructors.** Verdict: **no change; retain the
+  field-mutation write path.** ADR-0033 rejected constructors as a second write
+  path and set the reopen bar at ≥2 field-mutation error classes found in a
+  migration audit; the staged types exist (`staged_case.py`) but no such error
+  evidence surfaced, so the bar is unmet. Recorded in
+  `notes/lifecycle-staged-types.md`. No Task.
+- **#2955 — owner-close with an active embargo.** Verdict: **Option A — the Case
+  Actor MUST decline the owner close while an embargo is live**, via `as:Reject`
+  ("understood but declined", MSM-05-001). Declining does NOT terminate the
+  embargo; the owner must terminate-then-close. Codified as **CM-23-011**
+  (`specs/case-management.yaml`), the terminal/case-global strengthening of the
+  participant-scoped VP-13-005 / VP-13-009; rationale in
+  `notes/embargo-lifecycle.md`. Follow-on: enforce CM-23-011 → Task #3137 under
+  #2684. Option B (atomic teardown on close) was rejected as it buries a
+  significant protocol event inside the close path.
+
+### Already resolved before this session
+
+- **#2665** (VFD split granularity) — AC-3.
+- **#3008 / #3009** (enforcement gaps; `composite_state_violations` rename) — AC-6.
+
+## Implementation issues
+
+- #3137 — enforce CM-23-011 (decline owner-close while embargo live) → #2684
+- #3138 — retire resolved CS-representation TODO in cs.py → #2684
+
+Members close on merge of PR #3136 (Closes #2834/#2099/#1912/#2955).

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -2653,6 +2653,47 @@ groups:
     stories:
     - story_2022_088
     - story_2022_066
+  - id: CM-23-011
+    priority: MUST
+    kind: protocol
+    statement: >-
+      When the Case Actor receives `Leave(VulnerabilityCase)` from the Case Owner
+      while the case still holds an active embargo (`active_embargo` is non-None
+      and the current EM state is `EM.ACTIVE` or `EM.REVISE`), it MUST decline the
+      closure with an `as:Reject` response ("received and understood but declined",
+      MSM-05-001) and MUST NOT execute the CM-23-002 closure sequence (no
+      participant advances to `RM.CLOSED`; no `case_fully_closed` entry is
+      emitted). The Case Owner MUST terminate the active embargo first, then
+      re-issue the close. Declining the close does NOT itself terminate the
+      embargo — the embargo remains active until terminated through the normal EM
+      path. This is the terminal, case-global counterpart to the
+      participant-scoped VP-13-005 (participants SHOULD NOT close while embargoed)
+      and VP-13-009 (a participant close while others remain engaged does not
+      auto-terminate the embargo): owner-close ends the case for everyone, so the
+      soft participant-level guidance is raised to a hard case-actor refusal.
+    rationale: >-
+      Owner-close is a hard, terminal write boundary (ADR-0085): the Case Actor
+      then accepts no further external ledger writes. VP-13-009 keeps an embargo
+      alive across a participant close only while others remain engaged;
+      owner-close leaves none and no authority to lift it, so an embargo left
+      active could never be discharged. Refusing the premature close forces an
+      explicit terminate-then-close ordering. `Leave` is understood but declined —
+      hence `as:Reject`, not `Create(ProcessingFault)` (MSM-05-001).
+    verification: >-
+      A test confirms that a Case Owner `Leave(VulnerabilityCase)` on a case with
+      an active embargo produces an `as:Reject` response and does not advance any
+      participant to `RM.CLOSED` or emit `case_fully_closed`; after the embargo is
+      terminated, the same close proceeds through the CM-23-002 sequence.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-23-002
+    - rel_type: refines
+      spec_id: VP-13-005
+    adr:
+    - ADR-0085
+    - ADR-0050
+    stories:
+    - story_2022_066
 - id: CM-24
   title: CaseActor-Delegated Activity Authorship Contract
   description: >-


### PR DESCRIPTION
- Closes #2834
- Closes #2099
- Closes #1912
- Closes #2955

## Summary

Planning group **G06 — lifecycle state representation**. Records the two
representation verdicts (no change) and the owner-close-with-active-embargo
decision as spec + notes. No ADR: the #2099/#1912 verdicts are "keep as-is,"
and the #2955 decision is captured as a normative spec MUST. Implementation
fans out to Tasks under Epic #2684.

## Changes

- **`specs/case-management.yaml`**: new **CM-23-011** — the Case Actor MUST
  decline an owner `Leave(VulnerabilityCase)` via `as:Reject` while an embargo
  is live (CONCERN-2955, Option A). Terminal, case-global strengthening of the
  participant-scoped VP-13-005 / VP-13-009; the refusal does **not** itself
  terminate the embargo (owner must terminate-then-close).
- **`notes/case-state-model.md`**: keep the compound `CS` enum (already
  `CompoundState(CS_vfd, CS_pxa)`); do not introduce `CaseState(BaseModel)`;
  retire the resolved `cs.py` TODO (CONCERN-2099).
- **`notes/lifecycle-staged-types.md`**: retain the field-mutation write path;
  transition constructors not adopted (CONCERN-1912; ADR-0033 reopen bar unmet).
- **`notes/embargo-lifecycle.md`**: owner-close-with-active-embargo decision,
  its relation to VP-13, and why Option A over Option B.

## Member Disposition (G06 / #2834)

- **#2099** CS representation — keep compound enum; retire TODO →
  `notes/case-state-model.md` + follow-on Task under #2684.
- **#1912** transition constructors — no change; field mutation retained →
  `notes/lifecycle-staged-types.md` (no Task).
- **#2955** owner-close + active embargo — Option A (decline) → CM-23-011 +
  `notes/embargo-lifecycle.md` + follow-on Task under #2684.
- **#2665 / #3008 / #3009** — already planned/closed in prior sessions
  (satisfy AC-3 and most of AC-6); no action here.

## Implementation Issues

- #3137 — enforce CM-23-011 (decline owner-close while embargo live) [→ #2684]
- #3138 — retire resolved CS-representation TODO in cs.py [→ #2684]