### PR TITLE
docs(agents): define Epic as issue type, not label

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,13 @@ message.
 
 Issues live in GitHub Issues. See `docs/agents/issue-tracker.md`.
 
+**Epics are the `Epic` issue type, not a label.** An Epic is a first-class
+GitHub issue whose `issueType` is `Epic`, with its member issues wired as
+sub-issues via GraphQL (the `addSubIssue` mutation). There is no "epic" label —
+do not create or search for one. Detect Epics by `issueType.name == "Epic"` and
+find their contents through the sub-issue relationship, not a label query. Create
+them with the `create-epic` skill.
+
 **Never use `gh issue create`** — it cannot set issue types, parent/child
 relationships, or blocker/blocked-by links. Use
 `.agents/skills/manage-github-issue/manage_github_issue.sh` or the


### PR DESCRIPTION
## Problem

Agents working in this repo repeatedly assume Epics are regular issues tagged with an "epic" label, and have to be corrected by hand every time. The actual convention — a first-class GitHub issue of type `Epic` with member issues wired as sub-issues via GraphQL — was documented **only inside the `create-epic` skill**, which agents don't open unless they're already creating an Epic. So during triage, search, or general reasoning about issues, the convention was invisible.

## Change

Add an explicit definition to the **Issue tracker** section of `AGENTS.md`, which is loaded for every agent in the repo:

> **Epics are the `Epic` issue type, not a label.** ... Detect Epics by `issueType.name == "Epic"` and find their contents through the sub-issue relationship, not a label query.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)