### PR TITLE
chore(skills): remove hardcoded Co-authored-by trailers

### DIFF
--- a/.agents/skills/archive-history/SKILL.md
+++ b/.agents/skills/archive-history/SKILL.md
@@ -90,13 +90,8 @@ markdownlint-cli2 --fix --config .markdownlint-cli2.yaml \
 
 ```bash
 git add plan/history/
-git commit -m "history: archive <TYPE> <SOURCE> — <TITLE>
-
-Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git commit -m "history: archive <TYPE> <SOURCE> — <TITLE>"
 ```
-
-The `Co-authored-by` trailer is **required** on this commit just as on all
-others — the history commit is the most commonly missing it.
 
 ### Step 5 — Push
 

--- a/.agents/skills/bugfix-handoff/SKILL.md
+++ b/.agents/skills/bugfix-handoff/SKILL.md
@@ -34,9 +34,7 @@ git add -A
 git commit -m "wip: interrupted handoff — <short description>
 
 [WIP] This commit captures in-progress work at session interrupt time.
-The bug is NOT fixed. See the issue comment for handoff notes.
-
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+The bug is NOT fixed. See the issue comment for handoff notes."
 ```
 
 If the working tree is clean, skip this step.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -2,14 +2,14 @@
 name: commit
 description: >
   Thin git stage-and-commit wrapper. Stages the specified files and commits
-  with a clear message and the required Co-authored-by trailer. Does not
+  with a clear message. Does not
   perform finalization (history updates, plan cleanup) — the caller owns that.
   Use after all finalization and validation steps are complete.
 ---
 
 # Skill: Commit
 
-Stage and commit changes with the required Co-authored-by trailer. This skill
+Stage and commit changes. This skill
 does only one thing: git add + git commit. The caller is responsible for all
 finalization steps (updating history files, cleaning plan files, running
 linters and tests) before invoking this skill.
@@ -37,18 +37,13 @@ unless every change in the working tree belongs to this commit.
 ```bash
 uv run git commit -m "<subject line>
 
-<body: what changed and why, as bullet points>
-
-Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>"
+<body: what changed and why, as bullet points>"
 ```
 
 Commit message conventions:
 
 - Subject line: imperative mood, ≤72 characters, no trailing period
 - Body: bullet points describing what changed and why
-- **`Co-authored-by` trailer is required on every commit** — include it
-  verbatim as the last line of every commit message, including history
-  archive commits. `pr-triage` Phase 3 flags any commit that is missing it.
 
 ## Constraints
 

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -233,9 +233,7 @@ Always open a PR. If Phase 5 produced doc changes, commit them first:
 git add specs/ notes/ docs/adr/ AGENTS.md
 git commit -m "docs: plan issue #${ISSUE_NUMBER} — <short title>
 
-- <bullet: what was added or changed>
-
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+- <bullet: what was added or changed>"
 ```
 
 Then invoke the `create-pr` skill:

--- a/.agents/skills/pr-execute/REFERENCE.md
+++ b/.agents/skills/pr-execute/REFERENCE.md
@@ -224,8 +224,6 @@ Merge branch 'main' into task/1234-slug
 Resolved conflicts in:
 - vultron/core/models/case/case.py — kept both new fields
 - uv.lock — regenerated after taking main's version
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 ---

--- a/.agents/skills/pr-execute/SKILL.md
+++ b/.agents/skills/pr-execute/SKILL.md
@@ -74,8 +74,6 @@ or `IMPROVE`:
    fix(pr-execute): address <N> findings from triage
 
    <bullet per finding: phase-name — short description>
-
-   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
    ```
 
 4. Record `commit_ref` (short SHA) for each finding addressed in this commit.
@@ -181,8 +179,6 @@ Commit CI fixes separately from Phase 2 fixes:
 
 ```text
 fix(ci): resolve CI failures — <summary>
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 Record `commit_ref` for each CI finding addressed.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -83,7 +83,6 @@ Check against `.agents/skills/shared/pr-body-guide.md`:
 - Closing references at the **top**, one per bullet
 - Required sections present (Summary, Changes, Verification for impl PRs)
 - Test counts in Verification are real numbers, not placeholders
-- Co-authored-by trailer present in all commits
 
 ### Phase 4 — Domain Context
 

--- a/.agents/skills/pr-ship/SKILL.md
+++ b/.agents/skills/pr-ship/SKILL.md
@@ -117,9 +117,7 @@ adding `.claude/pr-*.json` to `.gitignore` (when missing) creates a dirty file.
 Commit the `.gitignore` change immediately if it was written:
 
 ```bash
-git add .gitignore && git commit -m "chore: gitignore pr-*.json session artifacts
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git add .gitignore && git commit -m "chore: gitignore pr-*.json session artifacts"
 ```
 
 ### Step 3 — Worktree Check

--- a/.agents/skills/pr-triage/SKILL.md
+++ b/.agents/skills/pr-triage/SKILL.md
@@ -97,7 +97,6 @@ Check against `.claude/skills/shared/pr-body-guide.md`:
 - Closing references at the **top**, one per bullet
 - Required sections present (Summary, Changes, Verification for impl PRs)
 - Test counts in Verification are real numbers, not placeholders
-- Co-authored-by trailer present in all commits
 
 ### Phase 4 — Domain Context
 


### PR DESCRIPTION
## Summary

Skills hardcoded a `Co-authored-by` trailer in commit examples (originally Copilot, later Claude Sonnet) and mandated its presence. This conflicts with Claude Code, which appends its own trailer automatically. This removes all hardcoded trailers, the "trailer required" rules, and the trailer-verification checks so the harness owns commit attribution.

## Changes

- **commit**: drop trailer from the example, description, and the "required on every commit" rule
- **bugfix-handoff**, **plan-issue**, **archive-history**, **pr-ship**: drop trailer from commit examples (and the "required" note in archive-history)
- **pr-execute**: drop trailer from all commit templates (SKILL.md ×2, REFERENCE.md ×1)
- **pr-triage**, **pr-review**: remove the "Co-authored-by trailer present in all commits" verification check

## Verification

- markdownlint-cli2 and flake8 pre-commit hooks passed
- Repo-wide grep confirms no `Co-authored-by` / `noreply@anthropic` / Copilot-trailer references remain in `.agents/` (the sole remaining `.copilot` hit is a filesystem path, unrelated to trailers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)