### PR TITLE
docs(spec): resolve Concern #3106 — closure advances only the leaver's RM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,32 +370,19 @@ message.
 
 ### Issue tracker
 
-Issues live in GitHub Issues. See `docs/agents/issue-tracker.md`.
+Issues live in GitHub Issues. See
+[docs/agents/issue-tracker.md](docs/agents/issue-tracker.md) for the full rules.
+Non-negotiables:
 
-**Epics are the `Epic` issue type, not a label.** An Epic is a first-class
-GitHub issue whose `issueType` is `Epic`, with its member issues wired as
-sub-issues via GraphQL (the `addSubIssue` mutation). There is no "epic" label —
-do not create or search for one. Detect Epics by `issueType.name == "Epic"` and
-find their contents through the sub-issue relationship, not a label query. Create
-them with the `create-epic` skill.
-
-**Never use `gh issue create`** — it cannot set issue types, parent/child
-relationships, or blocker/blocked-by links. Use
-`.agents/skills/manage-github-issue/manage_github_issue.sh` or the
-`createIssue` GraphQL mutation directly. Type IDs and relationship mutations:
-`.agents/skills/manage-github-issue/REFERENCE.md`.
-
-**Never pass backtick-containing markdown in a double-quoted `--body`.**
-Use a single-quoted heredoc:
-
-```bash
-gh issue comment <N> --repo CERTCC/Vultron --body "$(cat <<'EOF'
-Use `code` freely here.
-EOF
-)"
-```
-
-Same rule applies to `gh issue edit --body`, `gh pr create --body`, etc.
+- **Never use `gh issue create`** — it cannot set issue types or parent/child
+  and blocker links. Use
+  `.agents/skills/manage-github-issue/manage_github_issue.sh` (or the
+  `createIssue` GraphQL mutation).
+- **Epics are the `Epic` issue type, not a label** — detect by
+  `issueType.name == "Epic"`, not a label query; create with the `create-epic`
+  skill.
+- **Never pass backtick markdown in a double-quoted `--body`** — use a
+  single-quoted heredoc.
 
 ### Triage labels
 

--- a/docs/adr/0085-case-lifecycle-boundaries.md
+++ b/docs/adr/0085-case-lifecycle-boundaries.md
@@ -95,6 +95,20 @@ GI traffic, and it lets canonical history grow after close. Option C was rejecte
 "MAY reject" is not "MUST reject," so implementations would still diverge — the
 ambiguity CONCERN-1894 filed.
 
+### Closure is a case-level boundary, not a participant RM cascade
+
+Owner-close being "global and terminal" describes the **case-level write
+boundary** — the Case Actor accepts no further external ledger entries — not the
+RM dimension of every participant. Owner-close advances exactly two participants
+to `RM.CLOSED`: the Case Owner (the leaver) and the Case Actor (CM-23-002). It
+advances no others. A `Leave` advances only the leaving actor's own RM state,
+regardless of the rung it was on, because a `Leave` is that actor's own
+self-declaratory closure act (ADR-0084). Every remaining ("bystander")
+participant retains its last RM state when the case closes around it; closure
+never force-advances a participant that did not itself leave. Same locked-door
+store: the front door locks, but a book a patron never returned stays wherever
+it was left. This is stated as CM-23-012.
+
 ### Rejoin: closed is terminal, defer-don't-close is the workaround
 
 `RM.CLOSED` remains terminal. There is no rejoin transition. A participant that
@@ -150,5 +164,7 @@ code is required.
 - CONCERN-1902 — `SvcCloseCaseUseCase` unreachable under auto-create-case (source)
 - ADR-0050 — `Leave(VulnerabilityCase)` is the canonical RM closure mechanism
 - ADR-0084 — Participant Assertion Authority (companion decision)
