### PR TITLE
docs(agents): stop recommending `gh issue create` in issue-tracker.md

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,7 +4,7 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Create an issue**: use `.agents/skills/manage-github-issue/manage_github_issue.sh` (or the `createIssue` GraphQL mutation directly). **Never use `gh issue create`** — it cannot set the issue type, parent/child (sub-issue) relationships, or blocker/blocked-by links, all of which are required on create. Type IDs and relationship mutations are in `.agents/skills/manage-github-issue/REFERENCE.md`; use the `create-epic` skill for Epics.
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`


### PR DESCRIPTION
## Summary

Fixes a contradiction in `docs/agents/issue-tracker.md`: the "Create an issue" convention recommended `gh issue create`, which `AGENTS.md` explicitly forbids.

## Motivation

`gh issue create` cannot set the issue type, parent/child (sub-issue) relationships, or blocker/blocked-by links — all required on create in this repo. `AGENTS.md` mandates `manage_github_issue.sh` / the `createIssue` GraphQL mutation, and the doc's own Epics section already uses the structured GraphQL approach; only the "Create an issue" bullet was out of step.

## Changes

- **`docs/agents/issue-tracker.md`**: point "Create an issue" at `.agents/skills/manage-github-issue/manage_github_issue.sh` (or `createIssue` GraphQL), note that `gh issue create` must never be used and why, and reference `REFERENCE.md` and the `create-epic` skill.

## Verification

- Docs-only change; commit hooks (markdownlint, flake8) pass.
- No issue filed — trivial doc-consistency fix aligning to existing `AGENTS.md` policy. Surfaced during #3154.