### PR TITLE
fix: emit relative links from What's New auto-generated list (#3144)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,14 +140,9 @@ six-step checklist (enum → pattern → use-case → map → tests).
 - **Inbox**: `vultron/adapters/driving/fastapi/routers/actors/` (package; `_routes.py` defines endpoints)
 - **Errors**: `vultron/errors.py`
 - **Demo**: `vultron/demo/cli.py` (entry point)
-- **Case States**: `vultron/core/states/cs.py` — CS/VFD/PXA enums are
-  authoritative; `vultron/core/states/cs_invariants.py` holds the CS validity,
-  transition and history invariants (CSB-17). `vultron/core/case_states/` is the
-  legacy string-pattern reference model, retained as an independent oracle and
-  still imported by `states/cs.py` and `use_cases/query/action_rules.py`. Reach
-  for `cs_invariants.py` for new protocol-path work; the legacy module's only
-  remaining new-code use is as the oracle in the CSB-17 equivalence tests
-  (ADR-0060)
+- **Case States**: `vultron/core/states/cs.py` (CS/VFD/PXA enums, authoritative)
+  and `cs_invariants.py` (CSB-17 invariants) → [notes/case-state-model.md](notes/case-state-model.md)
+  for the legacy-oracle relationship (ADR-0060)
 
 Full core-layer map → [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md).
 Full wire-layer map → [`vultron/wire/as2/AGENTS.md`](vultron/wire/as2/AGENTS.md).
@@ -348,12 +343,10 @@ message.
 - Use `markdownlint-cli2` for markdown; `black` is Python-only. Default config
   ignores only `wip_notes/**`; all other dirs are linted.
 - **Notes frontmatter** (NF-06-001, NF-06-002): every `notes/*.md` (except
-  `README.md`) needs `title` and `status` frontmatter. `superseded_by` is a
-  scalar string. Schema: `vultron/metadata/notes/schema.py`. **Maintenance rule
-  (NF-06-001, documented here per NF-06-002):** when you modify a note, review
-  and update its `status`, `related_specs`, and `related_notes` in the same
-  change — a new spec citation or cross-note link in the body means a new
-  frontmatter entry, and cross-links SHOULD be two-way.
+  `README.md`) needs `title` + `status`. **Maintenance rule:** when you modify a
+  note, update its `status`, `related_specs`, and `related_notes` in the same
+  change; cross-links SHOULD be two-way. Full write-up + schema:
+  [notes/notes-frontmatter.md](notes/notes-frontmatter.md).
 - **Docs links must be relative**: links in `docs/` MUST be relative and MUST NOT
   go above `docs/`. Run `uv run mkdocs build --strict` before committing docs.
   `docs/developer/` pages are draft docs — visible in `mkdocs serve` but excluded from production builds.

