### PR TITLE
feat(tooling): memoize linters so pre-commit and skills skip unchanged trees

### DIFF
--- a/.agents/skills/format-code/SKILL.md
+++ b/.agents/skills/format-code/SKILL.md
@@ -8,7 +8,7 @@ tags:
   - dev-workflow
 shell: "zsh"
 commands:
-  - "uv run black vultron/ test/ && uv run flake8 vultron/ test/"
+  - "G=.agents/skills/shared/run-if-changed.sh; \"$G\" black vultron/ test/ pyproject.toml uv.lock -- uv run black vultron/ test/ && \"$G\" flake8 vultron/ test/ .flake8 uv.lock -- uv run flake8 vultron/ test/"
 inputs:
   - name: repo_root
     description: "Repository root"
@@ -37,13 +37,19 @@ consistent code style and avoids pre-commit failures.
 ## Procedure
 
 1. From the repository root, run Black and flake8 on the `vultron/` and
-   `test/` directories:
+   `test/` directories. Route each through the shared `run-if-changed.sh`
+   guard so a tool is skipped when its inputs (source files + its config +
+   `uv.lock`) are unchanged since the last successful run:
 
 ```bash
-uv run black vultron/ test/ && uv run flake8 vultron/ test/
+G=.agents/skills/shared/run-if-changed.sh
+"$G" black  vultron/ test/ pyproject.toml uv.lock -- uv run black  vultron/ test/
+"$G" flake8 vultron/ test/ .flake8       uv.lock -- uv run flake8 vultron/ test/
 ```
 
-1. Inspect the output and stage changes if any files were reformatted.
+1. Inspect the output and stage changes if any files were reformatted. A
+   `... inputs unchanged since last success — skipping` line means the guard
+   reused a prior pass; it is not an error.
 
 ## Constraints / Rules
 
@@ -55,7 +61,9 @@ uv run black vultron/ test/ && uv run flake8 vultron/ test/
 
 ```bash
 cd "$REPO_ROOT"
-uv run black vultron/ test/ && uv run flake8 vultron/ test/
+G=.agents/skills/shared/run-if-changed.sh
+"$G" black  vultron/ test/ pyproject.toml uv.lock -- uv run black  vultron/ test/
+"$G" flake8 vultron/ test/ .flake8       uv.lock -- uv run flake8 vultron/ test/
 ```
 
 ## Rationale

--- a/.agents/skills/run-linters/SKILL.md
+++ b/.agents/skills/run-linters/SKILL.md
@@ -9,7 +9,7 @@ tags:
   - dev-workflow
 shell: "zsh"
 commands:
-  - "uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv run pyright"
+  - "G=.agents/skills/shared/run-if-changed.sh; \"$G\" black vultron/ test/ pyproject.toml uv.lock -- uv run black vultron/ test/ && \"$G\" flake8 vultron/ test/ .flake8 uv.lock -- uv run flake8 vultron/ test/ && \"$G\" mypy vultron/ test/ .mypy.ini uv.lock -- uv run mypy && \"$G\" pyright vultron/ test/ pyrightconfig.json uv.lock -- uv run pyright"
 inputs:
   - name: repo_root
     description: "Repository root where the command will be executed"
@@ -21,8 +21,18 @@ outputs:
 
 # Skill: Run Linters
 
+Each tool is routed through the shared `run-if-changed.sh` guard, which skips a
+tool when its inputs (the `vultron/`+`test/` sources, that tool's config file,
+and `uv.lock`) are unchanged since its last successful run. So back-to-back
+lint passes — and the flake8 pre-commit hook — reuse work instead of repeating
+it, while any edit to a relevant file forces a fresh run.
+
 ```bash
-uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv run pyright
+G=.agents/skills/shared/run-if-changed.sh
+"$G" black   vultron/ test/ pyproject.toml     uv.lock -- uv run black  vultron/ test/
+"$G" flake8  vultron/ test/ .flake8            uv.lock -- uv run flake8 vultron/ test/
+"$G" mypy    vultron/ test/ .mypy.ini          uv.lock -- uv run mypy
+"$G" pyright vultron/ test/ pyrightconfig.json uv.lock -- uv run pyright
 ```
 
 ## Constraints
@@ -30,3 +40,6 @@ uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv
 - Run `black` first — formatting errors cause spurious `flake8` failures.
 - `flake8` enforces a CC gate (`max-complexity = 10` in `.flake8`); functions exceeding CC=10 are a hard failure (IMPLTS-07-008).
 - All four tools must exit 0 before staging.
+- A `... inputs unchanged since last success — skipping` line is the guard
+  reusing a prior pass, not a failure. On failure the guard records nothing, so
+  the next run re-executes the tool.