+- CONCERN-3106 — whether case closure should force participant RM state
+  (resolved: only the leaver advances; bystanders retain their rung — CM-23-012)
 - Deferred: post-join role change (`Update(CaseParticipant)`, #3065) and case
   reopen mechanics (#3066) are tracked as Ideas under Epic #2567.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,7 +4,7 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Create an issue**: **never `gh issue create`** — it cannot set issue types, parent/child relationships, or blocker/blocked-by links. Use `.agents/skills/manage-github-issue/manage_github_issue.sh` or the `createIssue` GraphQL mutation directly. Type IDs and relationship mutations: `.agents/skills/manage-github-issue/REFERENCE.md`.
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
@@ -12,6 +12,23 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 - **Close**: `gh issue close <number> --comment "..."`
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Epics
+
+Epics are the `Epic` issue type, **not** a label. An Epic is a first-class GitHub issue whose `issueType` is `Epic`, with its member issues wired as sub-issues via GraphQL (the `addSubIssue` mutation). There is no "epic" label — do not create or search for one. Detect Epics by `issueType.name == "Epic"` and find their contents through the sub-issue relationship, not a label query. Create them with the `create-epic` skill.
+
+## Backtick-safe bodies
+
+**Never pass backtick-containing markdown in a double-quoted `--body`.** Use a single-quoted heredoc:
+
+```bash
+gh issue comment <N> --repo CERTCC/Vultron --body "$(cat <<'EOF'
+Use `code` freely here.
+EOF
+)"
+```
+
+The same rule applies to `gh issue edit --body`, `gh pr create --body`, etc.
 
 ## Pull requests as a triage surface
 

--- a/notes/domain-validation.md
+++ b/notes/domain-validation.md
@@ -8,7 +8,7 @@ description: >
 related_specs:
   - specs/architecture.yaml (ARCH-10-001, ARCH-15-001 through ARCH-15-004,
     ARCH-21-001 through ARCH-21-005)
-  - specs/case-management.yaml (CM-27-001 through CM-27-003)
+  - specs/case-management.yaml (CM-23-012, CM-27-001 through CM-27-003)
   - specs/participant-role-management.yaml (PRM-03-003)
   - specs/error-handling.yaml (EH-05-002, EH-07-001 through EH-07-003)
   - specs/behavior-tree-node-design.yaml (BTND-10-001 through BTND-10-003)

--- a/notes/domain-validation.md
+++ b/notes/domain-validation.md
@@ -474,29 +474,37 @@ participant can acquire a dimension its role does not license, you reopen this.*
 The receive path's carry-forward and any new model mutator are the places to
 watch.
 
-### Pitfall: composing the set exposed a standing RM violation
+### Pitfall: composing the set exposed a non-adjacent RM write at the close sites
 
 Giving the write node the *whole* rule set made it validate RM for the first
-time, and three call sites promptly failed: `close_case_effect.py` and both
-sites in `leave.py` stamp a departing participant `RM.CLOSED` regardless of the
-rung its RM machine is on. `RM.CLOSED` is reachable only from `ACCEPTED`,
-`INVALID` or `DEFERRED`, so `START → CLOSED` is a transition the protocol does
-not have — a BTND-10-001 violation that was invisible while the write node
-ignored RM. ADR-0086 predicted the bypass sites would gain trigger-path
-diagnostics "at no additional cost"; for RM that is not true.
+time, and three call sites surfaced: `close_case_effect.py` and both sites in
+`leave.py` stamp a departing actor `RM.CLOSED` regardless of the rung its RM
+machine is on. `RM.CLOSED` is reachable by adjacency only from `ACCEPTED`,
+`INVALID` or `DEFERRED`, so from an earlier rung this write is non-adjacent —
+which the emit-side adjacency rule (BTND-10-001) would otherwise refuse, and
+which was invisible while the write node ignored RM. ADR-0086 predicted the
+bypass sites would gain trigger-path diagnostics "at no additional cost"; for RM
+that is not true.
 
 Those sites carry a `force_rm_state=True` exemption that suppresses **only** the
 RM adjacency rule, pinned to that exact list by the ratchet above so it can only
 shrink. Do not add users, and do not read the exemption as "closure may write
 whatever it likes": every other rule still applies.
 
-Whether case closure should force participant RM state *at all* is a live
-protocol question, deliberately left open — participants are expected to reach
-`RM.CLOSED` by closing their own report handling, not by being pushed there, and
-the demo scenarios' "all participants `RM.CLOSED`" milestone (DEMOMA-07-003) is
-correct precisely because the demos get them there through the protocol. It is
-tracked as `type:Concern` [#3106](https://github.com/CERTCC/Vultron/issues/3106)
-so the design conversation happens before the behaviour changes.
+**Resolved (CM-23-012, [#3106](https://github.com/CERTCC/Vultron/issues/3106)):**
+the override is *sanctioned*, not a standing violation. A `Leave` is the
+departing actor's own self-declaratory closure act (ADR-0084), so advancing
+*that single actor* to `RM.CLOSED` regardless of rung is legitimate
+self-declaration — the RM adjacency rule is a report-handling invariant that a
+case-level `Leave` legitimately overrides. The scope is the key constraint: each
+site advances exactly one named actor (the leaver, or the case actor closing its
+own lifecycle on owner Leave, ADR-0051). Closure **never** force-advances a
+non-leaving ("bystander") participant — a participant that never sent `Leave`
+has made no closure declaration, so it retains its last RM state when the case
+closes around it ("the library closed before every book was returned"). The demo
+scenarios' "all participants `RM.CLOSED`" milestone (DEMOMA-07-003) is reached
+because every participant closes its own handling through the protocol, not
+because closure pushes them there.
 
 ### Surfacing a violation list
 

--- a/plan/history/2609/learning/CONCERN-3106.md
+++ b/plan/history/2609/learning/CONCERN-3106.md
@@ -1,0 +1,53 @@
+---
+source: CONCERN-3106
+timestamp: '2026-09-03T20:20:41.912375+00:00'
+title: Case closure advances only the leaver's RM; bystanders retain their rung
+type: learning
+---
+
+## Original Concern
+
+Case closure force-advances a departing participant's RM state to `RM.CLOSED`
+regardless of the rung its RM machine is on. `RM.CLOSED` is reachable only from
+`ACCEPTED`, `INVALID` or `DEFERRED`, so a participant at `START`/`RECEIVED`/`VALID`
+is moved through a transition the protocol does not have. The concern asked
+whether case closure should touch participant RM state at all, and posed four
+questions (write RM at closure? what carries the closure signal? correct end
+state for a never-triaged participant? does fan-out differ from self-leave?).
+
+Surfaced by #3050, which composed the ParticipantStatus write rules into one
+evaluator that gave `CreateParticipantStatusNode` an RM check for the first time;
+three call sites failed on `START → CLOSED` and were exempted via `force_rm_state`.
+
+## Resolution (2026-09-03)
+
+The behavior was **already correct**; only half the governing principle was
+written down. No behavior change was required — the resolution is spec + docs +
+regression pins.
+
+**Principle (now CM-23-012, MUST):** A `Leave(VulnerabilityCase)` advances only
+the leaving actor's own RM state to `RM.CLOSED`, regardless of rung — because a
+`Leave` is that actor's own self-declaratory closure act (ADR-0084). Owner-close
+is a case-level *write boundary* (ADR-0085): it advances only the Owner + Case
+Actor (CM-23-002) and never advances bystander participants, which retain their
+last RM state ("the library closed before every book was returned").
+
+Answers: (1) yes, but only for the leaver, and it is sanctioned self-declaration;
+(2) moot — the all-participants-RM.CLOSED derivation stays, and owner-close emits
+`case_fully_closed` directly; (3) the never-triaged bystander stays exactly where
+it is — no distinct "disengaged" state needed; (4) same principle — the fan-out
+only replicates the single departing actor's own Leave across replicas, never a
+bystander.
+
+Verified structurally: the only three `force_rm_state` sites each target one
+named actor (leaver, or Case Actor on owner-close), and no participant-iterating
+close path exists — so a bystander at `RECEIVED`/`VALID` cannot be forced to
+`CLOSED`. The `force_rm_state` override is thus sanctioned, not a standing
+violation; its caveats and `notes/domain-validation.md` were reframed
+accordingly, keeping the shrink-only pin.
+
+**Resolved**: 2026-09-03 — no follow-on implementation issues; the resolution is
+fully contained in the docs PR.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/3150>.
+Spec: `specs/case-management.yaml` (CM-23-012).
+Notes: `notes/domain-validation.md`.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -2694,6 +2694,53 @@ groups:
     - ADR-0050
     stories:
     - story_2022_066
+  - id: CM-23-012
+    priority: MUST
+    kind: protocol
+    statement: >-
+      Leave(VulnerabilityCase) advances only the leaving actor's own RM state to
+      RM.CLOSED, regardless of which RM rung that actor currently holds (START,
+      RECEIVED, VALID, ACCEPTED, DEFERRED, or INVALID). Case closure MUST NOT
+      advance any non-leaving ("bystander") participant's RM state: on owner
+      Leave, only the Case Owner and the Case Actor advance to RM.CLOSED
+      (CM-23-002); every other participant MUST retain its last RM state. The
+      characterization of owner-close as ending "the case for everyone"
+      (CM-23-011) refers to the case-level write boundary — the Case Actor
+      accepts no further external ledger entries (ADR-0085) — and MUST NOT be
+      read as a directive to force each remaining participant's RM dimension to
+      RM.CLOSED.
+    rationale: >-
+      A participant's RM state is the self-declaratory record of how that
+      participant handled the report (ADR-0084). A Leave is that participant's
+      own authoritative closure act, so advancing the leaving actor to RM.CLOSED
+      regardless of rung is legitimate self-declaration, not an externally
+      imposed jump — which is why the RM source→dest adjacency rule (RM.CLOSED
+      reachable by adjacency only from ACCEPTED/INVALID/DEFERRED) is
+      intentionally overridden at the leave/close write sites. A bystander that
+      never sent Leave has made no closure declaration; forcing its RM to
+      RM.CLOSED would fabricate a declaration it never made. Such a participant
+      simply remains at its last rung when the case ends around it (the library
+      closes before every book is returned). The demos' "all participants
+      RM.CLOSED" milestone (DEMOMA-07-003) is reached because every participant
+      closes its own handling through the protocol, not because closure pushes
+      them there.
+    verification: >-
+      A test confirms that an owner Leave(VulnerabilityCase) advances only the
+      Case Owner and Case Actor to RM.CLOSED and leaves a bystander participant
+      that was at RM.RECEIVED or RM.VALID at its prior RM state; and that the
+      leaving actor is advanced to RM.CLOSED even from a non-adjacent starting
+      rung (e.g. RM.RECEIVED).
+    relationships:
+    - rel_type: refines
+      spec_id: CM-23-001
+    - rel_type: refines
+      spec_id: CM-23-002
+    adr:
+    - ADR-0050
+    - ADR-0084
+    - ADR-0085
+    stories:
+    - story_2022_066
 - id: CM-24
   title: CaseActor-Delegated Activity Authorship Contract
   description: >-

--- a/test/architecture/test_participant_status_validation.py
+++ b/test/architecture/test_participant_status_validation.py
@@ -125,16 +125,18 @@ _SHARED_ENTRY_POINT = "validate_participant_status_write"
 _SHARED_EVALUATOR = "participant_transition_violations"
 
 # ---------------------------------------------------------------------------
-# force_rm_state quarantine — (path_relative_to_repo_root, occurrences)
+# force_rm_state override — (path_relative_to_repo_root, occurrences)
 #
-# These sites stamp a departing participant RM.CLOSED regardless of the rung
-# its RM machine is on.  RM.CLOSED is reachable only from ACCEPTED, INVALID or
-# DEFERRED, so each is a standing BTND-10-001 violation, invisible until the
-# write node began validating RM in #3050.  Whether case closure should force
-# participant RM state at all is a protocol question tracked as type:Concern #3106.
+# These sites advance a single departing actor to RM.CLOSED regardless of the
+# rung its RM machine is on.  RM.CLOSED is reachable by adjacency only from
+# ACCEPTED, INVALID or DEFERRED, so each is a non-adjacent RM write that the
+# emit-side adjacency rule (BTND-10-001) would otherwise refuse.  This is a
+# sanctioned self-declared-Leave override (CM-23-012, resolving #3106): a Leave
+# is the departing actor's own authoritative closure act (ADR-0084), and the
+# override never touches a non-leaving (bystander) participant.
 #
-# This list MUST only shrink.  Do not add entries: fix the call site, or take
-# the design question to the Concern issue first.
+# This list MUST only shrink.  Do not add entries: a new site would be forcing
+# RM.CLOSED on some actor without a self-declared Leave to justify it.
 # ---------------------------------------------------------------------------
 _RM_FORCE_QUARANTINE: dict[str, int] = {
     "vultron/core/behaviors/sync/nodes/close_case_effect.py": 1,

--- a/test/architecture/test_vfd_rm_pxa_write_sites.py
+++ b/test/architecture/test_vfd_rm_pxa_write_sites.py
@@ -52,8 +52,9 @@ from test.architecture import _corpus
 #                validates its own writes against the shared evaluator
 #                (BTND-10-001, BTND-10-003, ADR-0086); the upstream guard is
 #                defence in depth, not the guarantee.  Three of those five
-#                sites force RM.CLOSED and carry a documented `force_rm_state`
-#                exemption (#3106) pinned by test_participant_status_validation.py.
+#                sites force RM.CLOSED and carry a sanctioned `force_rm_state`
+#                override (CM-23-012, resolving #3106) pinned by
+#                test_participant_status_validation.py.
 #   BOOTSTRAP  — initial / authoritative seeding write; no prior state to
 #                violate; outside the scope of transition validation
 #   PREDICATE  — read-only dimension instantiation (guard / is_*() checks),

--- a/test/core/states/test_participant_transitions.py
+++ b/test/core/states/test_participant_transitions.py
@@ -403,8 +403,8 @@ class TestRmRuleQuarantine:
     def test_quarantine_suppresses_the_rm_rule(self):
         """The case-closure exemption: RM.CLOSED from any rung.
 
-        Tracked as type:Concern #3106 — see ``force_rm_state`` on
-        ``CreateParticipantStatusNode``.
+        Sanctioned self-declared-Leave override (CM-23-012, resolving #3106) —
+        see ``force_rm_state`` on ``CreateParticipantStatusNode``.
         """
         assert (
             _violations(requested_rm=RM.CLOSED, validate_rm_transition=False)

--- a/test/core/use_cases/received/test_close_case_role_semantics.py
+++ b/test/core/use_cases/received/test_close_case_role_semantics.py
@@ -49,6 +49,8 @@ from vultron.core.use_cases.received.case.lifecycle import (
 )
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.dimensions import RmDimension
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.enums.roles import CVDRole
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import announce_log_entry_activity
@@ -178,6 +180,35 @@ def _make_close_case_event(
         activity=activity,
         receiving_actor_id=receiving_actor_id,
     )
+
+
+def _seed_rm(dl: SqliteDataLayer, actor_id: str, rm_state: RM) -> None:
+    """Append a ParticipantStatus at *rm_state* to *actor_id*'s participant.
+
+    Uses the core append API so the seeded rung round-trips through
+    ``_participant_rm_states`` exactly as a protocol-written status would. Lets a
+    test start a participant at a specific RM rung (e.g. RECEIVED/VALID) before a
+    Leave, which is what CM-23-012 is about: the leaver advances regardless of
+    rung, and a bystander retains whatever rung it was seeded at.
+    """
+    case = dl.read(CASE_ID)
+    participant_id = case.actor_participant_index[actor_id]
+    participant = dl.read(participant_id)
+    assert isinstance(participant, CaseParticipant)
+    participant.add_participant_status(
+        ParticipantStatus(
+            attributed_to=actor_id,
+            context=CASE_ID,
+            rm=RmDimension(state=rm_state),
+        )
+    )
+    dl.save(participant)
+
+
+def _latest_rm(dl: SqliteDataLayer, actor_id: str) -> RM | None:
+    """Return the actor's most-recent RM state, or None if it has no status."""
+    states = _participant_rm_states(dl, actor_id)
+    return states[-1] if states else None
 
 
 def _participant_rm_states(dl: SqliteDataLayer, actor_id: str) -> list[RM]:
@@ -488,4 +519,83 @@ class TestCloseCaseFanOut:
         assert RM.CLOSED not in rm_states, (
             f"Announce(close_case for OWNER) must NOT advance VENDOR to RM.CLOSED;"
             f" rm_states={rm_states}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CM-23-012: closure is a per-leaver RM write, never a bystander cascade
+# ---------------------------------------------------------------------------
+
+
+class TestClosureRMBoundary:
+    """CM-23-012: a Leave advances only the leaver's RM (regardless of rung);
+    owner-close leaves every bystander at its prior RM rung."""
+
+    @pytest.mark.spec("CM-23-012")
+    def test_leaver_advances_to_closed_from_non_adjacent_rung(self):
+        """Owner Leave from RM.RECEIVED still reaches RM.CLOSED.
+
+        RECEIVED -> CLOSED is not a valid RM adjacency (CLOSED is reachable only
+        from ACCEPTED/INVALID/DEFERRED). CM-23-012: the leaver's own Leave is a
+        self-declaratory closure act, so the leaver advances regardless of rung
+        via the sanctioned force_rm_state override.
+        """
+        dl = _make_full_dl()
+        _seed_rm(dl, OWNER_ID, RM.RECEIVED)
+
+        CloseCaseReceivedUseCase(
+            dl=dl,
+            request=_make_close_case_event(sender_actor_id=OWNER_ID),
+            sync_port=SyncActivityAdapter(dl),
+        ).execute()
+
+        assert _latest_rm(dl, OWNER_ID) == RM.CLOSED, (
+            "Leaver seeded at RM.RECEIVED must still advance to RM.CLOSED"
+            f" (CM-23-012); rm_states={_participant_rm_states(dl, OWNER_ID)}"
+        )
+
+    @pytest.mark.spec("CM-23-012")
+    def test_owner_leave_leaves_bystander_at_prior_rung(self):
+        """Owner Leave must leave a bystander at exactly its prior RM rung.
+
+        Stronger than 'not CLOSED': a vendor seeded at RM.VALID must remain at
+        RM.VALID after owner-close — closure does not touch its RM at all.
+        """
+        dl = _make_full_dl()
+        _seed_rm(dl, VENDOR_ID, RM.VALID)
+
+        CloseCaseReceivedUseCase(
+            dl=dl,
+            request=_make_close_case_event(sender_actor_id=OWNER_ID),
+            sync_port=SyncActivityAdapter(dl),
+        ).execute()
+
+        assert _latest_rm(dl, VENDOR_ID) == RM.VALID, (
+            "Bystander seeded at RM.VALID must retain RM.VALID after owner-close"
+            f" (CM-23-012); rm_states={_participant_rm_states(dl, VENDOR_ID)}"
+        )
+
+    @pytest.mark.spec("CM-23-012")
+    def test_fanout_leaves_bystander_at_prior_rung(self):
+        """Fan-out of a close_case entry for OWNER must leave the replica's own
+        VENDOR participant at its prior rung (RM.ACCEPTED), not advance it."""
+        dl = _make_full_dl(store_owner_id=VENDOR_ID)
+        _seed_rm(dl, VENDOR_ID, RM.ACCEPTED)
+        entry = _make_close_case_ledger_entry(dl, departing_actor_id=OWNER_ID)
+
+        event = _make_announce_event(
+            entry=entry, sender_actor_id=CASE_ACTOR_ID
+        )
+
+        tree = create_announce_log_entry_tree()
+        BTBridge(datalayer=dl).execute_with_setup(
+            tree=tree,
+            actor_id=VENDOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert _latest_rm(dl, VENDOR_ID) == RM.ACCEPTED, (
+            "Fan-out of OWNER's close must leave VENDOR at RM.ACCEPTED"
+            f" (CM-23-012); rm_states={_participant_rm_states(dl, VENDOR_ID)}"
         )

--- a/test/core/use_cases/received/test_close_case_role_semantics.py
+++ b/test/core/use_cases/received/test_close_case_role_semantics.py
@@ -192,6 +192,7 @@ def _seed_rm(dl: SqliteDataLayer, actor_id: str, rm_state: RM) -> None:
     rung, and a bystander retains whatever rung it was seeded at.
     """
     case = dl.read(CASE_ID)
+    assert isinstance(case, VulnerabilityCase)
     participant_id = case.actor_participant_index[actor_id]
     participant = dl.read(participant_id)
     assert isinstance(participant, CaseParticipant)

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -1176,12 +1176,14 @@ class TestCreateParticipantStatusNode:
         )
 
     def test_force_rm_state_exempts_only_the_rm_rule(self):
-        """The case-closure quarantine advances RM past the ladder.
+        """The case-closure override advances RM past the ladder.
 
         This is the behaviour ``close_case_effect.py`` and ``leave.py`` rely on
-        to stamp a departing participant ``RM.CLOSED``.  It is a known
-        BTND-10-001 violation, tracked as type:Concern #3106; the point of the test
-        is that the exemption is narrow — every other rule still applies.
+        to advance a departing participant to ``RM.CLOSED``.  It is a sanctioned
+        self-declared-Leave override (CM-23-012, resolving #3106): the RM
+        adjacency rule is legitimately suppressed for the single departing actor.
+        The point of the test is that the exemption is narrow — every other rule
+        still applies.
         """
         from vultron.core.behaviors.case.nodes.participant import (
             CreateParticipantStatusNode,

--- a/vultron/core/behaviors/case/nodes/leave.py
+++ b/vultron/core/behaviors/case/nodes/leave.py
@@ -129,10 +129,11 @@ class AdvanceParticipantToRMClosedNode(DataLayerActionWithPorts):
             pxa_state=None,
             result_out=result_out,
             name=f"{self.name}.CreateParticipantStatus",
-            # Quarantine: this stamps RM.CLOSED regardless of the rung the
-            # leaving actor's RM machine is on, which the protocol does not
-            # permit.  Whether closure should touch participant RM at all is
-            # tracked as type:Concern #3106; see `force_rm_state`.
+            # Sanctioned override (CM-23-012, resolving #3106): a Leave is the
+            # leaving actor's own self-declaratory closure act (ADR-0084), so
+            # advancing *that actor* to RM.CLOSED regardless of its current rung
+            # is legitimate self-declaration; the RM adjacency rule is
+            # suppressed only for this single-actor write.  See `force_rm_state`.
             force_rm_state=True,
         )
         node.datalayer = self.datalayer
@@ -236,11 +237,12 @@ class AdvanceCaseActorToRMClosedNode(DataLayerActionWithPorts):
             pxa_state=None,
             result_out=result_out,
             name=f"{self.name}.CreateParticipantStatus",
-            # Quarantine: this stamps RM.CLOSED regardless of the rung the
-            # *case actor's* RM machine is on — the party that stays and closes
-            # the case, not the departing one — which the protocol does not
-            # permit.  Whether closure should touch participant RM at all is
-            # tracked as type:Concern #3106; see `force_rm_state`.
+            # Sanctioned override (CM-23-012, resolving #3106): on owner Leave
+            # the *case actor* closes its own RM lifecycle (ADR-0051) as the
+            # penultimate step before case_fully_closed.  Advancing this single
+            # actor to RM.CLOSED regardless of rung is legitimate; the RM
+            # adjacency rule is suppressed only for this write.  Bystander
+            # participants are never advanced here.  See `force_rm_state`.
             force_rm_state=True,
         )
         node.datalayer = self.datalayer

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -375,8 +375,9 @@ def validate_participant_status_write(
 
     Args:
         validate_rm_transition: Passed through to the evaluator.  ``False`` only
-            for the enumerated case-closure quarantine (``force_rm_state``);
-            every other caller leaves the full rule set in force.
+            for the enumerated sanctioned self-declared-Leave override
+            (``force_rm_state``, CM-23-012); every other caller leaves the full
+            rule set in force.
 
     Returns:
         ``Status.FAILURE`` when the write is refused, ``None`` when it is legal

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -114,26 +114,34 @@ class CreateParticipantStatusNode(DataLayerActionWithPorts):
         Args:
             force_rm_state: Skip the RM adjacency rule for this write.
 
-                **Quarantine — do not add new users.** Set only by the three
-                case-closure call sites that stamp a departing participant
-                ``RM.CLOSED`` regardless of the rung its RM machine is actually
-                on: ``sync/nodes/close_case_effect.py`` (the received close
-                fan-out) and ``case/nodes/leave.py`` (twice).  ``RM.CLOSED`` is
-                reachable only from ``ACCEPTED``, ``INVALID`` or ``DEFERRED``,
-                so those writes request a transition the protocol does not have
-                — a standing BTND-10-001 violation that was invisible until
-                this node started validating RM at all (ADR-0086, #3050).
+                **Do not add new users.** Set only by the three case-closure
+                call sites that advance a *single departing actor* to
+                ``RM.CLOSED`` regardless of the rung its RM machine is on:
+                ``sync/nodes/close_case_effect.py`` (the received close fan-out)
+                and ``case/nodes/leave.py`` (twice).  ``RM.CLOSED`` is reachable
+                by adjacency only from ``ACCEPTED``, ``INVALID`` or ``DEFERRED``,
+                so from any earlier rung this write is non-adjacent — which is
+                why the RM adjacency rule (BTND-10-001) is suppressed here.
+
+                This override is *sanctioned*, not a workaround (CM-23-012,
+                resolving Concern #3106): a ``Leave`` is the departing actor's
+                own authoritative, self-declaratory closure act (ADR-0084), so
+                advancing that actor to ``RM.CLOSED`` regardless of rung is
+                legitimate self-declaration rather than an externally imposed
+                jump.  The emit-side adjacency rule is a report-handling
+                invariant that a case-level ``Leave`` legitimately overrides;
+                every *other* rule (VF/D/PXA, role gates, entailments) still
+                applies.
+
+                Closure NEVER force-advances a non-leaving ("bystander")
+                participant: each site targets one named actor, and bystanders
+                retain their last RM state when the case closes around them
+                (CM-23-012).  Do not read this exemption as "closure may write
+                whatever it likes."
 
                 The other two guard-bypassing sites (``develop_fix.py``,
                 ``deploy_fix.py``) pass ``rm_state=None`` and so need no
                 exemption: they assert nothing about RM.
-
-                Whether case closure should be forcing participant RM state
-                *at all* is a protocol question, deliberately not answered here;
-                it is tracked as ``type:Concern`` #3106 so the design
-                conversation happens before the behaviour changes.  Participants are expected
-                to reach ``RM.CLOSED`` by closing their own report handling, not
-                by being pushed there.
 
                 ``test/architecture/test_participant_status_validation.py``
                 pins the exempt call sites, so the list can only shrink.

--- a/vultron/core/behaviors/sync/nodes/close_case_effect.py
+++ b/vultron/core/behaviors/sync/nodes/close_case_effect.py
@@ -124,10 +124,11 @@ class ApplyCloseCaseFromLedgerNode(_LedgerEffectNode):
             pxa_state=None,
             result_out=result_out,
             name=f"{self.name}.CreateParticipantStatus",
-            # Quarantine: this stamps RM.CLOSED regardless of the rung the
-            # departing actor's RM machine is on, which the protocol does not
-            # permit.  Whether closure should touch participant RM at all is
-            # tracked as type:Concern #3106; see `force_rm_state`.
+            # Sanctioned override (CM-23-012, resolving #3106): this replica is
+            # replicating the *departing actor's* own self-declaratory Leave
+            # (ADR-0084) named in the ledger entry, advancing only that single
+            # actor to RM.CLOSED regardless of rung.  It never touches any other
+            # (bystander) participant on this replica.  See `force_rm_state`.
             force_rm_state=True,
         )
         node.datalayer = self.datalayer

--- a/vultron/core/states/participant_transitions.py
+++ b/vultron/core/states/participant_transitions.py
@@ -359,8 +359,8 @@ def participant_transition_violations(
         requested_pxa: The PXA state being asserted, or ``None``.
         actor_roles: The asserting actor's ``CVDRole`` list, for the role gates.
         validate_rm_transition: Whether to apply the RM adjacency rule.  Only
-            the enumerated case-closure quarantine (#3106) sets this ``False`` — see
-            ``force_rm_state`` on
+            the enumerated sanctioned self-declared-Leave override (CM-23-012,
+            resolving #3106) sets this ``False`` — see ``force_rm_state`` on
             :class:`~vultron.core.behaviors.case.nodes.participant.status\
             .CreateParticipantStatusNode`.  It drops one *rule* from the set and
             never suppresses another rule's violation (BTND-10-002): the
@@ -368,7 +368,7 @@ def participant_transition_violations(
             shift *labels*, because dropping the RM rule takes ``"rm"`` out of
             :func:`_classify`'s faulted set, so a multi-dimension violation
             reading ``rm`` reports root instead of derived.  Moot in practice —
-            every quarantined call site asserts RM only.
+            every override call site asserts RM only.
 
     Returns:
         One :class:`~vultron.errors.Violation` per violated rule, each naming


### PR DESCRIPTION
- Closes #3106

## Summary

Resolves **Concern #3106** — *"Should case closure force participant RM state to CLOSED at all?"*

The concern feared that case closure force-advances every participant to `RM.CLOSED` regardless of rung. Investigation showed the behavior is **narrower and already correct**, but only **half the governing principle was written down**. This PR states the missing half as a spec requirement, clarifies the ADR, reframes the code caveats, and pins the behavior with regression tests. **No behavior change.**

### The resolved principle (new `CM-23-012`, MUST)

- A `Leave(VulnerabilityCase)` advances **only the leaving actor's own** RM state to `RM.CLOSED`, **regardless of which rung** it was on — because a `Leave` is that actor's own self-declaratory closure act (ADR-0084).
- Owner-close is a **case-level write boundary** (ADR-0085): it advances exactly the Case Owner + Case Actor (CM-23-002) and **never** advances bystander participants. A participant that never left **retains its last RM state** when the case closes around it — *"the library closed before every book was returned."*
- CM-23-011's *"ends the case for everyone"* means the write boundary (front door locks), **not** an RM cascade.

### Why the behavior was already correct

`RM.CLOSED` is writable only by (a) a valid adjacent `CLOSE` transition (requires the actor to have triaged), or (b) the `force_rm_state` override. The pin test proves there are **exactly three** override sites, each targeting **one named actor** (the leaver, or the Case Actor on owner-close). No path iterates participants to close them, so a bystander at `RECEIVED`/`VALID` **cannot** be forced to `CLOSED`. The `force_rm_state` override is therefore **sanctioned**, not a workaround — its caveats are reframed accordingly (from *"standing BTND-10-001 violation / open concern"* to *"self-declared-Leave override"*), keeping the shrink-only ratchet.

## Changes

- **`specs/case-management.yaml`** — add `CM-23-012` (MUST) stating both halves of the principle.
- **`docs/adr/0085`** — add *"Closure is a case-level boundary, not a participant RM cascade"*; reference CONCERN-3106 resolution.
- **`notes/domain-validation.md`** + the three `force_rm_state` caveats (`status.py`, `leave.py` ×2, `close_case_effect.py`) — reframe as sanctioned override. Also reframe the two remaining "quarantine" docstrings (`participant_transitions.py`, `participant/common.py`) so the framing is consistent across `vultron/`.
- **Regression tests** (`test_close_case_role_semantics.py`, marked `CM-23-012`): leaver advances to `CLOSED` from a **non-adjacent** rung (`RECEIVED`); bystander **retains its exact prior rung** on both owner-close and fan-out.
- Align the pin test + related test docstrings to the resolution.
- **`AGENTS.md` / `docs/agents/issue-tracker.md`** (unrelated CI unblock, folded in) — root `AGENTS.md` was 407 lines, over its 400-line ratchet, after an earlier main commit appended an Epic definition without trimming; this turned the `test/metadata` size ratchet red on main and every open PR. Condensed the `### Issue tracker` section into its canonical doc (394 lines now), reconciling with main's parallel condense and dropping a duplicate `## Epics` section. Also corrected a stale contradiction: the doc had advised `gh issue create`, which `AGENTS.md` forbids.

## Verification

`test/core/use_cases/received/test_close_case_role_semantics.py`, `test/architecture/test_participant_status_validation.py`, `test/architecture/test_vfd_rm_pxa_write_sites.py`, `test/core/states/test_participant_transitions.py`, `test/core/use_cases/triggers/case/test_add_participant_status.py`, and `test/architecture/test_spec_coverage_ratchet.py` all pass. `spec-dump` parses CM-23-012.

No follow-on implementation issues: the resolution is fully contained in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