--- a/docs/about/whats_new.md
+++ b/docs/about/whats_new.md
@@ -3,45 +3,16 @@
 Pages added in the last 90 days:
 
 ```python exec="true" idprefix=""
-import subprocess
-import datetime
-import os
+import sys
+from pathlib import Path
 
-since = (datetime.date.today() - datetime.timedelta(days=90)).isoformat()
+_repo = Path.cwd()
+if str(_repo) not in sys.path:
+    sys.path.insert(0, str(_repo))
 
-result = subprocess.run(
-    [
-        "git", "log",
-        "--diff-filter=A",
-        "--name-only",
-        "--format=",
-        f"--since={since}",
-        "--",
-        "docs/",
-    ],
-    capture_output=True,
-    text=True,
-)
+from vultron.metadata.docs.whats_new import added_doc_pages, render_recent_pages
 
-files = sorted({
-    f.strip() for f in result.stdout.splitlines()
-    if f.strip().endswith(".md")
-})
-
-# Strip paths excluded from nav (underscore-prefixed, includes/, etc.)
-def is_navigable(path):
-    parts = path.split("/")
-    return not any(p.startswith("_") for p in parts) and "includes" not in parts
-
-files = [f for f in files if is_navigable(f)]
-
-if not files:
-    print("_No pages added in the last 90 days._")
-else:
-    for f in files:
-        # docs/some/path/page.md -> /some/path/page/
-        url_path = f.removeprefix("docs/").removesuffix(".md") + "/"
-        # Build a readable title from the filename
-        title = os.path.basename(f).removesuffix(".md").replace("-", " ").replace("_", " ").title()
-        print(f"- [{title}](/{url_path})")
+# Emit directory-style relative URLs (markdown-exec output is not rewritten by
+# MkDocs); root-absolute links would 404 under the /Vultron/ base path (#3144).
+print(render_recent_pages(added_doc_pages(since_days=90)))
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -372,7 +372,11 @@ validation:
 draft_docs: |
   draft-*.md
   !reference/draft-vultron-spec.md
-  docs/developer/
+  # Patterns are relative to docs_dir; `docs/developer/` was mis-anchored
+  # (matched a nonexistent docs/docs/developer/) so these maintainer pages were
+  # silently published. Exclude them from production builds per DOCBW-03-004
+  # while `mkdocs serve` still renders them for local review.
+  developer/
 theme:
   logo: 'assets/Software_Engineering_Institute_Unitmark_White.svg'
   name: 'material'

--- a/notes/notes-frontmatter.md
+++ b/notes/notes-frontmatter.md
@@ -264,6 +264,22 @@ should use `status: superseded` with `superseded_by` pointing to the replacement
 
 ---
 
+## Maintenance Rule (NF-06-001)
+
+When you modify any `notes/*.md` file, review and update its frontmatter in the
+**same** change — in particular `status`, `related_specs`, and `related_notes`.
+A new spec citation or cross-note link added to the body means a corresponding
+new frontmatter entry. Cross-links between notes SHOULD be two-way: if note A's
+frontmatter lists note B under `related_notes`, note B SHOULD list A.
+
+The schema is defined in `vultron/metadata/notes/schema.py`
+(`NoteStatus`, `NotesFrontmatter`); `superseded_by` is a scalar string, required
+when `status: superseded`. Per NF-06-002, root `AGENTS.md` carries a one-line
+statement of this rule so agents apply it consistently; this section is the
+canonical write-up.
+
+---
+
 ## Layer and Import Rules
 
 - `vultron/metadata/` is a **standalone tooling layer**.

--- a/test/metadata/docs/test_whats_new.py
+++ b/test/metadata/docs/test_whats_new.py
@@ -63,6 +63,18 @@ def test_render_recent_pages_keeps_undrafted_exception():
     assert "](../../reference/draft-vultron-spec/)" in out
 
 
+def test_render_recent_pages_excludes_developer_tree():
+    """developer/ pages are draft_docs (DOCBW-03-004) — excluded from prod build."""
+    out = render_recent_pages(
+        [
+            "docs/developer/how-to/build.md",
+            "docs/reference/quick_reference.md",
+        ]
+    )
+    assert "developer/how-to/build" not in out
+    assert "quick_reference" in out
+
+
 def test_render_recent_pages_docs_root_index_does_not_crash():
     """docs/index.md collapses to "" — relpath must not raise (#3144)."""
     out = render_recent_pages(["docs/index.md"])

--- a/test/metadata/docs/test_whats_new.py
+++ b/test/metadata/docs/test_whats_new.py
@@ -1,0 +1,139 @@
+"""Tests for vultron.metadata.docs.whats_new (issue #3144).
+
+The "What's New" page auto-generates a list of recently-added docs pages.
+The original implementation emitted root-absolute links (``/reference/...``),
+which drop the ``/Vultron/`` base-path prefix on the deployed site and 404.
+
+markdown-exec output is NOT processed by MkDocs' relative-link treeprocessor,
+so links must already be the final built URL. These tests pin the renderer to
+directory-style *relative* URLs (``../../reference/quick_reference/``), which
+resolve correctly both on the deployed sub-path and under ``mkdocs serve``.
+"""
+
+from vultron.metadata.docs.whats_new import (
+    NO_PAGES_MESSAGE,
+    keep_existing_pages,
+    render_recent_pages,
+)
+
+
+def test_render_recent_pages_emits_relative_dir_url_not_root_absolute():
+    """Links must be page-relative directory URLs, never root-absolute (#3144)."""
+    out = render_recent_pages(["docs/reference/quick_reference.md"])
+    # The regression: no leading-slash / root-absolute href.
+    assert "](/" not in out
+    # markdown-exec output is not rewritten by MkDocs, so the link must already
+    # be the final directory-style URL, relative to docs/about/whats_new.md.
+    assert "](../../reference/quick_reference/)" in out
+    # A .md source link would be emitted verbatim and 404 — never emit one.
+    assert ".md)" not in out
+
+
+def test_render_recent_pages_links_to_adr_page():
+    out = render_recent_pages(["docs/adr/0019-case-log.md"])
+    assert "](../../adr/0019-case-log/)" in out
+
+
+def test_render_recent_pages_index_page_collapses_to_directory():
+    out = render_recent_pages(["docs/reference/index.md"])
+    assert "](../../reference/)" in out
+
+
+def test_render_recent_pages_readme_collapses_to_directory():
+    """MkDocs serves README.md as the directory index, like index.md."""
+    out = render_recent_pages(["docs/adr/archived/README.md"])
+    assert "](../../adr/archived/)" in out
+
+
+def test_render_recent_pages_excludes_draft_pages():
+    """draft-*.md are dropped by mkdocs draft_docs and would 404 (#3144)."""
+    out = render_recent_pages(
+        [
+            "docs/reference/draft-vultron-replication-spec.md",
+            "docs/reference/quick_reference.md",
+        ]
+    )
+    assert "draft-vultron-replication-spec" not in out
+    assert "quick_reference" in out
+
+
+def test_render_recent_pages_keeps_undrafted_exception():
+    """The one file negated in draft_docs IS built, so keep it."""
+    out = render_recent_pages(["docs/reference/draft-vultron-spec.md"])
+    assert "](../../reference/draft-vultron-spec/)" in out
+
+
+def test_render_recent_pages_docs_root_index_does_not_crash():
+    """docs/index.md collapses to "" — relpath must not raise (#3144)."""
+    out = render_recent_pages(["docs/index.md"])
+    # From docs/about/whats_new.md up to the docs root is ../../ (two levels).
+    assert "](../../)" in out
+    assert "[Home]" in out
+
+
+def test_render_recent_pages_index_title_uses_directory_name():
+    """Index/README pages are titled after their directory, not "Index"/"Readme"."""
+    out = render_recent_pages(
+        ["docs/reference/index.md", "docs/adr/archived/README.md"]
+    )
+    assert "[Reference]" in out
+    assert "[Archived]" in out
+    assert "[Index]" not in out
+    assert "[Readme]" not in out
+
+
+def test_render_recent_pages_self_link_is_relative():
+    out = render_recent_pages(["docs/about/whats_new.md"])
+    assert "](./)" in out
+
+
+def test_render_recent_pages_humanizes_title():
+    out = render_recent_pages(["docs/reference/quick_reference.md"])
+    assert "[Quick Reference]" in out
+
+
+def test_render_recent_pages_empty_returns_placeholder():
+    assert render_recent_pages([]) == NO_PAGES_MESSAGE
+
+
+def test_render_recent_pages_filters_non_navigable():
+    """Underscore-prefixed and includes/ paths are excluded from nav."""
+    out = render_recent_pages(
+        [
+            "docs/howto/activitypub/activities/_create_report.md",
+            "docs/includes/curr_ver.md",
+            "docs/reference/quick_reference.md",
+        ]
+    )
+    assert "_create_report" not in out
+    assert "curr_ver" not in out
+    assert "quick_reference" in out
+
+
+def test_keep_existing_pages_drops_renamed_or_deleted(tmp_path):
+    """git reports the pre-rename path; if the file is gone its link 404s (#3144)."""
+    (tmp_path / "docs" / "adr").mkdir(parents=True)
+    (tmp_path / "docs" / "adr" / "0019-new-name.md").write_text("x")
+
+    kept = keep_existing_pages(
+        [
+            "docs/adr/0019-old-name.md",  # renamed away — must be dropped
+            "docs/adr/0019-new-name.md",  # exists — kept
+            "",  # blank line from git output — ignored
+        ],
+        repo_root=tmp_path,
+    )
+
+    assert kept == ["docs/adr/0019-new-name.md"]
+
+
+def test_render_recent_pages_sorts_and_dedups():
+    out = render_recent_pages(
+        [
+            "docs/reference/b.md",
+            "docs/reference/a.md",
+            "docs/reference/a.md",
+        ]
+    )
+    assert out.count("](../../reference/a/)") == 1
+    assert out.index("reference/a/") < out.index("reference/b/")

--- a/vultron/metadata/docs/__init__.py
+++ b/vultron/metadata/docs/__init__.py
@@ -1,0 +1,1 @@
+"""Docs-site rendering helpers used by markdown-exec blocks under ``docs/``."""

--- a/vultron/metadata/docs/whats_new.py
+++ b/vultron/metadata/docs/whats_new.py
@@ -1,0 +1,188 @@
+"""Renderer for the auto-generated list on ``docs/about/whats_new.md``.
+
+The "What's New" page lists docs pages added recently, as a Markdown bullet
+list. It is generated at build time by a markdown-exec Python block that calls
+into this module (mirroring the ``docs/reference/specs/*.md`` pages, which
+delegate to :mod:`vultron.metadata.specs.docs_render`).
+
+Links are emitted as **final, directory-style relative URLs** — e.g. a link
+from the What's New page to ``docs/reference/quick_reference.md`` renders as
+``../../reference/quick_reference/``. Two facts force this shape:
+
+* markdown-exec output bypasses MkDocs' relative-link treeprocessor, so a
+  ``.md`` source link (``../reference/quick_reference.md``) is emitted verbatim
+  and never rewritten — it 404s. The link must already be the built URL.
+* Under ``use_directory_urls`` (the default), each page ``docs/x/y.md`` is
+  served at ``x/y/``, so links must be computed against that URL layout.
+
+A directory-style *relative* URL works both on the deployed ``/Vultron/``
+sub-path and under ``mkdocs serve`` at the domain root, because it never
+references the site root. A root-absolute link (a leading ``/``) does reference
+the root and drops the ``/Vultron/`` base path — the bug in issue #3144. This
+mirrors the ``../slug/#anchor`` links :mod:`docs_render` emits for the same
+reason.
+
+Usage (in a markdown-exec Python block)::
+
+    from vultron.metadata.docs.whats_new import (
+        added_doc_pages,
+        render_recent_pages,
+    )
+    print(render_recent_pages(added_doc_pages(since_days=90)))
+"""
+
+from __future__ import annotations
+
+import datetime
+import posixpath
+import subprocess
+from collections.abc import Iterable
+from pathlib import Path
+
+# The source path of the page that hosts the generated list. Used as the base
+# for computing relative URLs to each listed page.
+WHATS_NEW_PAGE = "docs/about/whats_new.md"
+
+# Shown when no docs pages were added in the window. Kept in sync with the
+# 90-day default used by the whats_new.md exec block.
+NO_PAGES_MESSAGE = "_No pages added in the last 90 days._"
+
+
+# Draft pages that MkDocs excludes from the build (``draft_docs`` in mkdocs.yml)
+# have no built page, so linking to one 404s. Keep this in sync with mkdocs.yml:
+# draft_docs lists ``draft-*.md`` with a single un-drafted exception. (Pages in
+# ``not_in_nav`` are still built and reachable by URL, so they are NOT excluded.)
+_DRAFT_EXCEPTIONS = frozenset({"reference/draft-vultron-spec.md"})
+
+
+def _is_published(path: str) -> bool:
+    """Whether MkDocs builds a page for this source path.
+
+    Excludes underscore-prefixed segments and ``includes/`` (never standalone
+    pages) and ``draft-*`` files that mkdocs.yml ``draft_docs`` drops from the
+    build — a link to any of these would 404.
+    """
+    rel = path.removeprefix("docs/")
+    parts = rel.split("/")
+    if any(p.startswith("_") for p in parts) or "includes" in parts:
+        return False
+    if rel in _DRAFT_EXCEPTIONS:
+        return True
+    return not posixpath.basename(rel).startswith("draft-")
+
+
+def _title_for(path: str) -> str:
+    """Build a readable title from a docs file path.
+
+    Uses the page's URL path so that index/README pages are titled after their
+    directory (``docs/reference/index.md`` -> "Reference") rather than the
+    literal "Index"/"Readme"; the docs-root index is titled "Home".
+    """
+    url = _url_path(path)
+    stem = posixpath.basename(url) if url else "Home"
+    return stem.replace("-", " ").replace("_", " ").title()
+
+
+def _url_path(md_path: str) -> str:
+    """Return the ``use_directory_urls`` URL path for a docs source file.
+
+    ``docs/x/y.md`` -> ``x/y``; index pages collapse to their parent directory
+    (``docs/x/index.md`` -> ``x``, ``docs/index.md`` -> ``""``). ``README.md`` is
+    treated as an index page, matching MkDocs. The result has no leading or
+    trailing slash; callers add the trailing slash.
+    """
+    rel = md_path.removeprefix("docs/").removesuffix(".md")
+    if posixpath.basename(rel) in ("index", "README"):
+        return posixpath.dirname(rel)
+    return rel
+
+
+def _relative_url(target: str, *, page_path: str) -> str:
+    """Directory-style relative URL from ``page_path`` to ``target`` (both docs paths).
+
+    e.g. ``docs/reference/quick_reference.md`` from ``docs/about/whats_new.md``
+    -> ``../../reference/quick_reference/``.
+    """
+    # The docs-root index collapses to "" (see _url_path); posixpath.relpath
+    # raises on an empty path, so substitute "." for the repo-root directory.
+    page_url = _url_path(page_path) or "."
+    target_url = _url_path(target) or "."
+    rel = posixpath.relpath(target_url, page_url)
+    return rel + "/" if rel != "." else "./"
+
+
+def render_recent_pages(
+    files: Iterable[str], *, page_path: str = WHATS_NEW_PAGE
+) -> str:
+    """Render a Markdown bullet list of docs pages as relative-URL links.
+
+    Args:
+        files: Repo-relative docs paths (e.g.
+            ``docs/reference/quick_reference.md``), in any order and possibly
+            with duplicates.
+        page_path: Source path of the hosting page, used as the base for the
+            relative URLs (defaults to :data:`WHATS_NEW_PAGE`).
+
+    Returns:
+        A newline-joined Markdown bullet list, or :data:`NO_PAGES_MESSAGE` when
+        no navigable ``.md`` pages remain after filtering.
+    """
+    pages = sorted({f.strip() for f in files if f.strip().endswith(".md")})
+    pages = [f for f in pages if _is_published(f)]
+    if not pages:
+        return NO_PAGES_MESSAGE
+    lines = [
+        f"- [{_title_for(f)}]({_relative_url(f, page_path=page_path)})"
+        for f in pages
+    ]
+    return "\n".join(lines)
+
+
+def keep_existing_pages(
+    paths: Iterable[str], *, repo_root: Path | None = None
+) -> list[str]:
+    """Drop paths whose file no longer exists under ``repo_root``.
+
+    ``git log --diff-filter=A`` reports the *original* path of a file that was
+    later renamed (git records the rename as a separate ``R`` change). That
+    original path no longer exists and its built page 404s, so a link to it is
+    dead. Filtering to files present on disk keeps only paths that map to a
+    real, built page.
+    """
+    root = repo_root or Path.cwd()
+    return [
+        stripped
+        for p in paths
+        if (stripped := p.strip()) and (root / stripped).is_file()
+    ]
+
+
+def added_doc_pages(
+    *, since_days: int = 90, repo_root: Path | None = None
+) -> list[str]:
+    """Return docs files added within the last ``since_days`` days, per git.
+
+    Runs ``git log --diff-filter=A`` scoped to ``docs/``, then drops paths that
+    no longer exist on disk (added-then-renamed files, whose original path would
+    404 — see :func:`keep_existing_pages`). ``repo_root`` defaults to the process
+    working directory, which is the repository root during a MkDocs build.
+    """
+    since = (
+        datetime.date.today() - datetime.timedelta(days=since_days)
+    ).isoformat()
+    result = subprocess.run(
+        [
+            "git",
+            "log",
+            "--diff-filter=A",
+            "--name-only",
+            "--format=",
+            f"--since={since}",
+            "--",
+            "docs/",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    return keep_existing_pages(result.stdout.splitlines(), repo_root=repo_root)

--- a/vultron/metadata/docs/whats_new.py
+++ b/vultron/metadata/docs/whats_new.py
@@ -48,19 +48,21 @@ WHATS_NEW_PAGE = "docs/about/whats_new.md"
 NO_PAGES_MESSAGE = "_No pages added in the last 90 days._"
 
 
-# Draft pages that MkDocs excludes from the build (``draft_docs`` in mkdocs.yml)
-# have no built page, so linking to one 404s. Keep this in sync with mkdocs.yml:
-# draft_docs lists ``draft-*.md`` with a single un-drafted exception. (Pages in
-# ``not_in_nav`` are still built and reachable by URL, so they are NOT excluded.)
+# Draft pages that MkDocs excludes from the production build (``draft_docs`` in
+# mkdocs.yml) have no built page, so linking to one 404s. Keep this in sync with
+# mkdocs.yml draft_docs, which lists ``draft-*.md`` (with a single un-drafted
+# exception) and the ``developer/`` tree (maintainer pages, DOCBW-03-004). Pages
+# in ``not_in_nav`` are still built and reachable by URL, so they are NOT excluded.
 _DRAFT_EXCEPTIONS = frozenset({"reference/draft-vultron-spec.md"})
+_DRAFT_DIRS = ("developer/",)
 
 
 def _is_published(path: str) -> bool:
-    """Whether MkDocs builds a page for this source path.
+    """Whether MkDocs builds a production page for this source path.
 
     Excludes underscore-prefixed segments and ``includes/`` (never standalone
-    pages) and ``draft-*`` files that mkdocs.yml ``draft_docs`` drops from the
-    build — a link to any of these would 404.
+    pages), ``draft-*`` files, and the ``developer/`` tree — all dropped from the
+    production build by mkdocs.yml ``draft_docs``, so a link to any would 404.
     """
     rel = path.removeprefix("docs/")
     parts = rel.split("/")
@@ -68,6 +70,8 @@ def _is_published(path: str) -> bool:
         return False
     if rel in _DRAFT_EXCEPTIONS:
         return True
+    if rel.startswith(_DRAFT_DIRS):
+        return False
     return not posixpath.basename(rel).startswith("draft-")
 
 


### PR DESCRIPTION
- Closes #3144

## Summary

Fix the auto-generated "Pages added in the last 90 days" list on the What's
New page so its links resolve on the deployed site instead of 404ing.

## Problem

The `docs/about/whats_new.md` markdown-exec block emitted **root-absolute**
links (`/reference/quick_reference/`). The site deploys under a project
sub-path (`site_url: https://certcc.github.io/Vultron/`), so a leading-slash
link resolves against the domain root and drops the `/Vultron/` prefix —
every auto-generated link 404s.

markdown-exec output is **not** processed by MkDocs' relative-link
treeprocessor, so a `.md` source link is emitted verbatim and also 404s. Links
must already be the final, directory-style built URL.

## Changes

- **`vultron/metadata/docs/whats_new.py`** (new): renders the recent-pages list,
  mirroring `vultron/metadata/specs/docs_render.py`. Emits directory-style
  **relative** URLs (e.g. `../../reference/quick_reference/`) that resolve both
  on the deployed sub-path and under `mkdocs serve`. Also drops links that would
  404 for reasons surfaced while verifying the fix:
  - added-then-renamed files (git `--diff-filter=A` reports the pre-rename path),
  - `draft-*.md` pages excluded by mkdocs `draft_docs` (with the one negated
    exception kept),
  - `developer/` maintainer pages excluded from the production build (DOCBW-03-004),
  - `index.md`/`README.md` collapse to their directory URL, titled after the
    directory (docs-root index → "Home") rather than the literal "Index"/"Readme".
  - the docs-root index (`""` URL) no longer raises `ValueError` in `relpath`.
- **`docs/about/whats_new.md`**: exec block now delegates to the module.
- **`test/metadata/docs/test_whats_new.py`** (new): 15 unit tests.

## Also in this PR

### Fixes a mis-anchored `draft_docs` entry (DOCBW-03-004)

`mkdocs.yml`'s `draft_docs` patterns are relative to `docs_dir`, but the
`developer/` tree was listed as `docs/developer/` — which matched a nonexistent
`docs/docs/developer/` and was therefore a silent no-op. Maintainer pages under
`docs/developer/` were being published to production, contradicting DOCBW-03-004.
Corrected the pattern to `developer/` (and documented why); `mkdocs serve` still
renders these pages for local review. The renderer above also excludes the
`developer/` tree so the What's New list never links to a now-unbuilt page.

### Unblocks a pre-existing CI failure

The `test_root_agents_md_within_target` ratchet was already red on `main`
(root `AGENTS.md` at 407 lines, over the 400 budget) — a pre-existing failure
blocking every PR branched from current main. Condensed it back under budget by
migrating two sections to their canonical `notes/` homes (Case States →
`notes/case-state-model.md`; notes-frontmatter maintenance rule →
`notes/notes-frontmatter.md`), leaving concise pointers.

## Verification

- 15 new unit tests pass; full suite (`-m ""`) 9766 passed, 0 failed;
  integration suite passing.
- `mkdocs build --strict` passes; built site verified — What's New generated
  list links resolve, 0 broken; `site/developer/` no longer produced.
- AGENTS.md size ratchet passes (393 lines after freshen).
- Black, flake8, mypy, pyright clean.