--- a/.agents/skills/shared/run-if-changed.sh
+++ b/.agents/skills/shared/run-if-changed.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# run-if-changed.sh — run a command only if its relevant inputs changed since
+# the last successful run. Lets black/flake8/mypy/pyright be invoked from
+# several places (format-code, run-linters, the pre-commit hook) without
+# re-doing identical whole-tree work when nothing relevant changed.
+#
+# Usage:
+#   run-if-changed.sh <key> <input-path>... -- <command>...
+#
+#   <key>          Cache label. Invocations sharing a key + input set share a
+#                  cache entry, so a run in one skill satisfies the next.
+#   <input-path>   Files/dirs whose contents form the fingerprint (source
+#                  roots plus the tool's own config and uv.lock). Directories
+#                  are expanded to their tracked + untracked-non-ignored files
+#                  via git, so build artifacts and .venv never count.
+#   <command>...   The command to run (everything after `--`).
+#
+# The command runs when the fingerprint differs from the last success (or when
+# the fingerprint can't be computed — e.g. outside a git repo). On success the
+# post-run fingerprint is stored, so mutating tools like black stabilize after
+# one run. Cache lives in .git/ (per-worktree, never committed).
+
+set -uo pipefail
+
+key="${1:?usage: run-if-changed.sh <key> <input-path>... -- <command>...}"
+shift
+
+inputs=()
+while [ $# -gt 0 ] && [ "$1" != "--" ]; do
+  inputs+=("$1")
+  shift
+done
+[ "${1:-}" = "--" ] && shift
+if [ $# -eq 0 ]; then
+  echo "run-if-changed: no command given after --" >&2
+  exit 2
+fi
+
+git_dir="$(git rev-parse --git-dir 2>/dev/null)" || git_dir=""
+
+# Fingerprint = hash of (path + content) over every tracked or
+# untracked-non-ignored file under the inputs. Additions, deletions, renames
+# and edits all change it; ignored artifacts never do.
+fingerprint() {
+  [ -n "$git_dir" ] || return 1
+  git ls-files -z --cached --others --exclude-standard -- "${inputs[@]}" 2>/dev/null \
+    | sort -z \
+    | xargs -0 -r sha1sum 2>/dev/null \
+    | sha1sum | awk '{print $1}'
+}
+
+# No git / no fingerprint: run unconditionally, don't cache.
+if [ -z "$git_dir" ]; then
+  exec "$@"
+fi
+
+cache_dir="$git_dir/lint-cache"
+cache_file="$cache_dir/$key"
+
+current="$(fingerprint)"
+if [ -n "$current" ] && [ -f "$cache_file" ] && [ "$(cat "$cache_file")" = "$current" ]; then
+  echo "run-if-changed: '$key' inputs unchanged since last success — skipping"
+  exit 0
+fi
+
+"$@"
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  # Recompute after the run so mutating tools (black) store their result state.
+  post="$(fingerprint)"
+  if [ -n "$post" ]; then
+    mkdir -p "$cache_dir"
+    printf '%s\n' "$post" > "$cache_file"
+  fi
+fi
+
+exit "$status"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,9 +65,15 @@ repos:
 
       - id: flake8
         name: flake8 (with CC gate)
-        entry: uv run flake8
+        # Routed through run-if-changed.sh so this whole-tree lint is skipped
+        # when the sources, .flake8, and uv.lock are unchanged since the last
+        # successful flake8 run (e.g. the run-linters pass just before commit).
+        # Same cache key + inputs as the skills, so they share one cache entry.
+        entry: .agents/skills/shared/run-if-changed.sh
         language: system
-        args: ["vultron/", "test/"]
+        args:
+          ["flake8", "vultron/", "test/", ".flake8", "uv.lock", "--",
+           "uv", "run", "flake8", "vultron/", "test/"]
         pass_filenames: false
 
       - id: spec-lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,12 +179,14 @@ entry vs. both.
 
 **Before committing**, run skills in order:
 
-1. `format-code` — Black + flake8
-2. `run-linters` — all four linters must pass
-3. `run-tests` — unit suite once; read output. If `vultron/demo/` or `test/demo/`
+1. `run-linters` — all four linters (Black, flake8, mypy, pyright) must pass.
+   Supersedes `format-code` (which is just Black + flake8), so run it alone —
+   no separate `format-code` step. Each tool is memoized by `run-if-changed.sh`
+   (see below), so re-running is cheap when nothing changed.
+2. `run-tests` — unit suite once; read output. If `vultron/demo/` or `test/demo/`
    touched, also run full suite: `uv run pytest -m "" --tb=short 2>&1 | tail -5`
-4. `build-docs` — only if `docs/` modified
-5. `commit` skill — include Co-authored-by trailer
+3. `build-docs` — only if `docs/` modified
+4. `commit` skill — include Co-authored-by trailer
 
 **PR body**: use `.agents/skills/shared/pr-body-guide.md` template. Put
 `- Closes #N` at top, one per line.
@@ -192,8 +194,18 @@ entry vs. both.
 **`append-history`**: stage the new entry file (`git add plan/history/`).
 The monthly `README.md` under `plan/history/YYMM/` is gitignored — do not stage it.
 
-Pre-commit hooks are fail-only. If a hook fails, run `format-code` (black/markdown)
-or `run-linters` (flake8), re-stage, then commit.
+Pre-commit hooks are fail-only. If a hook fails, run `run-linters` (black,
+flake8, mypy, pyright) or `format-code` (markdown), re-stage, then commit.
+
+**Lint memoization**: black/flake8/mypy/pyright are invoked through
+`.agents/skills/shared/run-if-changed.sh <key> <inputs>... -- <cmd>`, which
+fingerprints each tool's inputs (the `vultron/`+`test/` sources, its config
+file, and `uv.lock`) and skips the run when they are unchanged since the last
+success. `run-linters`, `format-code`, and the flake8 pre-commit hook share one
+cache per tool, so a `run-linters` pass immediately before `commit` makes the
+hook a fast no-op — but any edit to a relevant file forces a fresh run, and a
+failure is never cached. A `... inputs unchanged ... skipping` line is expected,
+not an error.
 
 **After a PR merges** in a named worktree slot:
 `bash "$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh" reset <slot-name>`
@@ -268,7 +280,7 @@ linked file before touching that area. New pitfalls MUST be routed per
 | Persistence / stores | [datalayer-design](notes/datalayer-design.md) | `dl.read()` returns core objects (ADR-0034); core must not re-read wire activities for semantics (ADR-0035); an actor id **is** a store name (DL-07-004); `_dehydrate_data` deliberately keeps inline Activity sub-fields as snapshots |
 | Embargo / consent | [embargo-lifecycle](notes/embargo-lifecycle.md), [participant-embargo-consent](notes/participant-embargo-consent.md) | delegate to `EmbargoLifecycle`, never inline `EMAdapter`; consent only via `apply_pec_transition()` (CM-18-005/006); `embargo_adherence` is a `@computed_field` (ADR-0056); don't downgrade consent on retries; test `REVISE → REVISE` separately |
 | Participant records | [participant-role-management](notes/participant-role-management.md) | `actor_participant_index` is the fast path, and RM mutation MUST use it (CM-19-003); RM terminal guard runs before the same-state shortcut |
-| Devcontainer / tooling | [devcontainer-tooling](notes/devcontainer-tooling.md) | always `uv run`; clear `PYTHONPATH` first; `UV_NO_SYNC=1` on sync failures; give `git commit` a 10-min timeout (whole-tree flake8 hook); `SKIP=actionlint` when not touching workflows (hook hangs, no Go); wrong `gh` path in the credential helper; `.agents/` and `.claude/` skills are hard links — edit only `.agents/` |
+| Devcontainer / tooling | [devcontainer-tooling](notes/devcontainer-tooling.md) | always `uv run`; clear `PYTHONPATH` first; `UV_NO_SYNC=1` on sync failures; give `git commit` a 10-min timeout (whole-tree flake8 hook — usually a fast no-op if `run-linters` just ran, but ~35s cold or after source edits); `SKIP=actionlint` when not touching workflows (hook hangs, no Go); wrong `gh` path in the credential helper; `.agents/` and `.claude/` skills are hard links — edit only `.agents/` |
 | git / branches / PRs | [git-workflow-pitfalls](notes/git-workflow-pitfalls.md) | rebase "local changes" can be a false positive; conflict-free ≠ working merge; related fix PRs need an integration branch (`create-pr` can't target one); `claim-issue.sh` needs a synced branch; re-check ADR numbers before merge; verify every AC against `origin/main` and always add `Closes #N`; scan peer files before closing |
 | GH Actions / CI YAML | [ci-workflow-authoring](notes/ci-workflow-authoring.md) | a red job may never have run its assertions (and an all-skipped run is green); `notify-failure` is mandatory on `main`/`schedule` (CISEC-05); PyYAML reads bare `on:` as `True`; matrix booleans differ job- vs. step-level; `python3 -c` blocks break `actionlint`; single-quoted YAML needs doubled apostrophes |
 | Spec authoring | [spec-authoring-rules](notes/spec-authoring-rules.md) | strict enums for `kind`/`priority`/`rel_type`; `references:` is dropped (use `adr:`); a new `kind: protocol` entry needs a marker test or strict `xfail`; grep bare filenames when retiring a name; "CaseActor MUST …" is usually a role/object category error |

--- a/notes/devcontainer-tooling.md
+++ b/notes/devcontainer-tooling.md
@@ -47,15 +47,19 @@ Sources: CONCERN-2321, Bug #2713
 
 ## `git commit` Needs a 10-Minute Timeout — the flake8 Hook Runs the Whole Tree
 
-The `flake8 (with CC gate)` pre-commit hook is declared with
-`pass_filenames: false` and `args: ["vultron/", "test/"]`, so it lints the entire
-codebase on every commit regardless of what is staged. That reliably exceeds a
-2-minute default command timeout, and the commit appears to hang.
+The `flake8 (with CC gate)` pre-commit hook is `pass_filenames: false` and lints
+the entire `vultron/`+`test/` tree on every commit regardless of what is staged
+(~35s). It is now routed through `.agents/skills/shared/run-if-changed.sh`, which
+skips the run when the sources, `.flake8`, and `uv.lock` are unchanged since the
+last successful flake8 run. `run-linters`, `format-code`, and this hook share
+that cache, so if `run-linters` ran just before the commit the hook is a fast
+no-op.
 
-Run commits as `UV_NO_SYNC=1 git commit ...` with a 600000 ms (10 min) timeout.
-Note that a bare `UV_NO_SYNC=1 uv run flake8` returns quickly — the cost is the
-pre-commit framework's whole-tree invocation, not flake8 itself, so a fast manual
-lint is not evidence that the hook will be fast.
+Still give `git commit` a 600000 ms (10 min) timeout with `UV_NO_SYNC=1`: the
+guard only skips when nothing relevant changed, so a cold cache or any edited
+source file makes the hook pay the full ~35s whole-tree cost. A fast manual
+`uv run flake8` is not evidence the hook will be fast — the cost is the
+whole-tree invocation, not flake8 startup.
 
 Sources: ISSUE-2479
 


### PR DESCRIPTION
- Closes #3153

## Summary

Adds a shared `run-if-changed.sh` guard so black/flake8/mypy/pyright are skipped when their inputs are unchanged since the last successful run, eliminating the ~105s of duplicate flake8 work per commit (three whole-tree runs across `format-code`, `run-linters`, and the pre-commit hook).

## Motivation

The commit workflow re-ran identical whole-tree linting with no intervening changes. flake8 ran three times per commit (~35s each): `format-code`, `run-linters`, and the `pass_filenames: false` whole-tree flake8 hook; black ran three times too, and `format-code` is a strict subset of `run-linters`. This was measured to be config-driven duplication, not system load (load ~5 on 20 cores, negligible `uv run` startup).

## Changes

- **`.agents/skills/shared/run-if-changed.sh`** (new): fingerprints a tool's inputs (the `vultron/`+`test/` sources via git, its config file, and `uv.lock`), skips the run when the fingerprint matches the last success, stores the fingerprint **only on exit 0** (failures never cached), and recomputes post-run so mutating tools like black stabilize in one pass. Cache in `.git/lint-cache/` (per-worktree, never committed); runs unconditionally outside a git repo.
- **`.pre-commit-config.yaml`**: routes the `flake8 (with CC gate)` hook through the guard with the same cache key + inputs as the skills, so a `run-linters` pass just before commit makes the hook a fast no-op. Whole-tree scope and the `max-complexity=10` gate are unchanged.
- **`.agents/skills/format-code/SKILL.md`**, **`.agents/skills/run-linters/SKILL.md`**: invoke each tool through the guard; document the skip line as expected, not an error.
- **`AGENTS.md`**: collapse the pre-commit sequence to `run-linters` alone (it supersedes `format-code`); document the memoization and update the fail-only note and devcontainer tooling row.
- **`notes/devcontainer-tooling.md`**: explain the guard on the flake8 hook while keeping the 10-min commit-timeout guidance for cold/edited runs.

## Verification

- No `.py` files changed; no runtime behavior affected.
- Guard behavior verified: identical rerun 35s→0.12s; reruns after a source edit (~34s); a failed run is not cached so the next run re-executes.
- flake8 pre-commit hook: 34s cold → 0.42s warm; full `run-linters` 2nd pass ~105s → 0.35s (4/4 tools skipped); cross-tool cache sharing confirmed (hook-populated flake8 cache skips the next skill run).
- `pre-commit validate-config` passes; commit hooks (black, markdownlint, flake8, frontmatter validators) all pass.